### PR TITLE
Fix duplicate file name extension

### DIFF
--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -660,7 +660,7 @@ class image:
             format = ext[1:]
         elif not ext and format:
             filename += '.'+format
-        else:
+        elif ext[1:].lower() != format.lower():
             filename += '.'+format
 
         img = cls.get(figure_or_data, format, width, height)


### PR DESCRIPTION
If a filename extension and a format are specified with the same string,
we create a file with a double file extension. Ie:

``` javascript
py.image.save_as(figure, 'filename2.png', 'png')
```

This will produce a file named filename2.png.png. When ext and format
are both present, the fix will only append format to the filename if the
format is different from ext. Ie:

``` javascript
py.image.save_as(figure, 'filename2.png', 'pdf')
```

This will create filename2.png.pdf.
