### PR TITLE
Added a space between attributes so that picky HTML parsers don't freak out

### DIFF
--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -339,7 +339,7 @@ def get_embed(file_owner_or_url, file_id=None, width="100%", height=525):
             "The 'file_id' argument must be a non-negative number."
         )
     if share_key is '':
-        s = ("<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\""
+        s = ("<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" "
              "seamless=\"seamless\" "
              "src=\"{plotly_rest_url}/"
              "~{file_owner}/{file_id}.embed\" "
@@ -349,7 +349,7 @@ def get_embed(file_owner_or_url, file_id=None, width="100%", height=525):
             file_owner=file_owner, file_id=file_id,
             iframe_height=height, iframe_width=width)
     else:
-        s = ("<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\""
+        s = ("<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" "
              "seamless=\"seamless\" "
              "src=\"{plotly_rest_url}/"
              "~{file_owner}/{file_id}.embed?share_key={share_key}\" "


### PR DESCRIPTION
The lack of space between the style attribute value and the seamless attribute in the following embed_code causes some parsers to consider the html code malformed:

```<iframe id="igraph" scrolling="no" style="border:none;"seamless="seamless" src="https://plotly.skd.midasplayer.com/~christophe.carvenius/28.embed" height="525px" width="100%"></iframe>```