### PR TITLE
manage plotly/colors.py and plotly/figure_factory/utils.py

### DIFF
--- a/plotly/colors.py
+++ b/plotly/colors.py
@@ -608,3 +608,50 @@ def convert_colorscale_to_rgb(colorscale):
     for color in colorscale:
         color[1] = label_rgb(color[1])
     return colorscale
+
+
+def endpts_to_intervals(endpts):
+    """
+    Returns a list of intervals for categorical colormaps
+
+    Accepts a list or tuple of sequentially increasing numbers and returns
+    a list representation of the mathematical intervals with these numbers
+    as endpoints. For example, [1, 6] returns [[-inf, 1], [1, 6], [6, inf]]
+
+    :raises: (PlotlyError) If input is not a list or tuple
+    :raises: (PlotlyError) If the input contains a string
+    :raises: (PlotlyError) If any number does not increase after the
+        previous one in the sequence
+    """
+    length = len(endpts)
+    # Check if endpts is a list or tuple
+    if not (isinstance(endpts, (tuple)) or isinstance(endpts, (list))):
+        raise exceptions.PlotlyError("The intervals_endpts argument must "
+                                     "be a list or tuple of a sequence "
+                                     "of increasing numbers.")
+    # Check if endpts contains only numbers
+    for item in endpts:
+        if isinstance(item, str):
+            raise exceptions.PlotlyError("The intervals_endpts argument "
+                                         "must be a list or tuple of a "
+                                         "sequence of increasing "
+                                         "numbers.")
+    # Check if numbers in endpts are increasing
+    for k in range(length - 1):
+        if endpts[k] >= endpts[k + 1]:
+            raise exceptions.PlotlyError("The intervals_endpts argument "
+                                         "must be a list or tuple of a "
+                                         "sequence of increasing "
+                                         "numbers.")
+    else:
+        intervals = []
+        # add -inf to intervals
+        intervals.append([float('-inf'), endpts[0]])
+        for k in range(length - 1):
+            interval = []
+            interval.append(endpts[k])
+            interval.append(endpts[k + 1])
+            intervals.append(interval)
+        # add +inf to intervals
+        intervals.append([endpts[length - 1], float('inf')])
+        return intervals

--- a/plotly/figure_factory/utils.py
+++ b/plotly/figure_factory/utils.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import decimal
 
 from plotly import exceptions
+from numbers import Number
 
 DEFAULT_PLOTLY_COLORS = ['rgb(31, 119, 180)', 'rgb(255, 127, 14)',
                          'rgb(44, 160, 44)', 'rgb(214, 39, 40)',
@@ -40,7 +41,6 @@ def validate_index(index_vals):
     :raises: (PlotlyError) If there are any two items in the list whose
         types differ
     """
-    from numbers import Number
     if isinstance(index_vals[0], Number):
         if not all(isinstance(item, Number) for item in index_vals):
             raise exceptions.PlotlyError("Error in indexing column. "
@@ -63,7 +63,6 @@ def validate_dataframe(array):
     :raises: (PlotlyError) If there are any two items in any list whose
         types differ
     """
-    from numbers import Number
     for vector in array:
         if isinstance(vector[0], Number):
             if not all(isinstance(item, Number) for item in vector):
@@ -267,7 +266,6 @@ def color_parser(colors, function):
     - rgb string, hex string or tuple
 
     """
-    from numbers import Number
     if isinstance(colors, str):
         return function(colors)
 
@@ -288,7 +286,6 @@ def validate_colors(colors, colortype='tuple'):
     """
     Validates color(s) and returns a list of color(s) of a specified type
     """
-    from numbers import Number
     if colors is None:
         colors = DEFAULT_PLOTLY_COLORS
 


### PR DESCRIPTION
Currently a couple figure factories are using incorrect plotly colorscales.

A PR to ensure that:
- the correct plotly colorscales are being used by all figure factories
- functions for color manipulating/handling are _only_ in the `colors.py` module
- rewritting some figure_factory code to comply with correct colorscales