### PR TITLE
Fix optional imports

### DIFF
--- a/plotly/figure_factory/_annotated_heatmap.py
+++ b/plotly/figure_factory/_annotated_heatmap.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import
 
-from plotly import exceptions
+from plotly import exceptions, optional_imports
 from plotly.figure_factory import utils
 from plotly.graph_objs import graph_objs
-from plotly.tools import _numpy_imported
 
-if _numpy_imported:
-    import numpy as np
+# Optional imports, may be None for users that only use our core functionality.
+np = optional_imports.get_module('numpy')
 
 
 def validate_annotated_heatmap(z, x, y, annotation_text):
@@ -206,7 +205,7 @@ class _AnnotatedHeatmap(object):
 
         :rtype (float) z_avg: average val from z matrix
         """
-        if _numpy_imported and isinstance(self.z, np.ndarray):
+        if np and isinstance(self.z, np.ndarray):
             z_min = np.amin(self.z)
             z_max = np.amax(self.z)
         else:

--- a/plotly/figure_factory/_dendrogram.py
+++ b/plotly/figure_factory/_dendrogram.py
@@ -4,23 +4,14 @@ from __future__ import absolute_import
 
 from collections import OrderedDict
 
-from plotly import exceptions
+from plotly import exceptions, optional_imports
 from plotly.graph_objs import graph_objs
-from plotly.tools import (_numpy_imported, _scipy_imported,
-                          _scipy__cluster__hierarchy_imported,
-                          _scipy__spatial_imported)
 
-if _numpy_imported:
-    import numpy as np
-
-if _scipy_imported:
-    import scipy as scp
-
-if _scipy__cluster__hierarchy_imported:
-    import scipy.cluster.hierarchy as sch
-
-if _scipy__spatial_imported:
-    import scipy.spatial as scs
+# Optional imports, may be None for users that only use our core functionality.
+np = optional_imports.get_module('numpy')
+scp = optional_imports.get_module('scipy')
+sch = optional_imports.get_module('scipy.cluster.hierarchy')
+scs = optional_imports.get_module('scipy.spatial')
 
 
 def create_dendrogram(X, orientation="bottom", labels=None,
@@ -82,10 +73,7 @@ def create_dendrogram(X, orientation="bottom", labels=None,
     url = py.plot(fig, filename='pandas-dendrogram')
     ```
     """
-    dependencies = (_scipy_imported and _scipy__spatial_imported and
-                    _scipy__cluster__hierarchy_imported)
-
-    if dependencies is False:
+    if not scp or not scs or not sch:
         raise ImportError("FigureFactory.create_dendrogram requires scipy, \
                             scipy.spatial and scipy.hierarchy")
 

--- a/plotly/figure_factory/_distplot.py
+++ b/plotly/figure_factory/_distplot.py
@@ -1,19 +1,14 @@
 from __future__ import absolute_import
 
-from plotly import exceptions
+from plotly import exceptions, optional_imports
 from plotly.figure_factory import utils
 from plotly.graph_objs import graph_objs
-from plotly.tools import _numpy_imported, _pandas_imported, _scipy_imported
 
-if _numpy_imported:
-    import numpy as np
-
-if _pandas_imported:
-    import pandas as pd
-
-if _scipy_imported:
-    import scipy
-    import scipy.stats
+# Optional imports, may be None for users that only use our core functionality.
+np = optional_imports.get_module('numpy')
+pd = optional_imports.get_module('pandas')
+scipy = optional_imports.get_module('scipy')
+scipy_stats = optional_imports.get_module('scipy.stats')
 
 
 DEFAULT_HISTNORM = 'probability density'
