### PR TITLE
Fix reversed color scale in annotated heatmap

### DIFF
--- a/plotly/figure_factory/_annotated_heatmap.py
+++ b/plotly/figure_factory/_annotated_heatmap.py
@@ -63,6 +63,7 @@ def create_annotated_heatmap(z, x=None, y=None, annotation_text=None,
         defined, the colors are defined logically as black or white
         depending on the heatmap's colorscale.
     :param (bool) showscale: Display colorscale. Default = False
+    :param (bool) reversescale: Reverse colorscale. Default = False
     :param kwargs: kwargs passed through plotly.graph_objs.Heatmap.
         These kwargs describe other attributes about the annotated Heatmap
         trace such as the colorscale. For more information on valid kwargs
@@ -92,14 +93,14 @@ def create_annotated_heatmap(z, x=None, y=None, annotation_text=None,
 
     if x or y:
         trace = dict(type='heatmap', z=z, x=x, y=y, colorscale=colorscale,
-                     showscale=showscale, **kwargs)
+                     showscale=showscale, reversescale=reversescale, **kwargs)
         layout = dict(annotations=annotations,
                       xaxis=dict(ticks='', dtick=1, side='top',
                                  gridcolor='rgb(0, 0, 0)'),
                       yaxis=dict(ticks='', dtick=1, ticksuffix='  '))
     else:
         trace = dict(type='heatmap', z=z, colorscale=colorscale,
-                     showscale=showscale, **kwargs)
+                     showscale=showscale, reversescale=reversescale, **kwargs)
         layout = dict(annotations=annotations,
                       xaxis=dict(ticks='', side='top',
                                  gridcolor='rgb(0, 0, 0)',


### PR DESCRIPTION
Currently, `reversescale` does not get included into the `trace` dictionary. Therefore, color scale doesn't change when setting `reversescale=True` (although the color of annotations gets inverted).

Here is how to reproduce the error:
```python
iplot(ff.create_annotated_heatmap(z=[[1, 30], [20, 60]], reversescale=False))
```
![plot1](https://user-images.githubusercontent.com/7109913/32079449-451654dc-ba70-11e7-849d-749b105bbccf.png)

```python
iplot(ff.create_annotated_heatmap(z=[[1, 30], [20, 60]], reversescale=True))
```
![plot2](https://user-images.githubusercontent.com/7109913/32079456-49bbf1fe-ba70-11e7-99b1-28fca4902bba.png)

This pull request fixes the problem.