### PR TITLE
Add json output type to offline plot.

### DIFF
--- a/plotly/tests/test_core/test_offline/test_offline.py
+++ b/plotly/tests/test_core/test_offline/test_offline.py
@@ -74,6 +74,13 @@ class PlotlyOfflineTestCase(PlotlyOfflineBaseTestCase):
         self.assertTrue('<html>' not in html and '</html>' not in html)
         self.assertTrue(html.startswith('<div>') and html.endswith('</div>'))
 
+    def test_json_output(self):
+        data, layout, config = plotly.offline.plot(fig, output_type='json', auto_open=False)
+
+        self.assertEqual(data, '[{"type": "scatter", "x": [1, 2, 3], "y": [10, 20, 30]}]')
+        self.assertEqual(layout, '{"title": "offline plot"}')
+        self.assertEqual(config, '{"showLink": true, "linkText": "Export to plot.ly"}')
+
     def test_autoresizing(self):
         resize_code_strings = [
             'window.addEventListener("resize", ',


### PR DESCRIPTION
I added a json output type to the offline plot function. It returns a (data, layout, config) tuple of json strings. 