### PR TITLE
Enhancements for SageMath Cloud

### DIFF
--- a/plotly/plotly.py
+++ b/plotly/plotly.py
@@ -176,11 +176,21 @@ class plotly:
 			except:
 				pass
 			return None
+		def sageJSONEncoder(self, obj):
+			try:
+				from sage.all import RR, ZZ
+				if obj in RR:
+					return float(obj)
+				elif obj in ZZ:
+					return int(obj)
+			except:
+				pass
+			return None
 		def default(self, obj):
 			try:
 				return json.dumps(obj)
 			except TypeError as e:
-				encoders = (self.datetimeJSONEncoder, self.numpyJSONEncoder, self.pandasJSONEncoder)
+				encoders = (self.datetimeJSONEncoder, self.numpyJSONEncoder, self.pandasJSONEncoder, self.sageJSONEncoder)
 				for encoder in encoders:
 					s = encoder(obj)
 					if s is not None:


### PR DESCRIPTION
I've added a fix to the existing `iplot()` function to make it work like in the IPython notebook. (I've also fixed the quite ugly line for the `<iframe ... >`

The other fix is for encoding "native" Sage number types to JSON (They are implicitly created when numbers like `42` or `4.2` are entered in the Sage Notebook.)

To test it, install it in a project at https://cloud.sagemath.com 
