### PR TITLE
fixing config bug in #589

### DIFF
--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -308,8 +308,9 @@ def iplot(figure_or_data, show_link=True, link_text='Export to plot.ly',
     if not tools._ipython_imported:
         raise ImportError('`iplot` can only run inside an IPython Notebook.')
 
+    config = {'showLink': show_link, 'linkText': link_text}
     plot_html, plotdivid, width, height = _plot_html(
-        figure_or_data, show_link, link_text, validate,
+        figure_or_data, config, validate,
         '100%', 525, global_requirejs=True)
 
     display(HTML(plot_html))
@@ -406,8 +407,9 @@ def plot(figure_or_data,
             "Adding .html to the end of your file.")
         filename += '.html'
 
+    config = {'showLink': show_link, 'linkText': link_text}
     plot_html, plotdivid, width, height = _plot_html(
-        figure_or_data, show_link, link_text, validate,
+        figure_or_data, config, validate,
         '100%', '100%', global_requirejs=False)
 
     resize_script = ''


### PR DESCRIPTION
#589 changed the argument signature of `_plot_html`.  This PR fixes the two calls to that function.

See https://github.com/plotly/plotly.py/issues/399#issuecomment-258153104