### PR TITLE
BUG FIX: init_notebook_mode(True) not work

### DIFF
--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -116,7 +116,7 @@ def init_notebook_mode(connected=False):
             'requirejs.config({'
             'paths: { '
             # Note we omit the extension .js because require will include it.
-            '\'plotly\': [\'https://cdn.plot.ly/plotly-latest.min\']},'
+            '\'plotly\': [\'https://cdn.plot.ly/plotly-latest.min.js\']},'
             '});'
             'if(!window.Plotly) {{'
             'require([\'plotly\'],'


### PR DESCRIPTION
Due to the wrong plotly-latest.min.js source url, the init_notebook_mode(connected=True) didn't work correctly. Changing the js url from https://cdn.plot.ly/plotly-latest.min to https://cdn.plot.ly/plotly-latest.min.js solves this issue