### PR TITLE
Fix iplot offline

### DIFF
--- a/plotly/graph_reference/default-schema.json
+++ b/plotly/graph_reference/default-schema.json
@@ -19,7 +19,8 @@
                 "description": "Any type.",
                 "otherOpts": [
                     "dflt",
-                    "values"
+                    "values",
+                    "arrayOk"
                 ],
                 "requiredOpts": []
             },
@@ -415,14 +416,10 @@
                 "role": "object"
             },
             "autosize": {
-                "description": "Determines whether or not the dimensions of the figure are computed as a function of the display size.",
+                "description": "Determines whether or not a layout width or height that has been left undefined by the user is initialized on each relayout. Note that, regardless of this attribute, an undefined layout width or height is always initialized on the first call to plot.",
+                "dflt": false,
                 "role": "info",
-                "valType": "enumerated",
-                "values": [
-                    true,
-                    false,
-                    "initial"
-                ]
+                "valType": "boolean"
             },
             "direction": {
                 "description": "For polar plots only. Sets the direction corresponding to positive angles.",
@@ -3014,7 +3011,7 @@
                 "active": {
                     "description": "Determines which button (by index starting from 0) is considered active.",
                     "dflt": 0,
-                    "min": -10,
+                    "min": 0,
                     "role": "info",
                     "valType": "number"
                 },
@@ -6148,6 +6145,18 @@
                         ]
                     }
                 },
+                "base": {
+                    "arrayOk": true,
+                    "description": "Sets where the bar base is drawn (in position axis units). In *stack* or *relative* barmode, traces that set *base* will be excluded and drawn in *overlay* mode instead.",
+                    "dflt": null,
+                    "role": "info",
+                    "valType": "any"
+                },
+                "basesrc": {
+                    "description": "Sets the source reference on plot.ly for  base .",
+                    "role": "info",
+                    "valType": "string"
+                },
                 "dx": {
                     "description": "Sets the x coordinate step. See `x0` for more info.",
                     "dflt": 1,
@@ -6856,6 +6865,18 @@
                     "role": "info",
                     "valType": "string"
                 },
+                "offset": {
+                    "arrayOk": true,
+                    "description": "Shifts the position where the bar is drawn (in position axis units). In *group* barmode, traces that set *offset* will be excluded and drawn in *overlay* mode instead.",
+                    "dflt": null,
+                    "role": "info",
+                    "valType": "number"
+                },
+                "offsetsrc": {
+                    "description": "Sets the source reference on plot.ly for  offset .",
+                    "role": "info",
+                    "valType": "string"
+                },
                 "opacity": {
                     "description": "Sets the opacity of the trace.",
                     "dflt": 1,
@@ -6945,6 +6966,19 @@
                         false,
                         "legendonly"
                     ]
+                },
+                "width": {
+                    "arrayOk": true,
+                    "description": "Sets the bar width (in position axis units).",
+                    "dflt": null,
+                    "min": 0,
+                    "role": "info",
+                    "valType": "number"
+                },
+                "widthsrc": {
+                    "description": "Sets the source reference on plot.ly for  width .",
+                    "role": "info",
+                    "valType": "string"
                 },
                 "x": {
                     "description": "Sets the x coordinates.",
@@ -20745,13 +20779,6 @@
                     "dflt": true,
                     "valType": "boolean"
                 },
-                "filtersrc": {
-                    "description": "Sets the variable in the parent trace object by which the filter will be applied. To filter about nested variables, use *.* to access them. For example, set `filtersrc` to *marker.color* to filter about the marker color array.",
-                    "dflt": "x",
-                    "noBlank": true,
-                    "strict": true,
-                    "valType": "string"
-                },
                 "operation": {
                     "description": "Sets the filter operation. *=* keeps items equal to `value` *<* keeps items less than `value` *<=* keeps items less than or equal to `value` *>* keeps items greater than `value` *>=* keeps items greater than or equal to `value` *[]* keeps items inside `value[0]` to value[1]` including both bounds` *()* keeps items inside `value[0]` to value[1]` excluding both bounds` *[)* keeps items inside `value[0]` to value[1]` including `value[0]` but excluding `value[1] *(]* keeps items inside `value[0]` to value[1]` excluding `value[0]` but including `value[1] *][* keeps items outside `value[0]` to value[1]` and equal to both bounds` *)(* keeps items outside `value[0]` to value[1]` *](* keeps items outside `value[0]` to value[1]` and equal to `value[0]` *)[* keeps items outside `value[0]` to value[1]` and equal to `value[1]` *{}* keeps items present in a set of values *}{* keeps items not present in a set of values",
                     "dflt": "=",
@@ -20774,8 +20801,21 @@
                         "}{"
                     ]
                 },
+                "target": {
+                    "arrayOk": true,
+                    "description": "Sets the filter target by which the filter is applied. If a string, *target* is assumed to be a reference to a data array in the parent trace object. To filter about nested variables, use *.* to access them. For example, set `target` to *marker.color* to filter about the marker color array. If an array, *target* is then the data array by which the filter is applied.",
+                    "dflt": "x",
+                    "noBlank": true,
+                    "strict": true,
+                    "valType": "string"
+                },
+                "targetsrc": {
+                    "description": "Sets the source reference on plot.ly for  target .",
+                    "role": "info",
+                    "valType": "string"
+                },
                 "value": {
-                    "description": "Sets the value or values by which to filter by. Values are expected to be in the same type as the data linked to *filtersrc*. When `operation` is set to one of the inequality values (=,<,>=,>,<=) *value* is expected to be a number or a string. When `operation` is set to one of the interval value ([],(),[),(],][,)(,](,)[) *value* is expected to be 2-item array where the first item is the lower bound and the second item is the upper bound. When `operation`, is set to one of the set value ({},}{) *value* is expected to be an array with as many items as the desired set elements.",
+                    "description": "Sets the value or values by which to filter by. Values are expected to be in the same type as the data linked to *target*. When `operation` is set to one of the inequality values (=,<,>=,>,<=) *value* is expected to be a number or a string. When `operation` is set to one of the interval value ([],(),[),(],][,)(,](,)[) *value* is expected to be 2-item array where the first item is the lower bound and the second item is the upper bound. When `operation`, is set to one of the set value ({},}{) *value* is expected to be an array with as many items as the desired set elements.",
                     "dflt": 0,
                     "valType": "any"
                 }

--- a/plotly/graph_reference/default-schema.json
+++ b/plotly/graph_reference/default-schema.json
@@ -1,103 +1,4 @@
 {
-    "animation": {
-        "direction": {
-            "description": "The direction in which to play the frames triggered by the animation call",
-            "dflt": "forward",
-            "role": "info",
-            "valType": "enumerated",
-            "values": [
-                "forward",
-                "reverse"
-            ]
-        },
-        "frame": {
-            "duration": {
-                "description": "The duration in milliseconds of each frame. If greater than the frame duration, it will be limited to the frame duration.",
-                "dflt": 500,
-                "min": 0,
-                "role": "info",
-                "valType": "number"
-            },
-            "redraw": {
-                "description": "Redraw the plot at completion of the transition. This is desirable for transitions that include properties that cannot be transitioned, but may significantly slow down updates that do not require a full redraw of the plot",
-                "dflt": true,
-                "role": "info",
-                "valType": "boolean"
-            },
-            "role": "object"
-        },
-        "fromcurrent": {
-            "description": "Play frames starting at the current frame instead of the beginning.",
-            "dflt": false,
-            "role": "info",
-            "valType": "boolean"
-        },
-        "mode": {
-            "description": "Describes how a new animate call interacts with currently-running animations. If `immediate`, current animations are interrupted and the new animation is started. If `next`, the current frame is allowed to complete, after which the new animation is started. If `afterall` all existing frames are animated to completion before the new animation is started.",
-            "dflt": "afterall",
-            "role": "info",
-            "valType": "enumerated",
-            "values": [
-                "immediate",
-                "next",
-                "afterall"
-            ]
-        },
-        "transition": {
-            "duration": {
-                "description": "The duration of the transition, in milliseconds. If equal to zero, updates are synchronous.",
-                "dflt": 500,
-                "min": 0,
-                "role": "info",
-                "valType": "number"
-            },
-            "easing": {
-                "description": "The easing function used for the transition",
-                "dflt": "cubic-in-out",
-                "role": "info",
-                "valType": "enumerated",
-                "values": [
-                    "linear",
-                    "quad",
-                    "cubic",
-                    "sin",
-                    "exp",
-                    "circle",
-                    "elastic",
-                    "back",
-                    "bounce",
-                    "linear-in",
-                    "quad-in",
-                    "cubic-in",
-                    "sin-in",
-                    "exp-in",
-                    "circle-in",
-                    "elastic-in",
-                    "back-in",
-                    "bounce-in",
-                    "linear-out",
-                    "quad-out",
-                    "cubic-out",
-                    "sin-out",
-                    "exp-out",
-                    "circle-out",
-                    "elastic-out",
-                    "back-out",
-                    "bounce-out",
-                    "linear-in-out",
-                    "quad-in-out",
-                    "cubic-in-out",
-                    "sin-in-out",
-                    "exp-in-out",
-                    "circle-in-out",
-                    "elastic-in-out",
-                    "back-in-out",
-                    "bounce-in-out"
-                ]
-            },
-            "role": "object"
-        }
-    },
     "defs": {
         "metaKeys": [
             "_isSubplotObj",
@@ -220,47 +121,6 @@
                     "dflt"
                 ]
             }
-        }
-    },
-    "frames": {
-        "baseframe": {
-            "description": "The name of the frame into which this frame's properties are merged before applying. This is used to unify properties and avoid needing to specify the same values for the same properties in multiple frames.",
-            "role": "info",
-            "valType": "string"
-        },
-        "data": {
-            "description": "A list of traces this frame modifies. The format is identical to the normal trace definition.",
-            "role": "data",
-            "valType": "data_array"
-        },
-        "datasrc": {
-            "description": "Sets the source reference on plot.ly for  data .",
-            "role": "info",
-            "valType": "string"
-        },
-        "group": {
-            "description": "An identifier that specifies the group to which the frame belongs, used by animate to select a subset of frames.",
-            "role": "info",
-            "valType": "string"
-        },
-        "layout": {
-            "description": "Layout properties which this frame modifies. The format is identical to the normal layout definition.",
-            "valType": "any"
-        },
-        "name": {
-            "description": "A label by which to identify the frame",
-            "role": "info",
-            "valType": "string"
-        },
-        "traces": {
-            "description": "A list of trace indices that identify the respective traces in the data attribute",
-            "role": "data",
-            "valType": "data_array"
-        },
-        "tracessrc": {
-            "description": "Sets the source reference on plot.ly for  traces .",
-            "role": "info",
-            "valType": "string"
         }
     },
     "layout": {
@@ -396,9 +256,10 @@
                             "valType": "number"
                         },
                         "ax": {
-                            "description": "Sets the x component of the arrow tail about the arrow head. If `axref` is `pixel`, a positive (negative)  component corresponds to an arrow pointing from right to left (left to right). If `axref` is an axis, this is an absolute value on that axis, like `x`, NOT a relative value.",
+                            "description": "Sets the x component of the arrow tail about the arrow head. If `axref` is `pixel`, a positive (negative)  component corresponds to an arrow pointing from right to left (left to right). If `axref` is an axis, this is a value on that axis.",
+                            "dflt": -10,
                             "role": "info",
-                            "valType": "any"
+                            "valType": "number"
                         },
                         "axref": {
                             "description": "Indicates in what terms the tail of the annotation (ax,ay)  is specified. If `pixel`, `ax` is a relative offset in pixels  from `x`. If set to an x axis id (e.g. *x* or *x2*), `ax` is  specified in the same terms as that axis. This is useful  for trendline annotations which should continue to indicate  the correct trend when zoomed.",
@@ -411,9 +272,10 @@
                             ]
                         },
                         "ay": {
-                            "description": "Sets the y component of the arrow tail about the arrow head. If `ayref` is `pixel`, a positive (negative)  component corresponds to an arrow pointing from bottom to top (top to bottom). If `ayref` is an axis, this is an absolute value on that axis, like `y`, NOT a relative value.",
+                            "description": "Sets the y component of the arrow tail about the arrow head. If `ayref` is `pixel`, a positive (negative)  component corresponds to an arrow pointing from bottom to top (top to bottom). If `ayref` is an axis, this is a value on that axis.",
+                            "dflt": -30,
                             "role": "info",
-                            "valType": "any"
+                            "valType": "number"
                         },
                         "ayref": {
                             "description": "Indicates in what terms the tail of the annotation (ax,ay)  is specified. If `pixel`, `ay` is a relative offset in pixels  from `y`. If set to a y axis id (e.g. *y* or *y2*), `ay` is  specified in the same terms as that axis. This is useful  for trendline annotations which should continue to indicate  the correct trend when zoomed.",
@@ -497,16 +359,10 @@
                             "role": "style",
                             "valType": "angle"
                         },
-                        "visible": {
-                            "description": "Determines whether or not this annotation is visible.",
-                            "dflt": true,
-                            "role": "info",
-                            "valType": "boolean"
-                        },
                         "x": {
-                            "description": "Sets the annotation's x position. If the axis `type` is *log*, then you must take the log of your desired range. If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                            "description": "Sets the annotation's x position. Note that dates and categories are converted to numbers.",
                             "role": "info",
-                            "valType": "any"
+                            "valType": "number"
                         },
                         "xanchor": {
                             "description": "Sets the annotation's horizontal position anchor This anchor binds the `x` position to the *left*, *center* or *right* of the annotation. For example, if `x` is set to 1, `xref` to *paper* and `xanchor` to *right* then the right-most portion of the annotation lines up with the right-most edge of the plotting area. If *auto*, the anchor is equivalent to *center* for data-referenced annotations whereas for paper-referenced, the anchor picked corresponds to the closest side.",
@@ -530,9 +386,9 @@
                             ]
                         },
                         "y": {
-                            "description": "Sets the annotation's y position. If the axis `type` is *log*, then you must take the log of your desired range. If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                            "description": "Sets the annotation's y position. Note that dates and categories are converted to numbers.",
                             "role": "info",
-                            "valType": "any"
+                            "valType": "number"
                         },
                         "yanchor": {
                             "description": "Sets the annotation's vertical position anchor This anchor binds the `y` position to the *top*, *middle* or *bottom* of the annotation. For example, if `y` is set to 1, `yref` to *paper* and `yanchor` to *top* then the top-most portion of the annotation lines up with the top-most edge of the plotting area. If *auto*, the anchor is equivalent to *middle* for data-referenced annotations whereas for paper-referenced, the anchor picked corresponds to the closest side.",
@@ -1052,17 +908,11 @@
                             "role": "info",
                             "valType": "string"
                         },
-                        "visible": {
-                            "description": "Determines whether or not this image is visible.",
-                            "dflt": true,
-                            "role": "info",
-                            "valType": "boolean"
-                        },
                         "x": {
                             "description": "Sets the image's x position. When `xref` is set to `paper`, units are sized relative to the plot height. See `xref` for more info",
                             "dflt": 0,
                             "role": "info",
-                            "valType": "any"
+                            "valType": "number"
                         },
                         "xanchor": {
                             "description": "Sets the anchor for the x position",
@@ -1089,7 +939,7 @@
                             "description": "Sets the image's y position. When `yref` is set to `paper`, units are sized relative to the plot height. See `yref` for more info",
                             "dflt": 0,
                             "role": "info",
-                            "valType": "any"
+                            "valType": "number"
                         },
                         "yanchor": {
                             "description": "Sets the anchor for the y position.",
@@ -1844,7 +1694,8 @@
                         "valType": "color"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -1882,7 +1733,7 @@
                         "valType": "number"
                     },
                     "hoverformat": {
-                        "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the hover text formatting rule for data values on this axis, using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -1921,13 +1772,13 @@
                         "valType": "integer"
                     },
                     "range": {
-                        "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the date range from January 1st 1970 to November 4th, 2013, set the range from 0 to 1380844800000.0",
                         "items": [
                             {
-                                "valType": "any"
+                                "valType": "number"
                             },
                             {
-                                "valType": "any"
+                                "valType": "number"
                             }
                         ],
                         "role": "info",
@@ -2042,9 +1893,10 @@
                         "valType": "number"
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                        "dflt": 0,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -2079,7 +1931,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -2253,7 +2105,8 @@
                         "valType": "color"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -2291,7 +2144,7 @@
                         "valType": "number"
                     },
                     "hoverformat": {
-                        "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the hover text formatting rule for data values on this axis, using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -2330,13 +2183,13 @@
                         "valType": "integer"
                     },
                     "range": {
-                        "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the date range from January 1st 1970 to November 4th, 2013, set the range from 0 to 1380844800000.0",
                         "items": [
                             {
-                                "valType": "any"
+                                "valType": "number"
                             },
                             {
-                                "valType": "any"
+                                "valType": "number"
                             }
                         ],
                         "role": "info",
@@ -2451,9 +2304,10 @@
                         "valType": "number"
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                        "dflt": 0,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -2488,7 +2342,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -2662,7 +2516,8 @@
                         "valType": "color"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -2700,7 +2555,7 @@
                         "valType": "number"
                     },
                     "hoverformat": {
-                        "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the hover text formatting rule for data values on this axis, using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -2739,13 +2594,13 @@
                         "valType": "integer"
                     },
                     "range": {
-                        "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the date range from January 1st 1970 to November 4th, 2013, set the range from 0 to 1380844800000.0",
                         "items": [
                             {
-                                "valType": "any"
+                                "valType": "number"
                             },
                             {
-                                "valType": "any"
+                                "valType": "number"
                             }
                         ],
                         "role": "info",
@@ -2860,9 +2715,10 @@
                         "valType": "number"
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                        "dflt": 0,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -2897,7 +2753,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -3104,12 +2960,6 @@
                                 "line"
                             ]
                         },
