### PR TITLE
Don't clobber the Notebook's require/requirejs/define instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- Offline mode will no longer delete the Jupyter Notebook's require, requirejs, and define variables.
 
 ## [1.9.6] - 2016-02-18
 ### Updated

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -61,14 +61,14 @@ def init_notebook_mode():
 
     global __PLOTLY_OFFLINE_INITIALIZED
     if not __PLOTLY_OFFLINE_INITIALIZED:
-        display(HTML('<script type="text/javascript">' +
-                     # ipython's includes `require` as a global, which
-                     # conflicts with plotly.js. so, unrequire it.
-                     'require=requirejs=define=undefined;' +
-                     '</script>' +
-                     '<script type="text/javascript">' +
+        display(HTML("<script type='text/javascript'>" +
+                     "define('plotly', function(require, exports, module) {" +
                      get_plotlyjs() +
-                     '</script>'))
+                     "});" +
+                     "require(['plotly'], function(Plotly) {" +
+                     "window.Plotly = Plotly;" +
+                     "});" +
+                     "</script>"))
     __PLOTLY_OFFLINE_INITIALIZED = True
 
 


### PR DESCRIPTION
It doesn't make sense to to clobber the require.js globals that live in the notebook for Plotly's offline mode.  Nor does it make sense to load the Plotly JS from the CDN when running in offline mode.  This PR uses requirejs named definitions and requirejs commonjs support to embed the plotly JS on the page.

This PR does not solve the workflow of getting the plotly.js build into the plotly.py repo.  In a separate PR that should be automated.

related to #408
closes #373
