### PR TITLE
Allow for the option of a CDN in offline mode

### DIFF
--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -67,10 +67,15 @@ def init_notebook_mode(connected=False):
         script_inject = (
             ''
             '<script>'
-            'if(!window.Plotly) {{'
-            'require([\'https://cdn.plot.ly/plotly-latest.min.js\'],'
+            # 'if(!window.Plotly) {{'
+            'requirejs.config({'
+            'paths: { '
+            '\'plotly\': [\'https://cdn.plot.ly/plotly-latest.min\']},'
+            '});'
+            'require([\'plotly\'],'
             'function(plotly) {window.Plotly=plotly;});'
-            '}} </script>'
+            # '}}'
+            '</script>'
             )
     else:
         # Inject plotly.js into the output cell
@@ -142,9 +147,8 @@ def _plot_html(figure_or_data, show_link, link_text,
         config=jconfig)
 
     optional_line1 = ('require(["plotly"], function(Plotly) {{ '
-                      if (global_requirejs and (not __PLOTLY_USE_CDN)) else '')
-    optional_line2 = ('}});' if (global_requirejs and (not __PLOTLY_USE_CDN))
-                      else '')
+                      if global_requirejs else '')
+    optional_line2 = ('}});' if global_requirejs else '')
 
     plotly_html_div = (
         ''

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -67,14 +67,14 @@ def init_notebook_mode(connected=False):
         script_inject = (
             ''
             '<script>'
-            # 'if(!window.Plotly) {{'
             'requirejs.config({'
             'paths: { '
             '\'plotly\': [\'https://cdn.plot.ly/plotly-latest.min\']},'
             '});'
+            'if(!window.Plotly) {{'
             'require([\'plotly\'],'
             'function(plotly) {window.Plotly=plotly;});'
-            # '}}'
+            '}}'
             '</script>'
             )
     else:

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -66,9 +66,12 @@ def init_notebook_mode(connected=False):
         # Inject plotly.js into the output cell
         script_inject = (
             ''
-            '<script '
-            'src=\'https://cdn.plot.ly/plotly-latest.min.js\'></script>'
-        )
+            '<script>'
+            'if(!window.Plotly) {{'
+            'require([\'https://cdn.plot.ly/plotly-latest.min.js\'],'
+            'function(plotly) {window.Plotly=plotly;});'
+            '}} </script>'
+            )
     else:
         # Inject plotly.js into the output cell
         script_inject = (
@@ -208,7 +211,7 @@ def iplot(figure_or_data, show_link=True, link_text='Export to plot.ly',
 
     plot_html, plotdivid, width, height = _plot_html(
         figure_or_data, show_link, link_text, validate,
-        '100%', 525, global_requirejs=__PLOTLY_USE_CDN)
+        '100%', 525, global_requirejs=True)
 
     display(HTML(plot_html))
 

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -139,8 +139,9 @@ def _plot_html(figure_or_data, show_link, link_text,
         config=jconfig)
 
     optional_line1 = ('require(["plotly"], function(Plotly) {{ '
-                      if global_requirejs else '')
-    optional_line2 = '}});' if global_requirejs else ''
+                      if (global_requirejs and (not __PLOTLY_USE_CDN)) else '')
+    optional_line2 = ('}});' if (global_requirejs and (not __PLOTLY_USE_CDN))
+                      else '')
 
     plotly_html_div = (
         ''


### PR DESCRIPTION
@chriddyp First attempt at it. Couldn't get it to work out. 
Notes: 
- When I view the html for the ipynb, I can see the `<script src ..>` for loading plotlyjs. 
- the connected parameter is to see if a user wants to use the cdn (could name it differently, but for now connected=True --> use the cdn)

What happens: 

![screen shot 2016-05-22 at 12 13 50 am](https://cloud.githubusercontent.com/assets/12302455/15452142/2412fef2-1fb2-11e6-8896-a1409356e6e4.png)
      