@@ -29,9 +24,9 @@ def validate_distplot(hist_data, curve_type):
         'normal').
     """
     hist_data_types = (list,)
-    if _numpy_imported:
+    if np:
         hist_data_types += (np.ndarray,)
-    if _pandas_imported:
+    if pd:
         hist_data_types += (pd.core.series.Series,)
 
     if not isinstance(hist_data[0], hist_data_types):
@@ -47,7 +42,7 @@ def validate_distplot(hist_data, curve_type):
         raise exceptions.PlotlyError("curve_type must be defined as "
                                      "'kde' or 'normal'")
 
-    if _scipy_imported is False:
+    if not scipy:
         raise ImportError("FigureFactory.create_distplot requires scipy")
 
 
@@ -312,7 +307,7 @@ class _Distplot(object):
             self.curve_x[index] = [self.start[index] +
                                    x * (self.end[index] - self.start[index])
                                    / 500 for x in range(500)]
-            self.curve_y[index] = (scipy.stats.gaussian_kde
+            self.curve_y[index] = (scipy_stats.gaussian_kde
                                    (self.hist_data[index])
                                    (self.curve_x[index]))
 
@@ -345,12 +340,12 @@ class _Distplot(object):
         sd = [None] * self.trace_number
 
         for index in range(self.trace_number):
-            mean[index], sd[index] = (scipy.stats.norm.fit
+            mean[index], sd[index] = (scipy_stats.norm.fit
                                       (self.hist_data[index]))
             self.curve_x[index] = [self.start[index] +
                                    x * (self.end[index] - self.start[index])
                                    / 500 for x in range(500)]
-            self.curve_y[index] = scipy.stats.norm.pdf(
+            self.curve_y[index] = scipy_stats.norm.pdf(
                 self.curve_x[index], loc=mean[index], scale=sd[index])
 
             if self.histnorm == ALTERNATIVE_HISTNORM:

--- a/plotly/figure_factory/_gantt.py
+++ b/plotly/figure_factory/_gantt.py
@@ -2,12 +2,10 @@ from __future__ import absolute_import
 
 from numbers import Number
 
-from plotly import exceptions
+from plotly import exceptions, optional_imports
 from plotly.figure_factory import utils
-from plotly.tools import _pandas_imported
 
-if _pandas_imported:
-    import pandas as pd
+pd = optional_imports.get_module('pandas')
 
 REQUIRED_GANTT_KEYS = ['Task', 'Start', 'Finish']
 
@@ -16,7 +14,7 @@ def validate_gantt(df):
     """
     Validates the inputted dataframe or list
     """
-    if _pandas_imported and isinstance(df, pd.core.frame.DataFrame):
+    if pd and isinstance(df, pd.core.frame.DataFrame):
         # validate that df has all the required keys
         for key in REQUIRED_GANTT_KEYS:
             if key not in df:

--- a/plotly/figure_factory/_scatterplot.py
+++ b/plotly/figure_factory/_scatterplot.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import
 
-from plotly import exceptions
+from plotly import exceptions, optional_imports
 from plotly.figure_factory import utils
 from plotly.graph_objs import graph_objs
-from plotly.tools import _pandas_imported, make_subplots
+from plotly.tools import make_subplots
 
-if _pandas_imported:
-    import pandas as pd
+pd = optional_imports.get_module('pandas')
 
 DIAG_CHOICES = ['scatter', 'histogram', 'box']
 VALID_COLORMAP_TYPES = ['cat', 'seq']
@@ -88,7 +87,7 @@ def validate_scatterplotmatrix(df, index, diag, colormap_type, **kwargs):
     :raises: (PlotlyError) If kwargs contains 'size', 'color' or
         'colorscale'
     """
-    if _pandas_imported is False:
+    if not pd:
         raise ImportError("FigureFactory.scatterplotmatrix requires "
                           "a pandas DataFrame.")
 

--- a/plotly/figure_factory/_streamline.py
+++ b/plotly/figure_factory/_streamline.py
@@ -2,13 +2,11 @@ from __future__ import absolute_import
 
 import math
 
-from plotly import exceptions
+from plotly import exceptions, optional_imports
 from plotly.figure_factory import utils
 from plotly.graph_objs import graph_objs
-from plotly.tools import _numpy_imported
 
-if _numpy_imported:
-    import numpy as np
+np = optional_imports.get_module('numpy')
 
 
 def validate_streamline(x, y):