-                        "visible": {
-                            "description": "Determines whether or not this shape is visible.",
-                            "dflt": true,
-                            "role": "info",
-                            "valType": "boolean"
-                        },
                         "x0": {
                             "description": "Sets the shape's starting x position. See `type` for more info.",
                             "role": "info",
@@ -3158,339 +3008,334 @@
                 "valType": "boolean"
             },
             "sliders": {
-                "items": {
-                    "slider": {
-                        "active": {
-                            "description": "Determines which button (by index starting from 0) is considered active.",
-                            "dflt": 0,
-                            "min": 0,
-                            "role": "info",
-                            "valType": "number"
-                        },
-                        "activebgcolor": {
-                            "description": "Sets the background color of the slider grip while dragging.",
-                            "dflt": "#dbdde0",
+                "active": {
+                    "description": "Determines which button (by index starting from 0) is considered active.",
+                    "dflt": 0,
+                    "min": 0,
+                    "role": "info",
+                    "valType": "number"
+                },
+                "activebgcolor": {
+                    "description": "Sets the background color of the slider grip while dragging.",
+                    "dflt": "#dbdde0",
+                    "role": "style",
+                    "valType": "color"
+                },
+                "bgcolor": {
+                    "description": "Sets the background color of the slider.",
+                    "dflt": "#f8fafc",
+                    "role": "style",
+                    "valType": "color"
+                },
+                "bordercolor": {
+                    "description": "Sets the color of the border enclosing the slider.",
+                    "dflt": "#bec8d9",
+                    "role": "style",
+                    "valType": "color"
+                },
+                "borderwidth": {
+                    "description": "Sets the width (in px) of the border enclosing the slider.",
+                    "dflt": 1,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "currentvalue": {
+                    "font": {
+                        "color": {
                             "role": "style",
                             "valType": "color"
                         },
-                        "bgcolor": {
-                            "description": "Sets the background color of the slider.",
-                            "dflt": "#f8fafc",
+                        "description": "Sets the font of the current value label text.",
+                        "family": {
+                            "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                            "noBlank": true,
                             "role": "style",
-                            "valType": "color"
-                        },
-                        "bordercolor": {
-                            "description": "Sets the color of the border enclosing the slider.",
-                            "dflt": "#bec8d9",
-                            "role": "style",
-                            "valType": "color"
-                        },
-                        "borderwidth": {
-                            "description": "Sets the width (in px) of the border enclosing the slider.",
-                            "dflt": 1,
-                            "min": 0,
-                            "role": "style",
-                            "valType": "number"
-                        },
-                        "currentvalue": {
-                            "font": {
-                                "color": {
-                                    "role": "style",
-                                    "valType": "color"
-                                },
-                                "description": "Sets the font of the current value label text.",
-                                "family": {
-                                    "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
-                                    "noBlank": true,
-                                    "role": "style",
-                                    "strict": true,
-                                    "valType": "string"
-                                },
-                                "role": "object",
-                                "size": {
-                                    "min": 1,
-                                    "role": "style",
-                                    "valType": "number"
-                                }
-                            },
-                            "offset": {
-                                "description": "The amount of space, in pixels, between the current value label and the slider.",
-                                "dflt": 10,
-                                "role": "info",
-                                "valType": "number"
-                            },
-                            "prefix": {
-                                "description": "When currentvalue.visible is true, this sets the prefix of the label.",
-                                "role": "info",
-                                "valType": "string"
-                            },
-                            "role": "object",
-                            "suffix": {
-                                "description": "When currentvalue.visible is true, this sets the suffix of the label.",
-                                "role": "info",
-                                "valType": "string"
-                            },
-                            "visible": {
-                                "description": "Shows the currently-selected value above the slider.",
-                                "dflt": true,
-                                "role": "info",
-                                "valType": "boolean"
-                            },
-                            "xanchor": {
-                                "description": "The alignment of the value readout relative to the length of the slider.",
-                                "dflt": "left",
-                                "role": "info",
-                                "valType": "enumerated",
-                                "values": [
-                                    "left",
-                                    "center",
-                                    "right"
-                                ]
-                            }
-                        },
-                        "font": {
-                            "color": {
-                                "role": "style",
-                                "valType": "color"
-                            },
-                            "description": "Sets the font of the slider step labels.",
-                            "family": {
-                                "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
-                                "noBlank": true,
-                                "role": "style",
-                                "strict": true,
-                                "valType": "string"
-                            },
-                            "role": "object",
-                            "size": {
-                                "min": 1,
-                                "role": "style",
-                                "valType": "number"
-                            }
-                        },
-                        "len": {
-                            "description": "Sets the length of the slider This measure excludes the padding of both ends. That is, the slider's length is this length minus the padding on both ends.",
-                            "dflt": 1,
-                            "min": 0,
-                            "role": "style",
-                            "valType": "number"
-                        },
-                        "lenmode": {
-                            "description": "Determines whether this slider length is set in units of plot *fraction* or in *pixels. Use `len` to set the value.",
-                            "dflt": "fraction",
-                            "role": "info",
-                            "valType": "enumerated",
-                            "values": [
-                                "fraction",
-                                "pixels"
-                            ]
-                        },
-                        "minorticklen": {
-                            "description": "Sets the length in pixels of minor step tick marks",
-                            "dflt": 4,
-                            "min": 0,
-                            "role": "style",
-                            "valType": "number"
-                        },
-                        "pad": {
-                            "b": {
-                                "description": "The amount of padding (in px) along the bottom of the component.",
-                                "dflt": 0,
-                                "role": "style",
-                                "valType": "number"
-                            },
-                            "description": "Set the padding of the slider component along each side.",
-                            "l": {
-                                "description": "The amount of padding (in px) on the left side of the component.",
-                                "dflt": 0,
-                                "role": "style",
-                                "valType": "number"
-                            },
-                            "r": {
-                                "description": "The amount of padding (in px) on the right side of the component.",
-                                "dflt": 0,
-                                "role": "style",
-                                "valType": "number"
-                            },
-                            "role": "object",
-                            "t": {
-                                "description": "The amount of padding (in px) along the top of the component.",
-                                "dflt": 20,
-                                "role": "style",
-                                "valType": "number"
-                            }
+                            "strict": true,
+                            "valType": "string"
                         },
                         "role": "object",
-                        "steps": {
-                            "items": {
-                                "step": {
-                                    "args": {
-                                        "description": "Sets the arguments values to be passed to the Plotly method set in `method` on slide.",
-                                        "freeLength": true,
-                                        "items": [
-                                            {
-                                                "valType": "any"
-                                            },
-                                            {
-                                                "valType": "any"
-                                            },
-                                            {
-                                                "valType": "any"
-                                            }
-                                        ],
-                                        "role": "info",
-                                        "valType": "info_array"
+                        "size": {
+                            "min": 1,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "offset": {
+                        "description": "The amount of space, in pixels, between the current value label and the slider.",
+                        "dflt": 10,
+                        "role": "info",
+                        "valType": "number"
+                    },
+                    "prefix": {
+                        "description": "When currentvalue.visible is true, this sets the prefix of the label.",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "role": "object",
+                    "suffix": {
+                        "description": "When currentvalue.visible is true, this sets the suffix of the label.",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "visible": {
+                        "description": "Shows the currently-selected value above the slider.",
+                        "dflt": true,
+                        "role": "info",
+                        "valType": "boolean"
+                    },
+                    "xanchor": {
+                        "description": "The alignment of the value readout relative to the length of the slider.",
+                        "dflt": "left",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "left",
+                            "center",
+                            "right"
+                        ]
+                    }
+                },
+                "font": {
+                    "color": {
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "description": "Sets the font of the slider step labels.",
+                    "family": {
+                        "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                        "noBlank": true,
+                        "role": "style",
+                        "strict": true,
+                        "valType": "string"
+                    },
+                    "role": "object",
+                    "size": {
+                        "min": 1,
+                        "role": "style",
+                        "valType": "number"
+                    }
+                },
+                "len": {
+                    "description": "Sets the length of the slider This measure excludes the padding of both ends. That is, the slider's length is this length minus the padding on both ends.",
+                    "dflt": 1,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "lenmode": {
+                    "description": "Determines whether this slider length is set in units of plot *fraction* or in *pixels. Use `len` to set the value.",
+                    "dflt": "fraction",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        "fraction",
+                        "pixels"
+                    ]
+                },
+                "minorticklen": {
+                    "description": "Sets the length in pixels of minor step tick marks",
+                    "dflt": 4,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "pad": {
+                    "b": {
+                        "description": "The amount of padding (in px) along the bottom of the component.",
+                        "dflt": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "description": "Set the padding of the slider component along each side.",
+                    "l": {
+                        "description": "The amount of padding (in px) on the left side of the component.",
+                        "dflt": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "r": {
+                        "description": "The amount of padding (in px) on the right side of the component.",
+                        "dflt": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "role": "object",
+                    "t": {
+                        "description": "The amount of padding (in px) along the top of the component.",
+                        "dflt": 20,
+                        "role": "style",
+                        "valType": "number"
+                    }
+                },
+                "role": "object",
+                "steps": {
+                    "items": {
+                        "step": {
+                            "args": {
+                                "description": "Sets the arguments values to be passed to the Plotly method set in `method` on slide.",
+                                "freeLength": true,
+                                "items": [
+                                    {
+                                        "valType": "any"
                                     },
-                                    "label": {
-                                        "description": "Sets the text label to appear on the slider",
-                                        "role": "info",
-                                        "valType": "string"
+                                    {
+                                        "valType": "any"
                                     },
-                                    "method": {
-                                        "description": "Sets the Plotly method to be called when the slider value is changed.",
-                                        "dflt": "restyle",
-                                        "role": "info",
-                                        "valType": "enumerated",
-                                        "values": [
-                                            "restyle",
-                                            "relayout",
-                                            "animate",
-                                            "update"
-                                        ]
-                                    },
-                                    "role": "object",
-                                    "value": {
-                                        "description": "Sets the value of the slider step, used to refer to the step programatically. Defaults to the slider label if not provided.",
-                                        "role": "info",
-                                        "valType": "string"
+                                    {
+                                        "valType": "any"
                                     }
-                                }
-                            },
-                            "role": "object"
-                        },
-                        "tickcolor": {
-                            "description": "Sets the color of the border enclosing the slider.",
-                            "dflt": "#333",
-                            "role": "style",
-                            "valType": "color"
-                        },
-                        "ticklen": {
-                            "description": "Sets the length in pixels of step tick marks",
-                            "dflt": 7,
-                            "min": 0,
-                            "role": "style",
-                            "valType": "number"
-                        },
-                        "tickwidth": {
-                            "description": "Sets the tick width (in px).",
-                            "dflt": 1,
-                            "min": 0,
-                            "role": "style",
-                            "valType": "number"
-                        },
-                        "transition": {
-                            "duration": {
-                                "description": "Sets the duration of the slider transition",
-                                "dflt": 150,
-                                "min": 0,
+                                ],
                                 "role": "info",
-                                "valType": "number"
+                                "valType": "info_array"
                             },
-                            "easing": {
-                                "description": "Sets the easing function of the slider transition",
-                                "dflt": "cubic-in-out",
+                            "label": {
+                                "description": "Sets the text label to appear on the slider",
+                                "role": "info",
+                                "valType": "string"
+                            },
+                            "method": {
+                                "description": "Sets the Plotly method to be called when the slider value is changed.",
+                                "dflt": "restyle",
                                 "role": "info",
                                 "valType": "enumerated",
                                 "values": [
-                                    "linear",
-                                    "quad",
-                                    "cubic",
-                                    "sin",
-                                    "exp",
-                                    "circle",
-                                    "elastic",
-                                    "back",
-                                    "bounce",
-                                    "linear-in",
-                                    "quad-in",
-                                    "cubic-in",
-                                    "sin-in",
-                                    "exp-in",
-                                    "circle-in",
-                                    "elastic-in",
-                                    "back-in",
-                                    "bounce-in",
-                                    "linear-out",
-                                    "quad-out",
-                                    "cubic-out",
-                                    "sin-out",
-                                    "exp-out",
-                                    "circle-out",
-                                    "elastic-out",
-                                    "back-out",
-                                    "bounce-out",
-                                    "linear-in-out",
-                                    "quad-in-out",
-                                    "cubic-in-out",
-                                    "sin-in-out",
-                                    "exp-in-out",
-                                    "circle-in-out",
-                                    "elastic-in-out",
-                                    "back-in-out",
-                                    "bounce-in-out"
+                                    "restyle",
+                                    "relayout",
+                                    "animate",
+                                    "update"
                                 ]
                             },
-                            "role": "object"
-                        },
-                        "visible": {
-                            "description": "Determines whether or not the slider is visible.",
-                            "dflt": true,
-                            "role": "info",
-                            "valType": "boolean"
-                        },
-                        "x": {
-                            "description": "Sets the x position (in normalized coordinates) of the slider.",
-                            "dflt": 0,
-                            "max": 3,
-                            "min": -2,
-                            "role": "style",
-                            "valType": "number"
-                        },
-                        "xanchor": {
-                            "description": "Sets the slider's horizontal position anchor. This anchor binds the `x` position to the *left*, *center* or *right* of the range selector.",
-                            "dflt": "left",
-                            "role": "info",
-                            "valType": "enumerated",
-                            "values": [
-                                "auto",
-                                "left",
-                                "center",
-                                "right"
-                            ]
-                        },
-                        "y": {
-                            "description": "Sets the y position (in normalized coordinates) of the slider.",
-                            "dflt": 0,
-                            "max": 3,
-                            "min": -2,
-                            "role": "style",
-                            "valType": "number"
-                        },
-                        "yanchor": {
-                            "description": "Sets the slider's vertical position anchor This anchor binds the `y` position to the *top*, *middle* or *bottom* of the range selector.",
-                            "dflt": "top",
-                            "role": "info",
-                            "valType": "enumerated",
-                            "values": [
-                                "auto",
-                                "top",
-                                "middle",
-                                "bottom"
-                            ]
+                            "role": "object",
+                            "value": {
+                                "description": "Sets the value of the slider step, used to refer to the step programatically. Defaults to the slider label if not provided.",
+                                "role": "info",
+                                "valType": "string"
+                            }
                         }
-                    }
+                    },
+                    "role": "object"
                 },
-                "role": "object"
+                "tickcolor": {
+                    "description": "Sets the color of the border enclosing the slider.",
+                    "dflt": "#333",
+                    "role": "style",
+                    "valType": "color"
+                },
+                "ticklen": {
+                    "description": "Sets the length in pixels of step tick marks",
+                    "dflt": 7,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "tickwidth": {
+                    "description": "Sets the tick width (in px).",
+                    "dflt": 1,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "transition": {
+                    "duration": {
+                        "description": "Sets the duration of the slider transition",
+                        "dflt": 150,
+                        "min": 0,
+                        "role": "info",
+                        "valType": "number"
+                    },
+                    "easing": {
+                        "description": "Sets the easing function of the slider transition",
+                        "dflt": "cubic-in-out",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "linear",
+                            "quad",
+                            "cubic",
+                            "sin",
+                            "exp",
+                            "circle",
+                            "elastic",
+                            "back",
+                            "bounce",
+                            "linear-in",
+                            "quad-in",
+                            "cubic-in",
+                            "sin-in",
+                            "exp-in",
+                            "circle-in",
+                            "elastic-in",
+                            "back-in",
+                            "bounce-in",
+                            "linear-out",
+                            "quad-out",
+                            "cubic-out",
+                            "sin-out",
+                            "exp-out",
+                            "circle-out",
+                            "elastic-out",
+                            "back-out",
+                            "bounce-out",
+                            "linear-in-out",
+                            "quad-in-out",
+                            "cubic-in-out",
+                            "sin-in-out",
+                            "exp-in-out",
+                            "circle-in-out",
+                            "elastic-in-out",
+                            "back-in-out",
+                            "bounce-in-out"
+                        ]
+                    },
+                    "role": "object"
+                },
+                "visible": {
+                    "description": "Determines whether or not the slider is visible.",
+                    "dflt": true,
+                    "role": "info",
+                    "valType": "boolean"
+                },
+                "x": {
+                    "description": "Sets the x position (in normalized coordinates) of the slider.",
+                    "dflt": 0,
+                    "max": 3,
+                    "min": -2,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "xanchor": {
+                    "description": "Sets the slider's horizontal position anchor. This anchor binds the `x` position to the *left*, *center* or *right* of the range selector.",
+                    "dflt": "left",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        "auto",
+                        "left",
+                        "center",
+                        "right"
+                    ]
+                },
+                "y": {
+                    "description": "Sets the y position (in normalized coordinates) of the slider.",
+                    "dflt": 0,
+                    "max": 3,
+                    "min": -2,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "yanchor": {
+                    "description": "Sets the slider's vertical position anchor This anchor binds the `y` position to the *top*, *middle* or *bottom* of the range selector.",
+                    "dflt": "top",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        "auto",
+                        "top",
+                        "middle",
+                        "bottom"
+                    ]
+                }
             },
             "smith": {
                 "dflt": false,
@@ -3510,7 +3355,8 @@
                         "valType": "color"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -3542,7 +3388,7 @@
                         "valType": "number"
                     },
                     "hoverformat": {
-                        "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the hover text formatting rule for data values on this axis, using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -3636,9 +3482,10 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                        "dflt": 0,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -3673,7 +3520,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -3778,7 +3625,8 @@
                         "valType": "color"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -3810,7 +3658,7 @@
                         "valType": "number"
                     },
                     "hoverformat": {
-                        "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the hover text formatting rule for data values on this axis, using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -3904,9 +3752,10 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                        "dflt": 0,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -3941,7 +3790,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -4052,7 +3901,8 @@
                         "valType": "color"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -4084,7 +3934,7 @@
                         "valType": "number"
                     },
                     "hoverformat": {
-                        "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the hover text formatting rule for data values on this axis, using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -4178,9 +4028,10 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                        "dflt": 0,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -4215,7 +4066,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -4676,7 +4527,8 @@
                     "valType": "info_array"
                 },
                 "dtick": {
-                    "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                    "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                    "dflt": 1,
                     "role": "style",
                     "valType": "any"
                 },
@@ -4714,7 +4566,7 @@
                     "valType": "number"
                 },
                 "hoverformat": {
-                    "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                    "description": "Sets the hover text formatting rule for data values on this axis, using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                     "dflt": "",
                     "role": "style",
                     "valType": "string"
@@ -4771,13 +4623,13 @@
                     "valType": "number"
                 },
                 "range": {
-                    "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                    "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the date range from January 1st 1970 to November 4th, 2013, set the range from 0 to 1380844800000.0",
                     "items": [
                         {
-                            "valType": "any"
+                            "valType": "number"
                         },
                         {
-                            "valType": "any"
+                            "valType": "number"
                         }
                     ],
                     "role": "info",
@@ -4951,13 +4803,13 @@
                         "valType": "integer"
                     },
                     "range": {
-                        "description": "Sets the range of the range slider. If not set, defaults to the full xaxis range. If the axis `type` is *log*, then you must take the log of your desired range. If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "description": "Sets the range of the range slider. If not set, defaults to the full xaxis range. If the axis `type` is *log*, then you must take the log of your desired range. If the axis `type` is *date*, then you must convert the date to unix time in milliseconds.",
                         "items": [
                             {
-                                "valType": "any"
+                                "valType": "number"
                             },
                             {
-                                "valType": "any"
+                                "valType": "number"
                             }
                         ],
                         "role": "info",
@@ -5051,9 +4903,10 @@
                     ]
                 },
                 "tick0": {
-                    "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                    "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                    "dflt": 0,
                     "role": "style",
-                    "valType": "any"
+                    "valType": "number"
                 },
                 "tickangle": {
                     "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -5088,7 +4941,7 @@
                     }
                 },
                 "tickformat": {
-                    "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                    "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                     "dflt": "",
                     "role": "style",
                     "valType": "string"
@@ -5295,7 +5148,8 @@
                     "valType": "info_array"
                 },
                 "dtick": {
-                    "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                    "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                    "dflt": 1,
                     "role": "style",
                     "valType": "any"
                 },
@@ -5333,7 +5187,7 @@
                     "valType": "number"
                 },
                 "hoverformat": {
-                    "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                    "description": "Sets the hover text formatting rule for data values on this axis, using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                     "dflt": "",
                     "role": "style",
                     "valType": "string"
@@ -5390,13 +5244,13 @@
                     "valType": "number"
                 },
                 "range": {
-                    "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                    "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the date range from January 1st 1970 to November 4th, 2013, set the range from 0 to 1380844800000.0",
                     "items": [
                         {
-                            "valType": "any"
+                            "valType": "number"
                         },
                         {
-                            "valType": "any"
+                            "valType": "number"
                         }
                     ],
                     "role": "info",
@@ -5412,6 +5266,191 @@
                         "tozero",
                         "nonnegative"
                     ]
+                },
+                "rangeselector": {
+                    "activecolor": {
+                        "description": "Sets the background color of the active range selector button.",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "bgcolor": {
+                        "description": "Sets the background color of the range selector buttons.",
+                        "dflt": "#eee",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "bordercolor": {
+                        "description": "Sets the color of the border enclosing the range selector.",
+                        "dflt": "#444",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "borderwidth": {
+                        "description": "Sets the width (in px) of the border enclosing the range selector.",
+                        "dflt": 0,
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "buttons": {
+                        "items": {
+                            "button": {
+                                "count": {
+                                    "description": "Sets the number of steps to take to update the range. Use with `step` to specify the update interval.",
+                                    "dflt": 1,
+                                    "min": 0,
+                                    "role": "info",
+                                    "valType": "number"
+                                },
+                                "description": "Sets the specifications for each buttons. By default, a range selector comes with no buttons.",
+                                "label": {
+                                    "description": "Sets the text label to appear on the button.",
+                                    "role": "info",
+                                    "valType": "string"
+                                },
+                                "role": "object",
+                                "step": {
+                                    "description": "The unit of measurement that the `count` value will set the range by.",
+                                    "dflt": "month",
+                                    "role": "info",
+                                    "valType": "enumerated",
+                                    "values": [
+                                        "month",
+                                        "year",
+                                        "day",
+                                        "hour",
+                                        "minute",
+                                        "second",
+                                        "all"
+                                    ]
+                                },
+                                "stepmode": {
+                                    "description": "Sets the range update mode. If *backward*, the range update shifts the start of range back *count* times *step* milliseconds. If *todate*, the range update shifts the start of range back to the first timestamp from *count* times *step* milliseconds back. For example, with `step` set to *year* and `count` set to *1* the range update shifts the start of the range back to January 01 of the current year.",
+                                    "dflt": "backward",
+                                    "role": "info",
+                                    "valType": "enumerated",
+                                    "values": [
+                                        "backward",
+                                        "todate"
+                                    ]
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
+                    "font": {
+                        "color": {
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "description": "Sets the font of the range selector button text.",
+                        "family": {
+                            "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                            "noBlank": true,
+                            "role": "style",
+                            "strict": true,
+                            "valType": "string"
+                        },
+                        "role": "object",
+                        "size": {
+                            "min": 1,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object",
+                    "visible": {
+                        "description": "Determines whether or not this range selector is visible. Note that range selectors are only available for x axes of `type` set to or auto-typed to *date*.",
+                        "role": "info",
+                        "valType": "boolean"
+                    },
+                    "x": {
+                        "description": "Sets the x position (in normalized coordinates) of the range selector.",
+                        "max": 3,
+                        "min": -2,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "xanchor": {
+                        "description": "Sets the range selector's horizontal position anchor. This anchor binds the `x` position to the *left*, *center* or *right* of the range selector.",
+                        "dflt": "left",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "auto",
+                            "left",
+                            "center",
+                            "right"
+                        ]
+                    },
+                    "y": {
+                        "description": "Sets the y position (in normalized coordinates) of the range selector.",
+                        "max": 3,
+                        "min": -2,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "yanchor": {
+                        "description": "Sets the range selector's vertical position anchor This anchor binds the `y` position to the *top*, *middle* or *bottom* of the range selector.",
+                        "dflt": "bottom",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "auto",
+                            "top",
+                            "middle",
+                            "bottom"
+                        ]
+                    }
+                },
+                "rangeslider": {
+                    "bgcolor": {
+                        "description": "Sets the background color of the range slider.",
+                        "dflt": "#fff",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "bordercolor": {
+                        "description": "Sets the border color of the range slider.",
+                        "dflt": "#444",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "borderwidth": {
+                        "description": "Sets the border color of the range slider.",
+                        "dflt": 0,
+                        "min": 0,
+                        "role": "style",
+                        "valType": "integer"
+                    },
+                    "range": {
+                        "description": "Sets the range of the range slider. If not set, defaults to the full xaxis range. If the axis `type` is *log*, then you must take the log of your desired range. If the axis `type` is *date*, then you must convert the date to unix time in milliseconds.",
+                        "items": [
+                            {
+                                "valType": "number"
+                            },
+                            {
+                                "valType": "number"
+                            }
+                        ],
+                        "role": "info",
+                        "valType": "info_array"
+                    },
+                    "role": "object",
+                    "thickness": {
+                        "description": "The height of the range slider as a fraction of the total plot area height.",
+                        "dflt": 0.15,
+                        "max": 1,
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "visible": {
+                        "description": "Determines whether or not the range slider will be visible. If visible, perpendicular axes will be set to `fixedrange`",
+                        "dflt": true,
+                        "role": "info",
+                        "valType": "boolean"
+                    }
                 },
                 "role": "object",
                 "separatethousands": {
@@ -5485,9 +5524,10 @@
                     ]
                 },
                 "tick0": {
-                    "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                    "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                    "dflt": 0,
                     "role": "style",
-                    "valType": "any"
+                    "valType": "number"
                 },
                 "tickangle": {
                     "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -5522,7 +5562,7 @@
                     }
                 },
                 "tickformat": {
-                    "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                    "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                     "dflt": "",
                     "role": "style",
                     "valType": "string"
@@ -6090,8 +6130,7 @@
                         "legendonly"
                     ]
                 }
-            },
-            "meta": {}
+            }
         },
         "bar": {
             "attributes": {
@@ -6412,7 +6451,8 @@
                             "valType": "number"
                         },
                         "dtick": {
-                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                            "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                            "dflt": 1,
                             "role": "style",
                             "valType": "any"
                         },
@@ -6534,9 +6574,10 @@
                             ]
                         },
                         "tick0": {
-                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                            "dflt": 0,
                             "role": "style",
-                            "valType": "any"
+                            "valType": "number"
                         },
                         "tickangle": {
                             "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -6571,7 +6612,7 @@
                             }
                         },
                         "tickformat": {
-                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                            "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                             "dflt": "",
                             "role": "style",
                             "valType": "string"
@@ -6984,6 +7025,7 @@
                     "valType": "string"
                 }
             },
+            "description": "The data visualized by the span of the bars is set in `y` if `orientation` is set th *v* (the default) and the labels are set in `x`. By setting `orientation` to *h*, the roles are interchanged.",
             "layoutAttributes": {
                 "bargap": {
                     "description": "Sets the gap (in plot fraction) between bars of adjacent location coordinates.",
@@ -7023,9 +7065,6 @@
                         "percent"
                     ]
                 }
-            },
-            "meta": {
-                "description": "The data visualized by the span of the bars is set in `y` if `orientation` is set th *v* (the default) and the labels are set in `x`. By setting `orientation` to *h*, the roles are interchanged."
             }
         },
         "box": {
@@ -7580,6 +7619,7 @@
                     "valType": "string"
                 }
             },
+            "description": "In vertical (horizontal) box plots, statistics are computed using `y` (`x`) values. By supplying an `x` (`y`) array, one box per distinct x (y) value is drawn If no `x` (`y`) {array} is provided, a single box is drawn. That box position is then positioned with with `name` or with `x0` (`y0`) if provided. Each box spans from quartile 1 (Q1) to quartile 3 (Q3). The second quartile (Q2) is marked by a line inside the box. By default, the whiskers correspond to the box' edges +/- 1.5 times the interquartile range (IQR = Q3-Q1), see *boxpoints* for other options.",
             "layoutAttributes": {
                 "boxgap": {
                     "description": "Sets the gap (in plot fraction) between boxes of adjacent location coordinates.",
@@ -7607,9 +7647,6 @@
                         "overlay"
                     ]
                 }
-            },
-            "meta": {
-                "description": "In vertical (horizontal) box plots, statistics are computed using `y` (`x`) values. By supplying an `x` (`y`) array, one box per distinct x (y) value is drawn If no `x` (`y`) {array} is provided, a single box is drawn. That box position is then positioned with with `name` or with `x0` (`y0`) if provided. Each box spans from quartile 1 (Q1) to quartile 3 (Q3). The second quartile (Q2) is marked by a line inside the box. By default, the whiskers correspond to the box' edges +/- 1.5 times the interquartile range (IQR = Q3-Q1), see *boxpoints* for other options."
             }
         },
         "candlestick": {
@@ -7859,9 +7896,7 @@
                     "valType": "subplotid"
                 }
             },
-            "meta": {
-                "description": "The candlestick is a style of financial chart describing open, high, low and close for a given `x` coordinate (most likely time). The boxes represent the spread between the `open` and `close` values and the lines represent the spread between the `low` and `high` values Sample points where the close value is higher (lower) then the open value are called increasing (decreasing). By default, increasing candles are drawn in green whereas decreasing are drawn in red."
-            }
+            "description": "The candlestick is a style of financial chart describing open, high, low and close for a given `x` coordinate (most likely time). The boxes represent the spread between the `open` and `close` values and the lines represent the spread between the `low` and `high` values Sample points where the close value is higher (lower) then the open value are called increasing (decreasing). By default, increasing candles are drawn in green whereas decreasing are drawn in red."
         },
         "choropleth": {
             "attributes": {
@@ -7892,7 +7927,8 @@
                         "valType": "number"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -8014,9 +8050,10 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                        "dflt": 0,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -8051,7 +8088,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -8236,7 +8273,6 @@
                         "location",
                         "z",
                         "text",
-                        "name",
                         "name"
                     ],
                     "role": "info",
@@ -8403,9 +8439,7 @@
                     "valType": "string"
                 }
             },
-            "meta": {
-                "description": "The data that describes the choropleth value-to-color mapping is set in `z`. The geographic locations corresponding to each value in `z` are set in `locations`."
-            }
+            "description": "The data that describes the choropleth value-to-color mapping is set in `z`. The geographic locations corresponding to each value in `z` are set in `locations`."
         },
         "contour": {
             "attributes": {
@@ -8442,7 +8476,8 @@
                         "valType": "number"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -8564,9 +8599,10 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                        "dflt": 0,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -8601,7 +8637,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -9065,9 +9101,7 @@
                     "valType": "string"
                 }
             },
-            "meta": {
-                "description": "The data from which contour lines are computed is set in `z`. Data in `z` must be a {2D array} of numbers. Say that `z` has N rows and M columns, then by default, these N rows correspond to N y coordinates (set in `y` or auto-generated) and the M columns correspond to M x coordinates (set in `x` or auto-generated). By setting `transpose` to *true*, the above behavior is flipped."
-            }
+            "description": "The data from which contour lines are computed is set in `z`. Data in `z` must be a {2D array} of numbers. Say that `z` has N rows and M columns, then by default, these N rows correspond to N y coordinates (set in `y` or auto-generated) and the M columns correspond to M x coordinates (set in `x` or auto-generated). By setting `transpose` to *true*, the above behavior is flipped."
         },
         "heatmap": {
             "attributes": {
@@ -9098,7 +9132,8 @@
                         "valType": "number"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -9220,9 +9255,10 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                        "dflt": 0,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -9257,7 +9293,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -9664,9 +9700,7 @@
                     "valType": "string"
                 }
             },
-            "meta": {
-                "description": "The data that describes the heatmap value-to-color mapping is set in `z`. Data in `z` can either be a {2D array} of values (ragged or not) or a 1D array of values. In the case where `z` is a {2D array}, say that `z` has N rows and M columns. Then, by default, the resulting heatmap will have N partitions along the y axis and M partitions along the x axis. In other words, the i-th row/ j-th column cell in `z` is mapped to the i-th partition of the y axis (starting from the bottom of the plot) and the j-th partition of the x-axis (starting from the left of the plot). This behavior can be flipped by using `transpose`. Moreover, `x` (`y`) can be provided with M or M+1 (N or N+1) elements. If M (N), then the coordinates correspond to the center of the heatmap cells and the cells have equal width. If M+1 (N+1), then the coordinates correspond to the edges of the heatmap cells. In the case where `z` is a 1D {array}, the x and y coordinates must be provided in `x` and `y` respectively to form data triplets."
-            }
+            "description": "The data that describes the heatmap value-to-color mapping is set in `z`. Data in `z` can either be a {2D array} of values (ragged or not) or a 1D array of values. In the case where `z` is a {2D array}, say that `z` has N rows and M columns. Then, by default, the resulting heatmap will have N partitions along the y axis and M partitions along the x axis. In other words, the i-th row/ j-th column cell in `z` is mapped to the i-th partition of the y axis (starting from the bottom of the plot) and the j-th partition of the x-axis (starting from the left of the plot). This behavior can be flipped by using `transpose`. Moreover, `x` (`y`) can be provided with M or M+1 (N or N+1) elements. If M (N), then the coordinates correspond to the center of the heatmap cells and the cells have equal width. If M+1 (N+1), then the coordinates correspond to the edges of the heatmap cells. In the case where `z` is a 1D {array}, the x and y coordinates must be provided in `x` and `y` respectively to form data triplets."
         },
         "histogram": {
             "attributes": {
@@ -9683,13 +9717,13 @@
                 },
                 "autobinx": {
                     "description": "Determines whether or not the x axis bin attributes are picked by an algorithm. Note that this should be set to false if you want to manually set the number of bins using the attributes in xbins.",
-                    "dflt": null,
+                    "dflt": true,
                     "role": "style",
                     "valType": "boolean"
                 },
                 "autobiny": {
                     "description": "Determines whether or not the y axis bin attributes are picked by an algorithm. Note that this should be set to false if you want to manually set the number of bins using the attributes in ybins.",
-                    "dflt": null,
+                    "dflt": true,
                     "role": "style",
                     "valType": "boolean"
                 },
@@ -10001,7 +10035,8 @@
                             "valType": "number"
                         },
                         "dtick": {
-                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                            "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                            "dflt": 1,
                             "role": "style",
                             "valType": "any"
                         },
@@ -10123,9 +10158,10 @@
                             ]
                         },
                         "tick0": {
-                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                            "dflt": 0,
                             "role": "style",
-                            "valType": "any"
+                            "valType": "number"
                         },
                         "tickangle": {
                             "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -10160,7 +10196,7 @@
                             }
                         },
                         "tickformat": {
-                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                            "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                             "dflt": "",
                             "role": "style",
                             "valType": "string"
@@ -10513,12 +10549,12 @@
                         "description": "Sets the end value for the x axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "role": "object",
                     "size": {
                         "description": "Sets the step in-between value each x axis bin.",
-                        "dflt": null,
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -10526,7 +10562,7 @@
                         "description": "Sets the starting value for the x axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     }
                 },
                 "xsrc": {
@@ -10550,12 +10586,12 @@
                         "description": "Sets the end value for the y axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "role": "object",
                     "size": {
                         "description": "Sets the step in-between value each y axis bin.",
-                        "dflt": null,
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -10563,7 +10599,7 @@
                         "description": "Sets the starting value for the y axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     }
                 },
                 "ysrc": {
@@ -10572,6 +10608,7 @@
                     "valType": "string"
                 }
             },
+            "description": "The sample data from which statistics are computed is set in `x` for vertically spanning histograms and in `y` for horizontally spanning histograms. Binning options are set `xbins` and `ybins` respectively if no aggregation data is provided.",
             "layoutAttributes": {
                 "bargap": {
                     "description": "Sets the gap (in plot fraction) between bars of adjacent location coordinates.",
@@ -10611,22 +10648,19 @@
                         "percent"
                     ]
                 }
-            },
-            "meta": {
-                "description": "The sample data from which statistics are computed is set in `x` for vertically spanning histograms and in `y` for horizontally spanning histograms. Binning options are set `xbins` and `ybins` respectively if no aggregation data is provided."
             }
         },
         "histogram2d": {
             "attributes": {
                 "autobinx": {
                     "description": "Determines whether or not the x axis bin attributes are picked by an algorithm. Note that this should be set to false if you want to manually set the number of bins using the attributes in xbins.",
-                    "dflt": null,
+                    "dflt": true,
                     "role": "style",
                     "valType": "boolean"
                 },
                 "autobiny": {
                     "description": "Determines whether or not the y axis bin attributes are picked by an algorithm. Note that this should be set to false if you want to manually set the number of bins using the attributes in ybins.",
-                    "dflt": null,
+                    "dflt": true,
                     "role": "style",
                     "valType": "boolean"
                 },
@@ -10657,7 +10691,8 @@
                         "valType": "number"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -10779,9 +10814,10 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                        "dflt": 0,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -10816,7 +10852,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -11142,12 +11178,12 @@
                         "description": "Sets the end value for the x axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "role": "object",
                     "size": {
                         "description": "Sets the step in-between value each x axis bin.",
-                        "dflt": null,
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -11155,7 +11191,7 @@
                         "description": "Sets the starting value for the x axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     }
                 },
                 "xgap": {
@@ -11186,12 +11222,12 @@
                         "description": "Sets the end value for the y axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "role": "object",
                     "size": {
                         "description": "Sets the step in-between value each y axis bin.",
-                        "dflt": null,
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -11199,7 +11235,7 @@
                         "description": "Sets the starting value for the y axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     }
                 },
                 "ygap": {
@@ -11254,22 +11290,20 @@
                     "valType": "string"
                 }
             },
-            "meta": {
-                "description": "The sample data from which statistics are computed is set in `x` and `y` (where `x` and `y` represent marginal distributions, binning is set in `xbins` and `ybins` in this case) or `z` (where `z` represent the 2D distribution and binning set, binning is set by `x` and `y` in this case). The resulting distribution is visualized as a heatmap.",
-                "hrName": "histogram_2d"
-            }
+            "description": "The sample data from which statistics are computed is set in `x` and `y` (where `x` and `y` represent marginal distributions, binning is set in `xbins` and `ybins` in this case) or `z` (where `z` represent the 2D distribution and binning set, binning is set by `x` and `y` in this case). The resulting distribution is visualized as a heatmap.",
+            "hrName": "histogram_2d"
         },
         "histogram2dcontour": {
             "attributes": {
                 "autobinx": {
                     "description": "Determines whether or not the x axis bin attributes are picked by an algorithm. Note that this should be set to false if you want to manually set the number of bins using the attributes in xbins.",
-                    "dflt": null,
+                    "dflt": true,
                     "role": "style",
                     "valType": "boolean"
                 },
                 "autobiny": {
                     "description": "Determines whether or not the y axis bin attributes are picked by an algorithm. Note that this should be set to false if you want to manually set the number of bins using the attributes in ybins.",
-                    "dflt": null,
+                    "dflt": true,
                     "role": "style",
                     "valType": "boolean"
                 },
@@ -11306,7 +11340,8 @@
                         "valType": "number"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -11428,9 +11463,10 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                        "dflt": 0,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -11465,7 +11501,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -11873,12 +11909,12 @@
                         "description": "Sets the end value for the x axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "role": "object",
                     "size": {
                         "description": "Sets the step in-between value each x axis bin.",
-                        "dflt": null,
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -11886,7 +11922,7 @@
                         "description": "Sets the starting value for the x axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     }
                 },
                 "xsrc": {
@@ -11910,12 +11946,12 @@
                         "description": "Sets the end value for the y axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "role": "object",
                     "size": {
                         "description": "Sets the step in-between value each y axis bin.",
-                        "dflt": null,
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -11923,7 +11959,7 @@
                         "description": "Sets the starting value for the y axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     }
                 },
                 "ysrc": {
@@ -11960,10 +11996,8 @@
                     "valType": "string"
                 }
             },
-            "meta": {
-                "description": "The sample data from which statistics are computed is set in `x` and `y` (where `x` and `y` represent marginal distributions, binning is set in `xbins` and `ybins` in this case) or `z` (where `z` represent the 2D distribution and binning set, binning is set by `x` and `y` in this case). The resulting distribution is visualized as a contour plot.",
-                "hrName": "histogram_2d_contour"
-            }
+            "description": "The sample data from which statistics are computed is set in `x` and `y` (where `x` and `y` represent marginal distributions, binning is set in `xbins` and `ybins` in this case) or `z` (where `z` represent the 2D distribution and binning set, binning is set by `x` and `y` in this case). The resulting distribution is visualized as a contour plot.",
+            "hrName": "histogram_2d_contour"
         },
         "mesh3d": {
             "attributes": {
@@ -11999,7 +12033,8 @@
                         "valType": "number"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -12121,9 +12156,10 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                        "dflt": 0,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -12158,7 +12194,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -12638,9 +12674,7 @@
                     "valType": "string"
                 }
             },
-            "meta": {
-                "description": "Draws sets of triangles with coordinates given by three 1-dimensional arrays in `x`, `y`, `z` and (1) a sets of `i`, `j`, `k` indices (2) Delaunay triangulation or (3) the Alpha-shape algorithm or (4) the Convex-hull algorithm"
-            }
+            "description": "Draws sets of triangles with coordinates given by three 1-dimensional arrays in `x`, `y`, `z` and (1) a sets of `i`, `j`, `k` indices (2) Delaunay triangulation or (3) the Alpha-shape algorithm or (4) the Convex-hull algorithm"
         },
         "ohlc": {
             "attributes": {
@@ -12921,9 +12955,7 @@
                     "valType": "subplotid"
                 }
             },
-            "meta": {
-                "description": "The ohlc (short for Open-High-Low-Close) is a style of financial chart describing open, high, low and close for a given `x` coordinate (most likely time). The tip of the lines represent the `low` and `high` values and the horizontal segments represent the `open` and `close` values. Sample points where the close value is higher (lower) then the open value are called increasing (decreasing). By default, increasing candles are drawn in green whereas decreasing are drawn in red."
-            }
+            "description": "The ohlc (short for Open-High-Low-Close) is a style of financial chart describing open, high, low and close for a given `x` coordinate (most likely time). The tip of the lines represent the `low` and `high` values and the horizontal segments represent the `open` and `close` values. Sample points where the close value is higher (lower) then the open value are called increasing (decreasing). By default, increasing candles are drawn in green whereas decreasing are drawn in red."
         },
         "pie": {
             "attributes": {
@@ -13278,6 +13310,7 @@
                     ]
                 }
             },
+            "description": "A data visualized by the sectors of the pie is set in `values`. The sector labels are set in `labels`. The sector colors are set in `marker.colors`",
             "layoutAttributes": {
                 "hiddenlabels": {
                     "role": "data",
@@ -13288,9 +13321,6 @@
                     "role": "info",
                     "valType": "string"
                 }
-            },
-            "meta": {
-                "description": "A data visualized by the sectors of the pie is set in `values`. The sector labels are set in `labels`. The sector colors are set in `marker.colors`"
             }
         },
         "pointcloud": {
@@ -13514,9 +13544,7 @@
                     "valType": "string"
                 }
             },
-            "meta": {
-                "description": "The data visualized as a point cloud set in `x` and `y` using the WebGl plotting engine."
-            }
+            "description": "The data visualized as a point cloud set in `x` and `y` using the WebGl plotting engine."
         },
         "scatter": {
             "attributes": {
@@ -13916,7 +13944,8 @@
                             "valType": "number"
                         },
                         "dtick": {
-                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                            "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                            "dflt": 1,
                             "role": "style",
                             "valType": "any"
                         },
@@ -14038,9 +14067,10 @@
                             ]
                         },
                         "tick0": {
-                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                            "dflt": 0,
                             "role": "style",
-                            "valType": "any"
+                            "valType": "number"
                         },
                         "tickangle": {
                             "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -14075,7 +14105,7 @@
                             }
                         },
                         "tickformat": {
-                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                            "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                             "dflt": "",
                             "role": "style",
                             "valType": "string"
@@ -14880,9 +14910,7 @@
                     "valType": "string"
                 }
             },
