### PR TITLE
Add support for config options for offline plots

### DIFF
--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -160,8 +160,8 @@ def init_notebook_mode(connected=False):
     __PLOTLY_OFFLINE_INITIALIZED = True
 
 
-def _plot_html(figure_or_data, show_link, link_text, validate,
-               default_width, default_height, global_requirejs):
+def _plot_html(figure_or_data, config, validate, default_width,
+               default_height, global_requirejs):
 
     figure = tools.return_figure_from_figure_or_data(figure_or_data, validate)
 
@@ -186,10 +186,30 @@ def _plot_html(figure_or_data, show_link, link_text, validate,
     jdata = json.dumps(figure.get('data', []), cls=utils.PlotlyJSONEncoder)
     jlayout = json.dumps(figure.get('layout', {}), cls=utils.PlotlyJSONEncoder)
 
-    config = {}
-    config['showLink'] = show_link
-    config['linkText'] = link_text
-    jconfig = json.dumps(config)
+    configkeys = (
+    'editable',
+    'autosizable',
+    'fillFrame',
+    'frameMargins',
+    'scrollZoom',
+    'doubleClick',
+    'showTips',
+    'showLink',
+    'sendData',
+    'linkText',
+    'showSources',
+    'displayModeBar',
+    'modeBarButtonsToRemove',
+    'modeBarButtonsToAdd',
+    'modeBarButtons',
+    'displaylogo',
+    'plotGlPixelRatio',
+    'setBackground',
+    'topojsonURL')
+
+    config_clean = dict((k,config[k]) for k in configkeys if k in config)
+
+    jconfig = json.dumps(config_clean)
 
     # TODO: The get_config 'source of truth' should
     # really be somewhere other than plotly.plotly


### PR DESCRIPTION
fixes issue #399

You can now enter in a dictionary for all the options you want using
the parameter ‘config’.
(cherry picked from commit ecfe1fb)