### PR TITLE
In python 3 `map` is a generator, `list()` it!

### DIFF
--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -1562,7 +1562,7 @@ class FigureFactory(object):
         points3D = np.vstack((x, y, z)).T
 
         # vertices of the surface triangles
-        tri_vertices = map(lambda index: points3D[index], simplices)
+        tri_vertices = list(map(lambda index: points3D[index], simplices))
         # mean values of z-coordinates of triangle vertices
         zmean = [np.mean(tri[:, 2]) for tri in tri_vertices]
         min_zmean = np.min(zmean)


### PR DESCRIPTION
In python 2, you typically get `list` objects. For efficiency (AFAIK) in
python 3 you’ll get a generator. Note that you can’t iterate through
a generator more than once though!