### PR TITLE
Improve `frames` support in graph_objs.py.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Updated
 - `plotly.plotly.create_animations` and `plotly.plotly.icreate_animations` now return appropriate error messages if the response is not successful.
+- `frames` are now integrated into GRAPH_REFERENCE and figure validation.
 
 ### Changed
 - The plot-schema from `https://api.plot.ly/plot-schema` is no longer updated on import.

--- a/plotly/graph_objs/graph_objs_tools.py
+++ b/plotly/graph_objs/graph_objs_tools.py
@@ -35,8 +35,14 @@ def get_help(object_name, path=(), parent_object_names=(), attribute=None):
 def _list_help(object_name, path=(), parent_object_names=()):
     """See get_help()."""
     items = graph_reference.ARRAYS[object_name]['items']
-    items_classes = [graph_reference.string_to_class_name(item)
-                     for item in items]
+    items_classes = set()
+    for item in items:
+        if item in graph_reference.OBJECT_NAME_TO_CLASS_NAME:
+            items_classes.add(graph_reference.string_to_class_name(item))
+        else:
+            # There are no lists objects which can contain list entries.
+            items_classes.add('dict')
+    items_classes = list(items_classes)
     items_classes.sort()
     lines = textwrap.wrap(repr(items_classes), width=LINE_SIZE-TAB_SIZE-1)
 

