### PR TITLE
Patch `Figure` to allow `frames`.

### DIFF
--- a/plotly/graph_objs/graph_objs.py
+++ b/plotly/graph_objs/graph_objs.py
@@ -836,6 +836,20 @@ def _patch_figure_class(figure_class):
                                                   _parent_key='data')
     figure_class.__init__ = __init__
 
+    def __setitem__(self, key, value, **kwargs):
+        if key == 'frames':
+            super(PlotlyDict, self).__setitem__(key, value)
+        else:
+            super(figure_class, self).__setitem__(key, value, **kwargs)
+    figure_class.__setitem__ = __setitem__
+
+    def _get_valid_attributes(self):
+        super(figure_class, self)._get_valid_attributes()
+        if 'frames' not in self._valid_attributes:
+            self._valid_attributes.add('frames')
+        return self._valid_attributes
+    figure_class._get_valid_attributes = _get_valid_attributes
+
     def get_data(self, flatten=False):
         """
         Returns the JSON for the plot with non-data elements stripped.


### PR DESCRIPTION
We need frames for animations, this is a hack since they don’t exist in
the graph reference.