### PR TITLE
Require plotly before attempting to show a plot

### DIFF
--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -127,9 +127,11 @@ def _plot_html(figure_or_data, show_link, link_text,
         'class="plotly-graph-div">'
         '</div>'
         '<script type="text/javascript">'
+        'requirejs(["plotly"], function(util) {{'
         'window.PLOTLYENV=window.PLOTLYENV || {{}};'
         'window.PLOTLYENV.BASE_URL="' + plotly_platform_url + '";'
         '{script}'
+        '}});'
         '</script>'
         '').format(
         id=plotdivid, script=script,


### PR DESCRIPTION
When refreshing a notebook, some plot may not be shown because the plotly
initialization script did not finish before the plot was shown. It results in a
console error like 'Plotly is not defined'. This patch fixes this error by
making every plot require plotly.