--- a/plotly/graph_reference.py
+++ b/plotly/graph_reference.py
@@ -33,7 +33,7 @@ _BACKWARDS_COMPAT_CLASS_NAMES = {
     'ErrorZ': {'object_name': 'error_z', 'base_type': dict},
     'Figure': {'object_name': 'figure', 'base_type': dict},
     'Font': {'object_name': 'font', 'base_type': dict},
-    'Frames': {'object_name': 'frames', 'base_type': dict},
+    'Frames': {'object_name': 'frames', 'base_type': list},
     'Heatmap': {'object_name': 'heatmap', 'base_type': dict},
     'Histogram': {'object_name': 'histogram', 'base_type': dict},
     'Histogram2d': {'object_name': 'histogram2d', 'base_type': dict},
@@ -68,9 +68,62 @@ def get_graph_reference():
     """
     path = os.path.join('package_data', 'default-schema.json')
     s = resource_string('plotly', path).decode('utf-8')
-    graph_reference = _json.loads(s)
+    graph_reference = utils.decode_unicode(_json.loads(s))
 
-    return utils.decode_unicode(graph_reference)
+    # TODO: Patch in frames info until it hits streambed. See #659
+    graph_reference['frames'] = {
+          "items": {
+              "frames_entry": {
+                  "baseframe": {
+                      "description": "The name of the frame into which this "
+                                     "frame's properties are merged before "
+                                     "applying. This is used to unify "
+                                     "properties and avoid needing to specify "
+                                     "the same values for the same properties "
+                                     "in multiple frames.",
+                      "role": "info",
+                      "valType": "string"
+                  },
+                  "data": {
+                      "description": "A list of traces this frame modifies. "
+                                     "The format is identical to the normal "
+                                     "trace definition.",
+                      "role": "object",
+                      "valType": "any"
+                  },
+                  "group": {
+                      "description": "An identifier that specifies the group "
+                                     "to which the frame belongs, used by "
+                                     "animate to select a subset of frames.",
+                      "role": "info",
+                      "valType": "string"
+                  },
+                  "layout": {
+                      "role": "object",
+                      "description": "Layout properties which this frame "
+                                     "modifies. The format is identical to "
+                                     "the normal layout definition.",
+                      "valType": "any"
+                  },
+                  "name": {
+                      "description": "A label by which to identify the frame",
+                      "role": "info",
+                      "valType": "string"
+                  },
+                  "role": "object",
+                  "traces": {
+                      "description": "A list of trace indices that identify "
+                                     "the respective traces in the data "
+                                     "attribute",
+                      "role": "info",
+                      "valType": "info_array"
+                  }
+              }
+          },
+          "role": "object"
+    }
+
+    return graph_reference
 
 
 def string_to_class_name(string):
@@ -135,6 +188,27 @@ def get_attributes_dicts(object_name, parent_object_names=()):
 
     # We should also one or more paths where attributes are defined.
     attribute_paths = list(object_dict['attribute_paths'])  # shallow copy
+
+    # Map frame 'data' and 'layout' to previously-defined figure attributes.
+    # Examples of parent_object_names changes:
+    #   ['figure', 'frames'] --> ['figure', 'frames']
+    #   ['figure', 'frames', FRAME_NAME] --> ['figure']
+    #   ['figure', 'frames', FRAME_NAME, 'data'] --> ['figure', 'data']
+    #   ['figure', 'frames', FRAME_NAME, 'layout'] --> ['figure', 'layout']
+    #   ['figure', 'frames', FRAME_NAME, 'foo'] -->
+    #     ['figure', 'frames', FRAME_NAME, 'foo']
+    #   [FRAME_NAME, 'layout'] --> ['figure', 'layout']
+    if FRAME_NAME in parent_object_names:
+        len_parent_object_names = len(parent_object_names)
+        index = parent_object_names.index(FRAME_NAME)
+        if len_parent_object_names == index + 1:
+            if object_name in ('data', 'layout'):
+                parent_object_names = ['figure', object_name]
+        elif len_parent_object_names > index + 1:
+            if parent_object_names[index + 1] in ('data', 'layout'):
+                parent_object_names = (
+                    ['figure'] + list(parent_object_names)[index + 1:]
+                )
 
     # If we have parent_names, some of these attribute paths may be invalid.
     for parent_object_name in reversed(parent_object_names):
@@ -410,8 +484,11 @@ def _patch_objects():
                          'attribute_paths': layout_attribute_paths,
                          'additional_attributes': {}}
 
-    figure_attributes = {'layout': {'role': 'object'},
-                         'data': {'role': 'object', '_isLinkedToArray': True}}
+    figure_attributes = {
+        'layout': {'role': 'object'},
+        'data': {'role': 'object', '_isLinkedToArray': True},
+        'frames': {'role': 'object', '_isLinkedToArray': True}
+    }
     OBJECTS['figure'] = {'meta_paths': [],
                          'attribute_paths': [],
                          'additional_attributes': figure_attributes}
@@ -478,6 +555,8 @@ def _get_classes():
 
 # The ordering here is important.
 GRAPH_REFERENCE = get_graph_reference()
+
+FRAME_NAME = list(GRAPH_REFERENCE['frames']['items'].keys())[0]
 
 # See http://blog.labix.org/2008/06/27/watch-out-for-listdictkeys-in-python-3
 TRACE_NAMES = list(GRAPH_REFERENCE['traces'].keys())

--- a/plotly/package_data/default-schema.json
+++ b/plotly/package_data/default-schema.json
@@ -9136,7 +9136,7 @@
                         ]
                     },
                     "end": {
-                        "description": "Sets the end contour level value.",
+                        "description": "Sets the end contour level value. Must be more than `contours.start`",
                         "dflt": null,
                         "role": "style",
                         "valType": "number"
@@ -9149,13 +9149,14 @@
                         "valType": "boolean"
                     },
                     "size": {
-                        "description": "Sets the step between each contour level.",
+                        "description": "Sets the step between each contour level. Must be positive.",
                         "dflt": null,
+                        "min": 0,
                         "role": "style",
                         "valType": "number"
                     },
                     "start": {
-                        "description": "Sets the starting contour level value.",
+                        "description": "Sets the starting contour level value. Must be less than `contours.end`",
                         "dflt": null,
                         "role": "style",
                         "valType": "number"
@@ -9240,8 +9241,9 @@
                     "valType": "string"
                 },
                 "ncontours": {
-                    "description": "Sets the maximum number of contour levels. The actual number of contours will be chosen automatically to be less than or equal to the value of `ncontours`. Has an effect only if `autocontour` is *true*.",
-                    "dflt": 0,
+                    "description": "Sets the maximum number of contour levels. The actual number of contours will be chosen automatically to be less than or equal to the value of `ncontours`. Has an effect only if `autocontour` is *true* or if `contours.size` is missing.",
+                    "dflt": 15,
+                    "min": 1,
                     "role": "style",
                     "valType": "integer"
                 },
@@ -12754,7 +12756,7 @@
                         ]
                     },
                     "end": {
-                        "description": "Sets the end contour level value.",
+                        "description": "Sets the end contour level value. Must be more than `contours.start`",
                         "dflt": null,
                         "role": "style",
                         "valType": "number"
@@ -12767,13 +12769,14 @@
                         "valType": "boolean"
                     },
                     "size": {
-                        "description": "Sets the step between each contour level.",
+                        "description": "Sets the step between each contour level. Must be positive.",
                         "dflt": null,
+                        "min": 0,
                         "role": "style",
                         "valType": "number"
                     },
                     "start": {
-                        "description": "Sets the starting contour level value.",
+                        "description": "Sets the starting contour level value. Must be less than `contours.end`",
                         "dflt": null,
                         "role": "style",
                         "valType": "number"
@@ -12899,8 +12902,9 @@
                     "valType": "integer"
                 },
                 "ncontours": {
-                    "description": "Sets the maximum number of contour levels. The actual number of contours will be chosen automatically to be less than or equal to the value of `ncontours`. Has an effect only if `autocontour` is *true*.",
-                    "dflt": 0,
+                    "description": "Sets the maximum number of contour levels. The actual number of contours will be chosen automatically to be less than or equal to the value of `ncontours`. Has an effect only if `autocontour` is *true* or if `contours.size` is missing.",
+                    "dflt": 15,
+                    "min": 1,
                     "role": "style",
                     "valType": "integer"
                 },

--- a/plotly/tests/test_core/test_graph_objs/test_figure.py
+++ b/plotly/tests/test_core/test_graph_objs/test_figure.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import
+
+from unittest import TestCase
+
+from plotly import exceptions
+from plotly.graph_objs import Figure
+
+
+class FigureTest(TestCase):
+
+    def test_instantiation(self):
+
+        native_figure = {
+            'data': [],
+            'layout': {},
+            'frames': []
+        }
+
+        Figure(native_figure)
+        Figure()
+
+    def test_access_top_level(self):
+
+        # Figure is special, we define top-level objects that always exist.
+
+        self.assertEqual(Figure().data, [])
+        self.assertEqual(Figure().layout, {})
+        self.assertEqual(Figure().frames, [])
+
+    def test_nested_frames(self):
+        with self.assertRaisesRegexp(exceptions.PlotlyDictKeyError, 'frames'):
+            Figure({'frames': [{'frames': []}]})
+
+        figure = Figure()
+        figure.frames = [{}]
+        with self.assertRaisesRegexp(exceptions.PlotlyDictKeyError, 'frames'):
+            figure.frames[0].frames = []

--- a/plotly/tests/test_core/test_graph_objs/test_frames.py
+++ b/plotly/tests/test_core/test_graph_objs/test_frames.py
@@ -1,0 +1,79 @@
+from __future__ import absolute_import
+
+from unittest import TestCase
+
+from plotly import exceptions
+from plotly.graph_objs import Bar, Frames
+
+
+class FramesTest(TestCase):
+
+    def test_instantiation(self):
+
+        native_frames = [
+            {},
+            {'data': []},
+            'foo',
+            {'data': [], 'group': 'baz', 'layout': {}, 'name': 'hoopla'}
+        ]
+
+        Frames(native_frames)
+        Frames()
+
+    def test_string_frame(self):
+        frames = Frames()
+        frames.append({'group': 'baz', 'data': []})
+        frames.append('foobar')
+        self.assertEqual(frames[1], 'foobar')
+        self.assertEqual(frames.to_string(),
+                         "Frames([\n"
+                         "    dict(\n"
+                         "        data=Data(),\n"
+                         "        group='baz'\n"
+                         "    ),\n"
+                         "    'foobar'\n"
+                         "])")
+
+    def test_non_string_frame(self):
+        frames = Frames()
+        frames.append({})
+
+        with self.assertRaises(exceptions.PlotlyListEntryError):
+            frames.append([])
+
+        with self.assertRaises(exceptions.PlotlyListEntryError):
+            frames.append(0)
+
+    def test_deeply_nested_layout_attributes(self):
+        frames = Frames()
+        frames.append({})
+        frames[0].layout.xaxis.showexponent = 'all'
+
+        # It's OK if this needs to change, but we should check *something*.
+        self.assertEqual(
+            frames[0].layout.font._get_valid_attributes(),
+            {'color', 'family', 'size'}
+        )
+
+    def test_deeply_nested_data_attributes(self):
+        frames = Frames()
+        frames.append({})
+        frames[0].data = [Bar()]
+        frames[0].data[0].marker.color = 'red'
+
+        # It's OK if this needs to change, but we should check *something*.
+        self.assertEqual(
+            frames[0].data[0].marker.line._get_valid_attributes(),
+            {'colorsrc', 'autocolorscale', 'cmin', 'colorscale', 'color',
+             'reversescale', 'width', 'cauto', 'widthsrc', 'cmax'}
+        )
+
+    def test_frame_only_attrs(self):
+        frames = Frames()
+        frames.append({})
+
+        # It's OK if this needs to change, but we should check *something*.
+        self.assertEqual(
+            frames[0]._get_valid_attributes(),
+            {'group', 'name', 'data', 'layout', 'baseframe', 'traces'}
+        )

--- a/plotly/tests/test_core/test_graph_reference/test_graph_reference.py
+++ b/plotly/tests/test_core/test_graph_reference/test_graph_reference.py
@@ -20,16 +20,6 @@ from plotly.tests.utils import PlotlyTestCase
 
 class TestGraphReferenceCaching(PlotlyTestCase):
 
-    def test_get_graph_reference(self):
-
-        # if we don't have a graph reference we load an outdated default
-
-        path = os.path.join('package_data', 'default-schema.json')
-        s = resource_string('plotly', path).decode('utf-8')
-        default_graph_reference = json.loads(s)
-        graph_reference = gr.get_graph_reference()
-        self.assertEqual(graph_reference, default_graph_reference)
-
     @attr('slow')
     def test_default_schema_is_up_to_date(self):
         api_domain = files.FILE_CONTENT[files.CONFIG_FILE]['plotly_api_domain']


### PR DESCRIPTION
This does the following:

* Allow object-or-string in frames array
* Refuse `frames` in frame object if nested
* Map frame entry `data` and `layout` objects to `figure` attribute information.
* Tests this functionality

Fixes #604