### PR TITLE
Solution to #71

### DIFF
--- a/plotly/graph_objs/graph_objs.py
+++ b/plotly/graph_objs/graph_objs.py
@@ -336,16 +336,16 @@ class PlotlyList(list):
                                                       entry=entry)
 
 
-    def update(self, changes, make_copies=True):
+    def update(self, changes, make_copies=False):
         """Update current list with changed_list, which must be iterable.
         The 'changes' should be a list of dictionaries, however,
         it is permitted to be a single dict object.
 
         Because mutable objects contain references to their values, updating
         multiple items in a list will cause the items to all reference the same
-        original set of objects. This behavior is usually not wanted and so
-        `make_copies=True` by default to deep copy the update items and
-        therefore break references. Add `make_copies=False` to change this.
+        original set of objects. To change this behavior add
+        `make_copies=True` which makes deep copies of the update items and
+        therefore break references. 
 
         """
         if isinstance(changes, dict):


### PR DESCRIPTION
- add a keyword argument to PlotlyList.update() called immutable (with default =False)
- leave PlotlyDict.update() as is in master branch

`fig['data'].update(some_dict, immutable=True)` creates list of copies
of `some_dict` before calling PlotlyDict.update().

Thus, further updates in `fig['data']` can be applied trace-wise e.g.

`fig['data'][0].update(some_other_dict) only updates the first trace.
