### PR TITLE
Raise for bad plot options in `_send_to_plotly`

### DIFF
--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -1390,6 +1390,11 @@ def _send_to_plotly(figure, **plot_options):
     """
 
     """
+    invalid_plot_options = [plot_option for plot_option in plot_options
+                            if plot_option not in DEFAULT_PLOT_OPTIONS]
+    if invalid_plot_options:
+        raise exceptions.PlotlyError('Invalid plot options, {}.'
+                                     .format(invalid_plot_options))
     fig = tools._replace_newline(figure)  # does not mutate figure
     data = json.dumps(fig['data'] if 'data' in fig else [],
                       cls=utils.PlotlyJSONEncoder)


### PR DESCRIPTION
Fixes #298

This is backwards incompatible as obsolete `plot_options` have previously been silently ignored. It _is_ a little misleading and has caused confusion for users (#298).

Another option is to allow `layout` again, but _only_ if (1) data is given as the first argument or (2) layout is not defined in the figure. We could just throw a deprecation warning and then stop supporting it in `2.x`?