-            "meta": {
-                "description": "The scatter trace type encompasses line charts, scatter charts, text charts, and bubble charts. The data visualized as scatter point or lines is set in `x` and `y`. Text (appearing either on the chart or on hover only) is via `text`. Bubble charts are achieved by setting `marker.size` and/or `marker.color` to numerical arrays."
-            }
+            "description": "The scatter trace type encompasses line charts, scatter charts, text charts, and bubble charts. The data visualized as scatter point or lines is set in `x` and `y`. Text (appearing either on the chart or on hover only) is via `text`. Bubble charts are achieved by setting `marker.size` and/or `marker.color` to numerical arrays."
         },
         "scatter3d": {
             "attributes": {
@@ -15353,7 +15381,8 @@
                             "valType": "number"
                         },
                         "dtick": {
-                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                            "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                            "dflt": 1,
                             "role": "style",
                             "valType": "any"
                         },
@@ -15475,9 +15504,10 @@
                             ]
                         },
                         "tick0": {
-                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                            "dflt": 0,
                             "role": "style",
-                            "valType": "any"
+                            "valType": "number"
                         },
                         "tickangle": {
                             "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -15512,7 +15542,7 @@
                             }
                         },
                         "tickformat": {
-                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                            "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                             "dflt": "",
                             "role": "style",
                             "valType": "string"
@@ -16092,10 +16122,8 @@
                     "valType": "string"
                 }
             },
-            "meta": {
-                "description": "The data visualized as scatter point or lines in 3D dimension is set in `x`, `y`, `z`. Text (appearing either on the chart or on hover only) is via `text`. Bubble charts are achieved by setting `marker.size` and/or `marker.color` Projections are achieved via `projection`. Surface fills are achieved via `surfaceaxis`.",
-                "hrName": "scatter_3d"
-            }
+            "description": "The data visualized as scatter point or lines in 3D dimension is set in `x`, `y`, `z`. Text (appearing either on the chart or on hover only) is via `text`. Bubble charts are achieved by setting `marker.size` and/or `marker.color` Projections are achieved via `projection`. Surface fills are achieved via `surfaceaxis`.",
+            "hrName": "scatter_3d"
         },
         "scattergeo": {
             "attributes": {
@@ -16272,7 +16300,8 @@
                             "valType": "number"
                         },
                         "dtick": {
-                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                            "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                            "dflt": 1,
                             "role": "style",
                             "valType": "any"
                         },
@@ -16394,9 +16423,10 @@
                             ]
                         },
                         "tick0": {
-                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                            "dflt": 0,
                             "role": "style",
-                            "valType": "any"
+                            "valType": "number"
                         },
                         "tickangle": {
                             "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -16431,7 +16461,7 @@
                             }
                         },
                         "tickformat": {
-                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                            "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                             "dflt": "",
                             "role": "style",
                             "valType": "string"
@@ -17166,10 +17196,8 @@
                     ]
                 }
             },
-            "meta": {
-                "description": "The data visualized as scatter point or lines on a geographic map is provided either by longitude/latitude pairs in `lon` and `lat` respectively or by geographic location IDs or names in `locations`.",
-                "hrName": "scatter_geo"
-            }
+            "description": "The data visualized as scatter point or lines on a geographic map is provided either by longitude/latitude pairs in `lon` and `lat` respectively or by geographic location IDs or names in `locations`.",
+            "hrName": "scatter_geo"
         },
         "scattergl": {
             "attributes": {
@@ -17518,7 +17546,8 @@
                             "valType": "number"
                         },
                         "dtick": {
-                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                            "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                            "dflt": 1,
                             "role": "style",
                             "valType": "any"
                         },
@@ -17640,9 +17669,10 @@
                             ]
                         },
                         "tick0": {
-                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                            "dflt": 0,
                             "role": "style",
-                            "valType": "any"
+                            "valType": "number"
                         },
                         "tickangle": {
                             "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -17677,7 +17707,7 @@
                             }
                         },
                         "tickformat": {
-                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                            "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                             "dflt": "",
                             "role": "style",
                             "valType": "string"
@@ -18118,9 +18148,7 @@
                     "valType": "string"
                 }
             },
-            "meta": {
-                "description": "The data visualized as scatter point or lines is set in `x` and `y` using the WebGl plotting engine. Bubble charts are achieved by setting `marker.size` and/or `marker.color` to a numerical arrays."
-            }
+            "description": "The data visualized as scatter point or lines is set in `x` and `y` using the WebGl plotting engine. Bubble charts are achieved by setting `marker.size` and/or `marker.color` to a numerical arrays."
         },
         "scattermapbox": {
             "attributes": {
@@ -18157,7 +18185,6 @@
                         "lon",
                         "lat",
                         "text",
-                        "name",
                         "name"
                     ],
                     "role": "info",
@@ -18270,7 +18297,8 @@
                             "valType": "number"
                         },
                         "dtick": {
-                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                            "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                            "dflt": 1,
                             "role": "style",
                             "valType": "any"
                         },
@@ -18392,9 +18420,10 @@
                             ]
                         },
                         "tick0": {
-                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                            "dflt": 0,
                             "role": "style",
-                            "valType": "any"
+                            "valType": "number"
                         },
                         "tickangle": {
                             "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -18429,7 +18458,7 @@
                             }
                         },
                         "tickformat": {
-                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                            "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                             "dflt": "",
                             "role": "style",
                             "valType": "string"
@@ -18797,10 +18826,8 @@
                     ]
                 }
             },
-            "meta": {
-                "description": "The data visualized as scatter point, lines or marker symbols on a Mapbox GL geographic map is provided by longitude/latitude pairs in `lon` and `lat`.",
-                "hrName": "scatter_mapbox"
-            }
+            "description": "The data visualized as scatter point, lines or marker symbols on a Mapbox GL geographic map is provided by longitude/latitude pairs in `lon` and `lat`.",
+            "hrName": "scatter_mapbox"
         },
         "scatterternary": {
             "attributes": {
@@ -18988,7 +19015,8 @@
                             "valType": "number"
                         },
                         "dtick": {
-                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                            "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                            "dflt": 1,
                             "role": "style",
                             "valType": "any"
                         },
@@ -19110,9 +19138,10 @@
                             ]
                         },
                         "tick0": {
-                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                            "dflt": 0,
                             "role": "style",
-                            "valType": "any"
+                            "valType": "number"
                         },
                         "tickangle": {
                             "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -19147,7 +19176,7 @@
                             }
                         },
                         "tickformat": {
-                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                            "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                             "dflt": "",
                             "role": "style",
                             "valType": "string"
@@ -19902,10 +19931,8 @@
                     ]
                 }
             },
-            "meta": {
-                "description": "Provides similar functionality to the *scatter* type but on a ternary phase diagram. The data is provided by at least two arrays out of `a`, `b`, `c` triplets.",
-                "hrName": "scatter_ternary"
-            }
+            "description": "Provides similar functionality to the *scatter* type but on a ternary phase diagram. The data is provided by at least two arrays out of `a`, `b`, `c` triplets.",
+            "hrName": "scatter_ternary"
         },
         "surface": {
             "attributes": {
@@ -19974,7 +20001,8 @@
                         "valType": "number"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
+                        "dflt": 1,
                         "role": "style",
                         "valType": "any"
                     },
@@ -20096,9 +20124,10 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
+                        "dflt": 0,
                         "role": "style",
-                        "valType": "any"
+                        "valType": "number"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -20133,7 +20162,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -20736,9 +20765,7 @@
                     "valType": "string"
                 }
             },
-            "meta": {
-                "description": "The data the describes the coordinates of the surface is set in `z`. Data in `z` should be a {2D array}. Coordinates in `x` and `y` can either be 1D {arrays} or {2D arrays} (e.g. to graph parametric surfaces). If not provided in `x` and `y`, the x and y coordinates are assumed to be linear starting at 0 with a unit step. The color scale corresponds to the `z` values by default. For custom color scales, use `surfacecolor` which should be a {2D array}, where its bounds can be controlled using `cmin` and `cmax`."
-            }
+            "description": "The data the describes the coordinates of the surface is set in `z`. Data in `z` should be a {2D array}. Coordinates in `x` and `y` can either be 1D {arrays} or {2D arrays} (e.g. to graph parametric surfaces). If not provided in `x` and `y`, the x and y coordinates are assumed to be linear starting at 0 with a unit step. The color scale corresponds to the `z` values by default. For custom color scales, use `surfacecolor` which should be a {2D array}, where its bounds can be controlled using `cmin` and `cmax`."
         }
     },
     "transforms": {

--- a/plotly/graph_reference/default-schema.json
+++ b/plotly/graph_reference/default-schema.json
@@ -1799,6 +1799,12 @@
                         ]
                     },
                     "role": "object",
+                    "separatethousands": {
+                        "description": "If \"true\", even 4-digit integers are separated",
+                        "dflt": false,
+                        "role": "style",
+                        "valType": "boolean"
+                    },
                     "showaxeslabels": {
                         "description": "Sets whether or not this axis is labeled",
                         "dflt": true,
@@ -2204,6 +2210,12 @@
                         ]
                     },
                     "role": "object",
+                    "separatethousands": {
+                        "description": "If \"true\", even 4-digit integers are separated",
+                        "dflt": false,
+                        "role": "style",
+                        "valType": "boolean"
+                    },
                     "showaxeslabels": {
                         "description": "Sets whether or not this axis is labeled",
                         "dflt": true,
@@ -2609,6 +2621,12 @@
                         ]
                     },
                     "role": "object",
+                    "separatethousands": {
+                        "description": "If \"true\", even 4-digit integers are separated",
+                        "dflt": false,
+                        "role": "style",
+                        "valType": "boolean"
+                    },
                     "showaxeslabels": {
                         "description": "Sets whether or not this axis is labeled",
                         "dflt": true,
@@ -2992,6 +3010,336 @@
                 "role": "info",
                 "valType": "boolean"
             },
