### PR TITLE
Add a lock for folks using threading. Mucho helpful.

### DIFF
--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -72,9 +72,8 @@ def check_file_permissions():
 def ensure_local_plotly_files():
     """Ensure that filesystem is setup/filled out in a valid way"""
     if _file_permissions:
-        if not os.path.isdir(PLOTLY_DIR):
-            os.mkdir(PLOTLY_DIR)
         for fn in [CREDENTIALS_FILE, CONFIG_FILE]:
+            utils.ensure_file_exists(fn)
             contents = utils.load_json_dict(fn)
             for key, val in list(_FILE_CONTENT[fn].items()):
                 # TODO: removed type checking below, may want to revisit

--- a/plotly/utils.py
+++ b/plotly/utils.py
@@ -14,6 +14,7 @@ import threading
 ### incase people are using threadig, we lock file reads
 lock = threading.Lock()
 
+
 ### general file setup tools ###
 
 def load_json_dict(filename, *args):
@@ -27,7 +28,7 @@ def load_json_dict(filename, *args):
                 if not isinstance(data, dict):
                     data = {}
             except:
-                pass # TODO: issue a warning and bubble it up
+                data = {}  # TODO: issue a warning and bubble it up
         lock.release()
         if args:
             d = dict()
@@ -41,15 +42,32 @@ def load_json_dict(filename, *args):
 
 
 def save_json_dict(filename, json_dict):
-    """Will error if filename is not appropriate, but it's checked elsewhere.
-    """
+    """Save json to file. Error if path DNE, not a dict, or invalid json."""
     if isinstance(json_dict, dict):
+        # this will raise a TypeError if something goes wrong
+        json_string = json.dumps(json_dict, indent=4)
         lock.acquire()
         with open(filename, "w") as f:
-            f.write(json.dumps(json_dict, indent=4))
+            f.write(json_string)
         lock.release()
     else:
-        raise TypeError("json_dict was not a dictionay. couldn't save.")
+        raise TypeError("json_dict was not a dictionary. not saving.")
+
+
+def ensure_file_exists(filename):
+    """Given a valid filename, make sure it exists (will create if DNE)."""
+    if not os.path.exists(filename):
+        head, tail = os.path.split(filename)
+        ensure_dir_exists(head)
+        with open(filename, 'w') as f:
+            pass  # just create the file
+
+
+def ensure_dir_exists(directory):
+    """Given a valid directory path, make sure it exists."""
+    if dir:
+        if not os.path.isdir(directory):
+            os.makedirs(directory)
 
 
 ### Custom JSON encoders ###


### PR DESCRIPTION
I can't see any _downside_ to including a lock here. Basically, it
just says that two threads running in parallel can't touch the code
between the lock.acquire() <--> lock.release() statements
concurrently. We use it in low-level util functions to prevent
concurrent file reads/writes.

This was a bug that showed up while running our auto-documentation
examples.
