### PR TITLE
Allow more than 2 colormaps again

### DIFF
--- a/plotly/graph_reference/default-schema.json
+++ b/plotly/graph_reference/default-schema.json
@@ -11230,6 +11230,7 @@
                 },
                 "lighting": {
                     "ambient": {
+                        "description": "Ambient light increases overall color visibility but can wash out the image.",
                         "dflt": 0.8,
                         "max": 1,
                         "min": 0,
@@ -11237,13 +11238,23 @@
                         "valType": "number"
                     },
                     "diffuse": {
+                        "description": "Represents the extent that incident rays are reflected in a range of angles.",
                         "dflt": 0.8,
                         "max": 1,
                         "min": 0,
                         "role": "style",
                         "valType": "number"
                     },
+                    "facenormalsepsilon": {
+                        "description": "Epsilon for face normals calculation avoids math issues arising from degenerate geometry.",
+                        "dflt": 1e-06,
+                        "max": 1,
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
                     "fresnel": {
+                        "description": "Represents the reflectance as a dependency of the viewing angle; e.g. paper is reflective when viewing it from the edge of the paper (almost 90 degrees), causing shine.",
                         "dflt": 0.2,
                         "max": 5,
                         "min": 0,
@@ -11252,6 +11263,7 @@
                     },
                     "role": "object",
                     "roughness": {
+                        "description": "Alters specular reflection; the rougher the surface, the wider and less contrasty the shine.",
                         "dflt": 0.5,
                         "max": 1,
                         "min": 0,
@@ -11259,9 +11271,45 @@
                         "valType": "number"
                     },
                     "specular": {
+                        "description": "Represents the level that incident rays are reflected in a single direction, causing shine.",
                         "dflt": 0.05,
                         "max": 2,
                         "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "vertexnormalsepsilon": {
+                        "description": "Epsilon for vertex normals calculation avoids math issues arising from degenerate geometry.",
+                        "dflt": 1e-12,
+                        "max": 1,
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    }
+                },
+                "lightposition": {
+                    "role": "object",
+                    "x": {
+                        "description": "Numeric vector, representing the X coordinate for each vertex.",
+                        "dflt": 100000,
+                        "max": 100000,
+                        "min": -100000,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "y": {
+                        "description": "Numeric vector, representing the Y coordinate for each vertex.",
+                        "dflt": 100000,
+                        "max": 100000,
+                        "min": -100000,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "z": {
+                        "description": "Numeric vector, representing the Z coordinate for each vertex.",
+                        "dflt": 0,
+                        "max": 100000,
+                        "min": -100000,
                         "role": "style",
                         "valType": "number"
                     }
@@ -17937,6 +17985,7 @@
                 },
                 "lighting": {
                     "ambient": {
+                        "description": "Ambient light increases overall color visibility but can wash out the image.",
                         "dflt": 0.8,
                         "max": 1,
                         "min": 0,
@@ -17944,6 +17993,7 @@
                         "valType": "number"
                     },
                     "diffuse": {
+                        "description": "Represents the extent that incident rays are reflected in a range of angles.",
                         "dflt": 0.8,
                         "max": 1,
                         "min": 0,
@@ -17951,6 +18001,7 @@
                         "valType": "number"
                     },
                     "fresnel": {
+                        "description": "Represents the reflectance as a dependency of the viewing angle; e.g. paper is reflective when viewing it from the edge of the paper (almost 90 degrees), causing shine.",
                         "dflt": 0.2,
                         "max": 5,
                         "min": 0,
@@ -17959,6 +18010,7 @@
                     },
                     "role": "object",
                     "roughness": {
+                        "description": "Alters specular reflection; the rougher the surface, the wider and less contrasty the shine.",
                         "dflt": 0.5,
                         "max": 1,
                         "min": 0,
@@ -17966,9 +18018,37 @@
                         "valType": "number"
                     },
                     "specular": {
+                        "description": "Represents the level that incident rays are reflected in a single direction, causing shine.",
                         "dflt": 0.05,
                         "max": 2,
                         "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    }
+                },
+                "lightposition": {
+                    "role": "object",
+                    "x": {
+                        "description": "Numeric vector, representing the X coordinate for each vertex.",
+                        "dflt": 10,
+                        "max": 100000,
+                        "min": -100000,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "y": {
+                        "description": "Numeric vector, representing the Y coordinate for each vertex.",
+                        "dflt": 100000,
+                        "max": 100000,
+                        "min": -100000,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "z": {
+                        "description": "Numeric vector, representing the Z coordinate for each vertex.",
+                        "dflt": 0,
+                        "max": 100000,
+                        "min": -100000,
                         "role": "style",
                         "valType": "number"
                     }

--- a/plotly/tests/test_optional/test_figure_factory.py
+++ b/plotly/tests/test_optional/test_figure_factory.py
@@ -929,7 +929,8 @@ class TestTrisurf(NumpyTestUtilsMixin, TestCase):
                           z, simplices, color_func=colors_bad)
         # Check converting custom colors to strings
         test_colors_plot = tls.FigureFactory.create_trisurf(
-                    x, y, z, simplices, color_func=colors_raw)
+            x, y, z, simplices, color_func=colors_raw
+        )
         self.assertTrue(isinstance(test_colors_plot['data'][0]['facecolor'][0],
                                    str))
 

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -1518,33 +1518,32 @@ class FigureFactory(object):
                                          "and vmax. The vmin value cannot be "
                                          "bigger than or equal to the value "
                                          "of vmax.")
-        # find the normalized distance t of a triangle face between vmin and
-        #vmax where the distance is normalized between 0 and 1
-        t = (face - vmin) / float((vmax - vmin))
 
-        if len(colormap) <= 1:
-            t_color = colormap[0]
-            color = FigureFactory._convert_to_RGB_255(t_color)
-            color = FigureFactory._label_rgb(color)
+        if len(colormap) == 1:
+            # color each triangle face with the same color in colormap
+            face_color = colormap[0]
+            face_color = FigureFactory._convert_to_RGB_255(face_color)
+            face_color = FigureFactory._label_rgb(face_color)
         else:
-            # account for colormaps with more than one color
-            incr = 1./(len(colormap) - 1)
-            low_color_index = int(t/incr)
+            # find the normalized distance t of a triangle face between vmin
+            # and vmax where the distance is normalized between 0 and 1
+            t = (face - vmin) / float((vmax - vmin))
+            low_color_index = int(t / (1./(len(colormap) - 1)))
 
             if t == 1:
-                t_color = colormap[low_color_index]
-                color = FigureFactory._convert_to_RGB_255(t_color)
-                color = FigureFactory._label_rgb(color)
+                face_color = colormap[low_color_index]
+                face_color = FigureFactory._convert_to_RGB_255(face_color)
+                face_color = FigureFactory._label_rgb(face_color)
 
             else:
-                t_color = FigureFactory._find_intermediate_color(
+                face_color = FigureFactory._find_intermediate_color(
                     colormap[low_color_index],
                     colormap[low_color_index + 1],
-                    (t - low_color_index * incr) / incr)
-                color = FigureFactory._convert_to_RGB_255(t_color)
-                color = FigureFactory._label_rgb(color)
+                    t * (len(colormap) - 1) - low_color_index)
+                face_color = FigureFactory._convert_to_RGB_255(face_color)
+                face_color = FigureFactory._label_rgb(face_color)
 
-        return color
+        return face_color
 
     @staticmethod
     def _trisurf(x, y, z, simplices, colormap=None, color_func=None,

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -1574,11 +1574,13 @@ class FigureFactory(object):
             if len(color_func) != len(simplices):
                 raise ValueError("If color_func is a list/array, it must "
                                  "be the same length as simplices.")
+
             # convert all colors to rgb
             for index in range(len(color_func)):
-                if '#' in color_func[index]:
-                    foo = FigureFactory._hex_to_rgb(color_func[index])
-                    color_func[index] = FigureFactory._label_rgb(foo)
+                if isinstance(color_func[index], str):
+                    if '#' in color_func[index]:
+                        foo = FigureFactory._hex_to_rgb(color_func[index])
+                        color_func[index] = FigureFactory._label_rgb(foo)
 
             mean_dists = np.asarray(color_func)
         else:

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -1507,10 +1507,10 @@ class FigureFactory(object):
         """
         Normalize facecolor values by vmin/vmax and return rgb-color strings
 
-        This function takes a tuple color with elements between 0 and 1, along
-        with a colormap and a minimum (vmin) and maximum (vmax) range of
-        possible mean distances for the given parametrized surface. It returns
-        an rgb color based on the mean distance between vmin and vmax
+        This function takes a tuple color along with a colormap and a minimum
+        (vmin) and maximum (vmax) range of possible mean distances for the
+        given parametrized surface. It returns an rgb color based on the mean
+        distance between vmin and vmax
 
         """
         if vmin >= vmax:
@@ -1679,10 +1679,12 @@ class FigureFactory(object):
         :param (array) simplices: an array of shape (ntri, 3) where ntri is
             the number of triangles in the triangularization. Each row of the
             array contains the indicies of the verticies of each triangle
-        :param (str|list) colormap: either a plotly scale name, or a list
-            containing 2 triplets. These triplets must be of the form (a,b,c)
-            or 'rgb(x,y,z)' where a,b,c belong to the interval [0,1] and x,y,z
-            belong to [0,255]
+        :param (str|tuple|list) colormap: either a plotly scale name, an rgb
+            or hex color, a color tuple or a list of colors. An rgb color is
+            of the form 'rgb(x, y, z)' where x, y, z belong to the interval
+            [0, 255] and a color tuple is a tuple of the form (a, b, c) where
+            a, b and c belong to [0, 1]. If colormap is a list, it must
+            contain the valid color types aforementioned as its members.
         :param (function|list) color_func: The parameter that determines the
             coloring of the surface. Takes either a function with 3 arguments
             x, y, z or a list/array of color values the same length as

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -1525,17 +1525,17 @@ class FigureFactory(object):
             face_color = FigureFactory._convert_to_RGB_255(face_color)
             face_color = FigureFactory._label_rgb(face_color)
         else:
-            # find the normalized distance t of a triangle face between vmin
-            # and vmax where the distance is normalized between 0 and 1
-            t = (face - vmin) / float((vmax - vmin))
-            low_color_index = int(t / (1./(len(colormap) - 1)))
-
-            if t == 1:
-                face_color = colormap[low_color_index]
+            if face == vmax:
+                # pick last color in colormap
+                face_color = colormap[-1]
                 face_color = FigureFactory._convert_to_RGB_255(face_color)
                 face_color = FigureFactory._label_rgb(face_color)
-
             else:
+                # find the normalized distance t of a triangle face between
+                # vmin and vmax where the distance is between 0 and 1
+                t = (face - vmin) / float((vmax - vmin))
+                low_color_index = int(t / (1./(len(colormap) - 1)))
+
                 face_color = FigureFactory._find_intermediate_color(
                     colormap[low_color_index],
                     colormap[low_color_index + 1],


### PR DESCRIPTION
@choldgraf @theengineear 

Guys,

So Chris, I think when you made the efficiency improvements to trisurf, you got rid of the capability of mapping divergent or colormaps of more than 2 colors. I have put that feature back now while trying to maintain the efficiency as best I could.

I put the 'rgb(%s, %s, %s)' stuff in the FigureFactory function _label_rgb(), which I was using anyways to convert a tuple to an rgb tuple.

Also, facecolor is not done in one line anymore, but is an empty list that keeps appending.

Let me know if you have any improvements to add.

(Also rewrote some doc strings for clarity)