### PR TITLE
minor fixes to contributing instructions

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -23,14 +23,14 @@ First, you'll need to *get* our project. This is the appropriate *clone* command
 **DO THIS (in the directory where you want the repo to live)**
 
 ```bash
-git clone https://github.com/plotly/python-api.git
+git clone https://github.com/your_github_username/plotly.py.git
 ```
 
 ### Submodules
 
 Second, this project uses git submodules! They're both helpful and, at times, difficult to work with. The good news is you probably don't need to think about them! Just run the following shell command to make sure that your local repo is wired properly:
 
-**DO THIS (run this command in your new `plotly-api` directory)**
+**DO THIS (run this command in your new `plotly.py` directory)**
 
 ```bash
 make setup_subs


### PR DESCRIPTION
Super minor changes from reading your `contributing.md` instructions as a new, would-be-contributor.

The instructed url to clone, `https://github.com/plotly/python-api` redirects here, so it seemed like one less thing to be confused about, especially since the instructions seemed geared toward being noob friendly.

Also, since you're instructing to fork, I changed your clone url: 
```
git clone https://github.com/your_github_username/plotly.py.git
```

I've done a reasonable amount of PRs and *still* get burned more than I'd like by cloning the upstream and then realizing I can't push my changes like I thought because I'm not in my fork!

---

Aside: maybe you meant for users to simply clone *this* repo, but then I'd suggest some different changes to clarify that since it's right after telling them to learn how to fork.