### PR TITLE
Conda build

### DIFF
--- a/bld.bat
+++ b/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 
-${PYTHON} setup.py install || exit 1;
+$PYTHON setup.py install
 
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+${PYTHON} setup.py install || exit 1;
+

--- a/meta.yaml
+++ b/meta.yaml
@@ -6,25 +6,10 @@ source:
   fn: plotly-1.9.3.tar.gz
   url: https://pypi.python.org/packages/source/p/plotly/plotly-1.9.3.tar.gz
   md5: f40ac2d3f0b1212f59c9a74d8f44067a
-#  patches:
-   # List any patch files here
-   # - fix.patch
 
-# build:
+build:
   # noarch_python: True
-  # preserve_egg_dir: True
-  # entry_points:
-    # Put any entry points (scripts to be generated automatically) here. The
-    # syntax is module:function.  For example
-    #
-    # - plotly = plotly:main
-    #
-    # Would create an entry point called plotly that calls plotly.main()
-
-
-  # If this is a new build for the same version, increment the build
-  # number. If you do not include this key, it defaults to 0.
-  # number: 1
+  number: 0
 
 requirements:
   build:
@@ -41,7 +26,6 @@ requirements:
     - pytz
 
 test:
-  # Python imports
   imports:
     - plotly
     - plotly/graph_objs
@@ -54,23 +38,7 @@ test:
     - plotly/plotly/chunked_requests
     - plotly/widgets
 
-  # commands:
-    # You can put test commands to be run here.  Use this to test that the
-    # entry points work.
-
-
-  # You can also put a file called run_test.py in the recipe that will be run
-  # at test time.
-
-  # requires:
-    # Put any additional test requirements here.  For example
-    # - nose
-
 about:
   home: https://plot.ly/python/
   license: MIT
   summary: 'Python plotting library for collaborative, interactive, publication-quality graphs.'
-
-# See
-# http://docs.continuum.io/conda/build.html for
-# more information about meta.yaml

--- a/meta.yaml
+++ b/meta.yaml
@@ -3,10 +3,28 @@ package:
   version: "1.9.3"
 
 source:
-  git_url: https://github.com/plotly/plotly.py
+  fn: plotly-1.9.3.tar.gz
+  url: https://pypi.python.org/packages/source/p/plotly/plotly-1.9.3.tar.gz
+  md5: f40ac2d3f0b1212f59c9a74d8f44067a
+#  patches:
+   # List any patch files here
+   # - fix.patch
 
-build:
-  number: 0
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - plotly = plotly:main
+    #
+    # Would create an entry point called plotly that calls plotly.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
 
 requirements:
   build:
@@ -15,14 +33,44 @@ requirements:
     - requests
     - six
     - pytz
+
   run:
     - python
-    - setuptools
     - requests
     - six
     - pytz
 
+test:
+  # Python imports
+  imports:
+    - plotly
+    - plotly/graph_objs
+    - plotly/grid_objs
+    - plotly/matplotlylib
+    - plotly/matplotlylib/mplexporter
+    - plotly/matplotlylib/mplexporter/renderers
+    - plotly/offline
+    - plotly/plotly
+    - plotly/plotly/chunked_requests
+    - plotly/widgets
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
 about:
-  home: https://plot.ly
+  home: https://plot.ly/python/
   license: MIT
-  summary: Python plotting library for collaborative, interactive, publication-quality graphs.
+  summary: 'Python plotting library for collaborative, interactive, publication-quality graphs.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,28 @@
+package:
+  name: plotly
+  version: "1.9.3"
+
+source:
+  git_url: https://github.com/plotly/plotly.py
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - requests
+    - six
+    - pytz
+  run:
+    - python
+    - setuptools
+    - requests
+    - six
+    - pytz
+
+about:
+  home: https://plot.ly
+  license: MIT
+  summary: Python plotting library for collaborative, interactive, publication-quality graphs.


### PR DESCRIPTION
Somewhat of a follow on to #136.

All of our (Jupyter/IPython) Docker environments rely on `conda`, which means we need this setup in order for it to be packaged with our conda environments.