### PR TITLE
Enable heartbeat in Stream.write

### DIFF
--- a/plotly/plotly/chunked_requests/chunked_request.py
+++ b/plotly/plotly/chunked_requests/chunked_request.py
@@ -69,8 +69,12 @@ class Stream:
             msglen = format(len(msg), 'x')  # msg length in hex
             # Send the message in chunk-encoded form
             self._conn.sock.setblocking(1)
-            self._conn.send('{msglen}\r\n{msg}\r\n'
-                            .format(msglen=msglen, msg=msg).encode('utf-8'))
+            formatted_message = '{msglen}\r\n{msg}\r\n'.format(
+                msglen=msglen, msg=msg)
+            if not msg:
+                # Send heartbeat
+                formatted_message = '\r\n'
+            self._conn.send(formatted_message.encode('utf-8'))
             self._conn.sock.setblocking(0)
         except http_client.socket.error:
             self._reconnect()


### PR DESCRIPTION
The [plot.ly streaming documentation](https://plot.ly/streaming/) under the
`Disconnections` section states that:

> A connection can be maintained by writing a heartbeat within the 60 second
> window, a heartbeat is simply a newline

If an empty string (and maybe an empty dictionary too, untested) is passed to
Stream's `write` method however it results in an empty row being created in the plot's
data rather than only keeping the connection awake.  This commit aims to support
using the write method for sending a heartbeat.