### PR TITLE
added `from __future__ import absolute_import`. Clearer imports.

### DIFF
--- a/plotly/__init__.py
+++ b/plotly/__init__.py
@@ -26,4 +26,6 @@ Modules:
 
 """
 
-from . import plotly, graph_objs, tools, utils
+from __future__ import absolute_import
+
+from plotly import plotly, graph_objs, tools, utils

--- a/plotly/graph_objs/__init__.py
+++ b/plotly/graph_objs/__init__.py
@@ -7,7 +7,9 @@ information, run help(Obj) on any of the following objects defined here.
 
 
 """
-from .graph_objs import *
+from __future__ import absolute_import
+
+from plotly.graph_objs.graph_objs import *
 
 __all__ = ["Data",
            "Annotations",

--- a/plotly/graph_objs/graph_objs.py
+++ b/plotly/graph_objs/graph_objs.py
@@ -22,13 +22,15 @@ graph_objs object and it should always be possible to make a graph_objs object
 from a dict/list JSON representation.
 
 """
+from __future__ import absolute_import
+
 import warnings
 import textwrap
 import six
 import sys
-from . import graph_objs_tools
+from plotly.graph_objs import graph_objs_tools
 import copy
-from .. import exceptions
+from plotly import exceptions
 from plotly import utils
 
 if sys.version[:3] == '2.6':

--- a/plotly/matplotlylib/renderer.py
+++ b/plotly/matplotlylib/renderer.py
@@ -6,11 +6,13 @@ fig_to_plotly, which is intended to be the main way that user's will interact
 with the matplotlylib package.
 
 """
+from __future__ import absolute_import
+
 import warnings
 
 from . mplexporter import Renderer
 from . import mpltools
-from ..graph_objs import *
+from plotly.graph_objs import *
 
 
 

--- a/plotly/plotly/__init__.py
+++ b/plotly/plotly/__init__.py
@@ -7,7 +7,9 @@ local machine and Plotly. Almost all functionality used here will require a
 verifiable account (username/api-key pair) and a network connection.
 
 """
-from .plotly import *
+from __future__ import absolute_import
+
+from plotly.plotly.plotly import *
 
 __all__ = ["sign_in", "update_plot_options", "get_plot_options",
            "get_credentials", "iplot", "plot", "iplot_mpl", "plot_mpl",

--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -14,6 +14,8 @@ and ploty's servers.
 4. update plot_options with kwargs!
 
 """
+from __future__ import absolute_import
+
 import json
 import warnings
 import copy
@@ -22,11 +24,11 @@ import six
 
 import requests
 
-from . import chunked_requests
-from .. import utils  # TODO make non-relative
-from .. import tools
-from .. import exceptions
-from .. import version
+from plotly.plotly import chunked_requests
+from plotly import utils
+from plotly import tools
+from plotly import exceptions
+from plotly import version
 
 
 __all__ = ["sign_in", "update_plot_options", "get_plot_options",

--- a/plotly/tests/test_get_figure/test_get_figure.py
+++ b/plotly/tests/test_get_figure/test_get_figure.py
@@ -5,9 +5,9 @@ test_get_figure:
 A module intended for use with Nose.
 
 """
-from ... graph_objs import graph_objs
-from ... plotly import plotly as py
-from ... import exceptions
+from plotly.graph_objs import graph_objs
+from plotly.plotly import plotly as py
+from plotly import exceptions
 
 
 # username for tests: 'plotlyimagetest'

--- a/plotly/tests/test_graph_objs/test_annotations.py
+++ b/plotly/tests/test_graph_objs/test_annotations.py
@@ -5,12 +5,15 @@ test_annotations:
 A module intended for use with Nose.
 
 """
+from __future__ import absolute_import
+
 from nose.tools import raises
-from ...graph_objs.graph_objs import *
-from ...exceptions import (PlotlyError,
-                           PlotlyDictKeyError,
-                           PlotlyDictValueError,
-                           PlotlyDataTypeError, PlotlyListEntryError)
+from plotly.graph_objs.graph_objs import *
+from plotly.exceptions import (PlotlyError,
+                               PlotlyDictKeyError,
+                               PlotlyDictValueError,
+                               PlotlyDataTypeError,
+                               PlotlyListEntryError)
 
 
 def setup():

--- a/plotly/tests/test_graph_objs/test_data.py
+++ b/plotly/tests/test_graph_objs/test_data.py
@@ -5,12 +5,15 @@ test_data:
 A module intended for use with Nose.
 
 """
+from __future__ import absolute_import
+
 from nose.tools import raises
-from ...graph_objs.graph_objs import *
-from ...exceptions import (PlotlyError,
-                           PlotlyDictKeyError,
-                           PlotlyDictValueError,
-                           PlotlyDataTypeError, PlotlyListEntryError)
+from plotly.graph_objs.graph_objs import *
+from plotly.exceptions import (PlotlyError,
+                               PlotlyDictKeyError,
+                               PlotlyDictValueError,
+                               PlotlyDataTypeError,
+                               PlotlyListEntryError)
 
 
 def setup():

--- a/plotly/tests/test_graph_objs/test_error_bars.py
+++ b/plotly/tests/test_graph_objs/test_error_bars.py
@@ -5,10 +5,14 @@ test_error_bars:
 A module intended for use with Nose.
 
 """
+from __future__ import absolute_import
+
 from nose.tools import raises
-from ...graph_objs.graph_objs import *
-from ...exceptions import (PlotlyDictKeyError, PlotlyDictValueError,
-                           PlotlyDataTypeError, PlotlyListEntryError)
+from plotly.graph_objs.graph_objs import *
+from plotly.exceptions import (PlotlyDictKeyError,
+                               PlotlyDictValueError,
+                               PlotlyDataTypeError,
+                               PlotlyListEntryError)
 
 
 def test_instantiate_error_x():

--- a/plotly/tests/test_graph_objs/test_plotly_dict.py
+++ b/plotly/tests/test_graph_objs/test_plotly_dict.py
@@ -5,9 +5,11 @@ test_plotly_dict:
 A module intended for use with Nose.
 
 """
+from __future__ import absolute_import
+
 from nose.tools import raises
-from ... graph_objs.graph_objs import PlotlyDict
-from ... exceptions import PlotlyError
+from plotly.graph_objs.graph_objs import PlotlyDict
+from plotly.exceptions import PlotlyError
 
 
 def test_trivial():

--- a/plotly/tests/test_graph_objs/test_plotly_list.py
+++ b/plotly/tests/test_graph_objs/test_plotly_list.py
@@ -5,9 +5,11 @@ test_plotly_list:
 A module intended for use with Nose.
 
 """
+from __future__ import absolute_import
+
 from nose.tools import raises
-from ... graph_objs.graph_objs import PlotlyList, PlotlyDict
-from ... exceptions import PlotlyError
+from plotly.graph_objs.graph_objs import PlotlyList, PlotlyDict
+from plotly.exceptions import PlotlyError
 
 
 def test_trivial():

--- a/plotly/tests/test_graph_objs/test_plotly_trace.py
+++ b/plotly/tests/test_graph_objs/test_plotly_trace.py
@@ -5,9 +5,11 @@ test_trace:
 A module intended for use with Nose.
 
 """
+from __future__ import absolute_import
+
 from nose.tools import raises
-from ... graph_objs.graph_objs import PlotlyTrace
-from ... exceptions import PlotlyError
+from plotly.graph_objs.graph_objs import PlotlyTrace
+from plotly.exceptions import PlotlyError
 
 
 def test_trivial():

--- a/plotly/tests/test_graph_objs/test_scatter.py
+++ b/plotly/tests/test_graph_objs/test_scatter.py
@@ -5,9 +5,11 @@ test_scatter:
 A module intended for use with Nose.
 
 """
+from __future__ import absolute_import
+
 from nose.tools import raises
-from ... graph_objs import Scatter
-from ... exceptions import PlotlyError
+from plotly.graph_objs import Scatter
+from plotly.exceptions import PlotlyError
 
 
 def test_trivial():

--- a/plotly/tests/test_graph_reference/test_key_types.py
+++ b/plotly/tests/test_graph_reference/test_key_types.py
@@ -5,6 +5,8 @@ test_key_types:
 A module intended for use with Nose.
 
 """
+from __future__ import absolute_import
+
 import plotly.graph_objs.graph_objs as go
 
 

--- a/plotly/tests/test_matplotlylib/nose_tools.py
+++ b/plotly/tests/test_matplotlylib/nose_tools.py
@@ -1,7 +1,9 @@
+from __future__ import absolute_import
+
 import matplotlib
 # Force matplotlib to not use any Xwindows backend.
 matplotlib.use('Agg')
-from ... matplotlylib import Exporter, PlotlyRenderer
+from plotly.matplotlylib import Exporter, PlotlyRenderer
 from numbers import Number as Num
 
 

--- a/plotly/tests/test_matplotlylib/test_annotations.py
+++ b/plotly/tests/test_matplotlylib/test_annotations.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import matplotlib
 # Force matplotlib to not use any Xwindows backend.
 matplotlib.use('Agg')

--- a/plotly/tests/test_plotly/test_plot.py
+++ b/plotly/tests/test_plotly/test_plot.py
@@ -5,9 +5,11 @@ test_plot:
 A module intended for use with Nose.
 
 """
-from ... graph_objs import graph_objs
-from ... plotly import plotly as py
-from ... import exceptions
+from __future__ import absolute_import
+
+from plotly.graph_objs import graph_objs
+from plotly.plotly import plotly as py
+from plotly import exceptions
 
 
 # username for tests: 'plotlyimagetest'

--- a/plotly/tests/test_plotly/test_plot_mpl.py
+++ b/plotly/tests/test_plotly/test_plot_mpl.py
@@ -5,8 +5,10 @@ test_plot_mpl:
 A module intended for use with Nose.
 
 """
-from ... plotly import plotly as py
-from ... import exceptions
+from __future__ import absolute_import
+
+from plotly.plotly import plotly as py
+from plotly import exceptions
 from nose.tools import raises
 import matplotlib
 # Force matplotlib to not use any Xwindows backend.

--- a/plotly/tests/test_stream/test_stream.py
+++ b/plotly/tests/test_stream/test_stream.py
@@ -5,11 +5,13 @@ test_get_figure:
 A module intended for use with Nose.
 
 """
+from __future__ import absolute_import
+
 import time
 from nose.tools import raises
-from ... graph_objs import *
-from ... plotly import plotly as py
-from ... import exceptions
+from plotly.graph_objs import *
+from plotly.plotly import plotly as py
+from plotly import exceptions
 
 un = 'pythonapi'
 ak = 'ubpiol2cve'

--- a/plotly/tests/test_tools/test_validate.py
+++ b/plotly/tests/test_tools/test_validate.py
@@ -1,4 +1,6 @@
-from ... import graph_objs
+from __future__ import absolute_import
+
+from plotly import graph_objs
 
 
 

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -7,22 +7,19 @@ tools
 Functions that USERS will possibly want access to.
 
 """
+from __future__ import absolute_import
+
 import os
 import os.path
 import warnings
 
-from . import utils
-from . import exceptions
+from plotly import utils
+from plotly import exceptions
 
-
-
-
-
-
-# Warning format
 from . import matplotlylib
 from . graph_objs import graph_objs
 
+# Warning format
 def warning_on_one_line(message, category, filename, lineno, file=None, line=None):
     return '%s:%s: %s:\n\n%s\n\n' % (filename, lineno, category.__name__, message)
 warnings.formatwarning = warning_on_one_line


### PR DESCRIPTION
In Python 3, you cannot have an ambiguous `import X` if X is
both a module and a subpackage/submodule. By importing this here,
we get rid of ridiculous relative imports like `from ... import X`.