@@ -24,7 +22,7 @@ def validate_streamline(x, y):
     :raises: (PlotlyError) If x is not evenly spaced.
     :raises: (PlotlyError) If y is not evenly spaced.
     """
-    if _numpy_imported is False:
+    if np is False:
         raise ImportError("FigureFactory.create_streamline requires numpy")
     for index in range(len(x) - 1):
         if ((x[index + 1] - x[index]) - (x[1] - x[0])) > .0001:

--- a/plotly/figure_factory/_table.py
+++ b/plotly/figure_factory/_table.py
@@ -1,11 +1,9 @@
 from __future__ import absolute_import
 
-from plotly import exceptions
+from plotly import exceptions, optional_imports
 from plotly.graph_objs import graph_objs
-from plotly.tools import _pandas_imported
 
-if _pandas_imported:
-    import pandas as pd
+pd = optional_imports.get_module('pandas')
 
 
 def validate_table(table_text, font_colors):
@@ -138,7 +136,7 @@ class _Table(object):
     """
     def __init__(self, table_text, colorscale, font_colors, index,
                  index_title, annotation_offset, **kwargs):
-        if _pandas_imported and isinstance(table_text, pd.DataFrame):
+        if pd and isinstance(table_text, pd.DataFrame):
             headers = table_text.columns.tolist()
             table_text_index = table_text.index.tolist()
             table_text = table_text.values.tolist()

--- a/plotly/figure_factory/_trisurf.py
+++ b/plotly/figure_factory/_trisurf.py
@@ -1,11 +1,9 @@
 from __future__ import absolute_import
 
-from plotly import colors, exceptions
+from plotly import colors, exceptions, optional_imports
 from plotly.graph_objs import graph_objs
-from plotly.tools import _numpy_imported
 
-if _numpy_imported:
-    import numpy as np
+np = optional_imports.get_module('numpy')
 
 
 def map_face2color(face, colormap, scale, vmin, vmax):
@@ -81,7 +79,7 @@ def trisurf(x, y, z, simplices, show_colorbar, edges_color, scale,
     Refer to FigureFactory.create_trisurf() for docstring
     """
     # numpy import check
-    if _numpy_imported is False:
+    if not np:
         raise ImportError("FigureFactory._trisurf() requires "
                           "numpy imported.")
     points3D = np.vstack((x, y, z)).T

--- a/plotly/figure_factory/_violin.py
+++ b/plotly/figure_factory/_violin.py
@@ -2,20 +2,14 @@ from __future__ import absolute_import
 
 from numbers import Number
 
-from plotly import exceptions
+from plotly import exceptions, optional_imports
 from plotly.figure_factory import utils
 from plotly.graph_objs import graph_objs
-from plotly.tools import (_numpy_imported, _pandas_imported, _scipy_imported,
-                          make_subplots)
+from plotly.tools import make_subplots
 
-if _pandas_imported:
-    import pandas as pd
-
-if _numpy_imported:
-    import numpy as np
-
-if _scipy_imported:
-    from scipy import stats
+pd = optional_imports.get_module('pandas')
+np = optional_imports.get_module('numpy')
+scipy_stats = optional_imports.get_module('scipy.stats')
 
 
 def calc_stats(data):
@@ -178,7 +172,7 @@ def violinplot(vals, fillcolor='#1f77b4', rugplot=True):
     d2 = calc_stats(vals)['d2']
 
     # kernel density estimation of pdf
-    pdf = stats.gaussian_kde(vals)
+    pdf = scipy_stats.gaussian_kde(vals)
     # grid over the data interval
     xx = np.linspace(vals_min, vals_max, 100)
     # evaluate the pdf at the grid xx
@@ -554,7 +548,7 @@ def create_violin(data, data_header=None, group_header=None, colors=None,
                 raise exceptions.PlotlyError("If data is a list, it must "
                                              "contain only numbers.")
 
-        if _pandas_imported and isinstance(data, pd.core.frame.DataFrame):
+        if pd and isinstance(data, pd.core.frame.DataFrame):
             if data_header is None:
                 raise exceptions.PlotlyError("data_header must be the "
                                              "column name with the "

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -15,21 +15,12 @@ import webbrowser
 from requests.compat import json as _json
 
 import plotly
-from plotly import tools, utils
+from plotly import optional_imports, tools, utils
 from plotly.exceptions import PlotlyError
 
-try:
-    import IPython
-    from IPython.display import HTML, display
-    _ipython_imported = True
-except ImportError:
-    _ipython_imported = False
-
-try:
-    import matplotlib
-    _matplotlib_imported = True
-except ImportError:
-    _matplotlib_imported = False
+ipython = optional_imports.get_module('IPython')
+ipython_display = optional_imports.get_module('IPython.display')
+matplotlib = optional_imports.get_module('matplotlib')
 
 __PLOTLY_OFFLINE_INITIALIZED = False
 
@@ -112,7 +103,7 @@ def init_notebook_mode(connected=False):
     your notebook, resulting in much larger notebook sizes compared to the case
     where `connected=True`.
     """
-    if not _ipython_imported:
+    if not ipython:
         raise ImportError('`iplot` can only run inside an IPython Notebook.')
 
     global __PLOTLY_OFFLINE_INITIALIZED
@@ -149,7 +140,7 @@ def init_notebook_mode(connected=False):
             '</script>'
             '').format(script=get_plotlyjs())
 