+            "sliders": {
+                "active": {
+                    "description": "Determines which button (by index starting from 0) is considered active.",
+                    "dflt": 0,
+                    "min": -10,
+                    "role": "info",
+                    "valType": "number"
+                },
+                "activebgcolor": {
+                    "description": "Sets the background color of the slider grip while dragging.",
+                    "dflt": "#dbdde0",
+                    "role": "style",
+                    "valType": "color"
+                },
+                "bgcolor": {
+                    "description": "Sets the background color of the slider.",
+                    "dflt": "#f8fafc",
+                    "role": "style",
+                    "valType": "color"
+                },
+                "bordercolor": {
+                    "description": "Sets the color of the border enclosing the slider.",
+                    "dflt": "#bec8d9",
+                    "role": "style",
+                    "valType": "color"
+                },
+                "borderwidth": {
+                    "description": "Sets the width (in px) of the border enclosing the slider.",
+                    "dflt": 1,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "currentvalue": {
+                    "font": {
+                        "color": {
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "description": "Sets the font of the current value label text.",
+                        "family": {
+                            "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                            "noBlank": true,
+                            "role": "style",
+                            "strict": true,
+                            "valType": "string"
+                        },
+                        "role": "object",
+                        "size": {
+                            "min": 1,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "offset": {
+                        "description": "The amount of space, in pixels, between the current value label and the slider.",
+                        "dflt": 10,
+                        "role": "info",
+                        "valType": "number"
+                    },
+                    "prefix": {
+                        "description": "When currentvalue.visible is true, this sets the prefix of the label.",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "role": "object",
+                    "suffix": {
+                        "description": "When currentvalue.visible is true, this sets the suffix of the label.",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "visible": {
+                        "description": "Shows the currently-selected value above the slider.",
+                        "dflt": true,
+                        "role": "info",
+                        "valType": "boolean"
+                    },
+                    "xanchor": {
+                        "description": "The alignment of the value readout relative to the length of the slider.",
+                        "dflt": "left",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "left",
+                            "center",
+                            "right"
+                        ]
+                    }
+                },
+                "font": {
+                    "color": {
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "description": "Sets the font of the slider step labels.",
+                    "family": {
+                        "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                        "noBlank": true,
+                        "role": "style",
+                        "strict": true,
+                        "valType": "string"
+                    },
+                    "role": "object",
+                    "size": {
+                        "min": 1,
+                        "role": "style",
+                        "valType": "number"
+                    }
+                },
+                "len": {
+                    "description": "Sets the length of the slider This measure excludes the padding of both ends. That is, the slider's length is this length minus the padding on both ends.",
+                    "dflt": 1,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "lenmode": {
+                    "description": "Determines whether this slider length is set in units of plot *fraction* or in *pixels. Use `len` to set the value.",
+                    "dflt": "fraction",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        "fraction",
+                        "pixels"
+                    ]
+                },
+                "minorticklen": {
+                    "description": "Sets the length in pixels of minor step tick marks",
+                    "dflt": 4,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "pad": {
+                    "b": {
+                        "description": "The amount of padding (in px) along the bottom of the component.",
+                        "dflt": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "description": "Set the padding of the slider component along each side.",
+                    "l": {
+                        "description": "The amount of padding (in px) on the left side of the component.",
+                        "dflt": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "r": {
+                        "description": "The amount of padding (in px) on the right side of the component.",
+                        "dflt": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "role": "object",
+                    "t": {
+                        "description": "The amount of padding (in px) along the top of the component.",
+                        "dflt": 20,
+                        "role": "style",
+                        "valType": "number"
+                    }
+                },
+                "role": "object",
+                "steps": {
+                    "items": {
+                        "step": {
+                            "args": {
+                                "description": "Sets the arguments values to be passed to the Plotly method set in `method` on slide.",
+                                "freeLength": true,
+                                "items": [
+                                    {
+                                        "valType": "any"
+                                    },
+                                    {
+                                        "valType": "any"
+                                    },
+                                    {
+                                        "valType": "any"
+                                    }
+                                ],
+                                "role": "info",
+                                "valType": "info_array"
+                            },
+                            "label": {
+                                "description": "Sets the text label to appear on the slider",
+                                "role": "info",
+                                "valType": "string"
+                            },
+                            "method": {
+                                "description": "Sets the Plotly method to be called when the slider value is changed.",
+                                "dflt": "restyle",
+                                "role": "info",
+                                "valType": "enumerated",
+                                "values": [
+                                    "restyle",
+                                    "relayout",
+                                    "animate",
+                                    "update"
+                                ]
+                            },
+                            "role": "object",
+                            "value": {
+                                "description": "Sets the value of the slider step, used to refer to the step programatically. Defaults to the slider label if not provided.",
+                                "role": "info",
+                                "valType": "string"
+                            }
+                        }
+                    },
+                    "role": "object"
+                },
+                "tickcolor": {
+                    "description": "Sets the color of the border enclosing the slider.",
+                    "dflt": "#333",
+                    "role": "style",
+                    "valType": "color"
+                },
+                "ticklen": {
+                    "description": "Sets the length in pixels of step tick marks",
+                    "dflt": 7,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "tickwidth": {
+                    "description": "Sets the tick width (in px).",
+                    "dflt": 1,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "transition": {
+                    "duration": {
+                        "description": "Sets the duration of the slider transition",
+                        "dflt": 150,
+                        "min": 0,
+                        "role": "info",
+                        "valType": "number"
+                    },
+                    "easing": {
+                        "description": "Sets the easing function of the slider transition",
+                        "dflt": "cubic-in-out",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "linear",
+                            "quad",
+                            "cubic",
+                            "sin",
+                            "exp",
+                            "circle",
+                            "elastic",
+                            "back",
+                            "bounce",
+                            "linear-in",
+                            "quad-in",
+                            "cubic-in",
+                            "sin-in",
+                            "exp-in",
+                            "circle-in",
+                            "elastic-in",
+                            "back-in",
+                            "bounce-in",
+                            "linear-out",
+                            "quad-out",
+                            "cubic-out",
+                            "sin-out",
+                            "exp-out",
+                            "circle-out",
+                            "elastic-out",
+                            "back-out",
+                            "bounce-out",
+                            "linear-in-out",
+                            "quad-in-out",
+                            "cubic-in-out",
+                            "sin-in-out",
+                            "exp-in-out",
+                            "circle-in-out",
+                            "elastic-in-out",
+                            "back-in-out",
+                            "bounce-in-out"
+                        ]
+                    },
+                    "role": "object"
+                },
+                "visible": {
+                    "description": "Determines whether or not the slider is visible.",
+                    "dflt": true,
+                    "role": "info",
+                    "valType": "boolean"
+                },
+                "x": {
+                    "description": "Sets the x position (in normalized coordinates) of the slider.",
+                    "dflt": 0,
+                    "max": 3,
+                    "min": -2,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "xanchor": {
+                    "description": "Sets the slider's horizontal position anchor. This anchor binds the `x` position to the *left*, *center* or *right* of the range selector.",
+                    "dflt": "left",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        "auto",
+                        "left",
+                        "center",
+                        "right"
+                    ]
+                },
+                "y": {
+                    "description": "Sets the y position (in normalized coordinates) of the slider.",
+                    "dflt": 0,
+                    "max": 3,
+                    "min": -2,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "yanchor": {
+                    "description": "Sets the slider's vertical position anchor This anchor binds the `y` position to the *top*, *middle* or *bottom* of the range selector.",
+                    "dflt": "top",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        "auto",
+                        "top",
+                        "middle",
+                        "bottom"
+                    ]
+                }
+            },
             "smith": {
                 "dflt": false,
                 "role": "info",
@@ -3076,6 +3424,12 @@
                         "valType": "integer"
                     },
                     "role": "object",
+                    "separatethousands": {
+                        "description": "If \"true\", even 4-digit integers are separated",
+                        "dflt": false,
+                        "role": "style",
+                        "valType": "boolean"
+                    },
                     "showexponent": {
                         "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                         "dflt": "all",
@@ -3340,6 +3694,12 @@
                         "valType": "integer"
                     },
                     "role": "object",
+                    "separatethousands": {
+                        "description": "If \"true\", even 4-digit integers are separated",
+                        "dflt": false,
+                        "role": "style",
+                        "valType": "boolean"
+                    },
                     "showexponent": {
                         "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                         "dflt": "all",
@@ -3610,6 +3970,12 @@
                         "valType": "integer"
                     },
                     "role": "object",
+                    "separatethousands": {
+                        "description": "If \"true\", even 4-digit integers are separated",
+                        "dflt": false,
+                        "role": "style",
+                        "valType": "boolean"
+                    },
                     "showexponent": {
                         "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                         "dflt": "all",
@@ -3941,13 +4307,27 @@
                                         "valType": "enumerated",
                                         "values": [
                                             "restyle",
-                                            "relayout"
+                                            "relayout",
+                                            "animate",
+                                            "update"
                                         ]
                                     },
                                     "role": "object"
                                 }
                             },
                             "role": "object"
+                        },
+                        "direction": {
+                            "description": "Determines the direction in which the buttons are laid out, whether in a dropdown menu or a row/column of buttons. For `left` and `up`, the buttons will still appear in left-to-right or top-to-bottom order respectively.",
+                            "dflt": "down",
+                            "role": "info",
+                            "valType": "enumerated",
+                            "values": [
+                                "left",
+                                "right",
+                                "up",
+                                "down"
+                            ]
                         },
                         "font": {
                             "color": {
@@ -3969,7 +4349,51 @@
                                 "valType": "number"
                             }
                         },
+                        "pad": {
+                            "b": {
+                                "description": "The amount of padding (in px) along the bottom of the component.",
+                                "dflt": 0,
+                                "role": "style",
+                                "valType": "number"
+                            },
+                            "description": "Sets the padding around the buttons or dropdown menu.",
+                            "l": {
+                                "description": "The amount of padding (in px) on the left side of the component.",
+                                "dflt": 0,
+                                "role": "style",
+                                "valType": "number"
+                            },
+                            "r": {
+                                "description": "The amount of padding (in px) on the right side of the component.",
+                                "dflt": 0,
+                                "role": "style",
+                                "valType": "number"
+                            },
+                            "role": "object",
+                            "t": {
+                                "description": "The amount of padding (in px) along the top of the component.",
+                                "dflt": 0,
+                                "role": "style",
+                                "valType": "number"
+                            }
+                        },
                         "role": "object",
+                        "showactive": {
+                            "description": "Highlights active dropdown item or active button if true.",
+                            "dflt": true,
+                            "role": "info",
+                            "valType": "boolean"
+                        },
+                        "type": {
+                            "description": "Determines whether the buttons are accessible via a dropdown menu or whether the buttons are stacked horizontally or vertically",
+                            "dflt": "dropdown",
+                            "role": "info",
+                            "valType": "enumerated",
+                            "values": [
+                                "dropdown",
+                                "buttons"
+                            ]
+                        },
                         "visible": {
                             "description": "Determines whether or not the update menu is visible.",
                             "role": "info",
@@ -4005,7 +4429,7 @@
                         },
                         "yanchor": {
                             "description": "Sets the update menu's vertical position anchor This anchor binds the `y` position to the *top*, *middle* or *bottom* of the range selector.",
-                            "dflt": "bottom",
+                            "dflt": "top",
                             "role": "info",
                             "valType": "enumerated",
                             "values": [
@@ -4411,6 +4835,12 @@
                     }
                 },
                 "role": "object",
+                "separatethousands": {
+                    "description": "If \"true\", even 4-digit integers are separated",
+                    "dflt": false,
+                    "role": "style",
+                    "valType": "boolean"
+                },
                 "showexponent": {
                     "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                     "dflt": "all",
@@ -5026,6 +5456,12 @@
                     }
                 },
                 "role": "object",
+                "separatethousands": {
+                    "description": "If \"true\", even 4-digit integers are separated",
+                    "dflt": false,
+                    "role": "style",
+                    "valType": "boolean"
+                },
                 "showexponent": {
                     "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                     "dflt": "all",
@@ -5262,11 +5698,12 @@
         "area": {
             "attributes": {
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "x",
@@ -5654,6 +6091,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -5928,11 +6367,12 @@
                     }
                 },
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "x",
@@ -6059,6 +6499,12 @@
                             "valType": "number"
                         },
                         "role": "object",
+                        "separatethousands": {
+                            "description": "If \"true\", even 4-digit integers are separated",
+                            "dflt": false,
+                            "role": "style",
+                            "valType": "boolean"
+                        },
                         "showexponent": {
                             "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                             "dflt": "all",
@@ -6446,6 +6892,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -6616,11 +7064,12 @@
                     "valType": "color"
                 },
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "x",
@@ -7053,6 +7502,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -7164,6 +7615,255 @@
                 }
             }
         },
+        "candlestick": {
+            "attributes": {
+                "close": {
+                    "description": "Sets the close values.",
+                    "dflt": [],
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "closesrc": {
+                    "description": "Sets the source reference on plot.ly for  close .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "decreasing": {
+                    "fillcolor": {
+                        "description": "Sets the fill color. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available.",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "line": {
+                        "color": {
+                            "description": "Sets the color of line bounding the box(es).",
+                            "dflt": "#FF4136",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "role": "object",
+                        "width": {
+                            "description": "Sets the width (in px) of line bounding the box(es).",
+                            "dflt": 2,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "name": {
+                        "description": "Sets the segment name. The segment name appear as the legend item and on hover.",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "role": "object",
+                    "showlegend": {
+                        "description": "Determines whether or not an item corresponding to this segment is shown in the legend.",
+                        "dflt": true,
+                        "role": "info",
+                        "valType": "boolean"
+                    }
+                },
+                "high": {
+                    "description": "Sets the high values.",
+                    "dflt": [],
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "highsrc": {
+                    "description": "Sets the source reference on plot.ly for  high .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "hoverinfo": {
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+                    "dflt": "all",
+                    "extras": [
+                        "all",
+                        "none",
+                        "skip"
+                    ],
+                    "flags": [
+                        "x",
+                        "y",
+                        "z",
+                        "text",
+                        "name"
+                    ],
+                    "role": "info",
+                    "valType": "flaglist"
+                },
+                "increasing": {
+                    "fillcolor": {
+                        "description": "Sets the fill color. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available.",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "line": {
+                        "color": {
+                            "description": "Sets the color of line bounding the box(es).",
+                            "dflt": "#3D9970",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "role": "object",
+                        "width": {
+                            "description": "Sets the width (in px) of line bounding the box(es).",
+                            "dflt": 2,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "name": {
+                        "description": "Sets the segment name. The segment name appear as the legend item and on hover.",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "role": "object",
+                    "showlegend": {
+                        "description": "Determines whether or not an item corresponding to this segment is shown in the legend.",
+                        "dflt": true,
+                        "role": "info",
+                        "valType": "boolean"
+                    }
+                },
+                "legendgroup": {
+                    "description": "Sets the legend group for this trace. Traces part of the same legend group hide/show at the same time when toggling legend items.",
+                    "dflt": "",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "line": {
+                    "role": "object",
+                    "width": {
+                        "description": "Sets the width (in px) of line bounding the box(es). Note that this style setting can also be set per direction via `increasing.line.width` and `decreasing.line.width`.",
+                        "dflt": 2,
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    }
+                },
+                "low": {
+                    "description": "Sets the low values.",
+                    "dflt": [],
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "lowsrc": {
+                    "description": "Sets the source reference on plot.ly for  low .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "name": {
+                    "description": "Sets the trace name. The trace name appear as the legend item and on hover.",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "opacity": {
+                    "description": "Sets the opacity of the trace.",
+                    "dflt": 1,
+                    "max": 1,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "open": {
+                    "description": "Sets the open values.",
+                    "dflt": [],
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "opensrc": {
+                    "description": "Sets the source reference on plot.ly for  open .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "showlegend": {
+                    "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
+                    "dflt": true,
+                    "role": "info",
+                    "valType": "boolean"
+                },
+                "stream": {
+                    "maxpoints": {
+                        "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
+                        "min": 0,
+                        "role": "info",
+                        "valType": "number"
+                    },
+                    "role": "object",
+                    "token": {
+                        "description": "The stream id number links a data trace on a plot with a stream. See https://plot.ly/settings for more details.",
+                        "noBlank": true,
+                        "role": "info",
+                        "strict": true,
+                        "valType": "string"
+                    }
+                },
+                "text": {
+                    "arrayOk": true,
+                    "description": "Sets hover text elements associated with each sample point. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to this trace's sample points.",
+                    "dflt": "",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "textsrc": {
+                    "description": "Sets the source reference on plot.ly for  text .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "type": "candlestick",
+                "uid": {
+                    "dflt": "",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "visible": {
+                    "description": "Determines whether or not this trace is visible. If *legendonly*, the trace is not drawn, but can appear as a legend item (provided that the legend itself is visible).",
+                    "dflt": true,
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        true,
+                        false,
+                        "legendonly"
+                    ]
+                },
+                "whiskerwidth": {
+                    "description": "Sets the width of the whiskers relative to the box' width. For example, with 1, the whiskers are as wide as the box(es).",
+                    "dflt": 0,
+                    "max": 1,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "x": {
+                    "description": "Sets the x coordinates. If absent, linear coordinate will be generated.",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "xaxis": {
+                    "description": "Sets a reference between this trace's x coordinates and a 2D cartesian x axis. If *x* (the default value), the x coordinates refer to `layout.xaxis`. If *x2*, the x coordinates refer to `layout.xaxis2`, and so on.",
+                    "dflt": "x",
+                    "role": "info",
+                    "valType": "subplotid"
+                },
+                "xsrc": {
+                    "description": "Sets the source reference on plot.ly for  x .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "yaxis": {
+                    "description": "Sets a reference between this trace's y coordinates and a 2D cartesian y axis. If *y* (the default value), the y coordinates refer to `layout.yaxis`. If *y2*, the y coordinates refer to `layout.xaxis2`, and so on.",
+                    "dflt": "y",
+                    "role": "info",
+                    "valType": "subplotid"
+                }
+            },
+            "description": "The candlestick is a style of financial chart describing open, high, low and close for a given `x` coordinate (most likely time). The boxes represent the spread between the `open` and `close` values and the lines represent the spread between the `low` and `high` values Sample points where the close value is higher (lower) then the open value are called increasing (decreasing). By default, increasing candles are drawn in green whereas decreasing are drawn in red."
+        },
         "choropleth": {
             "attributes": {
                 "autocolorscale": {
@@ -7250,6 +7950,12 @@
                         "valType": "number"
                     },
                     "role": "object",
+                    "separatethousands": {
+                        "description": "If \"true\", even 4-digit integers are separated",
+                        "dflt": false,
+                        "role": "style",
+                        "valType": "boolean"
+                    },
                     "showexponent": {
                         "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                         "dflt": "all",
@@ -7522,11 +8228,12 @@
                     "valType": "subplotid"
                 },
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "location",
@@ -7627,6 +8334,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -7790,6 +8499,12 @@
                         "valType": "number"
                     },
                     "role": "object",
+                    "separatethousands": {
+                        "description": "If \"true\", even 4-digit integers are separated",
+                        "dflt": false,
+                        "role": "style",
+                        "valType": "boolean"
+                    },
                     "showexponent": {
                         "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                         "dflt": "all",
@@ -8113,11 +8828,12 @@
                     "valType": "number"
                 },
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "x",
@@ -8212,6 +8928,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -8437,6 +9155,12 @@
                         "valType": "number"
                     },
                     "role": "object",
+                    "separatethousands": {
+                        "description": "If \"true\", even 4-digit integers are separated",
+                        "dflt": false,
+                        "role": "style",
+                        "valType": "boolean"
+                    },
                     "showexponent": {
                         "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                         "dflt": "all",
@@ -8721,11 +9445,12 @@
                     "valType": "number"
                 },
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "x",
@@ -8777,6 +9502,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -8840,6 +9567,13 @@
                     "role": "info",
                     "valType": "subplotid"
                 },
+                "xgap": {
+                    "description": "Sets the horizontal gap (in pixels) between bricks.",
+                    "dflt": 0,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
                 "xsrc": {
                     "description": "Sets the source reference on plot.ly for  x .",
                     "role": "info",
@@ -8870,6 +9604,13 @@
                     "dflt": "y",
                     "role": "info",
                     "valType": "subplotid"
+                },
+                "ygap": {
+                    "description": "Sets the vertical gap (in pixels) between bricks.",
+                    "dflt": 0,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
                 },
                 "ysrc": {
                     "description": "Sets the source reference on plot.ly for  y .",
@@ -9185,11 +9926,12 @@
                     ]
                 },
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "x",
@@ -9316,6 +10058,12 @@
                             "valType": "number"
                         },
                         "role": "object",
+                        "separatethousands": {
+                            "description": "If \"true\", even 4-digit integers are separated",
+                            "dflt": false,
+                            "role": "style",
+                            "valType": "boolean"
+                        },
                         "showexponent": {
                             "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                             "dflt": "all",
@@ -9707,6 +10455,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -9964,6 +10714,12 @@
                         "valType": "number"
                     },
                     "role": "object",
+                    "separatethousands": {
+                        "description": "If \"true\", even 4-digit integers are separated",
+                        "dflt": false,
+                        "role": "style",
+                        "valType": "boolean"
+                    },
                     "showexponent": {
                         "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                         "dflt": "all",
@@ -10256,11 +11012,12 @@
                     ]
                 },
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "x",
@@ -10339,6 +11096,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -10401,6 +11160,13 @@
                         "valType": "number"
                     }
                 },
+                "xgap": {
+                    "description": "Sets the horizontal gap (in pixels) between bricks.",
+                    "dflt": 0,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
                 "xsrc": {
                     "description": "Sets the source reference on plot.ly for  x .",
                     "role": "info",
@@ -10437,6 +11203,13 @@
                         "role": "style",
                         "valType": "number"
                     }
+                },
+                "ygap": {
+                    "description": "Sets the vertical gap (in pixels) between bricks.",
+                    "dflt": 0,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
                 },
                 "ysrc": {
                     "description": "Sets the source reference on plot.ly for  y .",
@@ -10590,6 +11363,12 @@
                         "valType": "number"
                     },
                     "role": "object",
+                    "separatethousands": {
+                        "description": "If \"true\", even 4-digit integers are separated",
+                        "dflt": false,
+                        "role": "style",
+                        "valType": "boolean"
+                    },
                     "showexponent": {
                         "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                         "dflt": "all",
@@ -10921,11 +11700,12 @@
                     ]
                 },
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "x",
@@ -11047,6 +11827,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -11274,6 +12056,12 @@
                         "valType": "number"
                     },
                     "role": "object",
+                    "separatethousands": {
+                        "description": "If \"true\", even 4-digit integers are separated",
+                        "dflt": false,
+                        "role": "style",
+                        "valType": "boolean"
+                    },
                     "showexponent": {
                         "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                         "dflt": "all",
@@ -11590,11 +12378,12 @@
                     "valType": "boolean"
                 },
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "x",
@@ -11778,6 +12567,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -11851,6 +12642,287 @@
             },
             "description": "Draws sets of triangles with coordinates given by three 1-dimensional arrays in `x`, `y`, `z` and (1) a sets of `i`, `j`, `k` indices (2) Delaunay triangulation or (3) the Alpha-shape algorithm or (4) the Convex-hull algorithm"
         },
+        "ohlc": {
+            "attributes": {
+                "close": {
+                    "description": "Sets the close values.",
+                    "dflt": [],
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "closesrc": {
+                    "description": "Sets the source reference on plot.ly for  close .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "decreasing": {
+                    "line": {
+                        "color": {
+                            "description": "Sets the line color.",
+                            "dflt": "#FF4136",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "dash": {
+                            "description": "Sets the style of the lines. Set to a dash string type or a dash length in px.",
+                            "dflt": "solid",
+                            "role": "style",
+                            "valType": "string",
+                            "values": [
+                                "solid",
+                                "dot",
+                                "dash",
+                                "longdash",
+                                "dashdot",
+                                "longdashdot"
+                            ]
+                        },
+                        "role": "object",
+                        "width": {
+                            "description": "Sets the line width (in px).",
+                            "dflt": 2,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "name": {
+                        "description": "Sets the segment name. The segment name appear as the legend item and on hover.",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "role": "object",
+                    "showlegend": {
+                        "description": "Determines whether or not an item corresponding to this segment is shown in the legend.",
+                        "dflt": true,
+                        "role": "info",
+                        "valType": "boolean"
+                    }
+                },
+                "high": {
+                    "description": "Sets the high values.",
+                    "dflt": [],
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "highsrc": {
+                    "description": "Sets the source reference on plot.ly for  high .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "hoverinfo": {
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+                    "dflt": "all",
+                    "extras": [
+                        "all",
+                        "none",
+                        "skip"
+                    ],
+                    "flags": [
+                        "x",
+                        "y",
+                        "z",
+                        "text",
+                        "name"
+                    ],
+                    "role": "info",
+                    "valType": "flaglist"
+                },
+                "increasing": {
+                    "line": {
+                        "color": {
+                            "description": "Sets the line color.",
+                            "dflt": "#3D9970",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "dash": {
+                            "description": "Sets the style of the lines. Set to a dash string type or a dash length in px.",
+                            "dflt": "solid",
+                            "role": "style",
+                            "valType": "string",
+                            "values": [
+                                "solid",
+                                "dot",
+                                "dash",
+                                "longdash",
+                                "dashdot",
+                                "longdashdot"
+                            ]
+                        },
+                        "role": "object",
+                        "width": {
+                            "description": "Sets the line width (in px).",
+                            "dflt": 2,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "name": {
+                        "description": "Sets the segment name. The segment name appear as the legend item and on hover.",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "role": "object",
+                    "showlegend": {
+                        "description": "Determines whether or not an item corresponding to this segment is shown in the legend.",
+                        "dflt": true,
+                        "role": "info",
+                        "valType": "boolean"
+                    }
+                },
+                "legendgroup": {
+                    "description": "Sets the legend group for this trace. Traces part of the same legend group hide/show at the same time when toggling legend items.",
+                    "dflt": "",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "line": {
+                    "dash": {
+                        "description": "[object Object] Note that this style setting can also be set per direction via `increasing.line.dash` and `decreasing.line.dash`.",
+                        "dflt": "solid",
+                        "role": "style",
+                        "valType": "string",
+                        "values": [
+                            "solid",
+                            "dot",
+                            "dash",
+                            "longdash",
+                            "dashdot",
+                            "longdashdot"
+                        ]
+                    },
+                    "role": "object",
+                    "width": {
+                        "description": "[object Object] Note that this style setting can also be set per direction via `increasing.line.width` and `decreasing.line.width`.",
+                        "dflt": 2,
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    }
+                },
+                "low": {
+                    "description": "Sets the low values.",
+                    "dflt": [],
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "lowsrc": {
+                    "description": "Sets the source reference on plot.ly for  low .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "name": {
+                    "description": "Sets the trace name. The trace name appear as the legend item and on hover.",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "opacity": {
+                    "description": "Sets the opacity of the trace.",
+                    "dflt": 1,
+                    "max": 1,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "open": {
+                    "description": "Sets the open values.",
+                    "dflt": [],
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "opensrc": {
+                    "description": "Sets the source reference on plot.ly for  open .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "showlegend": {
+                    "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
+                    "dflt": true,
+                    "role": "info",
+                    "valType": "boolean"
+                },
+                "stream": {
+                    "maxpoints": {
+                        "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
+                        "min": 0,
+                        "role": "info",
+                        "valType": "number"
+                    },
+                    "role": "object",
+                    "token": {
+                        "description": "The stream id number links a data trace on a plot with a stream. See https://plot.ly/settings for more details.",
+                        "noBlank": true,
+                        "role": "info",
+                        "strict": true,
+                        "valType": "string"
+                    }
+                },
+                "text": {
+                    "arrayOk": true,
+                    "description": "Sets hover text elements associated with each sample point. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to this trace's sample points.",
+                    "dflt": "",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "textsrc": {
+                    "description": "Sets the source reference on plot.ly for  text .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "tickwidth": {
+                    "description": "Sets the width of the open/close tick marks relative to the *x* minimal interval.",
+                    "dflt": 0.3,
+                    "max": 0.5,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "type": "ohlc",
+                "uid": {
+                    "dflt": "",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "visible": {
+                    "description": "Determines whether or not this trace is visible. If *legendonly*, the trace is not drawn, but can appear as a legend item (provided that the legend itself is visible).",
+                    "dflt": true,
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        true,
+                        false,
+                        "legendonly"
+                    ]
+                },
+                "x": {
+                    "description": "Sets the x coordinates. If absent, linear coordinate will be generated.",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "xaxis": {
+                    "description": "Sets a reference between this trace's x coordinates and a 2D cartesian x axis. If *x* (the default value), the x coordinates refer to `layout.xaxis`. If *x2*, the x coordinates refer to `layout.xaxis2`, and so on.",
+                    "dflt": "x",
+                    "role": "info",
+                    "valType": "subplotid"
+                },
+                "xsrc": {
+                    "description": "Sets the source reference on plot.ly for  x .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "yaxis": {
+                    "description": "Sets a reference between this trace's y coordinates and a 2D cartesian y axis. If *y* (the default value), the y coordinates refer to `layout.yaxis`. If *y2*, the y coordinates refer to `layout.xaxis2`, and so on.",
+                    "dflt": "y",
+                    "role": "info",
+                    "valType": "subplotid"
+                }
+            },
+            "description": "The ohlc (short for Open-High-Low-Close) is a style of financial chart describing open, high, low and close for a given `x` coordinate (most likely time). The tip of the lines represent the `low` and `high` values and the horizontal segments represent the `open` and `close` values. Sample points where the close value is higher (lower) then the open value are called increasing (decreasing). By default, increasing candles are drawn in green whereas decreasing are drawn in red."
+        },
         "pie": {
             "attributes": {
                 "direction": {
@@ -11923,11 +12995,12 @@
                     "valType": "number"
                 },
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "label",
@@ -12098,6 +13171,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -12213,6 +13288,229 @@
                     "valType": "string"
                 }
             }
+        },
+        "pointcloud": {
+            "attributes": {
+                "hoverinfo": {
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+                    "dflt": "all",
+                    "extras": [
+                        "all",
+                        "none",
+                        "skip"
+                    ],
+                    "flags": [
+                        "x",
+                        "y",
+                        "z",
+                        "text",
+                        "name"
+                    ],
+                    "role": "info",
+                    "valType": "flaglist"
+                },
+                "indices": {
+                    "description": "A sequential value, 0..n, supply it to avoid creating this array inside plotting. If specified, it must be a typed `Int32Array` array. Its length must be equal to or greater than the number of points. For the best performance and memory use, create one large `indices` typed array that is guaranteed to be at least as long as the largest number of points during use, and reuse it on each `Plotly.restyle()` call.",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "indicessrc": {
+                    "description": "Sets the source reference on plot.ly for  indices .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "legendgroup": {
+                    "description": "Sets the legend group for this trace. Traces part of the same legend group hide/show at the same time when toggling legend items.",
+                    "dflt": "",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "marker": {
+                    "blend": {
+                        "description": "Determines if colors are blended together for a translucency effect in case `opacity` is specified as a value less then `1`. Setting `blend` to `true` reduces zoom/pan speed if used with large numbers of points.",
+                        "dflt": null,
+                        "role": "style",
+                        "valType": "boolean"
+                    },
+                    "border": {
+                        "arearatio": {
+                            "description": "Specifies what fraction of the marker area is covered with the border.",
+                            "dflt": 0,
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "color": {
+                            "arrayOk": false,
+                            "description": "Sets the stroke color. It accepts a specific color. If the color is not fully opaque and there are hundreds of thousands of points, it may cause slower zooming and panning.",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "role": "object"
+                    },
+                    "color": {
+                        "arrayOk": false,
+                        "description": "Sets the marker fill color. It accepts a specific color.If the color is not fully opaque and there are hundreds of thousandsof points, it may cause slower zooming and panning.",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "opacity": {
+                        "arrayOk": false,
+                        "description": "Sets the marker opacity. The default value is `1` (fully opaque). If the markers are not fully opaque and there are hundreds of thousands of points, it may cause slower zooming and panning. Opacity fades the color even if `blend` is left on `false` even if there is no translucency effect in that case.",
+                        "dflt": 1,
+                        "max": 1,
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "role": "object",
+                    "sizemax": {
+                        "description": "Sets the maximum size (in px) of the rendered marker points. Effective when the `pointcloud` shows only few points.",
+                        "dflt": 20,
+                        "min": 0.1,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "sizemin": {
+                        "description": "Sets the minimum size (in px) of the rendered marker points, effective when the `pointcloud` shows a million or more points.",
+                        "dflt": 0.5,
+                        "max": 2,
+                        "min": 0.1,
+                        "role": "style",
+                        "valType": "number"
+                    }
+                },
+                "name": {
+                    "description": "Sets the trace name. The trace name appear as the legend item and on hover.",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "opacity": {
+                    "description": "Sets the opacity of the trace.",
+                    "dflt": 1,
+                    "max": 1,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "showlegend": {
+                    "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
+                    "dflt": true,
+                    "role": "info",
+                    "valType": "boolean"
+                },
+                "stream": {
+                    "maxpoints": {
+                        "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
+                        "min": 0,
+                        "role": "info",
+                        "valType": "number"
+                    },
+                    "role": "object",
+                    "token": {
+                        "description": "The stream id number links a data trace on a plot with a stream. See https://plot.ly/settings for more details.",
+                        "noBlank": true,
+                        "role": "info",
+                        "strict": true,
+                        "valType": "string"
+                    }
+                },
+                "text": {
+                    "arrayOk": true,
+                    "description": "Sets text elements associated with each (x,y) pair to appear on hover. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates.",
+                    "dflt": "",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "textsrc": {
+                    "description": "Sets the source reference on plot.ly for  text .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "type": "pointcloud",
+                "uid": {
+                    "dflt": "",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "visible": {
+                    "description": "Determines whether or not this trace is visible. If *legendonly*, the trace is not drawn, but can appear as a legend item (provided that the legend itself is visible).",
+                    "dflt": true,
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        true,
+                        false,
+                        "legendonly"
+                    ]
+                },
+                "x": {
+                    "description": "Sets the x coordinates.",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "xaxis": {
+                    "description": "Sets a reference between this trace's x coordinates and a 2D cartesian x axis. If *x* (the default value), the x coordinates refer to `layout.xaxis`. If *x2*, the x coordinates refer to `layout.xaxis2`, and so on.",
+                    "dflt": "x",
+                    "role": "info",
+                    "valType": "subplotid"
+                },
+                "xbounds": {
+                    "description": "Specify `xbounds` in the shape of `[xMin, xMax] to avoid looping through the `xy` typed array. Use it in conjunction with `xy` and `ybounds` for the performance benefits.",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "xboundssrc": {
+                    "description": "Sets the source reference on plot.ly for  xbounds .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "xsrc": {
+                    "description": "Sets the source reference on plot.ly for  x .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "xy": {
+                    "description": "Faster alternative to specifying `x` and `y` separately. If supplied, it must be a typed `Float32Array` array that represents points such that `xy[i * 2] = x[i]` and `xy[i * 2 + 1] = y[i]`",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "xysrc": {
+                    "description": "Sets the source reference on plot.ly for  xy .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "y": {
+                    "description": "Sets the y coordinates.",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "yaxis": {
+                    "description": "Sets a reference between this trace's y coordinates and a 2D cartesian y axis. If *y* (the default value), the y coordinates refer to `layout.yaxis`. If *y2*, the y coordinates refer to `layout.xaxis2`, and so on.",
+                    "dflt": "y",
+                    "role": "info",
+                    "valType": "subplotid"
+                },
+                "ybounds": {
+                    "description": "Specify `ybounds` in the shape of `[yMin, yMax] to avoid looping through the `xy` typed array. Use it in conjunction with `xy` and `xbounds` for the performance benefits.",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "yboundssrc": {
+                    "description": "Sets the source reference on plot.ly for  ybounds .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "ysrc": {
+                    "description": "Sets the source reference on plot.ly for  y .",
+                    "role": "info",
+                    "valType": "string"
+                }
+            },
+            "description": "The data visualized as a point cloud set in `x` and `y` using the WebGl plotting engine."
         },
         "scatter": {
             "attributes": {
@@ -12461,11 +13759,12 @@
                     "valType": "color"
                 },
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "x",
@@ -12485,6 +13784,16 @@
                     ],
                     "role": "info",
                     "valType": "flaglist"
+                },
+                "ids": {
+                    "description": "A list of keys for object constancy of data points during animation",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "idssrc": {
+                    "description": "Sets the source reference on plot.ly for  ids .",
+                    "role": "info",
+                    "valType": "string"
                 },
                 "legendgroup": {
                     "description": "Sets the legend group for this trace. Traces part of the same legend group hide/show at the same time when toggling legend items.",
@@ -12526,6 +13835,12 @@
                             "hvh",
                             "vhv"
                         ]
+                    },
+                    "simplify": {
+                        "description": "Simplifies lines by removing nearly-collinear points. When transitioning lines, it may be desirable to disable this so that the number of points along the resulting SVG path is unaffected.",
+                        "dflt": true,
+                        "role": "info",
+                        "valType": "boolean"
                     },
                     "smoothing": {
                         "description": "Has an effect only if `shape` is set to *spline* Sets the amount of smoothing. *0* corresponds to no smoothing (equivalent to a *linear* shape).",
@@ -12652,6 +13967,12 @@
                             "valType": "number"
                         },
                         "role": "object",
+                        "separatethousands": {
+                            "description": "If \"true\", even 4-digit integers are separated",
+                            "dflt": false,
+                            "role": "style",
+                            "valType": "boolean"
+                        },
                         "showexponent": {
                             "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                             "dflt": "all",
@@ -13396,6 +14717,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -13873,11 +15196,12 @@
                     }
                 },
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "x",
@@ -14080,6 +15404,12 @@
                             "valType": "number"
                         },
                         "role": "object",
+                        "separatethousands": {
+                            "description": "If \"true\", even 4-digit integers are separated",
+                            "dflt": false,
+                            "role": "style",
+                            "valType": "boolean"
+                        },
                         "showexponent": {
                             "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                             "dflt": "all",
@@ -14606,6 +15936,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -14761,6 +16093,27 @@
         },
         "scattergeo": {
             "attributes": {
+                "connectgaps": {
+                    "description": "Determines whether or not gaps (i.e. {nan} or missing values) in the provided data arrays are connected.",
+                    "dflt": false,
+                    "role": "info",
+                    "valType": "boolean"
+                },
+                "fill": {
+                    "description": "Sets the area to fill with a solid color. Use with `fillcolor` if not *none*. *toself* connects the endpoints of the trace (or each segment of the trace if it has gaps) into a closed shape.",
+                    "dflt": "none",
+                    "role": "style",
+                    "valType": "enumerated",
+                    "values": [
+                        "none",
+                        "toself"
+                    ]
+                },
+                "fillcolor": {
+                    "description": "Sets the fill color. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available.",
+                    "role": "style",
+                    "valType": "color"
+                },
                 "geo": {
                     "description": "Sets a reference between this trace's geospatial coordinates and a geographic map. If *geo* (the default value), the geospatial coordinates refer to `layout.geo`. If *geo2*, the geospatial coordinates refer to `layout.geo2`, and so on.",
                     "dflt": "geo",
@@ -14768,11 +16121,12 @@
                     "valType": "subplotid"
                 },
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "lon",
@@ -14969,6 +16323,12 @@
                             "valType": "number"
                         },
                         "role": "object",
+                        "separatethousands": {
+                            "description": "If \"true\", even 4-digit integers are separated",
+                            "dflt": false,
+                            "role": "style",
+                            "valType": "boolean"
+                        },
                         "showexponent": {
                             "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                             "dflt": "all",
@@ -15697,6 +17057,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -16046,11 +17408,12 @@
                     "valType": "color"
                 },
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "x",
@@ -16206,6 +17569,12 @@
                             "valType": "number"
                         },
                         "role": "object",
+                        "separatethousands": {
+                            "description": "If \"true\", even 4-digit integers are separated",
+                            "dflt": false,
+                            "role": "style",
+                            "valType": "boolean"
+                        },
                         "showexponent": {
                             "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                             "dflt": "all",
@@ -16656,6 +18025,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -16769,11 +18140,12 @@
                     "valType": "color"
                 },
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "lon",
@@ -16948,6 +18320,12 @@
                             "valType": "number"
                         },
                         "role": "object",
+                        "separatethousands": {
+                            "description": "If \"true\", even 4-digit integers are separated",
+                            "dflt": false,
+                            "role": "style",
+                            "valType": "boolean"
+                        },
                         "showexponent": {
                             "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                             "dflt": "all",
@@ -17324,6 +18702,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -17470,11 +18850,12 @@
                     "valType": "color"
                 },
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "a",
@@ -17657,6 +19038,12 @@
                             "valType": "number"
                         },
                         "role": "object",
+                        "separatethousands": {
+                            "description": "If \"true\", even 4-digit integers are separated",
+                            "dflt": false,
+                            "role": "style",
+                            "valType": "boolean"
+                        },
                         "showexponent": {
                             "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                             "dflt": "all",
@@ -18392,6 +19779,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -18635,6 +20024,12 @@
                         "valType": "number"
                     },
                     "role": "object",
+                    "separatethousands": {
+                        "description": "If \"true\", even 4-digit integers are separated",
+                        "dflt": false,
+                        "role": "style",
+                        "valType": "boolean"
+                    },
                     "showexponent": {
                         "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                         "dflt": "all",
@@ -19120,11 +20515,12 @@
                     "valType": "boolean"
                 },
                 "hoverinfo": {
-                    "description": "Determines which trace information appear on hover.",
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
                     "extras": [
                         "all",
-                        "none"
+                        "none",
+                        "skip"
                     ],
                     "flags": [
                         "x",
@@ -19252,6 +20648,8 @@
                 "stream": {
                     "maxpoints": {
                         "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "max": 10000,
                         "min": 0,
                         "role": "info",
                         "valType": "number"
@@ -19336,5 +20734,80 @@
             "description": "The data the describes the coordinates of the surface is set in `z`. Data in `z` should be a {2D array}. Coordinates in `x` and `y` can either be 1D {arrays} or {2D arrays} (e.g. to graph parametric surfaces). If not provided in `x` and `y`, the x and y coordinates are assumed to be linear starting at 0 with a unit step. The color scale corresponds to the `z` values by default. For custom color scales, use `surfacecolor` which should be a {2D array}, where its bounds can be controlled using `cmin` and `cmax`."
         }
     },
-    "transforms": {}
+    "transforms": {
+        "candlestick": {
+            "attributes": {}
+        },
+        "filter": {
+            "attributes": {
+                "enabled": {
+                    "description": "Determines whether this filter transform is enabled or disabled.",
+                    "dflt": true,
+                    "valType": "boolean"
+                },
+                "filtersrc": {
+                    "description": "Sets the variable in the parent trace object by which the filter will be applied. To filter about nested variables, use *.* to access them. For example, set `filtersrc` to *marker.color* to filter about the marker color array.",
+                    "dflt": "x",
+                    "noBlank": true,
+                    "strict": true,
+                    "valType": "string"
+                },
+                "operation": {
+                    "description": "Sets the filter operation. *=* keeps items equal to `value` *<* keeps items less than `value` *<=* keeps items less than or equal to `value` *>* keeps items greater than `value` *>=* keeps items greater than or equal to `value` *[]* keeps items inside `value[0]` to value[1]` including both bounds` *()* keeps items inside `value[0]` to value[1]` excluding both bounds` *[)* keeps items inside `value[0]` to value[1]` including `value[0]` but excluding `value[1] *(]* keeps items inside `value[0]` to value[1]` excluding `value[0]` but including `value[1] *][* keeps items outside `value[0]` to value[1]` and equal to both bounds` *)(* keeps items outside `value[0]` to value[1]` *](* keeps items outside `value[0]` to value[1]` and equal to `value[0]` *)[* keeps items outside `value[0]` to value[1]` and equal to `value[1]` *{}* keeps items present in a set of values *}{* keeps items not present in a set of values",
+                    "dflt": "=",
+                    "valType": "enumerated",
+                    "values": [
+                        "=",
+                        "<",
+                        ">=",
+                        ">",
+                        "<=",
+                        "[]",
+                        "()",
+                        "[)",
+                        "(]",
+                        "][",
+                        ")(",
+                        "](",
+                        ")[",
+                        "{}",
+                        "}{"
+                    ]
+                },
+                "value": {
+                    "description": "Sets the value or values by which to filter by. Values are expected to be in the same type as the data linked to *filtersrc*. When `operation` is set to one of the inequality values (=,<,>=,>,<=) *value* is expected to be a number or a string. When `operation` is set to one of the interval value ([],(),[),(],][,)(,](,)[) *value* is expected to be 2-item array where the first item is the lower bound and the second item is the upper bound. When `operation`, is set to one of the set value ({},}{) *value* is expected to be an array with as many items as the desired set elements.",
+                    "dflt": 0,
+                    "valType": "any"
+                }
+            }
+        },
+        "groupby": {
+            "attributes": {
+                "enabled": {
+                    "description": "Determines whether this group-by transform is enabled or disabled.",
+                    "dflt": true,
+                    "valType": "boolean"
+                },
+                "groups": {
+                    "description": "Sets the groups in which the trace data will be split. For example, with `x` set to *[1, 2, 3, 4]* and `groups` set to *['a', 'b', 'a', 'b']*, the groupby transform with split in one trace with `x` [1, 3] and one trace with `x` [2, 4].",
+                    "dflt": [],
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "groupssrc": {
+                    "description": "Sets the source reference on plot.ly for  groups .",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "style": {
+                    "description": "Sets each group style. For example, with `groups` set to *['a', 'b', 'a', 'b']* and `style` set to *{ a: { marker: { color: 'red' } }} marker points in group *'a'* will be drawn in red.",
+                    "dflt": {},
+                    "valType": "any"
+                }
+            }
+        },
+        "ohlc": {
+            "attributes": {}
+        }
+    }
 }

--- a/plotly/graph_reference/default-schema.json
+++ b/plotly/graph_reference/default-schema.json
@@ -1,4 +1,103 @@
 {
+    "animation": {
+        "direction": {
+            "description": "The direction in which to play the frames triggered by the animation call",
+            "dflt": "forward",
+            "role": "info",
+            "valType": "enumerated",
+            "values": [
+                "forward",
+                "reverse"
+            ]
+        },
+        "frame": {
+            "duration": {
+                "description": "The duration in milliseconds of each frame. If greater than the frame duration, it will be limited to the frame duration.",
+                "dflt": 500,
+                "min": 0,
+                "role": "info",
+                "valType": "number"
+            },
+            "redraw": {
+                "description": "Redraw the plot at completion of the transition. This is desirable for transitions that include properties that cannot be transitioned, but may significantly slow down updates that do not require a full redraw of the plot",
+                "dflt": true,
+                "role": "info",
+                "valType": "boolean"
+            },
+            "role": "object"
+        },
+        "fromcurrent": {
+            "description": "Play frames starting at the current frame instead of the beginning.",
+            "dflt": false,
+            "role": "info",
+            "valType": "boolean"
+        },
+        "mode": {
+            "description": "Describes how a new animate call interacts with currently-running animations. If `immediate`, current animations are interrupted and the new animation is started. If `next`, the current frame is allowed to complete, after which the new animation is started. If `afterall` all existing frames are animated to completion before the new animation is started.",
+            "dflt": "afterall",
+            "role": "info",
+            "valType": "enumerated",
+            "values": [
+                "immediate",
+                "next",
+                "afterall"
+            ]
+        },
+        "transition": {
+            "duration": {
+                "description": "The duration of the transition, in milliseconds. If equal to zero, updates are synchronous.",
+                "dflt": 500,
+                "min": 0,
+                "role": "info",
+                "valType": "number"
+            },
+            "easing": {
+                "description": "The easing function used for the transition",
+                "dflt": "cubic-in-out",
+                "role": "info",
+                "valType": "enumerated",
+                "values": [
+                    "linear",
+                    "quad",
+                    "cubic",
+                    "sin",
+                    "exp",
+                    "circle",
+                    "elastic",
+                    "back",
+                    "bounce",
+                    "linear-in",
+                    "quad-in",
+                    "cubic-in",
+                    "sin-in",
+                    "exp-in",
+                    "circle-in",
+                    "elastic-in",
+                    "back-in",
+                    "bounce-in",
+                    "linear-out",
+                    "quad-out",
+                    "cubic-out",
+                    "sin-out",
+                    "exp-out",
+                    "circle-out",
+                    "elastic-out",
+                    "back-out",
+                    "bounce-out",
+                    "linear-in-out",
+                    "quad-in-out",
+                    "cubic-in-out",
+                    "sin-in-out",
+                    "exp-in-out",
+                    "circle-in-out",
+                    "elastic-in-out",
+                    "back-in-out",
+                    "bounce-in-out"
+                ]
+            },
+            "role": "object"
+        }
+    },
     "defs": {
         "metaKeys": [
             "_isSubplotObj",
@@ -121,6 +220,47 @@
                     "dflt"
                 ]
             }
+        }
+    },
+    "frames": {
+        "baseframe": {
+            "description": "The name of the frame into which this frame's properties are merged before applying. This is used to unify properties and avoid needing to specify the same values for the same properties in multiple frames.",
+            "role": "info",
+            "valType": "string"
+        },
+        "data": {
+            "description": "A list of traces this frame modifies. The format is identical to the normal trace definition.",
+            "role": "data",
+            "valType": "data_array"
+        },
+        "datasrc": {
+            "description": "Sets the source reference on plot.ly for  data .",
+            "role": "info",
+            "valType": "string"
+        },
+        "group": {
+            "description": "An identifier that specifies the group to which the frame belongs, used by animate to select a subset of frames.",
+            "role": "info",
+            "valType": "string"
+        },
+        "layout": {
+            "description": "Layout properties which this frame modifies. The format is identical to the normal layout definition.",
+            "valType": "any"
+        },
+        "name": {
+            "description": "A label by which to identify the frame",
+            "role": "info",
+            "valType": "string"
+        },
+        "traces": {
+            "description": "A list of trace indices that identify the respective traces in the data attribute",
+            "role": "data",
+            "valType": "data_array"
+        },
+        "tracessrc": {
+            "description": "Sets the source reference on plot.ly for  traces .",
+            "role": "info",
+            "valType": "string"
         }
     },
     "layout": {
@@ -256,10 +396,9 @@
                             "valType": "number"
                         },
                         "ax": {
-                            "description": "Sets the x component of the arrow tail about the arrow head. If `axref` is `pixel`, a positive (negative)  component corresponds to an arrow pointing from right to left (left to right). If `axref` is an axis, this is a value on that axis.",
-                            "dflt": -10,
+                            "description": "Sets the x component of the arrow tail about the arrow head. If `axref` is `pixel`, a positive (negative)  component corresponds to an arrow pointing from right to left (left to right). If `axref` is an axis, this is an absolute value on that axis, like `x`, NOT a relative value.",
                             "role": "info",
-                            "valType": "number"
+                            "valType": "any"
                         },
                         "axref": {
                             "description": "Indicates in what terms the tail of the annotation (ax,ay)  is specified. If `pixel`, `ax` is a relative offset in pixels  from `x`. If set to an x axis id (e.g. *x* or *x2*), `ax` is  specified in the same terms as that axis. This is useful  for trendline annotations which should continue to indicate  the correct trend when zoomed.",
@@ -272,10 +411,9 @@
                             ]
                         },
                         "ay": {
-                            "description": "Sets the y component of the arrow tail about the arrow head. If `ayref` is `pixel`, a positive (negative)  component corresponds to an arrow pointing from bottom to top (top to bottom). If `ayref` is an axis, this is a value on that axis.",
-                            "dflt": -30,
+                            "description": "Sets the y component of the arrow tail about the arrow head. If `ayref` is `pixel`, a positive (negative)  component corresponds to an arrow pointing from bottom to top (top to bottom). If `ayref` is an axis, this is an absolute value on that axis, like `y`, NOT a relative value.",
                             "role": "info",
-                            "valType": "number"
+                            "valType": "any"
                         },
                         "ayref": {
                             "description": "Indicates in what terms the tail of the annotation (ax,ay)  is specified. If `pixel`, `ay` is a relative offset in pixels  from `y`. If set to a y axis id (e.g. *y* or *y2*), `ay` is  specified in the same terms as that axis. This is useful  for trendline annotations which should continue to indicate  the correct trend when zoomed.",
@@ -359,10 +497,16 @@
                             "role": "style",
                             "valType": "angle"
                         },
-                        "x": {
-                            "description": "Sets the annotation's x position. Note that dates and categories are converted to numbers.",
+                        "visible": {
+                            "description": "Determines whether or not this annotation is visible.",
+                            "dflt": true,
                             "role": "info",
-                            "valType": "number"
+                            "valType": "boolean"
+                        },
+                        "x": {
+                            "description": "Sets the annotation's x position. If the axis `type` is *log*, then you must take the log of your desired range. If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                            "role": "info",
+                            "valType": "any"
                         },
                         "xanchor": {
                             "description": "Sets the annotation's horizontal position anchor This anchor binds the `x` position to the *left*, *center* or *right* of the annotation. For example, if `x` is set to 1, `xref` to *paper* and `xanchor` to *right* then the right-most portion of the annotation lines up with the right-most edge of the plotting area. If *auto*, the anchor is equivalent to *center* for data-referenced annotations whereas for paper-referenced, the anchor picked corresponds to the closest side.",
@@ -386,9 +530,9 @@
                             ]
                         },
                         "y": {
-                            "description": "Sets the annotation's y position. Note that dates and categories are converted to numbers.",
+                            "description": "Sets the annotation's y position. If the axis `type` is *log*, then you must take the log of your desired range. If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
                             "role": "info",
-                            "valType": "number"
+                            "valType": "any"
                         },
                         "yanchor": {
                             "description": "Sets the annotation's vertical position anchor This anchor binds the `y` position to the *top*, *middle* or *bottom* of the annotation. For example, if `y` is set to 1, `yref` to *paper* and `yanchor` to *top* then the top-most portion of the annotation lines up with the top-most edge of the plotting area. If *auto*, the anchor is equivalent to *middle* for data-referenced annotations whereas for paper-referenced, the anchor picked corresponds to the closest side.",
@@ -908,11 +1052,17 @@
                             "role": "info",
                             "valType": "string"
                         },
+                        "visible": {
+                            "description": "Determines whether or not this image is visible.",
+                            "dflt": true,
+                            "role": "info",
+                            "valType": "boolean"
+                        },
                         "x": {
                             "description": "Sets the image's x position. When `xref` is set to `paper`, units are sized relative to the plot height. See `xref` for more info",
                             "dflt": 0,
                             "role": "info",
-                            "valType": "number"
+                            "valType": "any"
                         },
                         "xanchor": {
                             "description": "Sets the anchor for the x position",
@@ -939,7 +1089,7 @@
                             "description": "Sets the image's y position. When `yref` is set to `paper`, units are sized relative to the plot height. See `yref` for more info",
                             "dflt": 0,
                             "role": "info",
-                            "valType": "number"
+                            "valType": "any"
                         },
                         "yanchor": {
                             "description": "Sets the anchor for the y position.",
@@ -1694,8 +1844,7 @@
                         "valType": "color"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                        "dflt": 1,
+                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                         "role": "style",
                         "valType": "any"
                     },
@@ -1733,7 +1882,7 @@
                         "valType": "number"
                     },
                     "hoverformat": {
-                        "description": "Sets the hover text formatting rule for data values on this axis, using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -1772,13 +1921,13 @@
                         "valType": "integer"
                     },
                     "range": {
-                        "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the date range from January 1st 1970 to November 4th, 2013, set the range from 0 to 1380844800000.0",
+                        "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "items": [
                             {
-                                "valType": "number"
+                                "valType": "any"
                             },
                             {
-                                "valType": "number"
+                                "valType": "any"
                             }
                         ],
                         "role": "info",
@@ -1893,10 +2042,9 @@
                         "valType": "number"
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                        "dflt": 0,
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -1931,7 +2079,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -2105,8 +2253,7 @@
                         "valType": "color"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                        "dflt": 1,
+                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                         "role": "style",
                         "valType": "any"
                     },
@@ -2144,7 +2291,7 @@
                         "valType": "number"
                     },
                     "hoverformat": {
-                        "description": "Sets the hover text formatting rule for data values on this axis, using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -2183,13 +2330,13 @@
                         "valType": "integer"
                     },
                     "range": {
-                        "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the date range from January 1st 1970 to November 4th, 2013, set the range from 0 to 1380844800000.0",
+                        "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "items": [
                             {
-                                "valType": "number"
+                                "valType": "any"
                             },
                             {
-                                "valType": "number"
+                                "valType": "any"
                             }
                         ],
                         "role": "info",
@@ -2304,10 +2451,9 @@
                         "valType": "number"
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                        "dflt": 0,
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -2342,7 +2488,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -2516,8 +2662,7 @@
                         "valType": "color"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                        "dflt": 1,
+                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                         "role": "style",
                         "valType": "any"
                     },
@@ -2555,7 +2700,7 @@
                         "valType": "number"
                     },
                     "hoverformat": {
-                        "description": "Sets the hover text formatting rule for data values on this axis, using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -2594,13 +2739,13 @@
                         "valType": "integer"
                     },
                     "range": {
-                        "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the date range from January 1st 1970 to November 4th, 2013, set the range from 0 to 1380844800000.0",
+                        "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "items": [
                             {
-                                "valType": "number"
+                                "valType": "any"
                             },
                             {
-                                "valType": "number"
+                                "valType": "any"
                             }
                         ],
                         "role": "info",
@@ -2715,10 +2860,9 @@
                         "valType": "number"
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                        "dflt": 0,
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -2753,7 +2897,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -2960,6 +3104,12 @@
                                 "line"
                             ]
                         },
+                        "visible": {
+                            "description": "Determines whether or not this shape is visible.",
+                            "dflt": true,
+                            "role": "info",
+                            "valType": "boolean"
+                        },
                         "x0": {
                             "description": "Sets the shape's starting x position. See `type` for more info.",
                             "role": "info",
@@ -3008,334 +3158,339 @@
                 "valType": "boolean"
             },
             "sliders": {
-                "active": {
-                    "description": "Determines which button (by index starting from 0) is considered active.",
-                    "dflt": 0,
-                    "min": 0,
-                    "role": "info",
-                    "valType": "number"
-                },
-                "activebgcolor": {
-                    "description": "Sets the background color of the slider grip while dragging.",
-                    "dflt": "#dbdde0",
-                    "role": "style",
-                    "valType": "color"
-                },
-                "bgcolor": {
-                    "description": "Sets the background color of the slider.",
-                    "dflt": "#f8fafc",
-                    "role": "style",
-                    "valType": "color"
-                },
-                "bordercolor": {
-                    "description": "Sets the color of the border enclosing the slider.",
-                    "dflt": "#bec8d9",
-                    "role": "style",
-                    "valType": "color"
-                },
-                "borderwidth": {
-                    "description": "Sets the width (in px) of the border enclosing the slider.",
-                    "dflt": 1,
-                    "min": 0,
-                    "role": "style",
-                    "valType": "number"
-                },
-                "currentvalue": {
-                    "font": {
-                        "color": {
+                "items": {
+                    "slider": {
+                        "active": {
+                            "description": "Determines which button (by index starting from 0) is considered active.",
+                            "dflt": 0,
+                            "min": 0,
+                            "role": "info",
+                            "valType": "number"
+                        },
+                        "activebgcolor": {
+                            "description": "Sets the background color of the slider grip while dragging.",
+                            "dflt": "#dbdde0",
                             "role": "style",
                             "valType": "color"
                         },
-                        "description": "Sets the font of the current value label text.",
-                        "family": {
-                            "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
-                            "noBlank": true,
+                        "bgcolor": {
+                            "description": "Sets the background color of the slider.",
+                            "dflt": "#f8fafc",
                             "role": "style",
-                            "strict": true,
-                            "valType": "string"
+                            "valType": "color"
                         },
-                        "role": "object",
-                        "size": {
-                            "min": 1,
+                        "bordercolor": {
+                            "description": "Sets the color of the border enclosing the slider.",
+                            "dflt": "#bec8d9",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "borderwidth": {
+                            "description": "Sets the width (in px) of the border enclosing the slider.",
+                            "dflt": 1,
+                            "min": 0,
                             "role": "style",
                             "valType": "number"
-                        }
-                    },
-                    "offset": {
-                        "description": "The amount of space, in pixels, between the current value label and the slider.",
-                        "dflt": 10,
-                        "role": "info",
-                        "valType": "number"
-                    },
-                    "prefix": {
-                        "description": "When currentvalue.visible is true, this sets the prefix of the label.",
-                        "role": "info",
-                        "valType": "string"
-                    },
-                    "role": "object",
-                    "suffix": {
-                        "description": "When currentvalue.visible is true, this sets the suffix of the label.",
-                        "role": "info",
-                        "valType": "string"
-                    },
-                    "visible": {
-                        "description": "Shows the currently-selected value above the slider.",
-                        "dflt": true,
-                        "role": "info",
-                        "valType": "boolean"
-                    },
-                    "xanchor": {
-                        "description": "The alignment of the value readout relative to the length of the slider.",
-                        "dflt": "left",
-                        "role": "info",
-                        "valType": "enumerated",
-                        "values": [
-                            "left",
-                            "center",
-                            "right"
-                        ]
-                    }
-                },
-                "font": {
-                    "color": {
-                        "role": "style",
-                        "valType": "color"
-                    },
-                    "description": "Sets the font of the slider step labels.",
-                    "family": {
-                        "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
-                        "noBlank": true,
-                        "role": "style",
-                        "strict": true,
-                        "valType": "string"
-                    },
-                    "role": "object",
-                    "size": {
-                        "min": 1,
-                        "role": "style",
-                        "valType": "number"
-                    }
-                },
-                "len": {
-                    "description": "Sets the length of the slider This measure excludes the padding of both ends. That is, the slider's length is this length minus the padding on both ends.",
-                    "dflt": 1,
-                    "min": 0,
-                    "role": "style",
-                    "valType": "number"
-                },
-                "lenmode": {
-                    "description": "Determines whether this slider length is set in units of plot *fraction* or in *pixels. Use `len` to set the value.",
-                    "dflt": "fraction",
-                    "role": "info",
-                    "valType": "enumerated",
-                    "values": [
-                        "fraction",
-                        "pixels"
-                    ]
-                },
-                "minorticklen": {
-                    "description": "Sets the length in pixels of minor step tick marks",
-                    "dflt": 4,
-                    "min": 0,
-                    "role": "style",
-                    "valType": "number"
-                },
-                "pad": {
-                    "b": {
-                        "description": "The amount of padding (in px) along the bottom of the component.",
-                        "dflt": 0,
-                        "role": "style",
-                        "valType": "number"
-                    },
-                    "description": "Set the padding of the slider component along each side.",
-                    "l": {
-                        "description": "The amount of padding (in px) on the left side of the component.",
-                        "dflt": 0,
-                        "role": "style",
-                        "valType": "number"
-                    },
-                    "r": {
-                        "description": "The amount of padding (in px) on the right side of the component.",
-                        "dflt": 0,
-                        "role": "style",
-                        "valType": "number"
-                    },
-                    "role": "object",
-                    "t": {
-                        "description": "The amount of padding (in px) along the top of the component.",
-                        "dflt": 20,
-                        "role": "style",
-                        "valType": "number"
-                    }
-                },
-                "role": "object",
-                "steps": {
-                    "items": {
-                        "step": {
-                            "args": {
-                                "description": "Sets the arguments values to be passed to the Plotly method set in `method` on slide.",
-                                "freeLength": true,
-                                "items": [
-                                    {
-                                        "valType": "any"
-                                    },
-                                    {
-                                        "valType": "any"
-                                    },
-                                    {
-                                        "valType": "any"
-                                    }
-                                ],
-                                "role": "info",
-                                "valType": "info_array"
+                        },
+                        "currentvalue": {
+                            "font": {
+                                "color": {
+                                    "role": "style",
+                                    "valType": "color"
+                                },
+                                "description": "Sets the font of the current value label text.",
+                                "family": {
+                                    "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                                    "noBlank": true,
+                                    "role": "style",
+                                    "strict": true,
+                                    "valType": "string"
+                                },
+                                "role": "object",
+                                "size": {
+                                    "min": 1,
+                                    "role": "style",
+                                    "valType": "number"
+                                }
                             },
-                            "label": {
-                                "description": "Sets the text label to appear on the slider",
+                            "offset": {
+                                "description": "The amount of space, in pixels, between the current value label and the slider.",
+                                "dflt": 10,
+                                "role": "info",
+                                "valType": "number"
+                            },
+                            "prefix": {
+                                "description": "When currentvalue.visible is true, this sets the prefix of the label.",
                                 "role": "info",
                                 "valType": "string"
                             },
-                            "method": {
-                                "description": "Sets the Plotly method to be called when the slider value is changed.",
-                                "dflt": "restyle",
+                            "role": "object",
+                            "suffix": {
+                                "description": "When currentvalue.visible is true, this sets the suffix of the label.",
+                                "role": "info",
+                                "valType": "string"
+                            },
+                            "visible": {
+                                "description": "Shows the currently-selected value above the slider.",
+                                "dflt": true,
+                                "role": "info",
+                                "valType": "boolean"
+                            },
+                            "xanchor": {
+                                "description": "The alignment of the value readout relative to the length of the slider.",
+                                "dflt": "left",
                                 "role": "info",
                                 "valType": "enumerated",
                                 "values": [
-                                    "restyle",
-                                    "relayout",
-                                    "animate",
-                                    "update"
+                                    "left",
+                                    "center",
+                                    "right"
                                 ]
+                            }
+                        },
+                        "font": {
+                            "color": {
+                                "role": "style",
+                                "valType": "color"
+                            },
+                            "description": "Sets the font of the slider step labels.",
+                            "family": {
+                                "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                                "noBlank": true,
+                                "role": "style",
+                                "strict": true,
+                                "valType": "string"
                             },
                             "role": "object",
-                            "value": {
-                                "description": "Sets the value of the slider step, used to refer to the step programatically. Defaults to the slider label if not provided.",
-                                "role": "info",
-                                "valType": "string"
+                            "size": {
+                                "min": 1,
+                                "role": "style",
+                                "valType": "number"
                             }
+                        },
+                        "len": {
+                            "description": "Sets the length of the slider This measure excludes the padding of both ends. That is, the slider's length is this length minus the padding on both ends.",
+                            "dflt": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "lenmode": {
+                            "description": "Determines whether this slider length is set in units of plot *fraction* or in *pixels. Use `len` to set the value.",
+                            "dflt": "fraction",
+                            "role": "info",
+                            "valType": "enumerated",
+                            "values": [
+                                "fraction",
+                                "pixels"
+                            ]
+                        },
+                        "minorticklen": {
+                            "description": "Sets the length in pixels of minor step tick marks",
+                            "dflt": 4,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "pad": {
+                            "b": {
+                                "description": "The amount of padding (in px) along the bottom of the component.",
+                                "dflt": 0,
+                                "role": "style",
+                                "valType": "number"
+                            },
+                            "description": "Set the padding of the slider component along each side.",
+                            "l": {
+                                "description": "The amount of padding (in px) on the left side of the component.",
+                                "dflt": 0,
+                                "role": "style",
+                                "valType": "number"
+                            },
+                            "r": {
+                                "description": "The amount of padding (in px) on the right side of the component.",
+                                "dflt": 0,
+                                "role": "style",
+                                "valType": "number"
+                            },
+                            "role": "object",
+                            "t": {
+                                "description": "The amount of padding (in px) along the top of the component.",
+                                "dflt": 20,
+                                "role": "style",
+                                "valType": "number"
+                            }
+                        },
+                        "role": "object",
+                        "steps": {
+                            "items": {
+                                "step": {
+                                    "args": {
+                                        "description": "Sets the arguments values to be passed to the Plotly method set in `method` on slide.",
+                                        "freeLength": true,
+                                        "items": [
+                                            {
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "label": {
+                                        "description": "Sets the text label to appear on the slider",
+                                        "role": "info",
+                                        "valType": "string"
+                                    },
+                                    "method": {
+                                        "description": "Sets the Plotly method to be called when the slider value is changed.",
+                                        "dflt": "restyle",
+                                        "role": "info",
+                                        "valType": "enumerated",
+                                        "values": [
+                                            "restyle",
+                                            "relayout",
+                                            "animate",
+                                            "update"
+                                        ]
+                                    },
+                                    "role": "object",
+                                    "value": {
+                                        "description": "Sets the value of the slider step, used to refer to the step programatically. Defaults to the slider label if not provided.",
+                                        "role": "info",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
+                        "tickcolor": {
+                            "description": "Sets the color of the border enclosing the slider.",
+                            "dflt": "#333",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "ticklen": {
+                            "description": "Sets the length in pixels of step tick marks",
+                            "dflt": 7,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "tickwidth": {
+                            "description": "Sets the tick width (in px).",
+                            "dflt": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "transition": {
+                            "duration": {
+                                "description": "Sets the duration of the slider transition",
+                                "dflt": 150,
+                                "min": 0,
+                                "role": "info",
+                                "valType": "number"
+                            },
+                            "easing": {
+                                "description": "Sets the easing function of the slider transition",
+                                "dflt": "cubic-in-out",
+                                "role": "info",
+                                "valType": "enumerated",
+                                "values": [
+                                    "linear",
+                                    "quad",
+                                    "cubic",
+                                    "sin",
+                                    "exp",
+                                    "circle",
+                                    "elastic",
+                                    "back",
+                                    "bounce",
+                                    "linear-in",
+                                    "quad-in",
+                                    "cubic-in",
+                                    "sin-in",
+                                    "exp-in",
+                                    "circle-in",
+                                    "elastic-in",
+                                    "back-in",
+                                    "bounce-in",
+                                    "linear-out",
+                                    "quad-out",
+                                    "cubic-out",
+                                    "sin-out",
+                                    "exp-out",
+                                    "circle-out",
+                                    "elastic-out",
+                                    "back-out",
+                                    "bounce-out",
+                                    "linear-in-out",
+                                    "quad-in-out",
+                                    "cubic-in-out",
+                                    "sin-in-out",
+                                    "exp-in-out",
+                                    "circle-in-out",
+                                    "elastic-in-out",
+                                    "back-in-out",
+                                    "bounce-in-out"
+                                ]
+                            },
+                            "role": "object"
+                        },
+                        "visible": {
+                            "description": "Determines whether or not the slider is visible.",
+                            "dflt": true,
+                            "role": "info",
+                            "valType": "boolean"
+                        },
+                        "x": {
+                            "description": "Sets the x position (in normalized coordinates) of the slider.",
+                            "dflt": 0,
+                            "max": 3,
+                            "min": -2,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "xanchor": {
+                            "description": "Sets the slider's horizontal position anchor. This anchor binds the `x` position to the *left*, *center* or *right* of the range selector.",
+                            "dflt": "left",
+                            "role": "info",
+                            "valType": "enumerated",
+                            "values": [
+                                "auto",
+                                "left",
+                                "center",
+                                "right"
+                            ]
+                        },
+                        "y": {
+                            "description": "Sets the y position (in normalized coordinates) of the slider.",
+                            "dflt": 0,
+                            "max": 3,
+                            "min": -2,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "yanchor": {
+                            "description": "Sets the slider's vertical position anchor This anchor binds the `y` position to the *top*, *middle* or *bottom* of the range selector.",
+                            "dflt": "top",
+                            "role": "info",
+                            "valType": "enumerated",
+                            "values": [
+                                "auto",
+                                "top",
+                                "middle",
+                                "bottom"
+                            ]
                         }
-                    },
-                    "role": "object"
+                    }
                 },
-                "tickcolor": {
-                    "description": "Sets the color of the border enclosing the slider.",
-                    "dflt": "#333",
-                    "role": "style",
-                    "valType": "color"
-                },
-                "ticklen": {
-                    "description": "Sets the length in pixels of step tick marks",
-                    "dflt": 7,
-                    "min": 0,
-                    "role": "style",
-                    "valType": "number"
-                },
-                "tickwidth": {
-                    "description": "Sets the tick width (in px).",
-                    "dflt": 1,
-                    "min": 0,
-                    "role": "style",
-                    "valType": "number"
-                },
-                "transition": {
-                    "duration": {
-                        "description": "Sets the duration of the slider transition",
-                        "dflt": 150,
-                        "min": 0,
-                        "role": "info",
-                        "valType": "number"
-                    },
-                    "easing": {
-                        "description": "Sets the easing function of the slider transition",
-                        "dflt": "cubic-in-out",
-                        "role": "info",
-                        "valType": "enumerated",
-                        "values": [
-                            "linear",
-                            "quad",
-                            "cubic",
-                            "sin",
-                            "exp",
-                            "circle",
-                            "elastic",
-                            "back",
-                            "bounce",
-                            "linear-in",
-                            "quad-in",
-                            "cubic-in",
-                            "sin-in",
-                            "exp-in",
-                            "circle-in",
-                            "elastic-in",
-                            "back-in",
-                            "bounce-in",
-                            "linear-out",
-                            "quad-out",
-                            "cubic-out",
-                            "sin-out",
-                            "exp-out",
-                            "circle-out",
-                            "elastic-out",
-                            "back-out",
-                            "bounce-out",
-                            "linear-in-out",
-                            "quad-in-out",
-                            "cubic-in-out",
-                            "sin-in-out",
-                            "exp-in-out",
-                            "circle-in-out",
-                            "elastic-in-out",
-                            "back-in-out",
-                            "bounce-in-out"
-                        ]
-                    },
-                    "role": "object"
-                },
-                "visible": {
-                    "description": "Determines whether or not the slider is visible.",
-                    "dflt": true,
-                    "role": "info",
-                    "valType": "boolean"
-                },
-                "x": {
-                    "description": "Sets the x position (in normalized coordinates) of the slider.",
-                    "dflt": 0,
-                    "max": 3,
-                    "min": -2,
-                    "role": "style",
-                    "valType": "number"
-                },
-                "xanchor": {
-                    "description": "Sets the slider's horizontal position anchor. This anchor binds the `x` position to the *left*, *center* or *right* of the range selector.",
-                    "dflt": "left",
-                    "role": "info",
-                    "valType": "enumerated",
-                    "values": [
-                        "auto",
-                        "left",
-                        "center",
-                        "right"
-                    ]
-                },
-                "y": {
-                    "description": "Sets the y position (in normalized coordinates) of the slider.",
-                    "dflt": 0,
-                    "max": 3,
-                    "min": -2,
-                    "role": "style",
-                    "valType": "number"
-                },
-                "yanchor": {
-                    "description": "Sets the slider's vertical position anchor This anchor binds the `y` position to the *top*, *middle* or *bottom* of the range selector.",
-                    "dflt": "top",
-                    "role": "info",
-                    "valType": "enumerated",
-                    "values": [
-                        "auto",
-                        "top",
-                        "middle",
-                        "bottom"
-                    ]
-                }
+                "role": "object"
             },
             "smith": {
                 "dflt": false,
@@ -3355,8 +3510,7 @@
                         "valType": "color"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                        "dflt": 1,
+                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                         "role": "style",
                         "valType": "any"
                     },
@@ -3388,7 +3542,7 @@
                         "valType": "number"
                     },
                     "hoverformat": {
-                        "description": "Sets the hover text formatting rule for data values on this axis, using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -3482,10 +3636,9 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                        "dflt": 0,
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -3520,7 +3673,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -3625,8 +3778,7 @@
                         "valType": "color"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                        "dflt": 1,
+                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                         "role": "style",
                         "valType": "any"
                     },
@@ -3658,7 +3810,7 @@
                         "valType": "number"
                     },
                     "hoverformat": {
-                        "description": "Sets the hover text formatting rule for data values on this axis, using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -3752,10 +3904,9 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                        "dflt": 0,
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -3790,7 +3941,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -3901,8 +4052,7 @@
                         "valType": "color"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                        "dflt": 1,
+                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                         "role": "style",
                         "valType": "any"
                     },
@@ -3934,7 +4084,7 @@
                         "valType": "number"
                     },
                     "hoverformat": {
-                        "description": "Sets the hover text formatting rule for data values on this axis, using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -4028,10 +4178,9 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                        "dflt": 0,
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -4066,7 +4215,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -4527,8 +4676,7 @@
                     "valType": "info_array"
                 },
                 "dtick": {
-                    "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                    "dflt": 1,
+                    "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                     "role": "style",
                     "valType": "any"
                 },
@@ -4566,7 +4714,7 @@
                     "valType": "number"
                 },
                 "hoverformat": {
-                    "description": "Sets the hover text formatting rule for data values on this axis, using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                    "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                     "dflt": "",
                     "role": "style",
                     "valType": "string"
@@ -4623,13 +4771,13 @@
                     "valType": "number"
                 },
                 "range": {
-                    "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the date range from January 1st 1970 to November 4th, 2013, set the range from 0 to 1380844800000.0",
+                    "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
                     "items": [
                         {
-                            "valType": "number"
+                            "valType": "any"
                         },
                         {
-                            "valType": "number"
+                            "valType": "any"
                         }
                     ],
                     "role": "info",
@@ -4803,13 +4951,13 @@
                         "valType": "integer"
                     },
                     "range": {
-                        "description": "Sets the range of the range slider. If not set, defaults to the full xaxis range. If the axis `type` is *log*, then you must take the log of your desired range. If the axis `type` is *date*, then you must convert the date to unix time in milliseconds.",
+                        "description": "Sets the range of the range slider. If not set, defaults to the full xaxis range. If the axis `type` is *log*, then you must take the log of your desired range. If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "items": [
                             {
-                                "valType": "number"
+                                "valType": "any"
                             },
                             {
-                                "valType": "number"
+                                "valType": "any"
                             }
                         ],
                         "role": "info",
@@ -4903,10 +5051,9 @@
                     ]
                 },
                 "tick0": {
-                    "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                    "dflt": 0,
+                    "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                     "role": "style",
-                    "valType": "number"
+                    "valType": "any"
                 },
                 "tickangle": {
                     "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -4941,7 +5088,7 @@
                     }
                 },
                 "tickformat": {
-                    "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                    "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                     "dflt": "",
                     "role": "style",
                     "valType": "string"
@@ -5148,8 +5295,7 @@
                     "valType": "info_array"
                 },
                 "dtick": {
-                    "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                    "dflt": 1,
+                    "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                     "role": "style",
                     "valType": "any"
                 },
@@ -5187,7 +5333,7 @@
                     "valType": "number"
                 },
                 "hoverformat": {
-                    "description": "Sets the hover text formatting rule for data values on this axis, using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                    "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                     "dflt": "",
                     "role": "style",
                     "valType": "string"
@@ -5244,13 +5390,13 @@
                     "valType": "number"
                 },
                 "range": {
-                    "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the date range from January 1st 1970 to November 4th, 2013, set the range from 0 to 1380844800000.0",
+                    "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
                     "items": [
                         {
-                            "valType": "number"
+                            "valType": "any"
                         },
                         {
-                            "valType": "number"
+                            "valType": "any"
                         }
                     ],
                     "role": "info",
@@ -5266,191 +5412,6 @@
                         "tozero",
                         "nonnegative"
                     ]
-                },
-                "rangeselector": {
-                    "activecolor": {
-                        "description": "Sets the background color of the active range selector button.",
-                        "role": "style",
-                        "valType": "color"
-                    },
-                    "bgcolor": {
-                        "description": "Sets the background color of the range selector buttons.",
-                        "dflt": "#eee",
-                        "role": "style",
-                        "valType": "color"
-                    },
-                    "bordercolor": {
-                        "description": "Sets the color of the border enclosing the range selector.",
-                        "dflt": "#444",
-                        "role": "style",
-                        "valType": "color"
-                    },
-                    "borderwidth": {
-                        "description": "Sets the width (in px) of the border enclosing the range selector.",
-                        "dflt": 0,
-                        "min": 0,
-                        "role": "style",
-                        "valType": "number"
-                    },
-                    "buttons": {
-                        "items": {
-                            "button": {
-                                "count": {
-                                    "description": "Sets the number of steps to take to update the range. Use with `step` to specify the update interval.",
-                                    "dflt": 1,
-                                    "min": 0,
-                                    "role": "info",
-                                    "valType": "number"
-                                },
-                                "description": "Sets the specifications for each buttons. By default, a range selector comes with no buttons.",
-                                "label": {
-                                    "description": "Sets the text label to appear on the button.",
-                                    "role": "info",
-                                    "valType": "string"
-                                },
-                                "role": "object",
-                                "step": {
-                                    "description": "The unit of measurement that the `count` value will set the range by.",
-                                    "dflt": "month",
-                                    "role": "info",
-                                    "valType": "enumerated",
-                                    "values": [
-                                        "month",
-                                        "year",
-                                        "day",
-                                        "hour",
-                                        "minute",
-                                        "second",
-                                        "all"
-                                    ]
-                                },
-                                "stepmode": {
-                                    "description": "Sets the range update mode. If *backward*, the range update shifts the start of range back *count* times *step* milliseconds. If *todate*, the range update shifts the start of range back to the first timestamp from *count* times *step* milliseconds back. For example, with `step` set to *year* and `count` set to *1* the range update shifts the start of the range back to January 01 of the current year.",
-                                    "dflt": "backward",
-                                    "role": "info",
-                                    "valType": "enumerated",
-                                    "values": [
-                                        "backward",
-                                        "todate"
-                                    ]
-                                }
-                            }
-                        },
-                        "role": "object"
-                    },
-                    "font": {
-                        "color": {
-                            "role": "style",
-                            "valType": "color"
-                        },
-                        "description": "Sets the font of the range selector button text.",
-                        "family": {
-                            "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
-                            "noBlank": true,
-                            "role": "style",
-                            "strict": true,
-                            "valType": "string"
-                        },
-                        "role": "object",
-                        "size": {
-                            "min": 1,
-                            "role": "style",
-                            "valType": "number"
-                        }
-                    },
-                    "role": "object",
-                    "visible": {
-                        "description": "Determines whether or not this range selector is visible. Note that range selectors are only available for x axes of `type` set to or auto-typed to *date*.",
-                        "role": "info",
-                        "valType": "boolean"
-                    },
-                    "x": {
-                        "description": "Sets the x position (in normalized coordinates) of the range selector.",
-                        "max": 3,
-                        "min": -2,
-                        "role": "style",
-                        "valType": "number"
-                    },
-                    "xanchor": {
-                        "description": "Sets the range selector's horizontal position anchor. This anchor binds the `x` position to the *left*, *center* or *right* of the range selector.",
-                        "dflt": "left",
-                        "role": "info",
-                        "valType": "enumerated",
-                        "values": [
-                            "auto",
-                            "left",
-                            "center",
-                            "right"
-                        ]
-                    },
-                    "y": {
-                        "description": "Sets the y position (in normalized coordinates) of the range selector.",
-                        "max": 3,
-                        "min": -2,
-                        "role": "style",
-                        "valType": "number"
-                    },
-                    "yanchor": {
-                        "description": "Sets the range selector's vertical position anchor This anchor binds the `y` position to the *top*, *middle* or *bottom* of the range selector.",
-                        "dflt": "bottom",
-                        "role": "info",
-                        "valType": "enumerated",
-                        "values": [
-                            "auto",
-                            "top",
-                            "middle",
-                            "bottom"
-                        ]
-                    }
-                },
-                "rangeslider": {
-                    "bgcolor": {
-                        "description": "Sets the background color of the range slider.",
-                        "dflt": "#fff",
-                        "role": "style",
-                        "valType": "color"
-                    },
-                    "bordercolor": {
-                        "description": "Sets the border color of the range slider.",
-                        "dflt": "#444",
-                        "role": "style",
-                        "valType": "color"
-                    },
-                    "borderwidth": {
-                        "description": "Sets the border color of the range slider.",
-                        "dflt": 0,
-                        "min": 0,
-                        "role": "style",
-                        "valType": "integer"
-                    },
-                    "range": {
-                        "description": "Sets the range of the range slider. If not set, defaults to the full xaxis range. If the axis `type` is *log*, then you must take the log of your desired range. If the axis `type` is *date*, then you must convert the date to unix time in milliseconds.",
-                        "items": [
-                            {
-                                "valType": "number"
-                            },
-                            {
-                                "valType": "number"
-                            }
-                        ],
-                        "role": "info",
-                        "valType": "info_array"
-                    },
-                    "role": "object",
-                    "thickness": {
-                        "description": "The height of the range slider as a fraction of the total plot area height.",
-                        "dflt": 0.15,
-                        "max": 1,
-                        "min": 0,
-                        "role": "style",
-                        "valType": "number"
-                    },
-                    "visible": {
-                        "description": "Determines whether or not the range slider will be visible. If visible, perpendicular axes will be set to `fixedrange`",
-                        "dflt": true,
-                        "role": "info",
-                        "valType": "boolean"
-                    }
                 },
                 "role": "object",
                 "separatethousands": {
@@ -5524,10 +5485,9 @@
                     ]
                 },
                 "tick0": {
-                    "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                    "dflt": 0,
+                    "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                     "role": "style",
-                    "valType": "number"
+                    "valType": "any"
                 },
                 "tickangle": {
                     "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -5562,7 +5522,7 @@
                     }
                 },
                 "tickformat": {
-                    "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                    "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                     "dflt": "",
                     "role": "style",
                     "valType": "string"
@@ -6130,7 +6090,8 @@
                         "legendonly"
                     ]
                 }
-            }
+            },
+            "meta": {}
         },
         "bar": {
             "attributes": {
@@ -6451,8 +6412,7 @@
                             "valType": "number"
                         },
                         "dtick": {
-                            "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                            "dflt": 1,
+                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                             "role": "style",
                             "valType": "any"
                         },
@@ -6574,10 +6534,9 @@
                             ]
                         },
                         "tick0": {
-                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                            "dflt": 0,
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                             "role": "style",
-                            "valType": "number"
+                            "valType": "any"
                         },
                         "tickangle": {
                             "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -6612,7 +6571,7 @@
                             }
                         },
                         "tickformat": {
-                            "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                             "dflt": "",
                             "role": "style",
                             "valType": "string"
@@ -7025,7 +6984,6 @@
                     "valType": "string"
                 }
             },
-            "description": "The data visualized by the span of the bars is set in `y` if `orientation` is set th *v* (the default) and the labels are set in `x`. By setting `orientation` to *h*, the roles are interchanged.",
             "layoutAttributes": {
                 "bargap": {
                     "description": "Sets the gap (in plot fraction) between bars of adjacent location coordinates.",
@@ -7065,6 +7023,9 @@
                         "percent"
                     ]
                 }
+            },
+            "meta": {
+                "description": "The data visualized by the span of the bars is set in `y` if `orientation` is set th *v* (the default) and the labels are set in `x`. By setting `orientation` to *h*, the roles are interchanged."
             }
         },
         "box": {
@@ -7619,7 +7580,6 @@
                     "valType": "string"
                 }
             },
-            "description": "In vertical (horizontal) box plots, statistics are computed using `y` (`x`) values. By supplying an `x` (`y`) array, one box per distinct x (y) value is drawn If no `x` (`y`) {array} is provided, a single box is drawn. That box position is then positioned with with `name` or with `x0` (`y0`) if provided. Each box spans from quartile 1 (Q1) to quartile 3 (Q3). The second quartile (Q2) is marked by a line inside the box. By default, the whiskers correspond to the box' edges +/- 1.5 times the interquartile range (IQR = Q3-Q1), see *boxpoints* for other options.",
             "layoutAttributes": {
                 "boxgap": {
                     "description": "Sets the gap (in plot fraction) between boxes of adjacent location coordinates.",
@@ -7647,6 +7607,9 @@
                         "overlay"
                     ]
                 }
+            },
+            "meta": {
+                "description": "In vertical (horizontal) box plots, statistics are computed using `y` (`x`) values. By supplying an `x` (`y`) array, one box per distinct x (y) value is drawn If no `x` (`y`) {array} is provided, a single box is drawn. That box position is then positioned with with `name` or with `x0` (`y0`) if provided. Each box spans from quartile 1 (Q1) to quartile 3 (Q3). The second quartile (Q2) is marked by a line inside the box. By default, the whiskers correspond to the box' edges +/- 1.5 times the interquartile range (IQR = Q3-Q1), see *boxpoints* for other options."
             }
         },
         "candlestick": {
@@ -7896,7 +7859,9 @@
                     "valType": "subplotid"
                 }
             },
-            "description": "The candlestick is a style of financial chart describing open, high, low and close for a given `x` coordinate (most likely time). The boxes represent the spread between the `open` and `close` values and the lines represent the spread between the `low` and `high` values Sample points where the close value is higher (lower) then the open value are called increasing (decreasing). By default, increasing candles are drawn in green whereas decreasing are drawn in red."
+            "meta": {
+                "description": "The candlestick is a style of financial chart describing open, high, low and close for a given `x` coordinate (most likely time). The boxes represent the spread between the `open` and `close` values and the lines represent the spread between the `low` and `high` values Sample points where the close value is higher (lower) then the open value are called increasing (decreasing). By default, increasing candles are drawn in green whereas decreasing are drawn in red."
+            }
         },
         "choropleth": {
             "attributes": {
@@ -7927,8 +7892,7 @@
                         "valType": "number"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                        "dflt": 1,
+                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                         "role": "style",
                         "valType": "any"
                     },
@@ -8050,10 +8014,9 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                        "dflt": 0,
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -8088,7 +8051,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -8273,6 +8236,7 @@
                         "location",
                         "z",
                         "text",
+                        "name",
                         "name"
                     ],
                     "role": "info",
@@ -8439,7 +8403,9 @@
                     "valType": "string"
                 }
             },
-            "description": "The data that describes the choropleth value-to-color mapping is set in `z`. The geographic locations corresponding to each value in `z` are set in `locations`."
+            "meta": {
+                "description": "The data that describes the choropleth value-to-color mapping is set in `z`. The geographic locations corresponding to each value in `z` are set in `locations`."
+            }
         },
         "contour": {
             "attributes": {
@@ -8476,8 +8442,7 @@
                         "valType": "number"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                        "dflt": 1,
+                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                         "role": "style",
                         "valType": "any"
                     },
@@ -8599,10 +8564,9 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                        "dflt": 0,
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -8637,7 +8601,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -9101,7 +9065,9 @@
                     "valType": "string"
                 }
             },
-            "description": "The data from which contour lines are computed is set in `z`. Data in `z` must be a {2D array} of numbers. Say that `z` has N rows and M columns, then by default, these N rows correspond to N y coordinates (set in `y` or auto-generated) and the M columns correspond to M x coordinates (set in `x` or auto-generated). By setting `transpose` to *true*, the above behavior is flipped."
+            "meta": {
+                "description": "The data from which contour lines are computed is set in `z`. Data in `z` must be a {2D array} of numbers. Say that `z` has N rows and M columns, then by default, these N rows correspond to N y coordinates (set in `y` or auto-generated) and the M columns correspond to M x coordinates (set in `x` or auto-generated). By setting `transpose` to *true*, the above behavior is flipped."
+            }
         },
         "heatmap": {
             "attributes": {
@@ -9132,8 +9098,7 @@
                         "valType": "number"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                        "dflt": 1,
+                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                         "role": "style",
                         "valType": "any"
                     },
@@ -9255,10 +9220,9 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                        "dflt": 0,
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -9293,7 +9257,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -9700,7 +9664,9 @@
                     "valType": "string"
                 }
             },
-            "description": "The data that describes the heatmap value-to-color mapping is set in `z`. Data in `z` can either be a {2D array} of values (ragged or not) or a 1D array of values. In the case where `z` is a {2D array}, say that `z` has N rows and M columns. Then, by default, the resulting heatmap will have N partitions along the y axis and M partitions along the x axis. In other words, the i-th row/ j-th column cell in `z` is mapped to the i-th partition of the y axis (starting from the bottom of the plot) and the j-th partition of the x-axis (starting from the left of the plot). This behavior can be flipped by using `transpose`. Moreover, `x` (`y`) can be provided with M or M+1 (N or N+1) elements. If M (N), then the coordinates correspond to the center of the heatmap cells and the cells have equal width. If M+1 (N+1), then the coordinates correspond to the edges of the heatmap cells. In the case where `z` is a 1D {array}, the x and y coordinates must be provided in `x` and `y` respectively to form data triplets."
+            "meta": {
+                "description": "The data that describes the heatmap value-to-color mapping is set in `z`. Data in `z` can either be a {2D array} of values (ragged or not) or a 1D array of values. In the case where `z` is a {2D array}, say that `z` has N rows and M columns. Then, by default, the resulting heatmap will have N partitions along the y axis and M partitions along the x axis. In other words, the i-th row/ j-th column cell in `z` is mapped to the i-th partition of the y axis (starting from the bottom of the plot) and the j-th partition of the x-axis (starting from the left of the plot). This behavior can be flipped by using `transpose`. Moreover, `x` (`y`) can be provided with M or M+1 (N or N+1) elements. If M (N), then the coordinates correspond to the center of the heatmap cells and the cells have equal width. If M+1 (N+1), then the coordinates correspond to the edges of the heatmap cells. In the case where `z` is a 1D {array}, the x and y coordinates must be provided in `x` and `y` respectively to form data triplets."
+            }
         },
         "histogram": {
             "attributes": {
@@ -9717,13 +9683,13 @@
                 },
                 "autobinx": {
                     "description": "Determines whether or not the x axis bin attributes are picked by an algorithm. Note that this should be set to false if you want to manually set the number of bins using the attributes in xbins.",
-                    "dflt": true,
+                    "dflt": null,
                     "role": "style",
                     "valType": "boolean"
                 },
                 "autobiny": {
                     "description": "Determines whether or not the y axis bin attributes are picked by an algorithm. Note that this should be set to false if you want to manually set the number of bins using the attributes in ybins.",
-                    "dflt": true,
+                    "dflt": null,
                     "role": "style",
                     "valType": "boolean"
                 },
@@ -10035,8 +10001,7 @@
                             "valType": "number"
                         },
                         "dtick": {
-                            "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                            "dflt": 1,
+                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                             "role": "style",
                             "valType": "any"
                         },
@@ -10158,10 +10123,9 @@
                             ]
                         },
                         "tick0": {
-                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                            "dflt": 0,
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                             "role": "style",
-                            "valType": "number"
+                            "valType": "any"
                         },
                         "tickangle": {
                             "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -10196,7 +10160,7 @@
                             }
                         },
                         "tickformat": {
-                            "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                             "dflt": "",
                             "role": "style",
                             "valType": "string"
@@ -10549,12 +10513,12 @@
                         "description": "Sets the end value for the x axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "role": "object",
                     "size": {
                         "description": "Sets the step in-between value each x axis bin.",
-                        "dflt": 1,
+                        "dflt": null,
                         "role": "style",
                         "valType": "any"
                     },
@@ -10562,7 +10526,7 @@
                         "description": "Sets the starting value for the x axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     }
                 },
                 "xsrc": {
@@ -10586,12 +10550,12 @@
                         "description": "Sets the end value for the y axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "role": "object",
                     "size": {
                         "description": "Sets the step in-between value each y axis bin.",
-                        "dflt": 1,
+                        "dflt": null,
                         "role": "style",
                         "valType": "any"
                     },
@@ -10599,7 +10563,7 @@
                         "description": "Sets the starting value for the y axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     }
                 },
                 "ysrc": {
@@ -10608,7 +10572,6 @@
                     "valType": "string"
                 }
             },
-            "description": "The sample data from which statistics are computed is set in `x` for vertically spanning histograms and in `y` for horizontally spanning histograms. Binning options are set `xbins` and `ybins` respectively if no aggregation data is provided.",
             "layoutAttributes": {
                 "bargap": {
                     "description": "Sets the gap (in plot fraction) between bars of adjacent location coordinates.",
@@ -10648,19 +10611,22 @@
                         "percent"
                     ]
                 }
+            },
+            "meta": {
+                "description": "The sample data from which statistics are computed is set in `x` for vertically spanning histograms and in `y` for horizontally spanning histograms. Binning options are set `xbins` and `ybins` respectively if no aggregation data is provided."
             }
         },
         "histogram2d": {
             "attributes": {
                 "autobinx": {
                     "description": "Determines whether or not the x axis bin attributes are picked by an algorithm. Note that this should be set to false if you want to manually set the number of bins using the attributes in xbins.",
-                    "dflt": true,
+                    "dflt": null,
                     "role": "style",
                     "valType": "boolean"
                 },
                 "autobiny": {
                     "description": "Determines whether or not the y axis bin attributes are picked by an algorithm. Note that this should be set to false if you want to manually set the number of bins using the attributes in ybins.",
-                    "dflt": true,
+                    "dflt": null,
                     "role": "style",
                     "valType": "boolean"
                 },
@@ -10691,8 +10657,7 @@
                         "valType": "number"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                        "dflt": 1,
+                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                         "role": "style",
                         "valType": "any"
                     },
@@ -10814,10 +10779,9 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                        "dflt": 0,
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -10852,7 +10816,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -11178,12 +11142,12 @@
                         "description": "Sets the end value for the x axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "role": "object",
                     "size": {
                         "description": "Sets the step in-between value each x axis bin.",
-                        "dflt": 1,
+                        "dflt": null,
                         "role": "style",
                         "valType": "any"
                     },
@@ -11191,7 +11155,7 @@
                         "description": "Sets the starting value for the x axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     }
                 },
                 "xgap": {
@@ -11222,12 +11186,12 @@
                         "description": "Sets the end value for the y axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "role": "object",
                     "size": {
                         "description": "Sets the step in-between value each y axis bin.",
-                        "dflt": 1,
+                        "dflt": null,
                         "role": "style",
                         "valType": "any"
                     },
@@ -11235,7 +11199,7 @@
                         "description": "Sets the starting value for the y axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     }
                 },
                 "ygap": {
@@ -11290,20 +11254,22 @@
                     "valType": "string"
                 }
             },
-            "description": "The sample data from which statistics are computed is set in `x` and `y` (where `x` and `y` represent marginal distributions, binning is set in `xbins` and `ybins` in this case) or `z` (where `z` represent the 2D distribution and binning set, binning is set by `x` and `y` in this case). The resulting distribution is visualized as a heatmap.",
-            "hrName": "histogram_2d"
+            "meta": {
+                "description": "The sample data from which statistics are computed is set in `x` and `y` (where `x` and `y` represent marginal distributions, binning is set in `xbins` and `ybins` in this case) or `z` (where `z` represent the 2D distribution and binning set, binning is set by `x` and `y` in this case). The resulting distribution is visualized as a heatmap.",
+                "hrName": "histogram_2d"
+            }
         },
         "histogram2dcontour": {
             "attributes": {
                 "autobinx": {
                     "description": "Determines whether or not the x axis bin attributes are picked by an algorithm. Note that this should be set to false if you want to manually set the number of bins using the attributes in xbins.",
-                    "dflt": true,
+                    "dflt": null,
                     "role": "style",
                     "valType": "boolean"
                 },
                 "autobiny": {
                     "description": "Determines whether or not the y axis bin attributes are picked by an algorithm. Note that this should be set to false if you want to manually set the number of bins using the attributes in ybins.",
-                    "dflt": true,
+                    "dflt": null,
                     "role": "style",
                     "valType": "boolean"
                 },
@@ -11340,8 +11306,7 @@
                         "valType": "number"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                        "dflt": 1,
+                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                         "role": "style",
                         "valType": "any"
                     },
@@ -11463,10 +11428,9 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                        "dflt": 0,
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -11501,7 +11465,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -11909,12 +11873,12 @@
                         "description": "Sets the end value for the x axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "role": "object",
                     "size": {
                         "description": "Sets the step in-between value each x axis bin.",
-                        "dflt": 1,
+                        "dflt": null,
                         "role": "style",
                         "valType": "any"
                     },
@@ -11922,7 +11886,7 @@
                         "description": "Sets the starting value for the x axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     }
                 },
                 "xsrc": {
@@ -11946,12 +11910,12 @@
                         "description": "Sets the end value for the y axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "role": "object",
                     "size": {
                         "description": "Sets the step in-between value each y axis bin.",
-                        "dflt": 1,
+                        "dflt": null,
                         "role": "style",
                         "valType": "any"
                     },
@@ -11959,7 +11923,7 @@
                         "description": "Sets the starting value for the y axis bins.",
                         "dflt": null,
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     }
                 },
                 "ysrc": {
@@ -11996,8 +11960,10 @@
                     "valType": "string"
                 }
             },
-            "description": "The sample data from which statistics are computed is set in `x` and `y` (where `x` and `y` represent marginal distributions, binning is set in `xbins` and `ybins` in this case) or `z` (where `z` represent the 2D distribution and binning set, binning is set by `x` and `y` in this case). The resulting distribution is visualized as a contour plot.",
-            "hrName": "histogram_2d_contour"
+            "meta": {
+                "description": "The sample data from which statistics are computed is set in `x` and `y` (where `x` and `y` represent marginal distributions, binning is set in `xbins` and `ybins` in this case) or `z` (where `z` represent the 2D distribution and binning set, binning is set by `x` and `y` in this case). The resulting distribution is visualized as a contour plot.",
+                "hrName": "histogram_2d_contour"
+            }
         },
         "mesh3d": {
             "attributes": {
@@ -12033,8 +11999,7 @@
                         "valType": "number"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                        "dflt": 1,
+                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                         "role": "style",
                         "valType": "any"
                     },
@@ -12156,10 +12121,9 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                        "dflt": 0,
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -12194,7 +12158,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -12674,7 +12638,9 @@
                     "valType": "string"
                 }
             },
-            "description": "Draws sets of triangles with coordinates given by three 1-dimensional arrays in `x`, `y`, `z` and (1) a sets of `i`, `j`, `k` indices (2) Delaunay triangulation or (3) the Alpha-shape algorithm or (4) the Convex-hull algorithm"
+            "meta": {
+                "description": "Draws sets of triangles with coordinates given by three 1-dimensional arrays in `x`, `y`, `z` and (1) a sets of `i`, `j`, `k` indices (2) Delaunay triangulation or (3) the Alpha-shape algorithm or (4) the Convex-hull algorithm"
+            }
         },
         "ohlc": {
             "attributes": {
@@ -12955,7 +12921,9 @@
                     "valType": "subplotid"
                 }
             },
-            "description": "The ohlc (short for Open-High-Low-Close) is a style of financial chart describing open, high, low and close for a given `x` coordinate (most likely time). The tip of the lines represent the `low` and `high` values and the horizontal segments represent the `open` and `close` values. Sample points where the close value is higher (lower) then the open value are called increasing (decreasing). By default, increasing candles are drawn in green whereas decreasing are drawn in red."
+            "meta": {
+                "description": "The ohlc (short for Open-High-Low-Close) is a style of financial chart describing open, high, low and close for a given `x` coordinate (most likely time). The tip of the lines represent the `low` and `high` values and the horizontal segments represent the `open` and `close` values. Sample points where the close value is higher (lower) then the open value are called increasing (decreasing). By default, increasing candles are drawn in green whereas decreasing are drawn in red."
+            }
         },
         "pie": {
             "attributes": {
@@ -13310,7 +13278,6 @@
                     ]
                 }
             },
-            "description": "A data visualized by the sectors of the pie is set in `values`. The sector labels are set in `labels`. The sector colors are set in `marker.colors`",
             "layoutAttributes": {
                 "hiddenlabels": {
                     "role": "data",
@@ -13321,6 +13288,9 @@
                     "role": "info",
                     "valType": "string"
                 }
+            },
+            "meta": {
+                "description": "A data visualized by the sectors of the pie is set in `values`. The sector labels are set in `labels`. The sector colors are set in `marker.colors`"
             }
         },
         "pointcloud": {
@@ -13544,7 +13514,9 @@
                     "valType": "string"
                 }
             },
-            "description": "The data visualized as a point cloud set in `x` and `y` using the WebGl plotting engine."
+            "meta": {
+                "description": "The data visualized as a point cloud set in `x` and `y` using the WebGl plotting engine."
+            }
         },
         "scatter": {
             "attributes": {
@@ -13944,8 +13916,7 @@
                             "valType": "number"
                         },
                         "dtick": {
-                            "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                            "dflt": 1,
+                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                             "role": "style",
                             "valType": "any"
                         },
@@ -14067,10 +14038,9 @@
                             ]
                         },
                         "tick0": {
-                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                            "dflt": 0,
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                             "role": "style",
-                            "valType": "number"
+                            "valType": "any"
                         },
                         "tickangle": {
                             "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -14105,7 +14075,7 @@
                             }
                         },
                         "tickformat": {
-                            "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                             "dflt": "",
                             "role": "style",
                             "valType": "string"
@@ -14910,7 +14880,9 @@
                     "valType": "string"
                 }
             },
-            "description": "The scatter trace type encompasses line charts, scatter charts, text charts, and bubble charts. The data visualized as scatter point or lines is set in `x` and `y`. Text (appearing either on the chart or on hover only) is via `text`. Bubble charts are achieved by setting `marker.size` and/or `marker.color` to numerical arrays."
+            "meta": {
+                "description": "The scatter trace type encompasses line charts, scatter charts, text charts, and bubble charts. The data visualized as scatter point or lines is set in `x` and `y`. Text (appearing either on the chart or on hover only) is via `text`. Bubble charts are achieved by setting `marker.size` and/or `marker.color` to numerical arrays."
+            }
         },
         "scatter3d": {
             "attributes": {
@@ -15381,8 +15353,7 @@
                             "valType": "number"
                         },
                         "dtick": {
-                            "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                            "dflt": 1,
+                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                             "role": "style",
                             "valType": "any"
                         },
@@ -15504,10 +15475,9 @@
                             ]
                         },
                         "tick0": {
-                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                            "dflt": 0,
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                             "role": "style",
-                            "valType": "number"
+                            "valType": "any"
                         },
                         "tickangle": {
                             "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -15542,7 +15512,7 @@
                             }
                         },
                         "tickformat": {
-                            "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                             "dflt": "",
                             "role": "style",
                             "valType": "string"
@@ -16122,8 +16092,10 @@
                     "valType": "string"
                 }
             },
-            "description": "The data visualized as scatter point or lines in 3D dimension is set in `x`, `y`, `z`. Text (appearing either on the chart or on hover only) is via `text`. Bubble charts are achieved by setting `marker.size` and/or `marker.color` Projections are achieved via `projection`. Surface fills are achieved via `surfaceaxis`.",
-            "hrName": "scatter_3d"
+            "meta": {
+                "description": "The data visualized as scatter point or lines in 3D dimension is set in `x`, `y`, `z`. Text (appearing either on the chart or on hover only) is via `text`. Bubble charts are achieved by setting `marker.size` and/or `marker.color` Projections are achieved via `projection`. Surface fills are achieved via `surfaceaxis`.",
+                "hrName": "scatter_3d"
+            }
         },
         "scattergeo": {
             "attributes": {
@@ -16300,8 +16272,7 @@
                             "valType": "number"
                         },
                         "dtick": {
-                            "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                            "dflt": 1,
+                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                             "role": "style",
                             "valType": "any"
                         },
@@ -16423,10 +16394,9 @@
                             ]
                         },
                         "tick0": {
-                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                            "dflt": 0,
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                             "role": "style",
-                            "valType": "number"
+                            "valType": "any"
                         },
                         "tickangle": {
                             "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -16461,7 +16431,7 @@
                             }
                         },
                         "tickformat": {
-                            "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                             "dflt": "",
                             "role": "style",
                             "valType": "string"
@@ -17196,8 +17166,10 @@
                     ]
                 }
             },
