### PR TITLE
Make using offline.init_notebook_mode() optional

### DIFF
--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -322,25 +322,12 @@ def iplot(figure_or_data, show_link=True, link_text='Export to plot.ly',
     iplot([{'x': [1, 2, 3], 'y': [5, 2, 7]}], image='png')
     ```
     """
-    if not __PLOTLY_OFFLINE_INITIALIZED:
-        raise PlotlyError('\n'.join([
-            'Plotly Offline mode has not been initialized in this notebook. '
-            'Run: ',
-            '',
-            'import plotly',
-            'plotly.offline.init_notebook_mode() '
-            '# run at the start of every ipython notebook',
-        ]))
     if not ipython:
         raise ImportError('`iplot` can only run inside an IPython Notebook.')
 
     config = dict(config) if config else {}
     config.setdefault('showLink', show_link)
     config.setdefault('linkText', link_text)
-
-    plot_html, plotdivid, width, height = _plot_html(
-        figure_or_data, config, validate, '100%', 525, True
-    )
 
     figure = tools.return_figure_from_figure_or_data(figure_or_data, validate)
 
@@ -358,14 +345,27 @@ def iplot(figure_or_data, show_link=True, link_text='Export to plot.ly',
     if frames:
         fig['frames'] = frames
 
-    display_bundle = {
-        'application/vnd.plotly.v1+json': fig,
-        'text/html': plot_html,
-        'text/vnd.plotly.v1+html': plot_html
-    }
+    display_bundle = {'application/vnd.plotly.v1+json': fig}
+
+    if __PLOTLY_OFFLINE_INITIALIZED:
+        plot_html, plotdivid, width, height = _plot_html(
+            figure_or_data, config, validate, '100%', 525, True
+        )
+        display_bundle['text/html'] = plot_html
+        display_bundle['text/vnd.plotly.v1+html'] = plot_html
+
     ipython_display.display(display_bundle, raw=True)
 
     if image:
+        if not __PLOTLY_OFFLINE_INITIALIZED:
+            raise PlotlyError('\n'.join([
+                'Plotly Offline mode has not been initialized in this notebook. '
+                'Run: ',
+                '',
+                'import plotly',
+                'plotly.offline.init_notebook_mode() '
+                '# run at the start of every ipython notebook',
+            ]))
         if image not in __IMAGE_FORMATS:
             raise ValueError('The image parameter must be one of the following'
                              ': {}'.format(__IMAGE_FORMATS)

--- a/plotly/tests/test_optional/test_offline/test_offline.py
+++ b/plotly/tests/test_optional/test_offline/test_offline.py
@@ -29,16 +29,19 @@ class PlotlyOfflineTestCase(TestCase):
     def setUp(self):
         pass
 
-    @raises(plotly.exceptions.PlotlyError)
-    def test_iplot_doesnt_work_before_you_call_init_notebook_mode(self):
+    def test_iplot_works_without_init_notebook_mode(self):
         plotly.offline.iplot([{}])
+
+    @raises(plotly.exceptions.PlotlyError)
+    def test_iplot_doesnt_work_before_you_call_init_notebook_mode_when_requesting_download(self):
+        plotly.offline.iplot([{}], image='png')
 
     def test_iplot_works_after_you_call_init_notebook_mode(self):
         plotly.offline.init_notebook_mode()
         plotly.offline.iplot([{}])
 
     @attr('matplotlib')
-    def test_iplot_mpl_works_after_you_call_init_notebook_mode(self):
+    def test_iplot_mpl_works(self):
         # Generate matplotlib plot for tests
         fig = plt.figure()
 
@@ -46,7 +49,6 @@ class PlotlyOfflineTestCase(TestCase):
         y = [100, 200, 300]
         plt.plot(x, y, "o")
 
-        plotly.offline.init_notebook_mode()
         plotly.offline.iplot_mpl(fig)
 
 


### PR DESCRIPTION
Running `init_notebook_mode()` isn't required in frontends with support for the `application/vnd.plotly.v1+json` mime type (like [nteract](https://github.com/nteract/nteract) and [Hydrogen](https://github.com/nteract/hydrogen)):
![plotly](https://user-images.githubusercontent.com/13285808/27988881-727f418e-642d-11e7-900e-0c328a72255d.png)

This PR makes `offline.init_notebook_mode()` optional when using `offline.iplot()`

/cc @rgbkrk 