### PR TITLE
Customize the titlefont of a subplot within make_subplots.

### DIFF
--- a/plotly/tests/test_core/test_tools/test_make_subplots.py
+++ b/plotly/tests/test_core/test_tools/test_make_subplots.py
@@ -2201,3 +2201,54 @@ def test_subplot_titles_insets():
     fig = tls.make_subplots(insets=[{'cell': (1, 1), 'l': 0.7, 'b': 0.3}],
                             subplot_titles=("", 'Inset'))
     assert fig == expected
+
+def test_subplot_titlefont():
+    # make a 2x1 subplot with a title with a custom font
+    expected = Figure(
+        data=Data(),
+        layout=Layout(
+            annotations=Annotations([
+                Annotation(
+                    x=0.5,
+                    y=1.0,
+                    xref='paper',
+                    yref='paper',
+                    text='Title 1',
+                    showarrow=False,
+                    font=Font(size=20),
+                    xanchor='center',
+                    yanchor='bottom'
+                ),
+                Annotation(
+                    x=0.5,
+                    y=0.375,
+                    xref='paper',
+                    yref='paper',
+                    text='Title 2',
+                    showarrow=False,
+                    font=Font(size=20),
+                    xanchor='center',
+                    yanchor='bottom'
+                )
+            ]),
+            xaxis1=XAxis(
+                domain=[0.0, 1.0],
+                anchor='y1'
+            ),
+            xaxis2=XAxis(
+                domain=[0.0, 1.0],
+                anchor='y2'
+            ),
+            yaxis1=YAxis(
+                domain=[0.625, 1.0],
+                anchor='x1'
+            ),
+            yaxis2=YAxis(
+                domain=[0.0, 0.375],
+                anchor='x2'
+            )
+        )
+    )
+    fig = tls.make_subplots(rows=2, subplot_titles=('Title 1', 'Title 2'),
+        subplot_titlefont=Font(size=20))
+    assert fig == expected

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -686,6 +686,15 @@ def make_subplots(rows=1, cols=1,
     fig['data'] += [Scatter(x=[1,2,3], y=[2,1,2])]
     fig['data'] += [Scatter(x=[1,2,3], y=[2,1,2], xaxis='x2', yaxis='y2')]
 
+    Example 7:
+    # Provide a custom subplot_titlefont
+    fig = tools.make_subplots(rows=2, subplot_titles=('Plot 1','Plot 2')),
+                              subplot_titlefont=graph_objs.Font(size=20))
+
+    This is the format of your plot grid:
+    [ (1,1) x1,y1 ]
+    [ (2,1) x2,y2 ]
+
     Keywords arguments with constant defaults:
 
     rows (kwarg, int greater than 0, default=1):
@@ -715,6 +724,10 @@ def make_subplots(rows=1, cols=1,
     start_cell (kwarg, 'bottom-left' or 'top-left', default='top-left')
         Choose the starting cell in the subplot grid used to set the
         domains of the subplots.
+
+    subplot_titlefont (kwarg, graph_objs.Font,
+                       default=graph_objs.Font(size=16))
+        Set the font for subplot titles.
 
     print_grid (kwarg, boolean, default=True):
         If True, prints a tab-delimited string representation of
@@ -826,13 +839,17 @@ def make_subplots(rows=1, cols=1,
 
     # Throw exception if non-valid kwarg is sent
     VALID_KWARGS = ['horizontal_spacing', 'vertical_spacing',
-                    'specs', 'insets', 'subplot_titles']
+                    'specs', 'insets', 'subplot_titles', 'subplot_titlefont']
     for key in kwargs.keys():
         if key not in VALID_KWARGS:
             raise Exception("Invalid keyword argument: '{0}'".format(key))
 
     # Set 'subplot_titles'
     subplot_titles = kwargs.get('subplot_titles', [""] * rows * cols)
+
+    # Set 'subplot_titlefont'
+    subplot_titlefont = kwargs.get('subplot_titlefont',
+                                   graph_objs.Font(size=16))
 
     # Set 'horizontal_spacing' / 'vertical_spacing' w.r.t. rows / cols
     try:
@@ -1284,7 +1301,7 @@ def make_subplots(rows=1, cols=1,
                                 'yref': 'paper',
                                 'text': subplot_titles[index],
                                 'showarrow': False,
-                                'font': graph_objs.Font(size=16),
+                                'font': subplot_titlefont,
                                 'xanchor': 'center',
                                 'yanchor': 'bottom'
                                 })


### PR DESCRIPTION
When using plots in e.g. presentations, the default font for subplot titles is usually too small to cut it. This allows the subplot_titlefont to be set within the make_subplots kwargs.
- The default is still Font(size=16)
- I've added a single test.

This is my first PR here, apologies if I've missed something.