-            "description": "The data visualized as scatter point or lines on a geographic map is provided either by longitude/latitude pairs in `lon` and `lat` respectively or by geographic location IDs or names in `locations`.",
-            "hrName": "scatter_geo"
+            "meta": {
+                "description": "The data visualized as scatter point or lines on a geographic map is provided either by longitude/latitude pairs in `lon` and `lat` respectively or by geographic location IDs or names in `locations`.",
+                "hrName": "scatter_geo"
+            }
         },
         "scattergl": {
             "attributes": {
@@ -17546,8 +17518,7 @@
                             "valType": "number"
                         },
                         "dtick": {
-                            "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                            "dflt": 1,
+                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                             "role": "style",
                             "valType": "any"
                         },
@@ -17669,10 +17640,9 @@
                             ]
                         },
                         "tick0": {
-                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                            "dflt": 0,
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                             "role": "style",
-                            "valType": "number"
+                            "valType": "any"
                         },
                         "tickangle": {
                             "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -17707,7 +17677,7 @@
                             }
                         },
                         "tickformat": {
-                            "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                             "dflt": "",
                             "role": "style",
                             "valType": "string"
@@ -18148,7 +18118,9 @@
                     "valType": "string"
                 }
             },
-            "description": "The data visualized as scatter point or lines is set in `x` and `y` using the WebGl plotting engine. Bubble charts are achieved by setting `marker.size` and/or `marker.color` to a numerical arrays."
+            "meta": {
+                "description": "The data visualized as scatter point or lines is set in `x` and `y` using the WebGl plotting engine. Bubble charts are achieved by setting `marker.size` and/or `marker.color` to a numerical arrays."
+            }
         },
         "scattermapbox": {
             "attributes": {
@@ -18185,6 +18157,7 @@
                         "lon",
                         "lat",
                         "text",
+                        "name",
                         "name"
                     ],
                     "role": "info",
@@ -18297,8 +18270,7 @@
                             "valType": "number"
                         },
                         "dtick": {
-                            "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                            "dflt": 1,
+                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                             "role": "style",
                             "valType": "any"
                         },
