### PR TITLE
introduce new check to see if page is loaded

### DIFF
--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -62,7 +62,7 @@ def get_image_download_script(caller):
     """
 
     if caller == 'iplot':
-        check_start = 'if(document.readyState == \'complete\') {{'
+        check_start = 'if(window.is_loaded==true){{'
         check_end = '}}'
     elif caller == 'plot':
         check_start = ''
@@ -129,6 +129,8 @@ def init_notebook_mode(connected=False):
         script_inject = (
             ''
             '<script>'
+            'window.is_loaded = false;'
+            'setTimeout(function(){{window.is_loaded=true}},100);'
             'requirejs.config({'
             'paths: { '
             # Note we omit the extension .js because require will include it.
@@ -145,6 +147,8 @@ def init_notebook_mode(connected=False):
         script_inject = (
             ''
             '<script type=\'text/javascript\'>'
+            'window.is_loaded = false;'
+            'setTimeout(function(){{window.is_loaded=true}},100);'
             'if(!window.Plotly){{'
             'define(\'plotly\', function(require, exports, module) {{'
             '{script}'

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -62,9 +62,9 @@ def get_image_download_script(caller):
     """
 
     if caller == 'iplot':
-        # note: 5500/5.5s is a handpicked delay. The script will not run again
+        # note: 20000(20s) is a handpicked delay. The script will not run again
         # once this time has elapsed after the timestamp is instantiated.
-        check_start = 'if(!((new Date()).getTime()>{utime}+5500)){{'
+        check_start = 'if(!((new Date()).getTime()>{utime}+20000)){{'
         check_end = '}}'
     elif caller == 'plot':
         check_start = ''

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -64,7 +64,7 @@ def get_image_download_script(caller):
     if caller == 'iplot':
         # note: 5500/5.5s is a handpicked delay. The script will not run again
         # once this time has elapsed after the timestamp is instantiated.
-        check_start = 'var d=(new Date()).getTime();if(!(d>{utime}+5500)){{'
+        check_start = 'if(!((new Date()).getTime()>{utime}+5500)){{'
         check_end = '}}'
     elif caller == 'plot':
         check_start = ''


### PR DESCRIPTION
@theengineear Unfortunately the check I was using before the prevent pop ups on page reloads doesn't work for Chrome. Previously I was only able to test it on the Firefox because there was a plotly.js bug that  caused an issue with Chrome. I've tried the current method in both browsers, and it seems to be working. 
