### PR TITLE
Change to offline.init_notebook_mode()

### DIFF
--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -46,15 +46,16 @@ def init_notebook_mode():
     from IPython.display import HTML, display
 
     global __PLOTLY_OFFLINE_INITIALIZED
+    if not __PLOTLY_OFFLINE_INITIALIZED:
+        display(HTML('<script type="text/javascript">' +
+                     # ipython's includes `require` as a global, which
+                     # conflicts with plotly.js. so, unrequire it.
+                     'require=requirejs=define=undefined;' +
+                     '</script>' +
+                     '<script type="text/javascript">' +
+                     get_plotlyjs() +
+                     '</script>'))
     __PLOTLY_OFFLINE_INITIALIZED = True
-    display(HTML('<script type="text/javascript">' +
-                 # ipython's includes `require` as a global, which
-                 # conflicts with plotly.js. so, unrequire it.
-                 'require=requirejs=define=undefined;' +
-                 '</script>' +
-                 '<script type="text/javascript">' +
-                 get_plotlyjs() +
-                 '</script>'))
 
 
 def iplot(figure_or_data, show_link=True, link_text='Export to plot.ly',


### PR DESCRIPTION
Make `init_notebook_mode()` only import the JS library once. Otherwise if someone puts it at the top of a Jupyter cell and it gets executed every time (typical pattern of usage?), it adds ~1 s to the cell's execution time.