### PR TITLE
rm check_version

### DIFF
--- a/plotly/__init__.py
+++ b/plotly/__init__.py
@@ -1,4 +1,4 @@
-from . version import __version__, check_version
+from . version import __version__
 import graph_objs
 import plotly
 import tools


### PR DESCRIPTION
running

```
import plotly
```

at the root of python-api was failing cuz of this
