### PR TITLE
Build for conda

### DIFF
--- a/bld.bat
+++ b/bld.bat
@@ -1,0 +1,8 @@
+"%PYTHON%" setup.py install 
+if errorlevel 1 exit 1
+
+:: Add more build steps here, if they are necessary.
+
+:: See
+:: http://docs.continuum.io/conda/build.html
+:: for a list of environment variables that are set during the build process.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+$PYTHON setup.py install 
+
+# Add more build steps here, if they are necessary.
+
+# See
+# http://docs.continuum.io/conda/build.html
+# for a list of environment variables that are set during the build process.

--- a/build_for_conda.md
+++ b/build_for_conda.md
@@ -1,0 +1,19 @@
+Initial setup was done using:
+
+`conda skeleton pypi plotly --version 1.12.4`
+
+To test all imports, manually added following dependencies at runtime:
+```
+- matplotlib
+- numpy
+- ipython
+- ipywidgets
+```
+
+I also had to change all `module/submodule` in the test imports to `module.submodule`.
+
+Finally, build and test the created version:
+
+`conda build plotly`
+
+Currently, the updated (version 1.12.4) conda package sits at https://anaconda.org/chohner/plotly. There seems to be an old offial package at https://anaconda.org/plotly/plotly.

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,80 @@
+package:
+  name: plotly
+  version: "1.12.4"
+
+source:
+  fn: plotly-1.12.4.tar.gz
+  url: https://files.pythonhosted.org/packages/02/e0/5b739403c3180298ebe277cbc9f5ee99e546ab24768b1732a2d6b381091b/plotly-1.12.4.tar.gz
+  md5: f1ff6b1b18554258aab50449ab571ee2
+#  patches:
+   # List any patch files here
+   # - fix.patch
+
+# build:
+  # noarch_python: True
+  # preserve_egg_dir: True
+  # entry_points:
+    # Put any entry points (scripts to be generated automatically) here. The
+    # syntax is module:function.  For example
+    #
+    # - plotly = plotly:main
+    #
+    # Would create an entry point called plotly that calls plotly.main()
+
+
+  # If this is a new build for the same version, increment the build
+  # number. If you do not include this key, it defaults to 0.
+  # number: 1
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - requests
+    - six
+    - pytz
+
+  run:
+    - python
+    - requests
+    - six
+    - pytz
+    - matplotlib
+    - numpy
+    - ipython
+    - ipywidgets
+
+test:
+  # Python imports
+  imports:
+    - plotly
+    - plotly.graph_objs
+    - plotly.grid_objs
+    - plotly.matplotlylib
+    - plotly.matplotlylib.mplexporter
+    - plotly.matplotlylib.mplexporter.renderers
+    - plotly.offline
+    - plotly.plotly
+    - plotly.plotly.chunked_requests
+    - plotly.widgets
+
+  # commands:
+    # You can put test commands to be run here.  Use this to test that the
+    # entry points work.
+
+
+  # You can also put a file called run_test.py in the recipe that will be run
+  # at test time.
+
+  # requires:
+    # Put any additional test requirements here.  For example
+    # - nose
+
+about:
+  home: https://plot.ly/python/
+  license: MIT
+  summary: 'Python plotting library for collaborative, interactive, publication-quality graphs.'
+
+# See
+# http://docs.continuum.io/conda/build.html for
+# more information about meta.yaml


### PR DESCRIPTION
Added necessary files to run `conda build plotly`.
Includes a small readme (`build_for_conda.md`).

Current build (v 1.12.4) lives at https://anaconda.org/chohner/plotly