@@ -18420,10 +18392,9 @@
                             ]
                         },
                         "tick0": {
-                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                            "dflt": 0,
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                             "role": "style",
-                            "valType": "number"
+                            "valType": "any"
                         },
                         "tickangle": {
                             "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -18458,7 +18429,7 @@
                             }
                         },
                         "tickformat": {
-                            "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                             "dflt": "",
                             "role": "style",
                             "valType": "string"
@@ -18826,8 +18797,10 @@
                     ]
                 }
             },
-            "description": "The data visualized as scatter point, lines or marker symbols on a Mapbox GL geographic map is provided by longitude/latitude pairs in `lon` and `lat`.",
-            "hrName": "scatter_mapbox"
+            "meta": {
+                "description": "The data visualized as scatter point, lines or marker symbols on a Mapbox GL geographic map is provided by longitude/latitude pairs in `lon` and `lat`.",
+                "hrName": "scatter_mapbox"
+            }
         },
         "scatterternary": {
             "attributes": {
@@ -19015,8 +18988,7 @@
                             "valType": "number"
                         },
                         "dtick": {
-                            "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                            "dflt": 1,
+                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                             "role": "style",
                             "valType": "any"
                         },
@@ -19138,10 +19110,9 @@
                             ]
                         },
                         "tick0": {
-                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                            "dflt": 0,
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                             "role": "style",
-                            "valType": "number"
+                            "valType": "any"
                         },
                         "tickangle": {
                             "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -19176,7 +19147,7 @@
                             }
                         },
                         "tickformat": {
-                            "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                             "dflt": "",
                             "role": "style",
                             "valType": "string"
@@ -19931,8 +19902,10 @@
                     ]
                 }
             },
