### PR TITLE
Better error messages for (i)create_animations

### DIFF
--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -1586,15 +1586,15 @@ def create_animations(figure, filename=None, sharing='public', auto_open=True):
 
     api_url = _api_v2.api_url('plots')
     r = requests.post(api_url, auth=auth, headers=headers, json=json)
-    r.raise_for_status()
 
     try:
         parsed_response = r.json()
     except:
         parsed_response = r.content
 
-    if 'error' in r and r['error'] != '':
-        raise exceptions.PlotlyError(r['error'])
+    # raise error message
+    if r.ok is False:
+        raise exceptions.PlotlyError(parsed_response['errors'][-1]['message'])
 
     if sharing == 'secret':
         web_url = (parsed_response['file']['web_url'][:-1] +

--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -1593,8 +1593,17 @@ def create_animations(figure, filename=None, sharing='public', auto_open=True):
         parsed_response = r.content
 
     # raise error message
-    if r.ok is False:
-        raise exceptions.PlotlyError(parsed_response['errors'][-1]['message'])
+    if not r.ok:
+        message = ''
+        if isinstance(parsed_response, dict):
+            errors = parsed_response.get('errors')
+            if errors and errors[-1].get('message'):
+                message = errors[-1]['message']
+        if message:
+            raise exceptions.PlotlyError(message)
+        else:
+            # shucks, we're stuck with a generic error...
+            r.raise_for_status()
 
     if sharing == 'secret':
         web_url = (parsed_response['file']['web_url'][:-1] +


### PR DESCRIPTION
Regarding Chris' suggestion here: https://github.com/plotly/plotly.py/pull/584#discussion_r89549480

Haven't tested all of the ways in which a request can fail, mostly because most of the `not done` ones I don't know how to test (i.e. `Request was Throttled`, `Server was Down`) Yes, I said _most_ when we're talking about 2 of the 3 on the list. :slightly_smiling_face: 

- [x] A File already exists with this name
- [x] API key wasn't correct
- [x] API key wasn't supplied
- [x] User was offline
- [x] Permission denied (can't save the file as private)
- [ ]  Request was throttled
- [ ] ~Figure was malformed~
- [ ] Server was down