### PR TITLE
Python26 support

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
   environment:
 
     PLOTLY_CONFIG_DIR: ${HOME}/.plotly
-    TOX_TESTENV_PASSENV: PLOTLY_TOX_*
+    PLOTLY_TOX_PYTHON_26: /home/ubuntu/.pyenv/versions/2.6.8/bin/python2.6
     PLOTLY_TOX_PYTHON_27: /home/ubuntu/.pyenv/versions/2.7.10/bin/python2.7
     PLOTLY_TOX_PYTHON_33: /home/ubuntu/.pyenv/versions/3.3.3/bin/python3.3
     PLOTLY_TOX_PYTHON_34: /home/ubuntu/.pyenv/versions/3.4.3/bin/python3.4

--- a/plotly/graph_objs/graph_objs.py
+++ b/plotly/graph_objs/graph_objs.py
@@ -370,7 +370,7 @@ class PlotlyDict(dict, PlotlyBase):
             self['type'] = self._name
 
         # force key-value pairs to go through validation
-        d = {key: val for key, val in dict(*args, **kwargs).items()}
+        d = dict((key, val) for key, val in dict(*args, **kwargs).items())
         for key, val in d.items():
             self.__setitem__(key, val, _raise=_raise)
 

--- a/plotly/graph_objs/graph_objs_tools.py
+++ b/plotly/graph_objs/graph_objs_tools.py
@@ -115,12 +115,12 @@ def _dict_attribute_help(object_name, path, parent_object_names, attribute):
             if object_name in trace_names and attribute == 'type':
                 d = {'role': 'info'}
             else:
-                d = {k: v for k, v in attribute_dict[attribute].items()
-                     if k in meta_keys and not k.startswith('_')}
+                d = dict((k, v) for k, v in attribute_dict[attribute].items()
+                         if k in meta_keys and not k.startswith('_'))
         elif attribute in attribute_dict.get('_deprecated', {}):
             deprecate_attribute_dict = attribute_dict['_deprecated'][attribute]
-            d = {k: v for k, v in deprecate_attribute_dict.items()
-                 if k in meta_keys and not k.startswith('_')}
+            d = dict((k, v) for k, v in deprecate_attribute_dict.items()
+                     if k in meta_keys and not k.startswith('_'))
             d['deprecated'] = True
         else:
             continue

--- a/plotly/graph_reference.py
+++ b/plotly/graph_reference.py
@@ -86,8 +86,8 @@ def get_graph_reference():
 
     sha1 = hashlib.sha1(six.b(str(graph_reference))).hexdigest()
 
-    graph_reference_url = '{}{}?sha1={}'.format(plotly_api_domain,
-                                                GRAPH_REFERENCE_PATH, sha1)
+    graph_reference_url = plotly_api_domain + GRAPH_REFERENCE_PATH + \
+        "?sha1=" + sha1
     try:
         response = requests.get(graph_reference_url,
                                 timeout=GRAPH_REFERENCE_DOWNLOAD_TIMEOUT)
@@ -184,8 +184,8 @@ def get_attributes_dicts(object_name, parent_object_names=()):
 
     # We return a dict mapping paths to attributes. We also add in additional
     # attributes if defined.
-    attributes_dicts = {path: utils.get_by_path(GRAPH_REFERENCE, path)
-                  for path in attribute_paths}
+    attributes_dicts = dict((path, utils.get_by_path(GRAPH_REFERENCE, path))
+                            for path in attribute_paths)
     attributes_dicts['additional_attributes'] = additional_attributes
 
     return attributes_dicts
@@ -525,6 +525,6 @@ _patch_arrays()
 
 CLASSES = _get_classes()
 
-OBJECT_NAME_TO_CLASS_NAME = {class_dict['object_name']: class_name
-                             for class_name, class_dict in CLASSES.items()
-                             if class_dict['object_name'] is not None}
+OBJECT_NAME_TO_CLASS_NAME = dict((class_dict['object_name'], class_name)
+                                 for class_name, class_dict in CLASSES.items()
+                                 if class_dict['object_name'] is not None)

--- a/plotly/plotly/__init__.py
+++ b/plotly/plotly/__init__.py
@@ -7,7 +7,7 @@ local machine and Plotly. Almost all functionality used here will require a
 verifiable account (username/api-key pair) and a network connection.
 
 """
-from . plotly import (
+from .plotly import (
     sign_in,
     update_plot_options,
     get_credentials,

--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -112,8 +112,8 @@ def _plot_option_logic(plot_options_from_call_signature):
     user_plot_options.update(file_options)
     user_plot_options.update(session_options)
     user_plot_options.update(plot_options_from_call_signature)
-    user_plot_options = {k: v for k, v in user_plot_options.items()
-                         if k in default_plot_options}
+    user_plot_options = dict((k, v) for k, v in user_plot_options.items()
+                             if k in default_plot_options)
 
     return user_plot_options
 

--- a/plotly/utils.py
+++ b/plotly/utils.py
@@ -58,7 +58,7 @@ def load_json_dict(filename, *args):
                 data = {}  # TODO: issue a warning and bubble it up
         lock.release()
         if args:
-            return {key: data[key] for key in args if key in data}
+            return dict((key, data[key]) for key in args if key in data)
     return data
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@
 [tox]
 ; The py{A,B,C}-{X,Y} generates a matrix of envs:
 ;   pyA-X,pyA-Y,pyB-X,pyB-Y,pyC-X,pyC-Y
-envlist = py{27,34,35}-{core,optional},py33-core
+envlist = py{27,34,35}-{core,optional},py26-core,py33-core
 
 ; Note that envs can be targeted by deps using the <target>: dep syntax.
 ; Only one dep is allowed per line as of the time of writing. The <target>
@@ -62,6 +62,12 @@ deps=
     optional: scipy==0.18.1
 
 ; CORE ENVIRONMENTS
+[testenv:py26-core]
+basepython={env:PLOTLY_TOX_PYTHON_26:}
+commands=
+    python --version
+    nosetests {posargs} -x plotly/tests/test_core
+
 [testenv:py27-core]
 basepython={env:PLOTLY_TOX_PYTHON_27:}
 commands=


### PR DESCRIPTION
@casperdcl Here you go :)

If you can get this to pass, I'll be happy to merge it in. The current error is `OrderedDict` support You'll need to add `ordereddict` as a dep for 2.6, I believe and manage the imports.

I don't care to add `optional` support for Python 2.6, just the same `core` support we have for `Python 3.3`. Good luck!