### PR TITLE
Make offline embedded <div> plots responsive.

### DIFF
--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -511,7 +511,8 @@ def plot(figure_or_data, show_link=True, link_text='Export to plot.ly',
                 get_plotlyjs(),
                 '</script>',
                 plot_html,
-                '</div>'
+                resize_script,
+                '</div>',
             ])
         else:
             return plot_html


### PR DESCRIPTION
This PR enables responsiveness in offline plots, when `output_type == 'div'` by adding the `resize_script` to the return value of `plotly.offline.plot`, just as it is done if  `output_type == 'file'`, as seen here:

* https://github.com/Ismael-VC/plotly.py/blob/8cfa08ed1ca23ca67b1d3adf1674c29f9777d8f4/plotly/offline/offline.py#L489-L498

 I've been making use of [Django-JET](https://github.com/geex-arts/django-jet) dashboard widget plugins in order to embed a Plotly graph, before this change I would have to reload the page manually every time I resized the browser window in order to make the plot resize to the new size of the `django-jet` widget containing it (which is responsive).

## Before this change

* First load:

![image](https://cloud.githubusercontent.com/assets/4594825/24088556/5fe86ffc-0cf1-11e7-9fb5-440414d5f3dd.png)

* Resize:

![image](https://cloud.githubusercontent.com/assets/4594825/24088561/6b62b5c2-0cf1-11e7-90f9-56f4e3391836.png)

As you can see, plot is truncated.

*** 

## After this change

* First load:

![](https://files.gitter.im/geex-arts/django-jet/5ddL/blob)

* Resize:

![](https://files.gitter.im/geex-arts/django-jet/WfIM/blob)

Now it resizes properly.

This is the code I used to test.

In `dashboard_modules.py`:

```python
from plotly import graph_objs
from plotly.offline import plot

class Graph(DashboardModule):
    title = 'Graph'
    template = 'dashboard_modules/modules/graph.html'

    def init_with_context(self, context):
        x = [-2, 0, 4, 6, 7]
        y = [q ** 2 - q + 3 for q in x]
        trace1 = graph_objs.Scatter(
            x=x,
            y=y,
            marker={
                'color': 'red',
                'symbol': 104,
                'size': "10"
            },
            mode="lines",
            name='1st Trace'
        )
        data = graph_objs.Data([trace1])
        layout = graph_objs.Layout(
            title="Meine Daten",
            xaxis={'title': 'x1'},
            yaxis={'title': 'x2'}
        )
        figure = graph_objs.Figure(data=data, layout=layout)
        div = plot(figure, auto_open=False, output_type='div')

        self.graph = div
```

In `graph.html`:

```jinja
{% load humanize %}

{{ module.graph|safe }}
```

Related issue: Responsive plots 

* https://github.com/plotly/plotly.py/issues/421