### PR TITLE
Fix "'module' object has no attribute 'display'" for old ipython.

### DIFF
--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -33,6 +33,7 @@ except ImportError:
 
 try:
     import IPython
+    import IPython.core.display
     _ipython_imported = True
 except ImportError:
     _ipython_imported = False


### PR DESCRIPTION
IPython doesn't necessarily have this package organization. We're just more explicit about it now.