-            "description": "Provides similar functionality to the *scatter* type but on a ternary phase diagram. The data is provided by at least two arrays out of `a`, `b`, `c` triplets.",
-            "hrName": "scatter_ternary"
+            "meta": {
+                "description": "Provides similar functionality to the *scatter* type but on a ternary phase diagram. The data is provided by at least two arrays out of `a`, `b`, `c` triplets.",
+                "hrName": "scatter_ternary"
+            }
         },
         "surface": {
             "attributes": {
@@ -20001,8 +19974,7 @@
                         "valType": "number"
                     },
                     "dtick": {
-                        "description": "Sets the step in-between ticks on this axis Use with `tick0`. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0.",
-                        "dflt": 1,
+                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
                         "role": "style",
                         "valType": "any"
                     },
@@ -20124,10 +20096,9 @@
                         ]
                     },
                     "tick0": {
-                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2). If the axis `type` is *date*, then you must convert the date to unix time in milliseconds (the number of milliseconds since January 1st, 1970). For example, to set the starting tick to November 4th, 2013, set the range to 1380844800000.0.",
-                        "dflt": 0,
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "role": "style",
-                        "valType": "number"
+                        "valType": "any"
                     },
                     "tickangle": {
                         "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
@@ -20162,7 +20133,7 @@
                         }
                     },
                     "tickformat": {
-                        "description": "Sets the tick label formatting rule using the python/d3 number formatting language. See https://github.com/mbostock/d3/wiki/Formatting#numbers or https://docs.python.org/release/3.1.3/library/string.html#formatspec for more info.",
+                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                         "dflt": "",
                         "role": "style",
                         "valType": "string"
@@ -20765,7 +20736,9 @@
                     "valType": "string"
                 }
             },
