### PR TITLE
Remove useless line in offline plot function

### DIFF
--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -257,8 +257,6 @@ def plot(figure_or_data,
         figure_or_data, show_link, link_text, validate,
         '100%', '100%')
 
-    figure = tools.return_figure_from_figure_or_data(figure_or_data, validate)
-
     resize_script = ''
     if width == '100%' or height == '100%':
         resize_script = (
@@ -469,4 +467,3 @@ def enable_mpl_offline(resize=False, strip_style=False,
     formatter.for_type(matplotlib.figure.Figure,
                        lambda fig: iplot_mpl(fig, resize, strip_style, verbose,
                                              show_link, link_text, validate))
-


### PR DESCRIPTION
Hello all,

The last line on the snippet shown below (that should be clear in the commit diff) is useless as the `figure` variable is not used in `plot` function.

```python
plot_html, plotdivid, width, height = _plot_html(
  figure_or_data, show_link, link_text, validate, '100%', '100%'
)

figure = tools.return_figure_from_figure_or_data(figure_or_data, validate)
```

Moreover, the same call to `tools.return_figure_from_figure_or_data` is done within `_plot_html`.
It seems this is left-out garbage in the code.

A simple pep8/flake8 integration on the tests could solve similar issues.