### PR TITLE
Add missing rugplot property passing inside violin_no_colorscale

### DIFF
--- a/plotly/figure_factory/_violin.py
+++ b/plotly/figure_factory/_violin.py
@@ -224,7 +224,8 @@ def violin_no_colorscale(data, data_header, group_header, colors,
         if color_index >= len(colors):
             color_index = 0
         plot_data, plot_xrange = violinplot(vals,
-                                            fillcolor=colors[color_index])
+                                            fillcolor=colors[color_index],
+                                            rugplot=rugplot)
         layout = graph_objs.Layout()
 
         for item in plot_data:


### PR DESCRIPTION
When trying to plot my violin, I noticed rugplot=False was not being respected. This is a proposed fix.
As a point of discussion, should the rugplot=True|False property name be normalized between the figure factories? For example, in _distplot.py the corresponding property name is "show_rug" instead of "rugplot".