-            "description": "The data the describes the coordinates of the surface is set in `z`. Data in `z` should be a {2D array}. Coordinates in `x` and `y` can either be 1D {arrays} or {2D arrays} (e.g. to graph parametric surfaces). If not provided in `x` and `y`, the x and y coordinates are assumed to be linear starting at 0 with a unit step. The color scale corresponds to the `z` values by default. For custom color scales, use `surfacecolor` which should be a {2D array}, where its bounds can be controlled using `cmin` and `cmax`."
+            "meta": {
+                "description": "The data the describes the coordinates of the surface is set in `z`. Data in `z` should be a {2D array}. Coordinates in `x` and `y` can either be 1D {arrays} or {2D arrays} (e.g. to graph parametric surfaces). If not provided in `x` and `y`, the x and y coordinates are assumed to be linear starting at 0 with a unit step. The color scale corresponds to the `z` values by default. For custom color scales, use `surfacecolor` which should be a {2D array}, where its bounds can be controlled using `cmin` and `cmax`."
+            }
         }
     },
     "transforms": {

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -309,8 +309,12 @@ def iplot(figure_or_data, show_link=True, link_text='Export to plot.ly',
     if not tools._ipython_imported:
         raise ImportError('`iplot` can only run inside an IPython Notebook.')
 
+    config = {}
+    config['showLink'] = show_link
+    config['linkText'] = link_text
+
     plot_html, plotdivid, width, height = _plot_html(
-        figure_or_data, {}, validate, '100%', 525, True
+        figure_or_data, config, validate, '100%', 525, True
     )
 
     display(HTML(plot_html))
@@ -406,6 +410,10 @@ def plot(figure_or_data,
             "Your filename `" + filename + "` didn't end with .html. "
             "Adding .html to the end of your file.")
         filename += '.html'
+
+    config = {}
+    config['showLink'] = show_link
+    config['linkText'] = link_text
 
     plot_html, plotdivid, width, height = _plot_html(
         figure_or_data, config, validate,

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -408,7 +408,7 @@ def plot(figure_or_data,
         filename += '.html'
 
     plot_html, plotdivid, width, height = _plot_html(
-        figure_or_data, show_link, link_text, validate,
+        figure_or_data, config, validate,
         '100%', '100%', global_requirejs=False)
 
     resize_script = ''

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -187,35 +187,30 @@ def _plot_html(figure_or_data, config, validate, default_width,
     jlayout = json.dumps(figure.get('layout', {}), cls=utils.PlotlyJSONEncoder)
 
     configkeys = (
-    'editable',
-    'autosizable',
-    'fillFrame',
-    'frameMargins',
-    'scrollZoom',
-    'doubleClick',
-    'showTips',
-    'showLink',
-    'sendData',
-    'linkText',
-    'showSources',
-    'displayModeBar',
-    'modeBarButtonsToRemove',
-    'modeBarButtonsToAdd',
-    'modeBarButtons',
-    'displaylogo',
-    'plotGlPixelRatio',
-    'setBackground',
-    'topojsonURL')
+        'editable',
+        'autosizable',
+        'fillFrame',
+        'frameMargins',
+        'scrollZoom',
+        'doubleClick',
+        'showTips',
+        'showLink',
+        'sendData',
+        'linkText',
+        'showSources',
+        'displayModeBar',
+        'modeBarButtonsToRemove',
+        'modeBarButtonsToAdd',
+        'modeBarButtons',
+        'displaylogo',
+        'plotGlPixelRatio',
+        'setBackground',
+        'topojsonURL'
+    )
 
-    config_clean = dict((k,config[k]) for k in configkeys if k in config)
+    config_clean = dict((k, config[k]) for k in configkeys if k in config)
 
     jconfig = json.dumps(config_clean)
-
-    #config = {}
-    #config['showLink'] = show_link
-    #config['linkText'] = link_text
-    #jconfig = json.dumps(config)
-    #print jconfig
 
     # TODO: The get_config 'source of truth' should
     # really be somewhere other than plotly.plotly
@@ -314,19 +309,9 @@ def iplot(figure_or_data, show_link=True, link_text='Export to plot.ly',
     if not tools._ipython_imported:
         raise ImportError('`iplot` can only run inside an IPython Notebook.')
 
-    #plot_html, plotdivid, width, height = _plot_html(
-    #    figure_or_data, show_link, link_text, validate,
-    #    '100%', 525, global_requirejs=True)
-
     plot_html, plotdivid, width, height = _plot_html(
-        figure_or_data=figure_or_data,
-        config={},
-        #show_link,
-        #link_text,
-        validate=validate,
-        default_width='100%',
-        default_height=525,
-        global_requirejs=True)
+        figure_or_data, {}, validate, '100%', 525, True
+    )
 
     display(HTML(plot_html))
 
@@ -337,10 +322,10 @@ def iplot(figure_or_data, show_link=True, link_text='Export to plot.ly',
                              )
         # if image is given, and is a valid format, we will download the image
         script = get_image_download_script('iplot').format(format=image,
-                                                       width=image_width,
-                                                       height=image_height,
-                                                       filename=filename,
-                                                       plot_id=plotdivid)
+                                                           width=image_width,
+                                                           height=image_height,
+                                                           filename=filename,
+                                                           plot_id=plotdivid)
         # allow time for the plot to draw
         time.sleep(1)
         # inject code to download an image of the plot

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -211,6 +211,12 @@ def _plot_html(figure_or_data, config, validate, default_width,
 
     jconfig = json.dumps(config_clean)
 
+    #config = {}
+    #config['showLink'] = show_link
+    #config['linkText'] = link_text
+    #jconfig = json.dumps(config)
+    #print jconfig
+
     # TODO: The get_config 'source of truth' should
     # really be somewhere other than plotly.plotly
     plotly_platform_url = plotly.plotly.get_config().get('plotly_domain',
@@ -308,9 +314,19 @@ def iplot(figure_or_data, show_link=True, link_text='Export to plot.ly',
     if not tools._ipython_imported:
         raise ImportError('`iplot` can only run inside an IPython Notebook.')
 
+    #plot_html, plotdivid, width, height = _plot_html(
+    #    figure_or_data, show_link, link_text, validate,
+    #    '100%', 525, global_requirejs=True)
+
     plot_html, plotdivid, width, height = _plot_html(
-        figure_or_data, show_link, link_text, validate,
-        '100%', 525, global_requirejs=True)
+        figure_or_data=figure_or_data,
+        config={},
+        #show_link,
+        #link_text,
+        validate=validate,
+        default_width='100%',
+        default_height=525,
+        global_requirejs=True)
 
     display(HTML(plot_html))
 

--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -210,7 +210,6 @@ def plot(figure_or_data, validate=True, **plot_options):
 
     """
     figure = tools.return_figure_from_figure_or_data(figure_or_data, validate)
-
     for entry in figure['data']:
         if ('type' in entry) and (entry['type'] == 'scattergl'):
             continue
@@ -499,7 +498,7 @@ class Stream:
                 "cannot write to a closed connection. "
                 "Call `open()` on the stream to open the stream."
             )
-   
+
     @property
     def connected(self):
         if self._stream is None:
@@ -1400,10 +1399,14 @@ def add_share_key_to_url(plot_url, attempt=0):
 
 
 def _send_to_plotly(figure, **plot_options):
-    """
-
-    """
     fig = tools._replace_newline(figure)  # does not mutate figure
+
+    # replace '/' with ':' for errorless response
+    if 'data' in fig:
+        for item in fig['data']:
+            for key in ['xsrc', 'ysrc']:
+                item[key] = item[key].replace('/', ':')
+
     data = json.dumps(fig['data'] if 'data' in fig else [],
                       cls=utils.PlotlyJSONEncoder)
     credentials = get_credentials()
@@ -1414,8 +1417,7 @@ def _send_to_plotly(figure, **plot_options):
                              fileopt=plot_options['fileopt'],
                              world_readable=plot_options['world_readable'],
                              sharing=plot_options['sharing'],
-                             layout=fig['layout'] if 'layout' in fig
-                             else {}),
+                             layout=fig['layout'] if 'layout' in fig else {}),
                         cls=utils.PlotlyJSONEncoder)
 
     # TODO: It'd be cool to expose the platform for RaspPi and others

--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -868,7 +868,7 @@ class grid_ops:
         for req_col in request_columns:
             for resp_col in response_columns:
                 if resp_col['name'] == req_col.name:
-                    req_col.id = '{0}/{1}'.format(grid_id, resp_col['uid'])
+                    req_col.id = '{0}:{1}'.format(grid_id, resp_col['uid'])
                     response_columns.remove(resp_col)
 
     @classmethod

--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -1400,13 +1400,6 @@ def add_share_key_to_url(plot_url, attempt=0):
 
 def _send_to_plotly(figure, **plot_options):
     fig = tools._replace_newline(figure)  # does not mutate figure
-
-    # replace '/' with ':' for errorless response
-    #if 'data' in fig:
-    #    for item in fig['data']:
-    #        for key in ['xsrc', 'ysrc']:
-    #            item[key] = item[key].replace('/', ':')
-
     data = json.dumps(fig['data'] if 'data' in fig else [],
                       cls=utils.PlotlyJSONEncoder)
     credentials = get_credentials()

--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -1402,10 +1402,10 @@ def _send_to_plotly(figure, **plot_options):
     fig = tools._replace_newline(figure)  # does not mutate figure
 
     # replace '/' with ':' for errorless response
-    if 'data' in fig:
-        for item in fig['data']:
-            for key in ['xsrc', 'ysrc']:
-                item[key] = item[key].replace('/', ':')
+    #if 'data' in fig:
+    #    for item in fig['data']:
+    #        for key in ['xsrc', 'ysrc']:
+    #            item[key] = item[key].replace('/', ':')
 
     data = json.dumps(fig['data'] if 'data' in fig else [],
                       cls=utils.PlotlyJSONEncoder)

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -6140,9 +6140,9 @@ class FigureFactory(object):
         return graph_objs.Figure(data=data, layout=layout)
 
     @staticmethod
-    def create_dendrogram(X, orientation="bottom", labels=None,
-                          colorscale=None, distfun=scs.distance.pdist,
-                          linkagefun=lambda x: sch.linkage(x, 'complete')):
+    def create_dendrogram(X, orientation="bottom", labels=None, 
+                          colorscale=None, distfun=2,
+                          linkagefun=lambda x: sch.linkage(x, 'complete')): #scs.distance.pdist,
         """
         BETA function that returns a dendrogram Plotly figure object.
 
@@ -6207,6 +6207,8 @@ class FigureFactory(object):
         s = X.shape
         if len(s) != 2:
             exceptions.PlotlyError("X should be 2-dimensional array.")
+
+        distfun = scs.distance.pdist
 
         dendrogram = _Dendrogram(X, orientation, labels, colorscale,
                                  distfun=distfun, linkagefun=linkagefun)

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -6141,7 +6141,7 @@ class FigureFactory(object):
 
     @staticmethod
     def create_dendrogram(X, orientation="bottom", labels=None,
-                          colorscale=None, distfun=2,
+                          colorscale=None, distfun=None,
                           linkagefun=lambda x: sch.linkage(x, 'complete')):
         """
         BETA function that returns a dendrogram Plotly figure object.
@@ -7139,7 +7139,7 @@ class _Dendrogram(FigureFactory):
 
     def __init__(self, X, orientation='bottom', labels=None, colorscale=None,
                  width="100%", height="100%", xaxis='xaxis', yaxis='yaxis',
-                 distfun=scs.distance.pdist, linkagefun=lambda x: sch.linkage(x, 'complete')):
+                 distfun=None, linkagefun=lambda x: sch.linkage(x, 'complete')):
         # TODO: protected until #282
         from plotly.graph_objs import graph_objs
         self.orientation = orientation
@@ -7160,6 +7160,7 @@ class _Dendrogram(FigureFactory):
             self.sign[self.yaxis] = 1
         else:
             self.sign[self.yaxis] = -1
+        distfun = scs.distance.pdist
 
         (dd_traces, xvals, yvals,
             ordered_labels, leaves) = self.get_dendrogram_traces(X, colorscale, distfun, linkagefun)

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -6140,9 +6140,9 @@ class FigureFactory(object):
         return graph_objs.Figure(data=data, layout=layout)
 
     @staticmethod
-    def create_dendrogram(X, orientation="bottom", labels=None, 
+    def create_dendrogram(X, orientation="bottom", labels=None,
                           colorscale=None, distfun=2,
-                          linkagefun=lambda x: sch.linkage(x, 'complete')): #scs.distance.pdist,
+                          linkagefun=lambda x: sch.linkage(x, 'complete')):
         """
         BETA function that returns a dendrogram Plotly figure object.
 

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -90,7 +90,6 @@ except ImportError:
 
 try:
     import scipy as scp
-    import scipy.stats
     _scipy_imported = True
 except ImportError:
     _scipy_imported = False
@@ -107,12 +106,12 @@ try:
 except ImportError:
     _scipy__cluster__hierarchy_imported = False
 
-#try:
-#    import scipy
-#    import scipy.stats
-#    _scipy_imported = True
-#except ImportError:
-#    _scipy_imported = False
+try:
+    import scipy
+    import scipy.stats
+    _scipy_imported = True
+except ImportError:
+    _scipy_imported = False
 
 
 def get_config_defaults():

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -90,6 +90,7 @@ except ImportError:
 
 try:
     import scipy as scp
+    import scipy.stats
     _scipy_imported = True
 except ImportError:
     _scipy_imported = False
@@ -106,12 +107,12 @@ try:
 except ImportError:
     _scipy__cluster__hierarchy_imported = False
 
-try:
-    import scipy
-    import scipy.stats
-    _scipy_imported = True
-except ImportError:
-    _scipy_imported = False
+#try:
+#    import scipy
+#    import scipy.stats
+#    _scipy_imported = True
+#except ImportError:
+#    _scipy_imported = False
 
 
 def get_config_defaults():
@@ -6137,7 +6138,6 @@ class FigureFactory(object):
 
         data = sum(data, [])
         return graph_objs.Figure(data=data, layout=layout)
-
 
     @staticmethod
     def create_dendrogram(X, orientation="bottom", labels=None,

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -6208,7 +6208,8 @@ class FigureFactory(object):
         if len(s) != 2:
             exceptions.PlotlyError("X should be 2-dimensional array.")
 
-        distfun = scs.distance.pdist
+        if distfun is None:
+            distfun = scs.distance.pdist
 
         dendrogram = _Dendrogram(X, orientation, labels, colorscale,
                                  distfun=distfun, linkagefun=linkagefun)
@@ -7160,7 +7161,9 @@ class _Dendrogram(FigureFactory):
             self.sign[self.yaxis] = 1
         else:
             self.sign[self.yaxis] = -1
-        distfun = scs.distance.pdist
+
+        if distfun is None:
+            distfun = scs.distance.pdist
 
         (dd_traces, xvals, yvals,
             ordered_labels, leaves) = self.get_dendrogram_traces(X, colorscale, distfun, linkagefun)


### PR DESCRIPTION
Re iplot issue brought up in https://github.com/plotly/plotly.py/issues/593#issuecomment-257392993

Fixed by just removing the unnecessary `show_link` and `link_text` from the `_plot_html()` call in [this line](https://github.com/plotly/plotly.py/blob/master/plotly/offline/offline.py#L312).

`plot()` looks fine as it has `show_link` and `link_text` in the signature.