### PR TITLE
Added user warning when annotations lie outside plotly's 'paper' bounds.

### DIFF
--- a/plotly/matplotlylib/mpltools.py
+++ b/plotly/matplotlylib/mpltools.py
@@ -35,6 +35,21 @@ def check_bar_match(old_bar, new_bar):
         return False
 
 
+def check_corners(inner_obj, outer_obj):
+    inner_corners = inner_obj.get_window_extent().corners()
+    outer_corners = outer_obj.get_window_extent().corners()
+    if inner_corners[0][0] < outer_corners[0][0]:
+        return False
+    elif inner_corners[0][1] < outer_corners[0][1]:
+        return False
+    elif inner_corners[3][0] > outer_corners[3][0]:
+        return False
+    elif inner_corners[3][1] > outer_corners[3][1]:
+        return False
+    else:
+        return True
+
+
 def convert_affine_trans(dpi=None, aff=None):
     if aff is not None and dpi is not None:
         try:

--- a/plotly/matplotlylib/renderer.py
+++ b/plotly/matplotlylib/renderer.py
@@ -498,6 +498,12 @@ class PlotlyRenderer(Renderer):
 
         """
         self.msg += "    Attempting to draw an mpl text object\n"
+        if not mpltools.check_corners(props['mplobj'], self.mpl_fig):
+            warnings.warn("\n"
+                          "The annotation you're trying to draw lies outside "
+                          "the given figure size. Therefore, the resulting "
+                          "Plotly figure may not be large enough to view the "
+                          "full text.")
         align = props['mplobj']._multialignment
         if not align:
             align = props['style']['halign'] # mpl default


### PR DESCRIPTION
Closes #58
