### PR TITLE
Clearing data list

### DIFF
--- a/plotly/figure_factory/_gantt.py
+++ b/plotly/figure_factory/_gantt.py
@@ -274,6 +274,7 @@ def gantt_colorscale(chart, colors, title, index_col, show_colorbar, bar_width,
 
         if show_colorbar is True:
             # generate dummy data for colorscale visibility
+            data=[]
             data.append(
                 dict(
                     x=[tasks[index]['x0'], tasks[index]['x0']],
@@ -355,6 +356,7 @@ def gantt_colorscale(chart, colors, title, index_col, show_colorbar, bar_width,
 
         if show_colorbar is True:
             # generate dummy data to generate legend
+            data=[]
             showlegend = True
             for k, index_value in enumerate(index_vals):
                 data.append(
@@ -512,6 +514,7 @@ def gantt_dict(chart, colors, title, index_col, show_colorbar, bar_width,
 
     if show_colorbar is True:
         # generate dummy data to generate legend
+        data=[]
         showlegend = True
         for k, index_value in enumerate(index_vals):
             data.append(

--- a/plotly/figure_factory/_gantt.py
+++ b/plotly/figure_factory/_gantt.py
@@ -274,8 +274,10 @@ def gantt_colorscale(chart, colors, title, index_col, show_colorbar, bar_width,
 
         if show_colorbar is True:
             # generate dummy data for colorscale visibility
-            data=[]
-            data.append(
+            datalisted = data
+            newentries = []
+            
+            newentries.append(
                 dict(
                     x=[tasks[index]['x0'], tasks[index]['x0']],
                     y=[index, index],
@@ -287,6 +289,7 @@ def gantt_colorscale(chart, colors, title, index_col, show_colorbar, bar_width,
                             'cmin': 0}
                 )
             )
+            data = newentries + datalisted
 
     if isinstance(chart[0][index_col], str):
         index_vals = []
@@ -356,10 +359,12 @@ def gantt_colorscale(chart, colors, title, index_col, show_colorbar, bar_width,
 
         if show_colorbar is True:
             # generate dummy data to generate legend
-            data=[]
+            datalisted = data
+            newentries = []
+            
             showlegend = True
             for k, index_value in enumerate(index_vals):
-                data.append(
+                newentries.append(
                     dict(
                         x=[tasks[index]['x0'], tasks[index]['x0']],
                         y=[k, k],
@@ -372,6 +377,7 @@ def gantt_colorscale(chart, colors, title, index_col, show_colorbar, bar_width,
                         )
                     )
                 )
+            data = newentries + datalisted
 
     layout = dict(
         title=title,
@@ -514,10 +520,12 @@ def gantt_dict(chart, colors, title, index_col, show_colorbar, bar_width,
 
     if show_colorbar is True:
         # generate dummy data to generate legend
-        data=[]
+        datalisted = data
+        newentries = []
+        
         showlegend = True
         for k, index_value in enumerate(index_vals):
-            data.append(
+            newentries.append(
                 dict(
                     x=[tasks[index]['x0'], tasks[index]['x0']],
                     y=[k, k],
@@ -530,6 +538,7 @@ def gantt_dict(chart, colors, title, index_col, show_colorbar, bar_width,
                     )
                 )
             )
+        data = newentries + datalisted
 
     layout = dict(
         title=title,


### PR DESCRIPTION
Hi all,

I was playing around with gantt charts and experience that the legend (colorbar) needs to be scrolled to see my defined 'Tasks' at the very bottom (which is actually visible at the examples as well, above the 'Tasks' are hidden traces, which are even clickable). After checking through _gantt.py I identified the following rows, where the variable 'data' has many entries. 

new lines @ 277 
new lines @ 359
new lines @ 517

Can someone please verify and if agreeing, pushing the change to the repo?

Many thanks
Cheers
J

---edit---
found some issue and had to fix this
