### PR TITLE
Need to be more explicit about dependencies.

### DIFF
--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -9,7 +9,7 @@
 matplotlib==1.3.1
 
 ## testing dependencies ##
-nose==1.3.3
+nose>=1.3.3
 
 ## ipython dependencies ##
-ipython[all]
+ipython[notebook]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,7 @@
 ###################################################
 
 ## http request dependencies ##
-requests==2.3.0
+requests>=2.0
+
+## python 2 and python 3 compatibility
+six>=1.4

--- a/setup.py
+++ b/setup.py
@@ -39,5 +39,8 @@ setup(name='plotly',
                 'plotly/matplotlylib/mplexporter',
                 'plotly/matplotlylib/mplexporter/renderers'],
       package_data={'plotly': ['graph_reference/*.json']},
-      install_requires=['requests', 'six'],
+      install_requires=[
+          'requests>=2.0',
+          'six>=1.4'
+      ],
       zip_safe=False)


### PR DESCRIPTION
@etpinard @chriddyp , some users with old versions of six were getting errors because the `add_metaclass` attribute wasn't created yet. This makes our dependency range explicit.
