### PR TITLE
Validate signin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ failures. Previously either a `PlotlyError`, `PlotlyRequestException`, or a
 `requests.exceptions.ReqestException` could be raised. In particular, scripts
 which depend on `try-except` blocks containing network requests should be
 revisited.
+- `plotly.py:sign_in` now validates to the plotly server specified in your
+  config. If it cannot make a successful request, it raises a `PlotlyError`.
 
 ### Deprecated
 - `plotly.tools.FigureFactory`. Use `plotly.figure_factory.*`.

--- a/plotly/api/v2/__init__.py
+++ b/plotly/api/v2/__init__.py
@@ -1,3 +1,4 @@
 from __future__ import absolute_import
 
-from plotly.api.v2 import files, folders, grids, images, plot_schema, plots
+from plotly.api.v2 import (files, folders, grids, images, plot_schema, plots,
+                           users)

--- a/plotly/api/v2/users.py
+++ b/plotly/api/v2/users.py
@@ -1,0 +1,17 @@
+"""Interface to Plotly's /v2/files endpoints."""
+from __future__ import absolute_import
+
+from plotly.api.v2.utils import build_url, request
+
+RESOURCE = 'users'
+
+
+def current():
+    """
+    Retrieve information on the logged-in user from Plotly.
+
+    :returns: (requests.Response) Returns response directly from requests.
+
+    """
+    url = build_url(RESOURCE, route='current')
+    return request('get', url)

--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -48,7 +48,15 @@ tools.ensure_local_plotly_files()
 
 
 # don't break backwards compatibility
-sign_in = session.sign_in
+def sign_in(username, api_key, **kwargs):
+    session.sign_in(username, api_key, **kwargs)
+    try:
+        # The only way this can succeed is if the user can be authenticated
+        # with the given, username, api_key, and plotly_api_domain.
+        v2.users.current()
+    except exceptions.PlotlyRequestError:
+        raise exceptions.PlotlyError('Sign in failed.')
+
 update_plot_options = session.update_session_plot_options
 
 

--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -24,11 +24,9 @@ import six
 import six.moves
 from requests.compat import json as _json
 
-from plotly import exceptions, tools, utils, files
+from plotly import exceptions, files, session, tools, utils
 from plotly.api import v1, v2
 from plotly.plotly import chunked_requests
-from plotly.session import (sign_in, update_session_plot_options,
-                            get_session_plot_options)
 from plotly.grid_objs import Grid, Column
 
 # This is imported like this for backwards compat. Careful if changing.
@@ -50,8 +48,8 @@ tools.ensure_local_plotly_files()
 
 
 # don't break backwards compatibility
-sign_in = sign_in
-update_plot_options = update_session_plot_options
+sign_in = session.sign_in
+update_plot_options = session.update_session_plot_options
 
 
 def _plot_option_logic(plot_options_from_call_signature):
@@ -66,7 +64,7 @@ def _plot_option_logic(plot_options_from_call_signature):
     """
     default_plot_options = copy.deepcopy(DEFAULT_PLOT_OPTIONS)
     file_options = tools.get_config_file()
-    session_options = get_session_plot_options()
+    session_options = session.get_session_plot_options()
     plot_options_from_call_signature = copy.deepcopy(plot_options_from_call_signature)
 
     # Validate options and fill in defaults w world_readable and sharing

--- a/plotly/tests/test_core/test_api/test_v2/test_users.py
+++ b/plotly/tests/test_core/test_api/test_v2/test_users.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import
+
+from plotly.api.v2 import users
+from plotly.tests.test_core.test_api import PlotlyApiTestCase
+
+
+class UsersTest(PlotlyApiTestCase):
+
+    def setUp(self):
+        super(UsersTest, self).setUp()
+
+        # Mock the actual api call, we don't want to do network tests here.
+        self.request_mock = self.mock('plotly.api.v2.utils.requests.request')
+        self.request_mock.return_value = self.get_response()
+
+        # Mock the validation function since we can test that elsewhere.
+        self.mock('plotly.api.v2.utils.validate_response')
+
+    def test_current(self):
+        users.current()
+        self.request_mock.assert_called_once()
+        args, kwargs = self.request_mock.call_args
+        method, url = args
+        self.assertEqual(method, 'get')
+        self.assertEqual(
+            url, '{}/v2/users/current'.format(self.plotly_api_domain)
+        )
+        self.assertNotIn('params', kwargs)

--- a/plotly/tests/test_core/test_plotly/test_plot.py
+++ b/plotly/tests/test_core/test_plotly/test_plot.py
@@ -12,6 +12,7 @@ import six
 from requests.compat import json as _json
 
 from unittest import TestCase
+from mock import patch
 from nose.plugins.attrib import attr
 from nose.tools import raises
 
@@ -222,6 +223,14 @@ class TestPlotOptionLogic(PlotlyTestCase):
         {'world_readable': True, 'sharing': 'private'},
         {'world_readable': False, 'sharing': 'public'}
     )
+
+    def setUp(self):
+        super(TestPlotOptionLogic, self).setUp()
+
+        # Make sure we don't hit sign-in validation failures.
+        patcher = patch('plotly.api.v2.users.current')
+        self.users_current_mock = patcher.start()
+        self.addCleanup(patcher.stop)
 
     def test_default_options(self):
         options = py._plot_option_logic({})


### PR DESCRIPTION
Simply raises a `PlotlyError` if we can't hit `/v2/users/current` successfully given the session credentials.

I decided to let the session creds/config get set and not revert on fail. It felt simpler to me and I didn't know why it would be beneficial to do anything otherwise.