### PR TITLE
Jupyter Notebook: Fix window.Plotly not defined error when running all cells

### DIFF
--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -127,9 +127,11 @@ def _plot_html(figure_or_data, show_link, link_text,
         'class="plotly-graph-div">'
         '</div>'
         '<script type="text/javascript">'
+        'require(["plotly"], function(Plotly) {{'
         'window.PLOTLYENV=window.PLOTLYENV || {{}};'
         'window.PLOTLYENV.BASE_URL="' + plotly_platform_url + '";'
         '{script}'
+        '}});'
         '</script>'
         '').format(
         id=plotdivid, script=script,


### PR DESCRIPTION
In Dynamic Dashboards (https://github.com/jupyter-incubator/dashboards_server/issues/108) we need to be able to execute all code cells of a Jupyter Notebook file. Currently Plotly does not work, with the error that `window.Plotly` is not defined. This problem can also be observed in a notebook when performing a "Run All" of all cells.

@jdfreder's fix in #412 preserves requirejs when plotting in offline mode in the notebook, but causes an error if doing a "Run All" cells. The reason for this is the initialization of `window.Plotly` [occurs in a requirejs function](https://github.com/plotly/plotly.py/blob/127ebc5f0be979c52847a6427a2ada3b11fc4352/plotly/offline/offline.py#L69) and is immediately followed by an attempt to access it [outside of a requirejs function](https://github.com/plotly/plotly.py/blob/127ebc5f0be979c52847a6427a2ada3b11fc4352/plotly/offline/offline.py#L132). At this point `window.Plotly` won't yet be defined since the definition will execute asynchronously after the attempt to access it.

To fix, the call to `Plotly.newPlot()` could happen inside its own requrejs function, making use of the 'plotly' requirejs module. I have made the minimal change in this PR to demonstrate. (I kept the requirejs function that defines `window.Plotly`, but it could potentially be removed in favor of using the requirejs module only.) It works for me when doing a "Run All" in the notebook and also works when deploying a dashboard read from the notebook file.

This may also be related to #394 if the conversion of notebook to slides is doing a "Run All".