-    display(HTML(script_inject))
+    ipython_display.display(ipython_display.HTML(script_inject))
     __PLOTLY_OFFLINE_INITIALIZED = True
 
 
@@ -333,7 +324,7 @@ def iplot(figure_or_data, show_link=True, link_text='Export to plot.ly',
             'plotly.offline.init_notebook_mode() '
             '# run at the start of every ipython notebook',
         ]))
-    if not tools._ipython_imported:
+    if not ipython:
         raise ImportError('`iplot` can only run inside an IPython Notebook.')
 
     config = {}
@@ -344,7 +335,7 @@ def iplot(figure_or_data, show_link=True, link_text='Export to plot.ly',
         figure_or_data, config, validate, '100%', 525, True
     )
 
-    display(HTML(plot_html))
+    ipython_display.display(ipython_display.HTML(plot_html))
 
     if image:
         if image not in __IMAGE_FORMATS:
@@ -360,7 +351,7 @@ def iplot(figure_or_data, show_link=True, link_text='Export to plot.ly',
         # allow time for the plot to draw
         time.sleep(1)
         # inject code to download an image of the plot
-        display(HTML(script))
+        ipython_display.display(ipython_display.HTML(script))
 
 
 def plot(figure_or_data, show_link=True, link_text='Export to plot.ly',
@@ -690,7 +681,7 @@ def enable_mpl_offline(resize=False, strip_style=False,
     """
     init_notebook_mode()
 
-    ip = IPython.core.getipython.get_ipython()
+    ip = ipython.core.getipython.get_ipython()
     formatter = ip.display_formatter.formatters['text/html']
     formatter.for_type(matplotlib.figure.Figure,
                        lambda fig: iplot_mpl(fig, resize, strip_style, verbose,

--- a/plotly/optional_imports.py
+++ b/plotly/optional_imports.py
@@ -1,0 +1,25 @@
+"""
+Stand-alone module to provide information about whether optional deps exist.
+
+"""
+from __future__ import absolute_import
+
+from importlib import import_module
+
+_not_importable = set()
+
+
+def get_module(name):
+    """
+    Return module or None. Absolute import is required.
+
+    :param (str) name: Dot-separated module path. E.g., 'scipy.stats'.
+    :raise: (ImportError) Only when exc_msg is defined.
+    :return: (module|None) If import succeeds, the module will be returned.
+
+    """
+    if name not in _not_importable:
+        try:
+            return import_module(name)
+        except ImportError:
+            _not_importable.add(name)

--- a/plotly/tests/test_core/test_optional_imports/test_optional_imports.py
+++ b/plotly/tests/test_core/test_optional_imports/test_optional_imports.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import
+
+from unittest import TestCase
+
+from plotly.optional_imports import get_module
+
+
+class OptionalImportsTest(TestCase):
+
+    def test_get_module_exists(self):
+        import math
+        module = get_module('math')
+        self.assertIsNotNone(module)
+        self.assertEqual(math, module)
+
+    def test_get_module_exists_submodule(self):
+        import requests.sessions
+        module = get_module('requests.sessions')
+        self.assertIsNotNone(module)
+        self.assertEqual(requests.sessions, module)
+
+    def test_get_module_does_not_exist(self):
+        module = get_module('hoopla')
+        self.assertIsNone(module)

--- a/plotly/tests/test_core/test_tools/test_figure_factory.py
+++ b/plotly/tests/test_core/test_tools/test_figure_factory.py
@@ -1649,8 +1649,6 @@ class Test2D_Density(TestCase):
 
 #     def test_scipy_import_error(self):
 
-#         # make sure Import Error is raised when _scipy_imported = False
-
 #         hist_data = [[1.1, 1.1, 2.5, 3.0, 3.5,
 #                       3.5, 4.1, 4.4, 4.5, 4.5,
 #                       5.0, 5.0, 5.2, 5.5, 5.5,

--- a/plotly/tests/test_optional/optional_utils.py
+++ b/plotly/tests/test_optional/optional_utils.py
@@ -2,12 +2,13 @@ from __future__ import absolute_import
 
 import numpy as np
 
+from plotly import optional_imports
 from plotly.tests.utils import is_num_list
 from plotly.utils import get_by_path, node_generator
 
-# TODO: matplotlib-build-wip
-from plotly.tools import _matplotlylib_imported
-if _matplotlylib_imported:
+matplotlylib = optional_imports.get_module('plotly.matplotlylib')
+
+if matplotlylib:
     import matplotlib
     # Force matplotlib to not use any Xwindows backend.
     matplotlib.use('Agg')

--- a/plotly/tests/test_optional/test_matplotlylib/test_annotations.py
+++ b/plotly/tests/test_optional/test_matplotlylib/test_annotations.py
@@ -2,10 +2,11 @@ from __future__ import absolute_import
 
 from nose.plugins.attrib import attr
 
-# TODO: matplotlib-build-wip
-from plotly.tools import _matplotlylib_imported
+from plotly import optional_imports
 
-if _matplotlylib_imported:
+matplotlylib = optional_imports.get_module('plotly.matplotlylib')
+
+if matplotlylib:
     import matplotlib
     # Force matplotlib to not use any Xwindows backend.
     matplotlib.use('Agg')

--- a/plotly/tests/test_optional/test_matplotlylib/test_axis_scales.py
+++ b/plotly/tests/test_optional/test_matplotlylib/test_axis_scales.py
@@ -2,14 +2,14 @@ from __future__ import absolute_import
 
 from nose.plugins.attrib import attr
 
+from plotly import optional_imports
 from plotly.tests.utils import compare_dict
 from plotly.tests.test_optional.optional_utils import run_fig
 from plotly.tests.test_optional.test_matplotlylib.data.axis_scales import *
 
-# TODO: matplotlib-build-wip
-from plotly.tools import _matplotlylib_imported
+matplotlylib = optional_imports.get_module('plotly.matplotlylib')
 
-if _matplotlylib_imported:
+if matplotlylib:
     import matplotlib
     # Force matplotlib to not use any Xwindows backend.
     matplotlib.use('Agg')

--- a/plotly/tests/test_optional/test_matplotlylib/test_bars.py
+++ b/plotly/tests/test_optional/test_matplotlylib/test_bars.py
@@ -2,15 +2,15 @@ from __future__ import absolute_import
 
 from nose.plugins.attrib import attr
 
+from plotly import optional_imports
 from plotly.tests.utils import compare_dict
 from plotly.tests.test_optional.optional_utils import run_fig
 from plotly.tests.test_optional.test_matplotlylib.data.bars import *
 
-# TODO: matplotlib-build-wip
-from plotly.tools import _matplotlylib_imported
-if _matplotlylib_imported:
-    import matplotlib
+matplotlylib = optional_imports.get_module('plotly.matplotlylib')
 
+if matplotlylib:
+    import matplotlib
     # Force matplotlib to not use any Xwindows backend.
     matplotlib.use('Agg')
     import matplotlib.pyplot as plt

--- a/plotly/tests/test_optional/test_matplotlylib/test_data.py
+++ b/plotly/tests/test_optional/test_matplotlylib/test_data.py
@@ -2,12 +2,13 @@ from __future__ import absolute_import
 
 from nose.plugins.attrib import attr
 
+from plotly import optional_imports
 from plotly.tests.test_optional.optional_utils import run_fig
 from plotly.tests.test_optional.test_matplotlylib.data.data import *
 
-# TODO: matplotlib-build-wip
-from plotly.tools import _matplotlylib_imported
-if _matplotlylib_imported:
+matplotlylib = optional_imports.get_module('plotly.matplotlylib')
+
+if matplotlylib:
     import matplotlib
 
     # Force matplotlib to not use any Xwindows backend.

--- a/plotly/tests/test_optional/test_matplotlylib/test_date_times.py
+++ b/plotly/tests/test_optional/test_matplotlylib/test_date_times.py
@@ -8,10 +8,11 @@ import pandas as pd
 from nose.plugins.attrib import attr
 
 import plotly.tools as tls
+from plotly import optional_imports
 
-# TODO: matplotlib-build-wip
-from plotly.tools import _matplotlylib_imported
-if _matplotlylib_imported:
+matplotlylib = optional_imports.get_module('plotly.matplotlylib')
+
+if matplotlylib:
     import matplotlib
 
     # Force matplotlib to not use any Xwindows backend.

--- a/plotly/tests/test_optional/test_matplotlylib/test_lines.py
+++ b/plotly/tests/test_optional/test_matplotlylib/test_lines.py
@@ -2,13 +2,14 @@ from __future__ import absolute_import
 
 from nose.plugins.attrib import attr
 
+from plotly import optional_imports
 from plotly.tests.utils import compare_dict
 from plotly.tests.test_optional.optional_utils import run_fig
 from plotly.tests.test_optional.test_matplotlylib.data.lines import *
 
-# TODO: matplotlib-build-wip
-from plotly.tools import _matplotlylib_imported
-if _matplotlylib_imported:
+matplotlylib = optional_imports.get_module('plotly.matplotlylib')
+
+if matplotlylib:
     import matplotlib
 
     # Force matplotlib to not use any Xwindows backend.

--- a/plotly/tests/test_optional/test_matplotlylib/test_scatter.py
+++ b/plotly/tests/test_optional/test_matplotlylib/test_scatter.py
@@ -2,13 +2,14 @@ from __future__ import absolute_import
 
 from nose.plugins.attrib import attr
 
+from plotly import optional_imports
 from plotly.tests.utils import compare_dict
 from plotly.tests.test_optional.optional_utils import run_fig
 from plotly.tests.test_optional.test_matplotlylib.data.scatter import *
 
-# TODO: matplotlib-build-wip
-from plotly.tools import _matplotlylib_imported
-if _matplotlylib_imported:
+matplotlylib = optional_imports.get_module('plotly.matplotlylib')
+
+if matplotlylib:
     import matplotlib
 
     # Force matplotlib to not use any Xwindows backend.

--- a/plotly/tests/test_optional/test_matplotlylib/test_subplots.py
+++ b/plotly/tests/test_optional/test_matplotlylib/test_subplots.py
@@ -2,13 +2,14 @@ from __future__ import absolute_import
 
 from nose.plugins.attrib import attr
 
+from plotly import optional_imports
 from plotly.tests.utils import compare_dict
 from plotly.tests.test_optional.optional_utils import run_fig
 from plotly.tests.test_optional.test_matplotlylib.data.subplots import *
 
-# TODO: matplotlib-build-wip
-from plotly.tools import _matplotlylib_imported
-if _matplotlylib_imported:
+matplotlylib = optional_imports.get_module('plotly.matplotlylib')
+
+if matplotlylib:
     import matplotlib
 
     # Force matplotlib to not use any Xwindows backend.

--- a/plotly/tests/test_optional/test_offline/test_offline.py
+++ b/plotly/tests/test_optional/test_offline/test_offline.py
@@ -11,11 +11,11 @@ from requests.compat import json as _json
 from unittest import TestCase
 
 import plotly
+from plotly import optional_imports
 
-# TODO: matplotlib-build-wip
-from plotly.tools import _matplotlylib_imported
+matplotlylib = optional_imports.get_module('plotly.matplotlylib')
 
-if _matplotlylib_imported:
+if matplotlylib:
     import matplotlib
     # Force matplotlib to not use any Xwindows backend.
     matplotlib.use('Agg')
@@ -34,7 +34,6 @@ class PlotlyOfflineTestCase(TestCase):
         plotly.offline.iplot([{}])
 
     def test_iplot_works_after_you_call_init_notebook_mode(self):
-        plotly.tools._ipython_imported = True
         plotly.offline.init_notebook_mode()
         plotly.offline.iplot([{}])
 
@@ -47,7 +46,6 @@ class PlotlyOfflineTestCase(TestCase):
         y = [100, 200, 300]
         plt.plot(x, y, "o")
 
-        plotly.tools._ipython_imported = True
         plotly.offline.init_notebook_mode()
         plotly.offline.iplot_mpl(fig)
 

--- a/plotly/tests/test_optional/test_plotly/test_plot_mpl.py
+++ b/plotly/tests/test_optional/test_plotly/test_plot_mpl.py
@@ -10,13 +10,13 @@ from __future__ import absolute_import
 from nose.plugins.attrib import attr
 from nose.tools import raises
 
-from plotly import exceptions
+from plotly import exceptions, optional_imports
 from plotly.plotly import plotly as py
 from unittest import TestCase
 
-# TODO: matplotlib-build-wip
-from plotly.tools import _matplotlylib_imported
-if _matplotlylib_imported:
+matplotlylib = optional_imports.get_module('plotly.matplotlylib')
+
+if matplotlylib:
     import matplotlib
 
     # Force matplotlib to not use any Xwindows backend.

--- a/plotly/tests/test_optional/test_utils/test_utils.py
+++ b/plotly/tests/test_optional/test_utils/test_utils.py
@@ -17,13 +17,13 @@ from nose.plugins.attrib import attr
 from pandas.util.testing import assert_series_equal
 from requests.compat import json as _json
 
-from plotly import utils
+from plotly import optional_imports, utils
 from plotly.graph_objs import Scatter, Scatter3d, Figure, Data
 from plotly.grid_objs import Column
 
-# TODO: matplotlib-build-wip
-from plotly.tools import _matplotlylib_imported
-if _matplotlylib_imported:
+matplotlylib = optional_imports.get_module('plotly.matplotlylib')
+
+if matplotlylib:
     import matplotlib.pyplot as plt
     from plotly.matplotlylib import Exporter, PlotlyRenderer
 

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -13,9 +13,7 @@ import warnings
 
 import six
 
-from plotly import utils
-from plotly import exceptions
-from plotly import session
+from plotly import exceptions, optional_imports, session, utils
 from plotly.files import (CONFIG_FILE, CREDENTIALS_FILE, FILE_CONTENT,
                           check_file_permissions)
 
@@ -58,55 +56,9 @@ def warning_on_one_line(message, category, filename, lineno,
                                      message)
 warnings.formatwarning = warning_on_one_line
 
-try:
-    from . import matplotlylib
-    _matplotlylib_imported = True
-except ImportError:
-    _matplotlylib_imported = False
-
-try:
-    import IPython
-    import IPython.core.display
-    _ipython_imported = True
-except ImportError:
-    _ipython_imported = False
-
-try:
-    import numpy as np
-    _numpy_imported = True
-except ImportError:
-    _numpy_imported = False
-
-try:
-    import pandas as pd
-    _pandas_imported = True
-except ImportError:
-    _pandas_imported = False
-
-try:
-    import scipy as scp
-    _scipy_imported = True
-except ImportError:
-    _scipy_imported = False
-
-try:
-    import scipy.spatial as scs
-    _scipy__spatial_imported = True
-except ImportError:
-    _scipy__spatial_imported = False
-
-try:
-    import scipy.cluster.hierarchy as sch
-    _scipy__cluster__hierarchy_imported = True
-except ImportError:
-    _scipy__cluster__hierarchy_imported = False
-
-try:
-    import scipy
-    import scipy.stats
-    _scipy_imported = True
-except ImportError:
-    _scipy_imported = False
+ipython_core_display = optional_imports.get_module('IPython.core.display')
+matplotlylib = optional_imports.get_module('plotly.matplotlylib')
+sage_salvus = optional_imports.get_module('sage_salvus')
 
 
 def get_config_defaults():
@@ -414,11 +366,11 @@ def embed(file_owner_or_url, file_id=None, width="100%", height=525):
                       height=height)
 
         # see if we are in the SageMath Cloud
-        from sage_salvus import html
-        return html(s, hide=False)
+        if sage_salvus:
+            return sage_salvus.html(s, hide=False)
     except:
         pass
-    if _ipython_imported:
+    if ipython_core_display:
         if file_id:
             plotly_domain = (
                 session.get_session_config().get('plotly_domain') or
@@ -497,7 +449,7 @@ def mpl_to_plotly(fig, resize=False, strip_style=False, verbose=False):
     {plotly_domain}/python/getting-started
 
     """
-    if _matplotlylib_imported:
+    if matplotlylib:
         renderer = matplotlylib.PlotlyRenderer()
         matplotlylib.Exporter(renderer).run(fig)
         if resize:
@@ -1393,8 +1345,8 @@ def _replace_newline(obj):
         return obj  # we return the actual reference... but DON'T mutate.
 
 
-if _ipython_imported:
-    class PlotlyDisplay(IPython.core.display.HTML):
+if ipython_core_display:
+    class PlotlyDisplay(ipython_core_display.HTML):
         """An IPython display object for use with plotly urls
 
         PlotlyDisplay objects should be instantiated with a url for a plot.

--- a/plotly/utils.py
+++ b/plotly/utils.py
@@ -14,29 +14,16 @@ import threading
 import decimal
 
 import pytz
-
 from requests.compat import json as _json
 
+from plotly.optional_imports import get_module
 
 from . exceptions import PlotlyError
 
-try:
-    import numpy
-    _numpy_imported = True
-except ImportError:
-    _numpy_imported = False
-
-try:
-    import pandas
-    _pandas_imported = True
-except ImportError:
-    _pandas_imported = False
-
-try:
-    import sage.all
-    _sage_imported = True
-except ImportError:
-    _sage_imported = False
+# Optional imports, may be None for users that only use our core functionality.
+numpy = get_module('numpy')
+pandas = get_module('pandas')
+sage_all = get_module('sage.all')
 
 
 ### incase people are using threading, we lock file reads
@@ -233,12 +220,12 @@ class PlotlyJSONEncoder(_json.JSONEncoder):
     @staticmethod
     def encode_as_sage(obj):
         """Attempt to convert sage.all.RR to floats and sage.all.ZZ to ints"""
-        if not _sage_imported:
+        if not sage_all:
             raise NotEncodable
 
-        if obj in sage.all.RR:
+        if obj in sage_all.RR:
             return float(obj)
-        elif obj in sage.all.ZZ:
+        elif obj in sage_all.ZZ:
             return int(obj)
         else:
             raise NotEncodable
@@ -246,7 +233,7 @@ class PlotlyJSONEncoder(_json.JSONEncoder):
     @staticmethod
     def encode_as_pandas(obj):
         """Attempt to convert pandas.NaT"""
-        if not _pandas_imported:
+        if not pandas:
             raise NotEncodable
 
         if obj is pandas.NaT:
@@ -257,7 +244,7 @@ class PlotlyJSONEncoder(_json.JSONEncoder):
     @staticmethod
     def encode_as_numpy(obj):
         """Attempt to convert numpy.ma.core.masked"""
-        if not _numpy_imported:
+        if not numpy:
             raise NotEncodable
 
         if obj is numpy.ma.core.masked:


### PR DESCRIPTION
This is a stand-alone module to do the following:

* Don’t import optional things until we need them
* Keep all the optional imports centralized