### PR TITLE
python version check in order to import urlparse

### DIFF
--- a/plotly/plotly/chunked_requests/chunked_request.py
+++ b/plotly/plotly/chunked_requests/chunked_request.py
@@ -2,7 +2,12 @@ import time
 import six
 import os
 from six.moves import http_client
-from six.moves.urllib.parse import urlparse
+from platform import python_version
+version = python_version()
+if version[0] == '2':
+    import urlparse
+else:
+    from six.moves.urllib.parse import urlparse
 from ssl import SSLError
 
 


### PR DESCRIPTION
This small patch should fix issue #478 
Just check the python version and run the related code so that urlparse is installed on both python2 and python3
Tested on Windows XP, Windows 10, Linux Debian Stable. All with python 2 installed.
Maybe some test on machines with python3
