### PR TITLE
Fix distplot color looping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- `plotly.figure_factory.create_distplot` now can support more than 10 traces without raising an error. Updated so that if the list of `colors` (default colors too) is less than your number of traces, the color for your traces will loop around to start when it hits the end.
 
 ## [2.0.1] - 2017-02-07
 ### Added

--- a/plotly/figure_factory/_distplot.py
+++ b/plotly/figure_factory/_distplot.py
@@ -277,7 +277,7 @@ class _Distplot(object):
         :rtype (list) hist: list of histogram representations
         """
         hist = [None] * self.trace_number
-        print 'crapola'
+
         for index in range(self.trace_number):
             hist[index] = dict(type='histogram',
                                x=self.hist_data[index],
@@ -324,7 +324,7 @@ class _Distplot(object):
                                 name=self.group_labels[index],
                                 legendgroup=self.group_labels[index],
                                 showlegend=False if self.show_hist else True,
-                                marker=dict(color=self.colors[index]))
+                                marker=dict(color=self.colors[index % len(self.colors)]))
         return curve
 
     def make_normal(self):
@@ -361,7 +361,7 @@ class _Distplot(object):
                                 name=self.group_labels[index],
                                 legendgroup=self.group_labels[index],
                                 showlegend=False if self.show_hist else True,
-                                marker=dict(color=self.colors[index]))
+                                marker=dict(color=self.colors[index % len(self.colors)]))
         return curve
 
     def make_rug(self):
@@ -385,6 +385,6 @@ class _Distplot(object):
                               showlegend=(False if self.show_hist or
                                           self.show_curve else True),
                               text=self.rug_text[index],
-                              marker=dict(color=self.colors[index],
+                              marker=dict(color=self.colors[index % len(self.colors)],
                                           symbol='line-ns-open'))
         return rug

--- a/plotly/figure_factory/_distplot.py
+++ b/plotly/figure_factory/_distplot.py
@@ -277,7 +277,7 @@ class _Distplot(object):
         :rtype (list) hist: list of histogram representations
         """
         hist = [None] * self.trace_number
-
+        print 'crapola'
         for index in range(self.trace_number):
             hist[index] = dict(type='histogram',
                                x=self.hist_data[index],
@@ -286,7 +286,7 @@ class _Distplot(object):
                                histnorm=self.histnorm,
                                name=self.group_labels[index],
                                legendgroup=self.group_labels[index],
-                               marker=dict(color=self.colors[index]),
+                               marker=dict(color=self.colors[index % len(self.colors)]),
                                autobinx=False,
                                xbins=dict(start=self.start[index],
                                           end=self.end[index],


### PR DESCRIPTION
Re: a user's issue. Looks like if you have more than 10 traces in a `distplot`, your colors won't loop around and start on the first color. Just did `mod len(colors)`.