### PR TITLE
RFC: implement attr function and "magic" underscore behavior for PlotlyDict.update

### DIFF
--- a/plotly/graph_objs/__init__.py
+++ b/plotly/graph_objs/__init__.py
@@ -12,3 +12,5 @@ a clearer API for users.
 from __future__ import absolute_import
 
 from plotly.graph_objs.graph_objs import *  # this is protected with __all__
+
+from plotly.graph_objs.graph_objs_tools import attr

--- a/plotly/graph_objs/graph_objs.py
+++ b/plotly/graph_objs/graph_objs.py
@@ -612,7 +612,12 @@ class PlotlyDict(dict, PlotlyBase):
                     else:
                         self[key] = val
                 else:
-                    self[key] = val
+                    # don't have this key -- might be using underscore magic
+                    graph_objs_tools._underscore_magic(key, val, self)
+
+        # return self so we can chain this method (e.g. Scatter().update(**)
+        # returns an instance of Scatter)
+        return self
 
     def strip_style(self):
         """

--- a/plotly/graph_objs/graph_objs.py
+++ b/plotly/graph_objs/graph_objs.py
@@ -566,11 +566,22 @@ class PlotlyDict(dict, PlotlyBase):
 
     def update(self, dict1=None, **dict2):
         """
-        Update current dict with dict1 and then dict2.
+        Update current dict with dict1 and then dict2. Returns a modifed
+        version of self (updates are applied in place)
 
         This recursively updates the structure of the original dictionary-like
         object with the new entries in the second and third objects. This
         allows users to update with large, nested structures.
+
+        For all items in dict2, the "underscore magic" syntax for setting deep
+        attributes applies. To use this syntax, specify the path to the
+        attribute, separating each part of the path by an underscore. For
+        example, to set the "marker.line.color" attribute you can do
+        `obj.update(marker_line_color="red")` instead of
+        `obj.update(marker={"line": {"color": "red"}})`. Note that you can
+        use this in conjuction with the `plotly.graph_objs.attr` function to
+        set groups of deep attributes. See docstring for `attr` and the
+        examples below for more information.
 
         Note, because the dict2 packs up all the keyword arguments, you can
         specify the changes as a list of keyword agruments.
@@ -586,6 +597,19 @@ class PlotlyDict(dict, PlotlyBase):
         # update with list of keyword arguments
         obj = Layout(title='my title', xaxis=XAxis(range=[0,1], domain=[0,1]))
         obj.update(title='new title', xaxis=dict(domain=[0,.8]))
+        obj
+        {'title': 'new title', 'xaxis': {'range': [0,1], 'domain': [0,.8]}}
+
+        # Update with underscore magic syntax for xaxis.domain
+        obj = Layout(title='my title', xaxis=XAxis(range=[0,1], domain=[0,1]))
+        obj.update(title="new title", xaxis_domain=[0, 0.8])
+        obj
+        {'title': 'new title', 'xaxis': {'range': [0,1], 'domain': [0,.8]}}
+
+        # Use underscore magic and attr function for xaxis
+        obj = Layout().update(
+            title="new title",
+            xaxis=attr(range=[0, 1], domain=[0, 0.8]))
         obj
         {'title': 'new title', 'xaxis': {'range': [0,1], 'domain': [0,.8]}}
 

--- a/plotly/graph_objs/graph_objs.py
+++ b/plotly/graph_objs/graph_objs.py
@@ -834,10 +834,18 @@ class GraphObjectFactory(object):
 class AngularAxis(PlotlyDict):
     """
     Valid attributes for 'angularaxis' at path [] under parents ():
-
-        ['domain', 'endpadding', 'range', 'showline', 'showticklabels',
-        'tickcolor', 'ticklen', 'tickorientation', 'ticksuffix', 'visible']
-
+    
+        ['categoryarray', 'categoryarraysrc', 'categoryorder', 'color',
+        'direction', 'domain', 'dtick', 'endpadding', 'exponentformat',
+        'gridcolor', 'gridwidth', 'hoverformat', 'layer', 'linecolor',
+        'linewidth', 'nticks', 'period', 'range', 'rotation',
+        'separatethousands', 'showexponent', 'showgrid', 'showline',
+        'showticklabels', 'showtickprefix', 'showticksuffix', 'thetaunit',
+        'tick0', 'tickangle', 'tickcolor', 'tickfont', 'tickformat',
+        'tickformatstops', 'ticklen', 'tickmode', 'tickorientation',
+        'tickprefix', 'ticks', 'ticksuffix', 'ticktext', 'ticktextsrc',
+        'tickvals', 'tickvalssrc', 'tickwidth', 'type', 'visible']
+    
     Run `<angularaxis-object>.help('attribute')` on any of the above.
     '<angularaxis-object>' is the object at []
 
@@ -848,15 +856,16 @@ class AngularAxis(PlotlyDict):
 class Annotation(PlotlyDict):
     """
     Valid attributes for 'annotation' at path [] under parents ():
-
-        ['align', 'arrowcolor', 'arrowhead', 'arrowsize', 'arrowwidth', 'ax',
-        'axref', 'ay', 'ayref', 'bgcolor', 'bordercolor', 'borderpad',
-        'borderwidth', 'captureevents', 'clicktoshow', 'font', 'height',
-        'hoverlabel', 'hovertext', 'opacity', 'ref', 'showarrow', 'standoff',
+    
+        ['align', 'arrowcolor', 'arrowhead', 'arrowside', 'arrowsize',
+        'arrowwidth', 'ax', 'axref', 'ay', 'ayref', 'bgcolor', 'bordercolor',
+        'borderpad', 'borderwidth', 'captureevents', 'clicktoshow', 'font',
+        'height', 'hoverlabel', 'hovertext', 'opacity', 'ref', 'showarrow',
+        'standoff', 'startarrowhead', 'startarrowsize', 'startstandoff',
         'text', 'textangle', 'valign', 'visible', 'width', 'x', 'xanchor',
         'xclick', 'xref', 'xshift', 'y', 'yanchor', 'yclick', 'yref', 'yshift',
         'z']
-
+    
     Run `<annotation-object>.help('attribute')` on any of the above.
     '<annotation-object>' is the object at []
 
@@ -876,12 +885,12 @@ class Annotations(PlotlyList):
 class Area(PlotlyDict):
     """
     Valid attributes for 'area' at path [] under parents ():
-
+    
         ['customdata', 'customdatasrc', 'hoverinfo', 'hoverinfosrc',
         'hoverlabel', 'ids', 'idssrc', 'legendgroup', 'marker', 'name',
-        'opacity', 'r', 'rsrc', 'showlegend', 'stream', 't', 'tsrc', 'type',
-        'uid', 'visible']
-
+        'opacity', 'r', 'rsrc', 'selectedpoints', 'showlegend', 'stream', 't',
+        'tsrc', 'type', 'uid', 'visible']
+    
     Run `<area-object>.help('attribute')` on any of the above.
     '<area-object>' is the object at []
 
@@ -892,17 +901,17 @@ class Area(PlotlyDict):
 class Bar(PlotlyDict):
     """
     Valid attributes for 'bar' at path [] under parents ():
-
+    
         ['bardir', 'base', 'basesrc', 'constraintext', 'customdata',
         'customdatasrc', 'dx', 'dy', 'error_x', 'error_y', 'hoverinfo',
         'hoverinfosrc', 'hoverlabel', 'hovertext', 'hovertextsrc', 'ids',
         'idssrc', 'insidetextfont', 'legendgroup', 'marker', 'name', 'offset',
         'offsetsrc', 'opacity', 'orientation', 'outsidetextfont', 'r', 'rsrc',
-        'showlegend', 'stream', 't', 'text', 'textfont', 'textposition',
-        'textpositionsrc', 'textsrc', 'tsrc', 'type', 'uid', 'visible',
-        'width', 'widthsrc', 'x', 'x0', 'xaxis', 'xcalendar', 'xsrc', 'y',
-        'y0', 'yaxis', 'ycalendar', 'ysrc']
-
+        'selected', 'selectedpoints', 'showlegend', 'stream', 't', 'text',
+        'textfont', 'textposition', 'textpositionsrc', 'textsrc', 'tsrc',
+        'type', 'uid', 'unselected', 'visible', 'width', 'widthsrc', 'x', 'x0',
+        'xaxis', 'xcalendar', 'xsrc', 'y', 'y0', 'yaxis', 'ycalendar', 'ysrc']
+    
     Run `<bar-object>.help('attribute')` on any of the above.
     '<bar-object>' is the object at []
 
@@ -913,14 +922,15 @@ class Bar(PlotlyDict):
 class Box(PlotlyDict):
     """
     Valid attributes for 'box' at path [] under parents ():
-
+    
         ['boxmean', 'boxpoints', 'customdata', 'customdatasrc', 'fillcolor',
-        'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc', 'jitter',
-        'legendgroup', 'line', 'marker', 'name', 'opacity', 'orientation',
-        'pointpos', 'showlegend', 'stream', 'type', 'uid', 'visible',
-        'whiskerwidth', 'x', 'x0', 'xaxis', 'xcalendar', 'xsrc', 'y', 'y0',
-        'yaxis', 'ycalendar', 'ysrc']
-
+        'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'hoveron', 'ids', 'idssrc',
+        'jitter', 'legendgroup', 'line', 'marker', 'name', 'notched',
+        'notchwidth', 'opacity', 'orientation', 'pointpos', 'selected',
+        'selectedpoints', 'showlegend', 'stream', 'text', 'textsrc', 'type',
+        'uid', 'unselected', 'visible', 'whiskerwidth', 'x', 'x0', 'xaxis',
+        'xcalendar', 'xsrc', 'y', 'y0', 'yaxis', 'ycalendar', 'ysrc']
+    
     Run `<box-object>.help('attribute')` on any of the above.
     '<box-object>' is the object at []
 
@@ -931,14 +941,14 @@ class Box(PlotlyDict):
 class Candlestick(PlotlyDict):
     """
     Valid attributes for 'candlestick' at path [] under parents ():
-
+    
         ['close', 'closesrc', 'customdata', 'customdatasrc', 'decreasing',
         'high', 'highsrc', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids',
         'idssrc', 'increasing', 'legendgroup', 'line', 'low', 'lowsrc', 'name',
-        'opacity', 'open', 'opensrc', 'showlegend', 'stream', 'text',
-        'textsrc', 'type', 'uid', 'visible', 'whiskerwidth', 'x', 'xaxis',
-        'xcalendar', 'xsrc', 'yaxis']
-
+        'opacity', 'open', 'opensrc', 'selectedpoints', 'showlegend', 'stream',
+        'text', 'textsrc', 'type', 'uid', 'visible', 'whiskerwidth', 'x',
+        'xaxis', 'xcalendar', 'xsrc', 'yaxis']
+    
     Run `<candlestick-object>.help('attribute')` on any of the above.
     '<candlestick-object>' is the object at []
 
@@ -949,13 +959,14 @@ class Candlestick(PlotlyDict):
 class Carpet(PlotlyDict):
     """
     Valid attributes for 'carpet' at path [] under parents ():
-
+    
         ['a', 'a0', 'aaxis', 'asrc', 'b', 'b0', 'baxis', 'bsrc', 'carpet',
         'cheaterslope', 'color', 'customdata', 'customdatasrc', 'da', 'db',
         'font', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc',
-        'legendgroup', 'name', 'opacity', 'showlegend', 'stream', 'type',
-        'uid', 'visible', 'x', 'xaxis', 'xsrc', 'y', 'yaxis', 'ysrc']
-
+        'legendgroup', 'name', 'opacity', 'selectedpoints', 'showlegend',
+        'stream', 'type', 'uid', 'visible', 'x', 'xaxis', 'xsrc', 'y', 'yaxis',
+        'ysrc']
+    
     Run `<carpet-object>.help('attribute')` on any of the above.
     '<carpet-object>' is the object at []
 
@@ -966,14 +977,15 @@ class Carpet(PlotlyDict):
 class Choropleth(PlotlyDict):
     """
     Valid attributes for 'choropleth' at path [] under parents ():
-
+    
         ['autocolorscale', 'colorbar', 'colorscale', 'customdata',
         'customdatasrc', 'geo', 'hoverinfo', 'hoverinfosrc', 'hoverlabel',
         'ids', 'idssrc', 'legendgroup', 'locationmode', 'locations',
         'locationssrc', 'marker', 'name', 'opacity', 'reversescale',
-        'showlegend', 'showscale', 'stream', 'text', 'textsrc', 'type', 'uid',
-        'visible', 'z', 'zauto', 'zmax', 'zmin', 'zsrc']
-
+        'selected', 'selectedpoints', 'showlegend', 'showscale', 'stream',
+        'text', 'textsrc', 'type', 'uid', 'unselected', 'visible', 'z',
+        'zauto', 'zmax', 'zmin', 'zsrc']
+    
     Run `<choropleth-object>.help('attribute')` on any of the above.
     '<choropleth-object>' is the object at []
 
@@ -984,17 +996,17 @@ class Choropleth(PlotlyDict):
 class ColorBar(PlotlyDict):
     """
     Valid attributes for 'colorbar' at path [] under parents ():
-
+    
         ['bgcolor', 'bordercolor', 'borderwidth', 'dtick', 'exponentformat',
         'len', 'lenmode', 'nticks', 'outlinecolor', 'outlinewidth',
         'separatethousands', 'showexponent', 'showticklabels',
         'showtickprefix', 'showticksuffix', 'thickness', 'thicknessmode',
-        'tick0', 'tickangle', 'tickcolor', 'tickfont', 'tickformat', 'ticklen',
-        'tickmode', 'tickprefix', 'ticks', 'ticksuffix', 'ticktext',
-        'ticktextsrc', 'tickvals', 'tickvalssrc', 'tickwidth', 'title',
-        'titlefont', 'titleside', 'x', 'xanchor', 'xpad', 'y', 'yanchor',
-        'ypad']
-
+        'tick0', 'tickangle', 'tickcolor', 'tickfont', 'tickformat',
+        'tickformatstops', 'ticklen', 'tickmode', 'tickprefix', 'ticks',
+        'ticksuffix', 'ticktext', 'ticktextsrc', 'tickvals', 'tickvalssrc',
+        'tickwidth', 'title', 'titlefont', 'titleside', 'x', 'xanchor', 'xpad',
+        'y', 'yanchor', 'ypad']
+    
     Run `<colorbar-object>.help('attribute')` on any of the above.
     '<colorbar-object>' is the object at []
 
@@ -1005,16 +1017,16 @@ class ColorBar(PlotlyDict):
 class Contour(PlotlyDict):
     """
     Valid attributes for 'contour' at path [] under parents ():
-
+    
         ['autocolorscale', 'autocontour', 'colorbar', 'colorscale',
         'connectgaps', 'contours', 'customdata', 'customdatasrc', 'dx', 'dy',
-        'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc',
-        'legendgroup', 'line', 'name', 'ncontours', 'opacity', 'reversescale',
-        'showlegend', 'showscale', 'stream', 'text', 'textsrc', 'transpose',
-        'type', 'uid', 'visible', 'x', 'x0', 'xaxis', 'xcalendar', 'xsrc',
-        'xtype', 'y', 'y0', 'yaxis', 'ycalendar', 'ysrc', 'ytype', 'z',
-        'zauto', 'zmax', 'zmin', 'zsrc']
-
+        'fillcolor', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids',
+        'idssrc', 'legendgroup', 'line', 'name', 'ncontours', 'opacity',
+        'reversescale', 'selectedpoints', 'showlegend', 'showscale', 'stream',
+        'text', 'textsrc', 'transpose', 'type', 'uid', 'visible', 'x', 'x0',
+        'xaxis', 'xcalendar', 'xsrc', 'xtype', 'y', 'y0', 'yaxis', 'ycalendar',
+        'ysrc', 'ytype', 'z', 'zauto', 'zhoverformat', 'zmax', 'zmin', 'zsrc']
+    
     Run `<contour-object>.help('attribute')` on any of the above.
     '<contour-object>' is the object at []
 
@@ -1025,16 +1037,16 @@ class Contour(PlotlyDict):
 class Contourcarpet(PlotlyDict):
     """
     Valid attributes for 'contourcarpet' at path [] under parents ():
-
+    
         ['a', 'a0', 'asrc', 'atype', 'autocolorscale', 'autocontour', 'b',
-        'b0', 'bsrc', 'btype', 'carpet', 'colorbar', 'colorscale',
-        'connectgaps', 'contours', 'customdata', 'customdatasrc', 'da', 'db',
-        'fillcolor', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids',
-        'idssrc', 'legendgroup', 'line', 'mode', 'name', 'ncontours',
-        'opacity', 'reversescale', 'showlegend', 'showscale', 'stream', 'text',
-        'textsrc', 'transpose', 'type', 'uid', 'visible', 'xaxis', 'yaxis',
-        'z', 'zauto', 'zmax', 'zmin', 'zsrc']
-
+        'b0', 'bsrc', 'btype', 'carpet', 'colorbar', 'colorscale', 'contours',
+        'customdata', 'customdatasrc', 'da', 'db', 'fillcolor', 'hoverinfo',
+        'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc', 'legendgroup', 'line',
+        'name', 'ncontours', 'opacity', 'reversescale', 'selectedpoints',
+        'showlegend', 'showscale', 'stream', 'text', 'textsrc', 'transpose',
+        'type', 'uid', 'visible', 'xaxis', 'yaxis', 'z', 'zauto', 'zmax',
+        'zmin', 'zsrc']
+    
     Run `<contourcarpet-object>.help('attribute')` on any of the above.
     '<contourcarpet-object>' is the object at []
 
@@ -1045,11 +1057,11 @@ class Contourcarpet(PlotlyDict):
 class Contours(PlotlyDict):
     """
     Valid attributes for 'contours' at path [] under parents ():
-
+    
         ['coloring', 'end', 'labelfont', 'labelformat', 'operation',
         'showlabels', 'showlines', 'size', 'start', 'type', 'value', 'x', 'y',
         'z']
-
+    
     Run `<contours-object>.help('attribute')` on any of the above.
     '<contours-object>' is the object at []
 
@@ -1064,8 +1076,8 @@ class Data(PlotlyList):
         'Contour', 'Contourcarpet', 'Heatmap', 'Heatmapgl', 'Histogram',
         'Histogram2d', 'Histogram2dcontour', 'Mesh3d', 'Ohlc', 'Parcoords',
         'Pie', 'Pointcloud', 'Sankey', 'Scatter', 'Scatter3d', 'Scattercarpet',
-        'Scattergeo', 'Scattergl', 'Scattermapbox', 'Scatterternary',
-        'Surface', 'Table']
+        'Scattergeo', 'Scattergl', 'Scattermapbox', 'Scatterpolar',
+        'Scatterpolargl', 'Scatterternary', 'Surface', 'Table', 'Violin']
 
     """
     _name = 'data'
@@ -1131,12 +1143,12 @@ class Data(PlotlyList):
 class ErrorX(PlotlyDict):
     """
     Valid attributes for 'error_x' at path [] under parents ():
-
+    
         ['array', 'arrayminus', 'arrayminussrc', 'arraysrc', 'color',
         'copy_ystyle', 'copy_zstyle', 'opacity', 'symmetric', 'thickness',
         'traceref', 'tracerefminus', 'type', 'value', 'valueminus', 'visible',
         'width']
-
+    
     Run `<error_x-object>.help('attribute')` on any of the above.
     '<error_x-object>' is the object at []
 
@@ -1147,12 +1159,12 @@ class ErrorX(PlotlyDict):
 class ErrorY(PlotlyDict):
     """
     Valid attributes for 'error_y' at path [] under parents ():
-
+    
         ['array', 'arrayminus', 'arrayminussrc', 'arraysrc', 'color',
         'copy_ystyle', 'copy_zstyle', 'opacity', 'symmetric', 'thickness',
         'traceref', 'tracerefminus', 'type', 'value', 'valueminus', 'visible',
         'width']
-
+    
     Run `<error_y-object>.help('attribute')` on any of the above.
     '<error_y-object>' is the object at []
 
@@ -1163,12 +1175,12 @@ class ErrorY(PlotlyDict):
 class ErrorZ(PlotlyDict):
     """
     Valid attributes for 'error_z' at path [] under parents ():
-
+    
         ['array', 'arrayminus', 'arrayminussrc', 'arraysrc', 'color',
         'copy_ystyle', 'copy_zstyle', 'opacity', 'symmetric', 'thickness',
         'traceref', 'tracerefminus', 'type', 'value', 'valueminus', 'visible',
         'width']
-
+    
     Run `<error_z-object>.help('attribute')` on any of the above.
     '<error_z-object>' is the object at []
 
@@ -1179,9 +1191,9 @@ class ErrorZ(PlotlyDict):
 class Figure(PlotlyDict):
     """
     Valid attributes for 'figure' at path [] under parents ():
-
+    
         ['data', 'frames', 'layout']
-
+    
     Run `<figure-object>.help('attribute')` on any of the above.
     '<figure-object>' is the object at []
 
@@ -1299,9 +1311,9 @@ class Figure(PlotlyDict):
 class Font(PlotlyDict):
     """
     Valid attributes for 'font' at path [] under parents ():
-
+    
         ['color', 'colorsrc', 'family', 'familysrc', 'size', 'sizesrc']
-
+    
     Run `<font-object>.help('attribute')` on any of the above.
     '<font-object>' is the object at []
 
@@ -1326,7 +1338,7 @@ class Frames(PlotlyList):
     def to_string(self, level=0, indent=4, eol='\n',
                   pretty=True, max_chars=80):
         """Get formatted string by calling `to_string` on children items."""
-        if not self:
+        if not len(self):
             return "{name}()".format(name=self._get_class_name())
         string = "{name}([{eol}{indent}".format(
             name=self._get_class_name(),
@@ -1353,15 +1365,16 @@ class Frames(PlotlyList):
 class Heatmap(PlotlyDict):
     """
     Valid attributes for 'heatmap' at path [] under parents ():
-
+    
         ['autocolorscale', 'colorbar', 'colorscale', 'connectgaps',
         'customdata', 'customdatasrc', 'dx', 'dy', 'hoverinfo', 'hoverinfosrc',
         'hoverlabel', 'ids', 'idssrc', 'legendgroup', 'name', 'opacity',
-        'reversescale', 'showlegend', 'showscale', 'stream', 'text', 'textsrc',
-        'transpose', 'type', 'uid', 'visible', 'x', 'x0', 'xaxis', 'xcalendar',
-        'xgap', 'xsrc', 'xtype', 'y', 'y0', 'yaxis', 'ycalendar', 'ygap',
-        'ysrc', 'ytype', 'z', 'zauto', 'zmax', 'zmin', 'zsmooth', 'zsrc']
-
+        'reversescale', 'selectedpoints', 'showlegend', 'showscale', 'stream',
+        'text', 'textsrc', 'transpose', 'type', 'uid', 'visible', 'x', 'x0',
+        'xaxis', 'xcalendar', 'xgap', 'xsrc', 'xtype', 'y', 'y0', 'yaxis',
+        'ycalendar', 'ygap', 'ysrc', 'ytype', 'z', 'zauto', 'zhoverformat',
+        'zmax', 'zmin', 'zsmooth', 'zsrc']
+    
     Run `<heatmap-object>.help('attribute')` on any of the above.
     '<heatmap-object>' is the object at []
 
@@ -1372,14 +1385,15 @@ class Heatmap(PlotlyDict):
 class Heatmapgl(PlotlyDict):
     """
     Valid attributes for 'heatmapgl' at path [] under parents ():
-
+    
         ['autocolorscale', 'colorbar', 'colorscale', 'customdata',
         'customdatasrc', 'dx', 'dy', 'hoverinfo', 'hoverinfosrc', 'hoverlabel',
         'ids', 'idssrc', 'legendgroup', 'name', 'opacity', 'reversescale',
-        'showlegend', 'showscale', 'stream', 'text', 'textsrc', 'transpose',
-        'type', 'uid', 'visible', 'x', 'x0', 'xaxis', 'xsrc', 'xtype', 'y',
-        'y0', 'yaxis', 'ysrc', 'ytype', 'z', 'zauto', 'zmax', 'zmin', 'zsrc']
-
+        'selectedpoints', 'showlegend', 'showscale', 'stream', 'text',
+        'textsrc', 'transpose', 'type', 'uid', 'visible', 'x', 'x0', 'xaxis',
+        'xsrc', 'xtype', 'y', 'y0', 'yaxis', 'ysrc', 'ytype', 'z', 'zauto',
+        'zmax', 'zmin', 'zsrc']
+    
     Run `<heatmapgl-object>.help('attribute')` on any of the above.
     '<heatmapgl-object>' is the object at []
 
@@ -1390,15 +1404,16 @@ class Heatmapgl(PlotlyDict):
 class Histogram(PlotlyDict):
     """
     Valid attributes for 'histogram' at path [] under parents ():
-
+    
         ['autobinx', 'autobiny', 'bardir', 'cumulative', 'customdata',
         'customdatasrc', 'error_x', 'error_y', 'histfunc', 'histnorm',
         'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc',
         'legendgroup', 'marker', 'name', 'nbinsx', 'nbinsy', 'opacity',
-        'orientation', 'showlegend', 'stream', 'text', 'textsrc', 'type',
-        'uid', 'visible', 'x', 'xaxis', 'xbins', 'xcalendar', 'xsrc', 'y',
-        'yaxis', 'ybins', 'ycalendar', 'ysrc']
-
+        'orientation', 'selected', 'selectedpoints', 'showlegend', 'stream',
+        'text', 'textsrc', 'type', 'uid', 'unselected', 'visible', 'x',
+        'xaxis', 'xbins', 'xcalendar', 'xsrc', 'y', 'yaxis', 'ybins',
+        'ycalendar', 'ysrc']
+    
     Run `<histogram-object>.help('attribute')` on any of the above.
     '<histogram-object>' is the object at []
 
@@ -1409,15 +1424,16 @@ class Histogram(PlotlyDict):
 class Histogram2d(PlotlyDict):
     """
     Valid attributes for 'histogram2d' at path [] under parents ():
-
+    
         ['autobinx', 'autobiny', 'autocolorscale', 'colorbar', 'colorscale',
         'customdata', 'customdatasrc', 'histfunc', 'histnorm', 'hoverinfo',
         'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc', 'legendgroup', 'marker',
-        'name', 'nbinsx', 'nbinsy', 'opacity', 'reversescale', 'showlegend',
-        'showscale', 'stream', 'type', 'uid', 'visible', 'x', 'xaxis', 'xbins',
-        'xcalendar', 'xgap', 'xsrc', 'y', 'yaxis', 'ybins', 'ycalendar',
-        'ygap', 'ysrc', 'z', 'zauto', 'zmax', 'zmin', 'zsmooth', 'zsrc']
-
+        'name', 'nbinsx', 'nbinsy', 'opacity', 'reversescale',
+        'selectedpoints', 'showlegend', 'showscale', 'stream', 'type', 'uid',
+        'visible', 'x', 'xaxis', 'xbins', 'xcalendar', 'xgap', 'xsrc', 'y',
+        'yaxis', 'ybins', 'ycalendar', 'ygap', 'ysrc', 'z', 'zauto',
+        'zhoverformat', 'zmax', 'zmin', 'zsmooth', 'zsrc']
+    
     Run `<histogram2d-object>.help('attribute')` on any of the above.
     '<histogram2d-object>' is the object at []
 
@@ -1428,16 +1444,16 @@ class Histogram2d(PlotlyDict):
 class Histogram2dContour(PlotlyDict):
     """
     Valid attributes for 'histogram2dcontour' at path [] under parents ():
-
+    
         ['autobinx', 'autobiny', 'autocolorscale', 'autocontour', 'colorbar',
         'colorscale', 'contours', 'customdata', 'customdatasrc', 'histfunc',
         'histnorm', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc',
         'legendgroup', 'line', 'marker', 'name', 'nbinsx', 'nbinsy',
-        'ncontours', 'opacity', 'reversescale', 'showlegend', 'showscale',
-        'stream', 'type', 'uid', 'visible', 'x', 'xaxis', 'xbins', 'xcalendar',
-        'xsrc', 'y', 'yaxis', 'ybins', 'ycalendar', 'ysrc', 'z', 'zauto',
-        'zmax', 'zmin', 'zsrc']
-
+        'ncontours', 'opacity', 'reversescale', 'selectedpoints', 'showlegend',
+        'showscale', 'stream', 'type', 'uid', 'visible', 'x', 'xaxis', 'xbins',
+        'xcalendar', 'xsrc', 'y', 'yaxis', 'ybins', 'ycalendar', 'ysrc', 'z',
+        'zauto', 'zhoverformat', 'zmax', 'zmin', 'zsrc']
+    
     Run `<histogram2dcontour-object>.help('attribute')` on any of the above.
     '<histogram2dcontour-object>' is the object at []
 
@@ -1448,16 +1464,16 @@ class Histogram2dContour(PlotlyDict):
 class Histogram2dcontour(PlotlyDict):
     """
     Valid attributes for 'histogram2dcontour' at path [] under parents ():
-
+    
         ['autobinx', 'autobiny', 'autocolorscale', 'autocontour', 'colorbar',
         'colorscale', 'contours', 'customdata', 'customdatasrc', 'histfunc',
         'histnorm', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc',
         'legendgroup', 'line', 'marker', 'name', 'nbinsx', 'nbinsy',
-        'ncontours', 'opacity', 'reversescale', 'showlegend', 'showscale',
-        'stream', 'type', 'uid', 'visible', 'x', 'xaxis', 'xbins', 'xcalendar',
-        'xsrc', 'y', 'yaxis', 'ybins', 'ycalendar', 'ysrc', 'z', 'zauto',
-        'zmax', 'zmin', 'zsrc']
-
+        'ncontours', 'opacity', 'reversescale', 'selectedpoints', 'showlegend',
+        'showscale', 'stream', 'type', 'uid', 'visible', 'x', 'xaxis', 'xbins',
+        'xcalendar', 'xsrc', 'y', 'yaxis', 'ybins', 'ycalendar', 'ysrc', 'z',
+        'zauto', 'zhoverformat', 'zmax', 'zmin', 'zsrc']
+    
     Run `<histogram2dcontour-object>.help('attribute')` on any of the above.
     '<histogram2dcontour-object>' is the object at []
 
@@ -1468,16 +1484,18 @@ class Histogram2dcontour(PlotlyDict):
 class Layout(PlotlyDict):
     """
     Valid attributes for 'layout' at path [] under parents ():
-
+    
         ['angularaxis', 'annotations', 'autosize', 'bargap', 'bargroupgap',
         'barmode', 'barnorm', 'boxgap', 'boxgroupgap', 'boxmode', 'calendar',
-        'direction', 'dragmode', 'font', 'geo', 'height', 'hiddenlabels',
-        'hiddenlabelssrc', 'hidesources', 'hoverlabel', 'hovermode', 'images',
-        'legend', 'mapbox', 'margin', 'orientation', 'paper_bgcolor',
-        'plot_bgcolor', 'radialaxis', 'scene', 'separators', 'shapes',
-        'showlegend', 'sliders', 'smith', 'ternary', 'title', 'titlefont',
-        'updatemenus', 'width', 'xaxis', 'yaxis']
-
+        'colorway', 'datarevision', 'direction', 'dragmode', 'font', 'geo',
+        'height', 'hiddenlabels', 'hiddenlabelssrc', 'hidesources',
+        'hoverdistance', 'hoverlabel', 'hovermode', 'images', 'legend',
+        'mapbox', 'margin', 'orientation', 'paper_bgcolor', 'plot_bgcolor',
+        'polar', 'radialaxis', 'scene', 'separators', 'shapes', 'showlegend',
+        'sliders', 'spikedistance', 'ternary', 'title', 'titlefont',
+        'updatemenus', 'violingap', 'violingroupgap', 'violinmode', 'width',
+        'xaxis', 'yaxis']
+    
     Run `<layout-object>.help('attribute')` on any of the above.
     '<layout-object>' is the object at []
 
@@ -1488,10 +1506,10 @@ class Layout(PlotlyDict):
 class Legend(PlotlyDict):
     """
     Valid attributes for 'legend' at path [] under parents ():
-
+    
         ['bgcolor', 'bordercolor', 'borderwidth', 'font', 'orientation',
         'tracegroupgap', 'traceorder', 'x', 'xanchor', 'y', 'yanchor']
-
+    
     Run `<legend-object>.help('attribute')` on any of the above.
     '<legend-object>' is the object at []
 
@@ -1502,12 +1520,12 @@ class Legend(PlotlyDict):
 class Line(PlotlyDict):
     """
     Valid attributes for 'line' at path [] under parents ():
-
+    
         ['autocolorscale', 'cauto', 'cmax', 'cmin', 'color', 'colorbar',
         'colorscale', 'colorsrc', 'dash', 'outliercolor', 'outlierwidth',
         'reversescale', 'shape', 'showscale', 'simplify', 'smoothing', 'width',
         'widthsrc']
-
+    
     Run `<line-object>.help('attribute')` on any of the above.
     '<line-object>' is the object at []
 
@@ -1518,9 +1536,9 @@ class Line(PlotlyDict):
 class Margin(PlotlyDict):
     """
     Valid attributes for 'margin' at path [] under parents ():
-
+    
         ['autoexpand', 'b', 'l', 'pad', 'r', 't']
-
+    
     Run `<margin-object>.help('attribute')` on any of the above.
     '<margin-object>' is the object at []
 
@@ -1531,13 +1549,13 @@ class Margin(PlotlyDict):
 class Marker(PlotlyDict):
     """
     Valid attributes for 'marker' at path [] under parents ():
-
+    
         ['autocolorscale', 'blend', 'border', 'cauto', 'cmax', 'cmin', 'color',
         'colorbar', 'colors', 'colorscale', 'colorsrc', 'colorssrc',
         'gradient', 'line', 'maxdisplayed', 'opacity', 'opacitysrc',
         'outliercolor', 'reversescale', 'showscale', 'size', 'sizemax',
         'sizemin', 'sizemode', 'sizeref', 'sizesrc', 'symbol', 'symbolsrc']
-
+    
     Run `<marker-object>.help('attribute')` on any of the above.
     '<marker-object>' is the object at []
 
@@ -1548,17 +1566,18 @@ class Marker(PlotlyDict):
 class Mesh3d(PlotlyDict):
     """
     Valid attributes for 'mesh3d' at path [] under parents ():
-
+    
         ['alphahull', 'autocolorscale', 'cauto', 'cmax', 'cmin', 'color',
         'colorbar', 'colorscale', 'contour', 'customdata', 'customdatasrc',
         'delaunayaxis', 'facecolor', 'facecolorsrc', 'flatshading',
         'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'i', 'ids', 'idssrc',
         'intensity', 'intensitysrc', 'isrc', 'j', 'jsrc', 'k', 'ksrc',
         'legendgroup', 'lighting', 'lightposition', 'name', 'opacity',
-        'reversescale', 'scene', 'showlegend', 'showscale', 'stream', 'type',
-        'uid', 'vertexcolor', 'vertexcolorsrc', 'visible', 'x', 'xcalendar',
-        'xsrc', 'y', 'ycalendar', 'ysrc', 'z', 'zcalendar', 'zsrc']
-
+        'reversescale', 'scene', 'selectedpoints', 'showlegend', 'showscale',
+        'stream', 'text', 'textsrc', 'type', 'uid', 'vertexcolor',
+        'vertexcolorsrc', 'visible', 'x', 'xcalendar', 'xsrc', 'y',
+        'ycalendar', 'ysrc', 'z', 'zcalendar', 'zsrc']
+    
     Run `<mesh3d-object>.help('attribute')` on any of the above.
     '<mesh3d-object>' is the object at []
 
@@ -1569,14 +1588,14 @@ class Mesh3d(PlotlyDict):
 class Ohlc(PlotlyDict):
     """
     Valid attributes for 'ohlc' at path [] under parents ():
-
+    
         ['close', 'closesrc', 'customdata', 'customdatasrc', 'decreasing',
         'high', 'highsrc', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids',
         'idssrc', 'increasing', 'legendgroup', 'line', 'low', 'lowsrc', 'name',
-        'opacity', 'open', 'opensrc', 'showlegend', 'stream', 'text',
-        'textsrc', 'tickwidth', 'type', 'uid', 'visible', 'x', 'xaxis',
+        'opacity', 'open', 'opensrc', 'selectedpoints', 'showlegend', 'stream',
+        'text', 'textsrc', 'tickwidth', 'type', 'uid', 'visible', 'x', 'xaxis',
         'xcalendar', 'xsrc', 'yaxis']
-
+    
     Run `<ohlc-object>.help('attribute')` on any of the above.
     '<ohlc-object>' is the object at []
 
@@ -1587,12 +1606,13 @@ class Ohlc(PlotlyDict):
 class Parcoords(PlotlyDict):
     """
     Valid attributes for 'parcoords' at path [] under parents ():
-
+    
         ['customdata', 'customdatasrc', 'dimensions', 'domain', 'hoverinfo',
         'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc', 'labelfont',
-        'legendgroup', 'line', 'name', 'opacity', 'rangefont', 'showlegend',
-        'stream', 'tickfont', 'type', 'uid', 'visible']
-
+        'legendgroup', 'line', 'name', 'opacity', 'rangefont',
+        'selectedpoints', 'showlegend', 'stream', 'tickfont', 'type', 'uid',
+        'visible']
+    
     Run `<parcoords-object>.help('attribute')` on any of the above.
     '<parcoords-object>' is the object at []
 
@@ -1603,16 +1623,16 @@ class Parcoords(PlotlyDict):
 class Pie(PlotlyDict):
     """
     Valid attributes for 'pie' at path [] under parents ():
-
+    
         ['customdata', 'customdatasrc', 'direction', 'dlabel', 'domain',
         'hole', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'hovertext',
         'hovertextsrc', 'ids', 'idssrc', 'insidetextfont', 'label0', 'labels',
         'labelssrc', 'legendgroup', 'marker', 'name', 'opacity',
         'outsidetextfont', 'pull', 'pullsrc', 'rotation', 'scalegroup',
-        'showlegend', 'sort', 'stream', 'text', 'textfont', 'textinfo',
-        'textposition', 'textpositionsrc', 'textsrc', 'type', 'uid', 'values',
-        'valuessrc', 'visible']
-
+        'selectedpoints', 'showlegend', 'sort', 'stream', 'text', 'textfont',
+        'textinfo', 'textposition', 'textpositionsrc', 'textsrc', 'type',
+        'uid', 'values', 'valuessrc', 'visible']
+    
     Run `<pie-object>.help('attribute')` on any of the above.
     '<pie-object>' is the object at []
 
@@ -1623,13 +1643,14 @@ class Pie(PlotlyDict):
 class Pointcloud(PlotlyDict):
     """
     Valid attributes for 'pointcloud' at path [] under parents ():
-
+    
         ['customdata', 'customdatasrc', 'hoverinfo', 'hoverinfosrc',
         'hoverlabel', 'ids', 'idssrc', 'indices', 'indicessrc', 'legendgroup',
-        'marker', 'name', 'opacity', 'showlegend', 'stream', 'text', 'textsrc',
-        'type', 'uid', 'visible', 'x', 'xaxis', 'xbounds', 'xboundssrc',
-        'xsrc', 'xy', 'xysrc', 'y', 'yaxis', 'ybounds', 'yboundssrc', 'ysrc']
-
+        'marker', 'name', 'opacity', 'selectedpoints', 'showlegend', 'stream',
+        'text', 'textsrc', 'type', 'uid', 'visible', 'x', 'xaxis', 'xbounds',
+        'xboundssrc', 'xsrc', 'xy', 'xysrc', 'y', 'yaxis', 'ybounds',
+        'yboundssrc', 'ysrc']
+    
     Run `<pointcloud-object>.help('attribute')` on any of the above.
     '<pointcloud-object>' is the object at []
 
@@ -1640,11 +1661,19 @@ class Pointcloud(PlotlyDict):
 class RadialAxis(PlotlyDict):
     """
     Valid attributes for 'radialaxis' at path [] under parents ():
-
-        ['domain', 'endpadding', 'orientation', 'range', 'showline',
-        'showticklabels', 'tickcolor', 'ticklen', 'tickorientation',
-        'ticksuffix', 'visible']
-
+    
+        ['angle', 'autorange', 'calendar', 'categoryarray', 'categoryarraysrc',
+        'categoryorder', 'color', 'domain', 'dtick', 'endpadding',
+        'exponentformat', 'gridcolor', 'gridwidth', 'hoverformat', 'layer',
+        'linecolor', 'linewidth', 'nticks', 'orientation', 'range',
+        'rangemode', 'separatethousands', 'showexponent', 'showgrid',
+        'showline', 'showticklabels', 'showtickprefix', 'showticksuffix',
+        'side', 'tick0', 'tickangle', 'tickcolor', 'tickfont', 'tickformat',
+        'tickformatstops', 'ticklen', 'tickmode', 'tickorientation',
+        'tickprefix', 'ticks', 'ticksuffix', 'ticktext', 'ticktextsrc',
+        'tickvals', 'tickvalssrc', 'tickwidth', 'title', 'titlefont', 'type',
+        'visible']
+    
     Run `<radialaxis-object>.help('attribute')` on any of the above.
     '<radialaxis-object>' is the object at []
 
@@ -1655,12 +1684,13 @@ class RadialAxis(PlotlyDict):
 class Sankey(PlotlyDict):
     """
     Valid attributes for 'sankey' at path [] under parents ():
-
+    
         ['arrangement', 'customdata', 'customdatasrc', 'domain', 'hoverinfo',
         'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc', 'legendgroup', 'link',
-        'name', 'node', 'opacity', 'orientation', 'showlegend', 'stream',
-        'textfont', 'type', 'uid', 'valueformat', 'valuesuffix', 'visible']
-
+        'name', 'node', 'opacity', 'orientation', 'selectedpoints',
+        'showlegend', 'stream', 'textfont', 'type', 'uid', 'valueformat',
+        'valuesuffix', 'visible']
+    
     Run `<sankey-object>.help('attribute')` on any of the above.
     '<sankey-object>' is the object at []
 
@@ -1671,16 +1701,16 @@ class Sankey(PlotlyDict):
 class Scatter(PlotlyDict):
     """
     Valid attributes for 'scatter' at path [] under parents ():
-
+    
         ['cliponaxis', 'connectgaps', 'customdata', 'customdatasrc', 'dx',
         'dy', 'error_x', 'error_y', 'fill', 'fillcolor', 'hoverinfo',
         'hoverinfosrc', 'hoverlabel', 'hoveron', 'hovertext', 'hovertextsrc',
         'ids', 'idssrc', 'legendgroup', 'line', 'marker', 'mode', 'name',
-        'opacity', 'r', 'rsrc', 'showlegend', 'stream', 't', 'text',
-        'textfont', 'textposition', 'textpositionsrc', 'textsrc', 'tsrc',
-        'type', 'uid', 'visible', 'x', 'x0', 'xaxis', 'xcalendar', 'xsrc', 'y',
-        'y0', 'yaxis', 'ycalendar', 'ysrc']
-
+        'opacity', 'r', 'rsrc', 'selected', 'selectedpoints', 'showlegend',
+        'stream', 't', 'text', 'textfont', 'textposition', 'textpositionsrc',
+        'textsrc', 'tsrc', 'type', 'uid', 'unselected', 'visible', 'x', 'x0',
+        'xaxis', 'xcalendar', 'xsrc', 'y', 'y0', 'yaxis', 'ycalendar', 'ysrc']
+    
     Run `<scatter-object>.help('attribute')` on any of the above.
     '<scatter-object>' is the object at []
 
@@ -1691,16 +1721,16 @@ class Scatter(PlotlyDict):
 class Scatter3d(PlotlyDict):
     """
     Valid attributes for 'scatter3d' at path [] under parents ():
-
+    
         ['connectgaps', 'customdata', 'customdatasrc', 'error_x', 'error_y',
         'error_z', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'hovertext',
         'hovertextsrc', 'ids', 'idssrc', 'legendgroup', 'line', 'marker',
-        'mode', 'name', 'opacity', 'projection', 'scene', 'showlegend',
-        'stream', 'surfaceaxis', 'surfacecolor', 'text', 'textfont',
-        'textposition', 'textpositionsrc', 'textsrc', 'type', 'uid', 'visible',
-        'x', 'xcalendar', 'xsrc', 'y', 'ycalendar', 'ysrc', 'z', 'zcalendar',
-        'zsrc']
-
+        'mode', 'name', 'opacity', 'projection', 'scene', 'selectedpoints',
+        'showlegend', 'stream', 'surfaceaxis', 'surfacecolor', 'text',
+        'textfont', 'textposition', 'textpositionsrc', 'textsrc', 'type',
+        'uid', 'visible', 'x', 'xcalendar', 'xsrc', 'y', 'ycalendar', 'ysrc',
+        'z', 'zcalendar', 'zsrc']
+    
     Run `<scatter3d-object>.help('attribute')` on any of the above.
     '<scatter3d-object>' is the object at []
 
@@ -1711,14 +1741,15 @@ class Scatter3d(PlotlyDict):
 class Scattercarpet(PlotlyDict):
     """
     Valid attributes for 'scattercarpet' at path [] under parents ():
-
+    
         ['a', 'asrc', 'b', 'bsrc', 'carpet', 'connectgaps', 'customdata',
         'customdatasrc', 'fill', 'fillcolor', 'hoverinfo', 'hoverinfosrc',
         'hoverlabel', 'hoveron', 'ids', 'idssrc', 'legendgroup', 'line',
-        'marker', 'mode', 'name', 'opacity', 'showlegend', 'stream', 'text',
-        'textfont', 'textposition', 'textpositionsrc', 'textsrc', 'type',
-        'uid', 'visible', 'xaxis', 'yaxis']
-
+        'marker', 'mode', 'name', 'opacity', 'selected', 'selectedpoints',
+        'showlegend', 'stream', 'text', 'textfont', 'textposition',
+        'textpositionsrc', 'textsrc', 'type', 'uid', 'unselected', 'visible',
+        'xaxis', 'yaxis']
+    
     Run `<scattercarpet-object>.help('attribute')` on any of the above.
     '<scattercarpet-object>' is the object at []
 
@@ -1729,15 +1760,15 @@ class Scattercarpet(PlotlyDict):
 class Scattergeo(PlotlyDict):
     """
     Valid attributes for 'scattergeo' at path [] under parents ():
-
+    
         ['connectgaps', 'customdata', 'customdatasrc', 'fill', 'fillcolor',
         'geo', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'hovertext',
         'hovertextsrc', 'ids', 'idssrc', 'lat', 'latsrc', 'legendgroup',
         'line', 'locationmode', 'locations', 'locationssrc', 'lon', 'lonsrc',
-        'marker', 'mode', 'name', 'opacity', 'showlegend', 'stream', 'text',
-        'textfont', 'textposition', 'textpositionsrc', 'textsrc', 'type',
-        'uid', 'visible']
-
+        'marker', 'mode', 'name', 'opacity', 'selected', 'selectedpoints',
+        'showlegend', 'stream', 'text', 'textfont', 'textposition',
+        'textpositionsrc', 'textsrc', 'type', 'uid', 'unselected', 'visible']
+    
     Run `<scattergeo-object>.help('attribute')` on any of the above.
     '<scattergeo-object>' is the object at []
 
@@ -1748,14 +1779,15 @@ class Scattergeo(PlotlyDict):
 class Scattergl(PlotlyDict):
     """
     Valid attributes for 'scattergl' at path [] under parents ():
-
+    
         ['connectgaps', 'customdata', 'customdatasrc', 'dx', 'dy', 'error_x',
         'error_y', 'fill', 'fillcolor', 'hoverinfo', 'hoverinfosrc',
-        'hoverlabel', 'ids', 'idssrc', 'legendgroup', 'line', 'marker', 'mode',
-        'name', 'opacity', 'showlegend', 'stream', 'text', 'textsrc', 'type',
-        'uid', 'visible', 'x', 'x0', 'xaxis', 'xcalendar', 'xsrc', 'y', 'y0',
-        'yaxis', 'ycalendar', 'ysrc']
-
+        'hoverlabel', 'hoveron', 'ids', 'idssrc', 'legendgroup', 'line',
+        'marker', 'mode', 'name', 'opacity', 'selected', 'selectedpoints',
+        'showlegend', 'stream', 'text', 'textsrc', 'type', 'uid', 'unselected',
+        'visible', 'x', 'x0', 'xaxis', 'xcalendar', 'xsrc', 'y', 'y0', 'yaxis',
+        'ycalendar', 'ysrc']
+    
     Run `<scattergl-object>.help('attribute')` on any of the above.
     '<scattergl-object>' is the object at []
 
@@ -1766,14 +1798,15 @@ class Scattergl(PlotlyDict):
 class Scattermapbox(PlotlyDict):
     """
     Valid attributes for 'scattermapbox' at path [] under parents ():
-
+    
         ['connectgaps', 'customdata', 'customdatasrc', 'fill', 'fillcolor',
         'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'hovertext', 'hovertextsrc',
         'ids', 'idssrc', 'lat', 'latsrc', 'legendgroup', 'line', 'lon',
-        'lonsrc', 'marker', 'mode', 'name', 'opacity', 'showlegend', 'stream',
-        'subplot', 'text', 'textfont', 'textposition', 'textsrc', 'type',
-        'uid', 'visible']
-
+        'lonsrc', 'marker', 'mode', 'name', 'opacity', 'selected',
+        'selectedpoints', 'showlegend', 'stream', 'subplot', 'text',
+        'textfont', 'textposition', 'textsrc', 'type', 'uid', 'unselected',
+        'visible']
+    
     Run `<scattermapbox-object>.help('attribute')` on any of the above.
     '<scattermapbox-object>' is the object at []
 
@@ -1781,18 +1814,55 @@ class Scattermapbox(PlotlyDict):
     _name = 'scattermapbox'
 
 
+class Scatterpolar(PlotlyDict):
+    """
+    Valid attributes for 'scatterpolar' at path [] under parents ():
+    
+        ['cliponaxis', 'connectgaps', 'customdata', 'customdatasrc', 'fill',
+        'fillcolor', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'hoveron',
+        'hovertext', 'hovertextsrc', 'ids', 'idssrc', 'legendgroup', 'line',
+        'marker', 'mode', 'name', 'opacity', 'r', 'rsrc', 'selected',
+        'selectedpoints', 'showlegend', 'stream', 'subplot', 'text',
+        'textfont', 'textposition', 'textpositionsrc', 'textsrc', 'theta',
+        'thetasrc', 'thetaunit', 'type', 'uid', 'unselected', 'visible']
+    
+    Run `<scatterpolar-object>.help('attribute')` on any of the above.
+    '<scatterpolar-object>' is the object at []
+
+    """
+    _name = 'scatterpolar'
+
+
+class Scatterpolargl(PlotlyDict):
+    """
+    Valid attributes for 'scatterpolargl' at path [] under parents ():
+    
+        ['connectgaps', 'customdata', 'customdatasrc', 'fill', 'fillcolor',
+        'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'hoveron', 'ids', 'idssrc',
+        'legendgroup', 'line', 'marker', 'mode', 'name', 'opacity', 'r',
+        'rsrc', 'selected', 'selectedpoints', 'showlegend', 'stream',
+        'subplot', 'text', 'textsrc', 'theta', 'thetasrc', 'thetaunit', 'type',
+        'uid', 'unselected', 'visible']
+    
+    Run `<scatterpolargl-object>.help('attribute')` on any of the above.
+    '<scatterpolargl-object>' is the object at []
+
+    """
+    _name = 'scatterpolargl'
+
+
 class Scatterternary(PlotlyDict):
     """
     Valid attributes for 'scatterternary' at path [] under parents ():
-
+    
         ['a', 'asrc', 'b', 'bsrc', 'c', 'cliponaxis', 'connectgaps', 'csrc',
         'customdata', 'customdatasrc', 'fill', 'fillcolor', 'hoverinfo',
         'hoverinfosrc', 'hoverlabel', 'hoveron', 'hovertext', 'hovertextsrc',
         'ids', 'idssrc', 'legendgroup', 'line', 'marker', 'mode', 'name',
-        'opacity', 'showlegend', 'stream', 'subplot', 'sum', 'text',
-        'textfont', 'textposition', 'textpositionsrc', 'textsrc', 'type',
-        'uid', 'visible']
-
+        'opacity', 'selected', 'selectedpoints', 'showlegend', 'stream',
+        'subplot', 'sum', 'text', 'textfont', 'textposition',
+        'textpositionsrc', 'textsrc', 'type', 'uid', 'unselected', 'visible']
+    
     Run `<scatterternary-object>.help('attribute')` on any of the above.
     '<scatterternary-object>' is the object at []
 
@@ -1803,11 +1873,11 @@ class Scatterternary(PlotlyDict):
 class Scene(PlotlyDict):
     """
     Valid attributes for 'scene' at path [] under parents ():
-
+    
         ['annotations', 'aspectmode', 'aspectratio', 'bgcolor', 'camera',
         'cameraposition', 'domain', 'dragmode', 'hovermode', 'xaxis', 'yaxis',
         'zaxis']
-
+    
     Run `<scene-object>.help('attribute')` on any of the above.
     '<scene-object>' is the object at []
 
@@ -1818,9 +1888,9 @@ class Scene(PlotlyDict):
 class Stream(PlotlyDict):
     """
     Valid attributes for 'stream' at path [] under parents ():
-
+    
         ['maxpoints', 'token']
-
+    
     Run `<stream-object>.help('attribute')` on any of the above.
     '<stream-object>' is the object at []
 
@@ -1831,16 +1901,16 @@ class Stream(PlotlyDict):
 class Surface(PlotlyDict):
     """
     Valid attributes for 'surface' at path [] under parents ():
-
+    
         ['autocolorscale', 'cauto', 'cmax', 'cmin', 'colorbar', 'colorscale',
         'contours', 'customdata', 'customdatasrc', 'hidesurface', 'hoverinfo',
         'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc', 'legendgroup',
         'lighting', 'lightposition', 'name', 'opacity', 'reversescale',
-        'scene', 'showlegend', 'showscale', 'stream', 'surfacecolor',
-        'surfacecolorsrc', 'text', 'textsrc', 'type', 'uid', 'visible', 'x',
-        'xcalendar', 'xsrc', 'y', 'ycalendar', 'ysrc', 'z', 'zauto',
-        'zcalendar', 'zmax', 'zmin', 'zsrc']
-
+        'scene', 'selectedpoints', 'showlegend', 'showscale', 'stream',
+        'surfacecolor', 'surfacecolorsrc', 'text', 'textsrc', 'type', 'uid',
+        'visible', 'x', 'xcalendar', 'xsrc', 'y', 'ycalendar', 'ysrc', 'z',
+        'zauto', 'zcalendar', 'zmax', 'zmin', 'zsrc']
+    
     Run `<surface-object>.help('attribute')` on any of the above.
     '<surface-object>' is the object at []
 
@@ -1851,13 +1921,13 @@ class Surface(PlotlyDict):
 class Table(PlotlyDict):
     """
     Valid attributes for 'table' at path [] under parents ():
-
+    
         ['cells', 'columnorder', 'columnordersrc', 'columnwidth',
         'columnwidthsrc', 'customdata', 'customdatasrc', 'domain', 'header',
         'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc',
-        'legendgroup', 'name', 'opacity', 'showlegend', 'stream', 'type',
-        'uid', 'visible']
-
+        'legendgroup', 'name', 'opacity', 'selectedpoints', 'showlegend',
+        'stream', 'type', 'uid', 'visible']
+    
     Run `<table-object>.help('attribute')` on any of the above.
     '<table-object>' is the object at []
 
@@ -1869,10 +1939,30 @@ class Trace(dict):
     pass
 
 
+class Violin(PlotlyDict):
+    """
+    Valid attributes for 'violin' at path [] under parents ():
+    
+        ['bandwidth', 'box', 'customdata', 'customdatasrc', 'fillcolor',
+        'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'hoveron', 'ids', 'idssrc',
+        'jitter', 'legendgroup', 'line', 'marker', 'meanline', 'name',
+        'opacity', 'orientation', 'pointpos', 'points', 'scalegroup',
+        'scalemode', 'selected', 'selectedpoints', 'showlegend', 'side',
+        'span', 'spanmode', 'stream', 'text', 'textsrc', 'type', 'uid',
+        'unselected', 'visible', 'x', 'x0', 'xaxis', 'xsrc', 'y', 'y0',
+        'yaxis', 'ysrc']
+    
+    Run `<violin-object>.help('attribute')` on any of the above.
+    '<violin-object>' is the object at []
+
+    """
+    _name = 'violin'
+
+
 class XAxis(PlotlyDict):
     """
     Valid attributes for 'xaxis' at path [] under parents ():
-
+    
         ['anchor', 'autorange', 'autotick', 'backgroundcolor', 'calendar',
         'categoryarray', 'categoryarraysrc', 'categoryorder', 'color',
         'constrain', 'constraintoward', 'domain', 'dtick', 'exponentformat',
@@ -1882,12 +1972,13 @@ class XAxis(PlotlyDict):
         'scaleratio', 'separatethousands', 'showaxeslabels', 'showbackground',
         'showexponent', 'showgrid', 'showline', 'showspikes', 'showticklabels',
         'showtickprefix', 'showticksuffix', 'side', 'spikecolor', 'spikedash',
-        'spikemode', 'spikesides', 'spikethickness', 'tick0', 'tickangle',
-        'tickcolor', 'tickfont', 'tickformat', 'ticklen', 'tickmode',
-        'tickprefix', 'ticks', 'ticksuffix', 'ticktext', 'ticktextsrc',
-        'tickvals', 'tickvalssrc', 'tickwidth', 'title', 'titlefont', 'type',
-        'visible', 'zeroline', 'zerolinecolor', 'zerolinewidth']
-
+        'spikemode', 'spikesides', 'spikesnap', 'spikethickness', 'tick0',
+        'tickangle', 'tickcolor', 'tickfont', 'tickformat', 'tickformatstops',
+        'ticklen', 'tickmode', 'tickprefix', 'ticks', 'ticksuffix', 'ticktext',
+        'ticktextsrc', 'tickvals', 'tickvalssrc', 'tickwidth', 'title',
+        'titlefont', 'type', 'visible', 'zeroline', 'zerolinecolor',
+        'zerolinewidth']
+    
     Run `<xaxis-object>.help('attribute')` on any of the above.
     '<xaxis-object>' is the object at []
 
@@ -1898,9 +1989,9 @@ class XAxis(PlotlyDict):
 class XBins(PlotlyDict):
     """
     Valid attributes for 'xbins' at path [] under parents ():
-
+    
         ['end', 'size', 'start']
-
+    
     Run `<xbins-object>.help('attribute')` on any of the above.
     '<xbins-object>' is the object at []
 
@@ -1911,7 +2002,7 @@ class XBins(PlotlyDict):
 class YAxis(PlotlyDict):
     """
     Valid attributes for 'yaxis' at path [] under parents ():
-
+    
         ['anchor', 'autorange', 'autotick', 'backgroundcolor', 'calendar',
         'categoryarray', 'categoryarraysrc', 'categoryorder', 'color',
         'constrain', 'constraintoward', 'domain', 'dtick', 'exponentformat',
@@ -1921,12 +2012,13 @@ class YAxis(PlotlyDict):
         'showaxeslabels', 'showbackground', 'showexponent', 'showgrid',
         'showline', 'showspikes', 'showticklabels', 'showtickprefix',
         'showticksuffix', 'side', 'spikecolor', 'spikedash', 'spikemode',
-        'spikesides', 'spikethickness', 'tick0', 'tickangle', 'tickcolor',
-        'tickfont', 'tickformat', 'ticklen', 'tickmode', 'tickprefix', 'ticks',
-        'ticksuffix', 'ticktext', 'ticktextsrc', 'tickvals', 'tickvalssrc',
-        'tickwidth', 'title', 'titlefont', 'type', 'visible', 'zeroline',
-        'zerolinecolor', 'zerolinewidth']
-
+        'spikesides', 'spikesnap', 'spikethickness', 'tick0', 'tickangle',
+        'tickcolor', 'tickfont', 'tickformat', 'tickformatstops', 'ticklen',
+        'tickmode', 'tickprefix', 'ticks', 'ticksuffix', 'ticktext',
+        'ticktextsrc', 'tickvals', 'tickvalssrc', 'tickwidth', 'title',
+        'titlefont', 'type', 'visible', 'zeroline', 'zerolinecolor',
+        'zerolinewidth']
+    
     Run `<yaxis-object>.help('attribute')` on any of the above.
     '<yaxis-object>' is the object at []
 
@@ -1937,9 +2029,9 @@ class YAxis(PlotlyDict):
 class YBins(PlotlyDict):
     """
     Valid attributes for 'ybins' at path [] under parents ():
-
+    
         ['end', 'size', 'start']
-
+    
     Run `<ybins-object>.help('attribute')` on any of the above.
     '<ybins-object>' is the object at []
 
@@ -1950,7 +2042,7 @@ class YBins(PlotlyDict):
 class ZAxis(PlotlyDict):
     """
     Valid attributes for 'zaxis' at path [] under parents ():
-
+    
         ['autorange', 'backgroundcolor', 'calendar', 'categoryarray',
         'categoryarraysrc', 'categoryorder', 'color', 'dtick',
         'exponentformat', 'gridcolor', 'gridwidth', 'hoverformat', 'linecolor',
@@ -1959,11 +2051,11 @@ class ZAxis(PlotlyDict):
         'showexponent', 'showgrid', 'showline', 'showspikes', 'showticklabels',
         'showtickprefix', 'showticksuffix', 'spikecolor', 'spikesides',
         'spikethickness', 'tick0', 'tickangle', 'tickcolor', 'tickfont',
-        'tickformat', 'ticklen', 'tickmode', 'tickprefix', 'ticks',
-        'ticksuffix', 'ticktext', 'ticktextsrc', 'tickvals', 'tickvalssrc',
-        'tickwidth', 'title', 'titlefont', 'type', 'visible', 'zeroline',
-        'zerolinecolor', 'zerolinewidth']
-
+        'tickformat', 'tickformatstops', 'ticklen', 'tickmode', 'tickprefix',
+        'ticks', 'ticksuffix', 'ticktext', 'ticktextsrc', 'tickvals',
+        'tickvalssrc', 'tickwidth', 'title', 'titlefont', 'type', 'visible',
+        'zeroline', 'zerolinecolor', 'zerolinewidth']
+    
     Run `<zaxis-object>.help('attribute')` on any of the above.
     '<zaxis-object>' is the object at []
 

--- a/plotly/graph_reference.py
+++ b/plotly/graph_reference.py
@@ -574,6 +574,26 @@ def _get_classes():
     return classes
 
 
+def _get_underscore_attrs():
+
+    nms = set()
+
+    def extract_keys(x):
+        if isinstance(x, dict):
+            for val in x.values():
+                if isinstance(val, dict):
+                    extract_keys(val)
+            list(map(extract_keys, x.keys()))
+        elif isinstance(x, str):
+            nms.add(x)
+        else:
+            pass
+
+    extract_keys(GRAPH_REFERENCE["layout"]["layoutAttributes"])
+    extract_keys(GRAPH_REFERENCE["traces"])
+    return list(filter(lambda x: "_" in x and x[0] != "_", nms))
+
+
 # The ordering here is important.
 GRAPH_REFERENCE = get_graph_reference()
 
@@ -592,3 +612,5 @@ CLASSES = _get_classes()
 OBJECT_NAME_TO_CLASS_NAME = {class_dict['object_name']: class_name
                              for class_name, class_dict in CLASSES.items()
                              if class_dict['object_name'] is not None}
+
+UNDERSCORE_ATTRS = _get_underscore_attrs()

--- a/plotly/graph_reference.py
+++ b/plotly/graph_reference.py
@@ -575,6 +575,10 @@ def _get_classes():
 
 
 def _get_underscore_attrs():
+    """
+    Return a list of all figure attributes (on traces or layouts) that have
+    underscores in them
+    """
 
     nms = set()
 

--- a/plotly/package_data/default-schema.json
+++ b/plotly/package_data/default-schema.json
@@ -179,8 +179,15 @@
                 ],
                 "requiredOpts": []
             },
+            "colorlist": {
+                "description": "A list of colors. Must be an {array} containing valid colors.",
+                "otherOpts": [
+                    "dflt"
+                ],
+                "requiredOpts": []
+            },
             "colorscale": {
-                "description": "A Plotly colorscale either picked by a name: (any of Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis ) customized as an {array} of 2-element {arrays} where the first element is the normalized color level value (starting at *0* and ending at *1*), and the second item is a valid color string.",
+                "description": "A Plotly colorscale either picked by a name: (any of Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis ) customized as an {array} of 2-element {arrays} where the first element is the normalized color level value (starting at *0* and ending at *1*), and the second item is a valid color string.",
                 "otherOpts": [
                     "dflt"
                 ],
@@ -433,7 +440,7 @@
                             "valType": "color"
                         },
                         "arrowhead": {
-                            "description": "Sets the annotation arrow head style.",
+                            "description": "Sets the end annotation arrow head style.",
                             "dflt": 1,
                             "editType": "arraydraw",
                             "max": 8,
@@ -441,24 +448,38 @@
                             "role": "style",
                             "valType": "integer"
                         },
+                        "arrowside": {
+                            "description": "Sets the annotation arrow head position.",
+                            "dflt": "end",
+                            "editType": "arraydraw",
+                            "extras": [
+                                "none"
+                            ],
+                            "flags": [
+                                "end",
+                                "start"
+                            ],
+                            "role": "style",
+                            "valType": "flaglist"
+                        },
                         "arrowsize": {
-                            "description": "Sets the size of the annotation arrow head, relative to `arrowwidth`. A value of 1 (default) gives a head about 3x as wide as the line.",
+                            "description": "Sets the size of the end annotation arrow head, relative to `arrowwidth`. A value of 1 (default) gives a head about 3x as wide as the line.",
                             "dflt": 1,
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "min": 0.3,
                             "role": "style",
                             "valType": "number"
                         },
                         "arrowwidth": {
                             "description": "Sets the width (in px) of annotation arrow line.",
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "min": 0.1,
                             "role": "style",
                             "valType": "number"
                         },
                         "ax": {
                             "description": "Sets the x component of the arrow tail about the arrow head. If `axref` is `pixel`, a positive (negative)  component corresponds to an arrow pointing from right to left (left to right). If `axref` is an axis, this is an absolute value on that axis, like `x`, NOT a relative value.",
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "info",
                             "valType": "any"
                         },
@@ -475,7 +496,7 @@
                         },
                         "ay": {
                             "description": "Sets the y component of the arrow tail about the arrow head. If `ayref` is `pixel`, a positive (negative)  component corresponds to an arrow pointing from bottom to top (top to bottom). If `ayref` is an axis, this is an absolute value on that axis, like `y`, NOT a relative value.",
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "info",
                             "valType": "any"
                         },
@@ -507,7 +528,7 @@
                         "borderpad": {
                             "description": "Sets the padding (in px) between the `text` and the enclosing border.",
                             "dflt": 1,
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "min": 0,
                             "role": "style",
                             "valType": "number"
@@ -515,7 +536,7 @@
                         "borderwidth": {
                             "description": "Sets the width (in px) of the border enclosing the annotation `text`.",
                             "dflt": 1,
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "min": 0,
                             "role": "style",
                             "valType": "number"
@@ -546,10 +567,10 @@
                                 "valType": "color"
                             },
                             "description": "Sets the annotation text font.",
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "family": {
                                 "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
-                                "editType": "calcIfAutorange",
+                                "editType": "calcIfAutorange+arraydraw",
                                 "noBlank": true,
                                 "role": "style",
                                 "strict": true,
@@ -557,7 +578,7 @@
                             },
                             "role": "object",
                             "size": {
-                                "editType": "calcIfAutorange",
+                                "editType": "calcIfAutorange+arraydraw",
                                 "min": 1,
                                 "role": "style",
                                 "valType": "number"
@@ -566,7 +587,7 @@
                         "height": {
                             "description": "Sets an explicit height for the text box. null (default) lets the text set the box height. Taller text will be clipped.",
                             "dflt": null,
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "min": 1,
                             "role": "style",
                             "valType": "number"
@@ -630,28 +651,53 @@
                         "showarrow": {
                             "description": "Determines whether or not the annotation is drawn with an arrow. If *true*, `text` is placed near the arrow's tail. If *false*, `text` lines up with the `x` and `y` provided.",
                             "dflt": true,
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "style",
                             "valType": "boolean"
                         },
                         "standoff": {
-                            "description": "Sets a distance, in pixels, to move the arrowhead away from the position it is pointing at, for example to point at the edge of a marker independent of zoom. Note that this shortens the arrow from the `ax` / `ay` vector, in contrast to `xshift` / `yshift` which moves everything by this amount.",
+                            "description": "Sets a distance, in pixels, to move the end arrowhead away from the position it is pointing at, for example to point at the edge of a marker independent of zoom. Note that this shortens the arrow from the `ax` / `ay` vector, in contrast to `xshift` / `yshift` which moves everything by this amount.",
                             "dflt": 0,
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "startarrowhead": {
+                            "description": "Sets the start annotation arrow head style.",
+                            "dflt": 1,
+                            "editType": "arraydraw",
+                            "max": 8,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "integer"
+                        },
+                        "startarrowsize": {
+                            "description": "Sets the size of the start annotation arrow head, relative to `arrowwidth`. A value of 1 (default) gives a head about 3x as wide as the line.",
+                            "dflt": 1,
+                            "editType": "calcIfAutorange+arraydraw",
+                            "min": 0.3,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "startstandoff": {
+                            "description": "Sets a distance, in pixels, to move the start arrowhead away from the position it is pointing at, for example to point at the edge of a marker independent of zoom. Note that this shortens the arrow from the `ax` / `ay` vector, in contrast to `xshift` / `yshift` which moves everything by this amount.",
+                            "dflt": 0,
+                            "editType": "calcIfAutorange+arraydraw",
                             "min": 0,
                             "role": "style",
                             "valType": "number"
                         },
                         "text": {
                             "description": "Sets the text associated with this annotation. Plotly uses a subset of HTML tags to do things like newline (<br>), bold (<b></b>), italics (<i></i>), hyperlinks (<a href='...'></a>). Tags <em>, <sup>, <sub> <span> are also supported.",
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "info",
                             "valType": "string"
                         },
                         "textangle": {
                             "description": "Sets the angle at which the `text` is drawn with respect to the horizontal.",
                             "dflt": 0,
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "style",
                             "valType": "angle"
                         },
@@ -670,28 +716,28 @@
                         "visible": {
                             "description": "Determines whether or not this annotation is visible.",
                             "dflt": true,
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "info",
                             "valType": "boolean"
                         },
                         "width": {
                             "description": "Sets an explicit width for the text box. null (default) lets the text set the box width. Wider text will be clipped. There is no automatic wrapping; use <br> to start a new line.",
                             "dflt": null,
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "min": 1,
                             "role": "style",
                             "valType": "number"
                         },
                         "x": {
                             "description": "Sets the annotation's x position. If the axis `type` is *log*, then you must take the log of your desired range. If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "info",
                             "valType": "any"
                         },
                         "xanchor": {
                             "description": "Sets the text box's horizontal position anchor This anchor binds the `x` position to the *left*, *center* or *right* of the annotation. For example, if `x` is set to 1, `xref` to *paper* and `xanchor` to *right* then the right-most portion of the annotation lines up with the right-most edge of the plotting area. If *auto*, the anchor is equivalent to *center* for data-referenced annotations or if there is an arrow, whereas for paper-referenced with no arrow, the anchor picked corresponds to the closest side.",
                             "dflt": "auto",
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "info",
                             "valType": "enumerated",
                             "values": [
@@ -720,20 +766,20 @@
                         "xshift": {
                             "description": "Shifts the position of the whole annotation and arrow to the right (positive) or left (negative) by this many pixels.",
                             "dflt": 0,
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "style",
                             "valType": "number"
                         },
                         "y": {
                             "description": "Sets the annotation's y position. If the axis `type` is *log*, then you must take the log of your desired range. If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "info",
                             "valType": "any"
                         },
                         "yanchor": {
                             "description": "Sets the text box's vertical position anchor This anchor binds the `y` position to the *top*, *middle* or *bottom* of the annotation. For example, if `y` is set to 1, `yref` to *paper* and `yanchor` to *top* then the top-most portion of the annotation lines up with the top-most edge of the plotting area. If *auto*, the anchor is equivalent to *middle* for data-referenced annotations or if there is an arrow, whereas for paper-referenced with no arrow, the anchor picked corresponds to the closest side.",
                             "dflt": "auto",
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "info",
                             "valType": "enumerated",
                             "values": [
@@ -762,7 +808,7 @@
                         "yshift": {
                             "description": "Shifts the position of the whole annotation and arrow up (positive) or down (negative) by this many pixels.",
                             "dflt": 0,
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "style",
                             "valType": "number"
                         }
@@ -801,6 +847,30 @@
                     "thai",
                     "ummalqura"
                 ]
+            },
+            "colorway": {
+                "description": "Sets the default trace colors.",
+                "dflt": [
+                    "#1f77b4",
+                    "#ff7f0e",
+                    "#2ca02c",
+                    "#d62728",
+                    "#9467bd",
+                    "#8c564b",
+                    "#e377c2",
+                    "#7f7f7f",
+                    "#bcbd22",
+                    "#17becf"
+                ],
+                "editType": "calc",
+                "role": "style",
+                "valType": "colorlist"
+            },
+            "datarevision": {
+                "description": "If provided, a changed value tells `Plotly.react` that one or more data arrays has changed. This way you can modify arrays in-place rather than making a complete new copy for an incremental change. If NOT provided, `Plotly.react` assumes that data arrays are being treated as immutable, thus any data array with a different identity from its predecessor contains new data.",
+                "editType": "calc",
+                "role": "info",
+                "valType": "any"
             },
             "direction": {
                 "description": "For polar plots only. Sets the direction corresponding to positive angles.",
@@ -914,7 +984,7 @@
                     "editType": "plot",
                     "role": "object",
                     "x": {
-                        "description": "Sets the maximum horizontal domain of this map (in plot fraction). Note that geo subplots are constrained by domain. In general, when `projection.scale` is set to 1. a map will fit either its x or y domain, but not both. ",
+                        "description": "Sets the horizontal domain of this geo subplot (in plot fraction). Note that geo subplots are constrained by domain. In general, when `projection.scale` is set to 1. a map will fit either its x or y domain, but not both.",
                         "dflt": [
                             0,
                             1
@@ -938,7 +1008,7 @@
                         "valType": "info_array"
                     },
                     "y": {
-                        "description": "Sets the maximum vertical domain of this map (in plot fraction). Note that geo subplots are constrained by domain. In general, when `projection.scale` is set to 1. a map will fit either its x or y domain, but not both. ",
+                        "description": "Sets the vertical domain of this geo subplot (in plot fraction). Note that geo subplots are constrained by domain. In general, when `projection.scale` is set to 1. a map will fit either its x or y domain, but not both.",
                         "dflt": [
                             0,
                             1
@@ -1314,6 +1384,14 @@
                 "role": "info",
                 "valType": "boolean"
             },
+            "hoverdistance": {
+                "description": "Sets the default distance (in pixels) to look for data to add hover labels (-1 means no cutoff, 0 means no looking for data)",
+                "dflt": 20,
+                "editType": "none",
+                "min": -1,
+                "role": "info",
+                "valType": "integer"
+            },
             "hoverlabel": {
                 "bgcolor": {
                     "description": "Sets the background color of all hover labels on graph",
@@ -1671,7 +1749,7 @@
                     "editType": "plot",
                     "role": "object",
                     "x": {
-                        "description": "Sets the horizontal domain of this subplot (in plot fraction).",
+                        "description": "Sets the horizontal domain of this mapbox subplot (in plot fraction).",
                         "dflt": [
                             0,
                             1
@@ -1695,7 +1773,7 @@
                         "valType": "info_array"
                     },
                     "y": {
-                        "description": "Sets the vertical domain of this subplot (in plot fraction).",
+                        "description": "Sets the vertical domain of this mapbox subplot (in plot fraction).",
                         "dflt": [
                             0,
                             1
@@ -1993,6 +2071,976 @@
                 "role": "style",
                 "valType": "color"
             },
+            "polar": {
+                "_isSubplotObj": true,
+                "angularaxis": {
+                    "categoryarray": {
+                        "description": "Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.",
+                        "editType": "calc",
+                        "role": "data",
+                        "valType": "data_array"
+                    },
+                    "categoryarraysrc": {
+                        "description": "Sets the source reference on plot.ly for  categoryarray .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "categoryorder": {
+                        "description": "Specifies the ordering logic for the case of categorical variables. By default, plotly uses *trace*, which specifies the order that is present in the data supplied. Set `categoryorder` to *category ascending* or *category descending* if order should be determined by the alphanumerical order of the category names. Set `categoryorder` to *array* to derive the ordering from the attribute `categoryarray`. If a category is not found in the `categoryarray` array, the sorting behavior for that attribute will be identical to the *trace* mode. The unspecified categories will follow the categories in `categoryarray`.",
+                        "dflt": "trace",
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "trace",
+                            "category ascending",
+                            "category descending",
+                            "array"
+                        ]
+                    },
+                    "color": {
+                        "description": "Sets default for all colors associated with this axis all at once: line, font, tick, and grid colors. Grid color is lightened by blending this with the plot background Individual pieces can override this.",
+                        "dflt": "#444",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "direction": {
+                        "description": "Sets the direction corresponding to positive angles.",
+                        "dflt": "counterclockwise",
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "counterclockwise",
+                            "clockwise"
+                        ]
+                    },
+                    "dtick": {
+                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                        "editType": "plot",
+                        "impliedEdits": {
+                            "tickmode": "linear"
+                        },
+                        "role": "style",
+                        "valType": "any"
+                    },
+                    "editType": "plot",
+                    "exponentformat": {
+                        "description": "Determines a formatting rule for the tick exponents. For example, consider the number 1,000,000,000. If *none*, it appears as 1,000,000,000. If *e*, 1e+9. If *E*, 1E+9. If *power*, 1x10^9 (with 9 in a super script). If *SI*, 1G. If *B*, 1B.",
+                        "dflt": "B",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "enumerated",
+                        "values": [
+                            "none",
+                            "e",
+                            "E",
+                            "power",
+                            "SI",
+                            "B"
+                        ]
+                    },
+                    "gridcolor": {
+                        "description": "Sets the color of the grid lines.",
+                        "dflt": "#eee",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "gridwidth": {
+                        "description": "Sets the width (in px) of the grid lines.",
+                        "dflt": 1,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "hoverformat": {
+                        "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "dflt": "",
+                        "editType": "none",
+                        "role": "style",
+                        "valType": "string"
+                    },
+                    "layer": {
+                        "description": "Sets the layer on which this axis is displayed. If *above traces*, this axis is displayed above all the subplot's traces If *below traces*, this axis is displayed below all the subplot's traces, but above the grid lines. Useful when used together with scatter-like traces with `cliponaxis` set to *false* to show markers and/or text nodes above this axis.",
+                        "dflt": "above traces",
+                        "editType": "plot",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "above traces",
+                            "below traces"
+                        ]
+                    },
+                    "linecolor": {
+                        "description": "Sets the axis line color.",
+                        "dflt": "#444",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "linewidth": {
+                        "description": "Sets the width (in px) of the axis line.",
+                        "dflt": 1,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "nticks": {
+                        "description": "Specifies the maximum number of ticks for the particular axis. The actual number of ticks will be chosen automatically to be less than or equal to `nticks`. Has an effect only if `tickmode` is set to *auto*.",
+                        "dflt": 0,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "integer"
+                    },
+                    "period": {
+                        "description": "Set the angular period. Has an effect only when `angularaxis.type` is *category*.",
+                        "editType": "calc",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "number"
+                    },
+                    "role": "object",
+                    "rotation": {
+                        "description": "Sets that start position (in degrees) of the angular axis By default, polar subplots with `direction` set to *counterclockwise* get a `rotation` of *0* which corresponds to due East (like what mathematicians prefer). In turn, polar with `direction` set to *clockwise* get a rotation of *90* which corresponds to due North (like on a compass),",
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "angle"
+                    },
+                    "separatethousands": {
+                        "description": "If \"true\", even 4-digit integers are separated",
+                        "dflt": false,
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "boolean"
+                    },
+                    "showexponent": {
+                        "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
+                        "dflt": "all",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "enumerated",
+                        "values": [
+                            "all",
+                            "first",
+                            "last",
+                            "none"
+                        ]
+                    },
+                    "showgrid": {
+                        "description": "Determines whether or not grid lines are drawn. If *true*, the grid lines are drawn at every tick mark.",
+                        "dflt": true,
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "boolean"
+                    },
+                    "showline": {
+                        "description": "Determines whether or not a line bounding this axis is drawn.",
+                        "dflt": true,
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "boolean"
+                    },
+                    "showticklabels": {
+                        "description": "Determines whether or not the tick labels are drawn.",
+                        "dflt": true,
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "boolean"
+                    },
+                    "showtickprefix": {
+                        "description": "If *all*, all tick labels are displayed with a prefix. If *first*, only the first tick is displayed with a prefix. If *last*, only the last tick is displayed with a suffix. If *none*, tick prefixes are hidden.",
+                        "dflt": "all",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "enumerated",
+                        "values": [
+                            "all",
+                            "first",
+                            "last",
+                            "none"
+                        ]
+                    },
+                    "showticksuffix": {
+                        "description": "Same as `showtickprefix` but for tick suffixes.",
+                        "dflt": "all",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "enumerated",
+                        "values": [
+                            "all",
+                            "first",
+                            "last",
+                            "none"
+                        ]
+                    },
+                    "thetaunit": {
+                        "description": "Sets the format unit of the formatted *theta* values. Has an effect only when `angularaxis.type` is *linear*.",
+                        "dflt": "degrees",
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "radians",
+                            "degrees"
+                        ]
+                    },
+                    "tick0": {
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "editType": "plot",
+                        "impliedEdits": {
+                            "tickmode": "linear"
+                        },
+                        "role": "style",
+                        "valType": "any"
+                    },
+                    "tickangle": {
+                        "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
+                        "dflt": "auto",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "angle"
+                    },
+                    "tickcolor": {
+                        "description": "Sets the tick color.",
+                        "dflt": "#444",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "tickfont": {
+                        "color": {
+                            "editType": "plot",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "description": "Sets the tick font.",
+                        "editType": "plot",
+                        "family": {
+                            "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                            "editType": "plot",
+                            "noBlank": true,
+                            "role": "style",
+                            "strict": true,
+                            "valType": "string"
+                        },
+                        "role": "object",
+                        "size": {
+                            "editType": "plot",
+                            "min": 1,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "tickformat": {
+                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "dflt": "",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "string"
+                    },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "plot",
+                                    "items": [
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "plot",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "plot",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
+                    "ticklen": {
+                        "description": "Sets the tick length (in px).",
+                        "dflt": 5,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "tickmode": {
+                        "description": "Sets the tick mode for this axis. If *auto*, the number of ticks is set via `nticks`. If *linear*, the placement of the ticks is determined by a starting position `tick0` and a tick step `dtick` (*linear* is the default value if `tick0` and `dtick` are provided). If *array*, the placement of the ticks is set via `tickvals` and the tick text is `ticktext`. (*array* is the default value if `tickvals` is provided).",
+                        "editType": "plot",
+                        "impliedEdits": {},
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "auto",
+                            "linear",
+                            "array"
+                        ]
+                    },
+                    "tickprefix": {
+                        "description": "Sets a tick label prefix.",
+                        "dflt": "",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "string"
+                    },
+                    "ticks": {
+                        "description": "Determines whether ticks are drawn or not. If **, this axis' ticks are not drawn. If *outside* (*inside*), this axis' are drawn outside (inside) the axis lines.",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "enumerated",
+                        "values": [
+                            "outside",
+                            "inside",
+                            ""
+                        ]
+                    },
+                    "ticksuffix": {
+                        "description": "Sets a tick label suffix.",
+                        "dflt": "",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "string"
+                    },
+                    "ticktext": {
+                        "description": "Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.",
+                        "editType": "plot",
+                        "role": "data",
+                        "valType": "data_array"
+                    },
+                    "ticktextsrc": {
+                        "description": "Sets the source reference on plot.ly for  ticktext .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "tickvals": {
+                        "description": "Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.",
+                        "editType": "plot",
+                        "role": "data",
+                        "valType": "data_array"
+                    },
+                    "tickvalssrc": {
+                        "description": "Sets the source reference on plot.ly for  tickvals .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "tickwidth": {
+                        "description": "Sets the tick width (in px).",
+                        "dflt": 1,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "type": {
+                        "description": "Sets the angular axis type. If *linear*, set `thetaunit` to determine the unit in which axis value are shown. If *category, use `period` to set the number of integer coordinates around polar axis.",
+                        "dflt": "-",
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "-",
+                            "linear",
+                            "category"
+                        ]
+                    },
+                    "visible": {
+                        "description": "A single toggle to hide the axis while preserving interaction like dragging. Default is true when a cheater plot is present on the axis, otherwise false",
+                        "dflt": true,
+                        "editType": "plot",
+                        "role": "info",
+                        "valType": "boolean"
+                    }
+                },
+                "bgcolor": {
+                    "description": "Set the background color of the subplot",
+                    "dflt": "#fff",
+                    "editType": "plot",
+                    "role": "style",
+                    "valType": "color"
+                },
+                "domain": {
+                    "editType": "plot",
+                    "role": "object",
+                    "x": {
+                        "description": "Sets the horizontal domain of this polar subplot (in plot fraction).",
+                        "dflt": [
+                            0,
+                            1
+                        ],
+                        "editType": "plot",
+                        "items": [
+                            {
+                                "max": 1,
+                                "min": 0,
+                                "valType": "number"
+                            },
+                            {
+                                "max": 1,
+                                "min": 0,
+                                "valType": "number"
+                            }
+                        ],
+                        "role": "info",
+                        "valType": "info_array"
+                    },
+                    "y": {
+                        "description": "Sets the vertical domain of this polar subplot (in plot fraction).",
+                        "dflt": [
+                            0,
+                            1
+                        ],
+                        "editType": "plot",
+                        "items": [
+                            {
+                                "max": 1,
+                                "min": 0,
+                                "valType": "number"
+                            },
+                            {
+                                "max": 1,
+                                "min": 0,
+                                "valType": "number"
+                            }
+                        ],
+                        "role": "info",
+                        "valType": "info_array"
+                    }
+                },
+                "editType": "calc",
+                "radialaxis": {
+                    "angle": {
+                        "description": "Sets the angle (in degrees) from which the radial axis is drawn. Note that by default, radial axis line on the theta=0 line corresponds to a line pointing right (like what mathematicians prefer). Defaults to the first `polar.sector` angle.",
+                        "editType": "plot",
+                        "role": "info",
+                        "valType": "angle"
+                    },
+                    "autorange": {
+                        "description": "Determines whether or not the range of this axis is computed in relation to the input data. See `rangemode` for more info. If `range` is provided, then `autorange` is set to *false*.",
+                        "dflt": true,
+                        "editType": "calc",
+                        "impliedEdits": {},
+                        "role": "style",
+                        "valType": "enumerated",
+                        "values": [
+                            true,
+                            false,
+                            "reversed"
+                        ]
+                    },
+                    "calendar": {
+                        "description": "Sets the calendar system to use for `range` and `tick0` if this is a date axis. This does not set the calendar for interpreting data on this axis, that's specified in the trace or via the global `layout.calendar`",
+                        "dflt": "gregorian",
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "gregorian",
+                            "chinese",
+                            "coptic",
+                            "discworld",
+                            "ethiopian",
+                            "hebrew",
+                            "islamic",
+                            "julian",
+                            "mayan",
+                            "nanakshahi",
+                            "nepali",
+                            "persian",
+                            "jalali",
+                            "taiwan",
+                            "thai",
+                            "ummalqura"
+                        ]
+                    },
+                    "categoryarray": {
+                        "description": "Sets the order in which categories on this axis appear. Only has an effect if `categoryorder` is set to *array*. Used with `categoryorder`.",
+                        "editType": "calc",
+                        "role": "data",
+                        "valType": "data_array"
+                    },
+                    "categoryarraysrc": {
+                        "description": "Sets the source reference on plot.ly for  categoryarray .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "categoryorder": {
+                        "description": "Specifies the ordering logic for the case of categorical variables. By default, plotly uses *trace*, which specifies the order that is present in the data supplied. Set `categoryorder` to *category ascending* or *category descending* if order should be determined by the alphanumerical order of the category names. Set `categoryorder` to *array* to derive the ordering from the attribute `categoryarray`. If a category is not found in the `categoryarray` array, the sorting behavior for that attribute will be identical to the *trace* mode. The unspecified categories will follow the categories in `categoryarray`.",
+                        "dflt": "trace",
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "trace",
+                            "category ascending",
+                            "category descending",
+                            "array"
+                        ]
+                    },
+                    "color": {
+                        "description": "Sets default for all colors associated with this axis all at once: line, font, tick, and grid colors. Grid color is lightened by blending this with the plot background Individual pieces can override this.",
+                        "dflt": "#444",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "dtick": {
+                        "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                        "editType": "plot",
+                        "impliedEdits": {
+                            "tickmode": "linear"
+                        },
+                        "role": "style",
+                        "valType": "any"
+                    },
+                    "editType": "plot",
+                    "exponentformat": {
+                        "description": "Determines a formatting rule for the tick exponents. For example, consider the number 1,000,000,000. If *none*, it appears as 1,000,000,000. If *e*, 1e+9. If *E*, 1E+9. If *power*, 1x10^9 (with 9 in a super script). If *SI*, 1G. If *B*, 1B.",
+                        "dflt": "B",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "enumerated",
+                        "values": [
+                            "none",
+                            "e",
+                            "E",
+                            "power",
+                            "SI",
+                            "B"
+                        ]
+                    },
+                    "gridcolor": {
+                        "description": "Sets the color of the grid lines.",
+                        "dflt": "#eee",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "gridwidth": {
+                        "description": "Sets the width (in px) of the grid lines.",
+                        "dflt": 1,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "hoverformat": {
+                        "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "dflt": "",
+                        "editType": "none",
+                        "role": "style",
+                        "valType": "string"
+                    },
+                    "layer": {
+                        "description": "Sets the layer on which this axis is displayed. If *above traces*, this axis is displayed above all the subplot's traces If *below traces*, this axis is displayed below all the subplot's traces, but above the grid lines. Useful when used together with scatter-like traces with `cliponaxis` set to *false* to show markers and/or text nodes above this axis.",
+                        "dflt": "above traces",
+                        "editType": "plot",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "above traces",
+                            "below traces"
+                        ]
+                    },
+                    "linecolor": {
+                        "description": "Sets the axis line color.",
+                        "dflt": "#444",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "linewidth": {
+                        "description": "Sets the width (in px) of the axis line.",
+                        "dflt": 1,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "nticks": {
+                        "description": "Specifies the maximum number of ticks for the particular axis. The actual number of ticks will be chosen automatically to be less than or equal to `nticks`. Has an effect only if `tickmode` is set to *auto*.",
+                        "dflt": 0,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "integer"
+                    },
+                    "range": {
+                        "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "editType": "plot",
+                        "impliedEdits": {
+                            "autorange": false
+                        },
+                        "items": [
+                            {
+                                "editType": "plot",
+                                "impliedEdits": {
+                                    "^autorange": false
+                                },
+                                "valType": "any"
+                            },
+                            {
+                                "editType": "plot",
+                                "impliedEdits": {
+                                    "^autorange": false
+                                },
+                                "valType": "any"
+                            }
+                        ],
+                        "role": "info",
+                        "valType": "info_array"
+                    },
+                    "rangemode": {
+                        "description": "If *tozero*`, the range extends to 0, regardless of the input data If *nonnegative*, the range is non-negative, regardless of the input data. If *normal*, the range is computed in relation to the extrema of the input data (same behavior as for cartesian axes).",
+                        "dflt": "tozero",
+                        "editType": "calc",
+                        "role": "style",
+                        "valType": "enumerated",
+                        "values": [
+                            "tozero",
+                            "nonnegative",
+                            "normal"
+                        ]
+                    },
+                    "role": "object",
+                    "separatethousands": {
+                        "description": "If \"true\", even 4-digit integers are separated",
+                        "dflt": false,
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "boolean"
+                    },
+                    "showexponent": {
+                        "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
+                        "dflt": "all",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "enumerated",
+                        "values": [
+                            "all",
+                            "first",
+                            "last",
+                            "none"
+                        ]
+                    },
+                    "showgrid": {
+                        "description": "Determines whether or not grid lines are drawn. If *true*, the grid lines are drawn at every tick mark.",
+                        "dflt": true,
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "boolean"
+                    },
+                    "showline": {
+                        "description": "Determines whether or not a line bounding this axis is drawn.",
+                        "dflt": true,
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "boolean"
+                    },
+                    "showticklabels": {
+                        "description": "Determines whether or not the tick labels are drawn.",
+                        "dflt": true,
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "boolean"
+                    },
+                    "showtickprefix": {
+                        "description": "If *all*, all tick labels are displayed with a prefix. If *first*, only the first tick is displayed with a prefix. If *last*, only the last tick is displayed with a suffix. If *none*, tick prefixes are hidden.",
+                        "dflt": "all",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "enumerated",
+                        "values": [
+                            "all",
+                            "first",
+                            "last",
+                            "none"
+                        ]
+                    },
+                    "showticksuffix": {
+                        "description": "Same as `showtickprefix` but for tick suffixes.",
+                        "dflt": "all",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "enumerated",
+                        "values": [
+                            "all",
+                            "first",
+                            "last",
+                            "none"
+                        ]
+                    },
+                    "side": {
+                        "description": "Determines on which side of radial axis line the tick and tick labels appear.",
+                        "dflt": "clockwise",
+                        "editType": "plot",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "clockwise",
+                            "counterclockwise"
+                        ]
+                    },
+                    "tick0": {
+                        "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                        "editType": "plot",
+                        "impliedEdits": {
+                            "tickmode": "linear"
+                        },
+                        "role": "style",
+                        "valType": "any"
+                    },
+                    "tickangle": {
+                        "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
+                        "dflt": "auto",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "angle"
+                    },
+                    "tickcolor": {
+                        "description": "Sets the tick color.",
+                        "dflt": "#444",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "tickfont": {
+                        "color": {
+                            "editType": "plot",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "description": "Sets the tick font.",
+                        "editType": "plot",
+                        "family": {
+                            "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                            "editType": "plot",
+                            "noBlank": true,
+                            "role": "style",
+                            "strict": true,
+                            "valType": "string"
+                        },
+                        "role": "object",
+                        "size": {
+                            "editType": "plot",
+                            "min": 1,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "tickformat": {
+                        "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                        "dflt": "",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "string"
+                    },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "plot",
+                                    "items": [
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "plot",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "plot",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
+                    "ticklen": {
+                        "description": "Sets the tick length (in px).",
+                        "dflt": 5,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "tickmode": {
+                        "description": "Sets the tick mode for this axis. If *auto*, the number of ticks is set via `nticks`. If *linear*, the placement of the ticks is determined by a starting position `tick0` and a tick step `dtick` (*linear* is the default value if `tick0` and `dtick` are provided). If *array*, the placement of the ticks is set via `tickvals` and the tick text is `ticktext`. (*array* is the default value if `tickvals` is provided).",
+                        "editType": "plot",
+                        "impliedEdits": {},
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "auto",
+                            "linear",
+                            "array"
+                        ]
+                    },
+                    "tickprefix": {
+                        "description": "Sets a tick label prefix.",
+                        "dflt": "",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "string"
+                    },
+                    "ticks": {
+                        "description": "Determines whether ticks are drawn or not. If **, this axis' ticks are not drawn. If *outside* (*inside*), this axis' are drawn outside (inside) the axis lines.",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "enumerated",
+                        "values": [
+                            "outside",
+                            "inside",
+                            ""
+                        ]
+                    },
+                    "ticksuffix": {
+                        "description": "Sets a tick label suffix.",
+                        "dflt": "",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "string"
+                    },
+                    "ticktext": {
+                        "description": "Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.",
+                        "editType": "plot",
+                        "role": "data",
+                        "valType": "data_array"
+                    },
+                    "ticktextsrc": {
+                        "description": "Sets the source reference on plot.ly for  ticktext .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "tickvals": {
+                        "description": "Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.",
+                        "editType": "plot",
+                        "role": "data",
+                        "valType": "data_array"
+                    },
+                    "tickvalssrc": {
+                        "description": "Sets the source reference on plot.ly for  tickvals .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "tickwidth": {
+                        "description": "Sets the tick width (in px).",
+                        "dflt": 1,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "title": {
+                        "description": "Sets the title of this axis.",
+                        "dflt": "",
+                        "editType": "plot",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "titlefont": {
+                        "color": {
+                            "editType": "plot",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "description": "Sets this axis' title font.",
+                        "editType": "plot",
+                        "family": {
+                            "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                            "editType": "plot",
+                            "noBlank": true,
+                            "role": "style",
+                            "strict": true,
+                            "valType": "string"
+                        },
+                        "role": "object",
+                        "size": {
+                            "editType": "plot",
+                            "min": 1,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "type": {
+                        "description": "Sets the axis type. By default, plotly attempts to determined the axis type by looking into the data of the traces that referenced the axis in question.",
+                        "dflt": "-",
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "-",
+                            "linear",
+                            "log",
+                            "date",
+                            "category"
+                        ]
+                    },
+                    "visible": {
+                        "description": "A single toggle to hide the axis while preserving interaction like dragging. Default is true when a cheater plot is present on the axis, otherwise false",
+                        "dflt": true,
+                        "editType": "plot",
+                        "role": "info",
+                        "valType": "boolean"
+                    }
+                },
+                "role": "object",
+                "sector": {
+                    "description": "Sets angular span of this polar subplot with two angles (in degrees). Sector are assumed to be spanned in the counterclockwise direction with *0* corresponding to rightmost limit of the polar subplot.",
+                    "dflt": [
+                        0,
+                        360
+                    ],
+                    "editType": "plot",
+                    "items": [
+                        {
+                            "editType": "plot",
+                            "valType": "number"
+                        },
+                        {
+                            "editType": "plot",
+                            "valType": "number"
+                        }
+                    ],
+                    "role": "info",
+                    "valType": "info_array"
+                }
+            },
             "radialaxis": {
                 "domain": {
                     "description": "Polar chart subplots are not supported yet. This key has currently no effect.",
@@ -2130,7 +3178,7 @@
                                 "valType": "color"
                             },
                             "arrowhead": {
-                                "description": "Sets the annotation arrow head style.",
+                                "description": "Sets the end annotation arrow head style.",
                                 "dflt": 1,
                                 "editType": "calc",
                                 "max": 8,
@@ -2138,8 +3186,22 @@
                                 "role": "style",
                                 "valType": "integer"
                             },
+                            "arrowside": {
+                                "description": "Sets the annotation arrow head position.",
+                                "dflt": "end",
+                                "editType": "calc",
+                                "extras": [
+                                    "none"
+                                ],
+                                "flags": [
+                                    "end",
+                                    "start"
+                                ],
+                                "role": "style",
+                                "valType": "flaglist"
+                            },
                             "arrowsize": {
-                                "description": "Sets the size of the annotation arrow head, relative to `arrowwidth`. A value of 1 (default) gives a head about 3x as wide as the line.",
+                                "description": "Sets the size of the end annotation arrow head, relative to `arrowwidth`. A value of 1 (default) gives a head about 3x as wide as the line.",
                                 "dflt": 1,
                                 "editType": "calc",
                                 "min": 0.3,
@@ -2298,7 +3360,32 @@
                                 "valType": "boolean"
                             },
                             "standoff": {
-                                "description": "Sets a distance, in pixels, to move the arrowhead away from the position it is pointing at, for example to point at the edge of a marker independent of zoom. Note that this shortens the arrow from the `ax` / `ay` vector, in contrast to `xshift` / `yshift` which moves everything by this amount.",
+                                "description": "Sets a distance, in pixels, to move the end arrowhead away from the position it is pointing at, for example to point at the edge of a marker independent of zoom. Note that this shortens the arrow from the `ax` / `ay` vector, in contrast to `xshift` / `yshift` which moves everything by this amount.",
+                                "dflt": 0,
+                                "editType": "calc",
+                                "min": 0,
+                                "role": "style",
+                                "valType": "number"
+                            },
+                            "startarrowhead": {
+                                "description": "Sets the start annotation arrow head style.",
+                                "dflt": 1,
+                                "editType": "calc",
+                                "max": 8,
+                                "min": 0,
+                                "role": "style",
+                                "valType": "integer"
+                            },
+                            "startarrowsize": {
+                                "description": "Sets the size of the start annotation arrow head, relative to `arrowwidth`. A value of 1 (default) gives a head about 3x as wide as the line.",
+                                "dflt": 1,
+                                "editType": "calc",
+                                "min": 0.3,
+                                "role": "style",
+                                "valType": "number"
+                            },
+                            "startstandoff": {
+                                "description": "Sets a distance, in pixels, to move the start arrowhead away from the position it is pointing at, for example to point at the edge of a marker independent of zoom. Note that this shortens the arrow from the `ax` / `ay` vector, in contrast to `xshift` / `yshift` which moves everything by this amount.",
                                 "dflt": 0,
                                 "editType": "calc",
                                 "min": 0,
@@ -2540,7 +3627,7 @@
                     "editType": "plot",
                     "role": "object",
                     "x": {
-                        "description": "Sets the horizontal domain of this scene (in plot fraction).",
+                        "description": "Sets the horizontal domain of this scene subplot (in plot fraction).",
                         "dflt": [
                             0,
                             1
@@ -2548,13 +3635,11 @@
                         "editType": "plot",
                         "items": [
                             {
-                                "editType": "plot",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
                             },
                             {
-                                "editType": "plot",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
@@ -2564,7 +3649,7 @@
                         "valType": "info_array"
                     },
                     "y": {
-                        "description": "Sets the vertical domain of this scene (in plot fraction).",
+                        "description": "Sets the vertical domain of this scene subplot (in plot fraction).",
                         "dflt": [
                             0,
                             1
@@ -2572,13 +3657,11 @@
                         "editType": "plot",
                         "items": [
                             {
-                                "editType": "plot",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
                             },
                             {
-                                "editType": "plot",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
@@ -2977,6 +4060,38 @@
                         "editType": "plot",
                         "role": "style",
                         "valType": "string"
+                    },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "plot",
+                                    "items": [
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "plot",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "plot",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
                     },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
@@ -3489,6 +4604,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "plot",
+                                    "items": [
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "plot",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "plot",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
                         "dflt": 5,
@@ -4000,6 +5147,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "plot",
+                                    "items": [
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "plot",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "plot",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
                         "dflt": 5,
@@ -4150,8 +5329,7 @@
                 }
             },
             "separators": {
-                "description": "Sets the decimal and thousand separators. For example, *. * puts a '.' before decimals and a space between thousands.",
-                "dflt": ".,",
+                "description": "Sets the decimal and thousand separators. For example, *. * puts a '.' before decimals and a space between thousands. In English locales, dflt is *.,* but other locales may alter this default.",
                 "editType": "plot",
                 "role": "style",
                 "valType": "string"
@@ -4200,12 +5378,12 @@
                                     "longdashdot"
                                 ]
                             },
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "object",
                             "width": {
                                 "description": "Sets the line width (in px).",
                                 "dflt": 2,
-                                "editType": "calcIfAutorange",
+                                "editType": "calcIfAutorange+arraydraw",
                                 "min": 0,
                                 "role": "style",
                                 "valType": "number"
@@ -4222,14 +5400,14 @@
                         },
                         "path": {
                             "description": "For `type` *path* - a valid SVG path but with the pixel values replaced by data values. There are a few restrictions / quirks only absolute instructions, not relative. So the allowed segments are: M, L, H, V, Q, C, T, S, and Z arcs (A) are not allowed because radius rx and ry are relative. In the future we could consider supporting relative commands, but we would have to decide on how to handle date and log axes. Note that even as is, Q and C Bezier paths that are smooth on linear axes may not be smooth on log, and vice versa. no chained \"polybezier\" commands - specify the segment type for each one. On category axes, values are numbers scaled to the serial numbers of categories because using the categories themselves there would be no way to describe fractional positions On data axes: because space and T are both normal components of path strings, we can't use either to separate date from time parts. Therefore we'll use underscore for this purpose: 2015-02-21_13:45:56.789",
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "info",
                             "valType": "string"
                         },
                         "role": "object",
                         "type": {
                             "description": "Specifies the shape type to be drawn. If *line*, a line is drawn from (`x0`,`y0`) to (`x1`,`y1`) If *circle*, a circle is drawn from ((`x0`+`x1`)/2, (`y0`+`y1`)/2)) with radius (|(`x0`+`x1`)/2 - `x0`|, |(`y0`+`y1`)/2 -`y0`)|) If *rect*, a rectangle is drawn linking (`x0`,`y0`), (`x1`,`y0`), (`x1`,`y1`), (`x0`,`y1`), (`x0`,`y0`) If *path*, draw a custom SVG path using `path`.",
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "info",
                             "valType": "enumerated",
                             "values": [
@@ -4242,19 +5420,19 @@
                         "visible": {
                             "description": "Determines whether or not this shape is visible.",
                             "dflt": true,
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "info",
                             "valType": "boolean"
                         },
                         "x0": {
                             "description": "Sets the shape's starting x position. See `type` for more info.",
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "info",
                             "valType": "any"
                         },
                         "x1": {
                             "description": "Sets the shape's end x position. See `type` for more info.",
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "info",
                             "valType": "any"
                         },
@@ -4270,13 +5448,13 @@
                         },
                         "y0": {
                             "description": "Sets the shape's starting y position. See `type` for more info.",
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "info",
                             "valType": "any"
                         },
                         "y1": {
                             "description": "Sets the shape's end y position. See `type` for more info.",
-                            "editType": "calcIfAutorange",
+                            "editType": "calcIfAutorange+arraydraw",
                             "role": "info",
                             "valType": "any"
                         },
@@ -4690,14 +5868,13 @@
                 },
                 "role": "object"
             },
-            "smith": {
-                "dflt": false,
+            "spikedistance": {
+                "description": "Sets the default distance (in pixels) to look for data to draw spikelines to (-1 means no cutoff, 0 means no looking for data).",
+                "dflt": 20,
                 "editType": "none",
+                "min": -1,
                 "role": "info",
-                "valType": "enumerated",
-                "values": [
-                    false
-                ]
+                "valType": "integer"
             },
             "ternary": {
                 "_isSubplotObj": true,
@@ -4919,6 +6096,38 @@
                         "editType": "plot",
                         "role": "style",
                         "valType": "string"
+                    },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "plot",
+                                    "items": [
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "plot",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "plot",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
                     },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
@@ -5246,6 +6455,38 @@
                         "editType": "plot",
                         "role": "style",
                         "valType": "string"
+                    },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "plot",
+                                    "items": [
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "plot",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "plot",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
                     },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
@@ -5581,6 +6822,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "plot",
+                                    "items": [
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "plot",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "plot",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
                         "dflt": 5,
@@ -5693,7 +6966,7 @@
                     "editType": "plot",
                     "role": "object",
                     "x": {
-                        "description": "Sets the horizontal domain of this subplot (in plot fraction).",
+                        "description": "Sets the horizontal domain of this ternary subplot (in plot fraction).",
                         "dflt": [
                             0,
                             1
@@ -5717,7 +6990,7 @@
                         "valType": "info_array"
                     },
                     "y": {
-                        "description": "Sets the vertical domain of this subplot (in plot fraction).",
+                        "description": "Sets the vertical domain of this ternary subplot (in plot fraction).",
                         "dflt": [
                             0,
                             1
@@ -5754,7 +7027,6 @@
             },
             "title": {
                 "description": "Sets the plot's title.",
-                "dflt": "Click to enter Plot title",
                 "editType": "layoutstyle",
                 "role": "info",
                 "valType": "string"
@@ -6487,6 +7759,7 @@
                         "description": "Determines whether or not the range slider range is computed in relation to the input data. If `range` is provided, then `autorange` is set to *false*.",
                         "dflt": true,
                         "editType": "calc",
+                        "impliedEdits": {},
                         "role": "style",
                         "valType": "boolean"
                     },
@@ -6516,13 +7789,22 @@
                     "range": {
                         "description": "Sets the range of the range slider. If not set, defaults to the full xaxis range. If the axis `type` is *log*, then you must take the log of your desired range. If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
                         "editType": "calc",
+                        "impliedEdits": {
+                            "autorange": false
+                        },
                         "items": [
                             {
                                 "editType": "calc",
+                                "impliedEdits": {
+                                    "^autorange": false
+                                },
                                 "valType": "any"
                             },
                             {
                                 "editType": "calc",
+                                "impliedEdits": {
+                                    "^autorange": false
+                                },
                                 "valType": "any"
                             }
                         ],
@@ -6685,6 +7967,17 @@
                     "role": "style",
                     "valType": "flaglist"
                 },
+                "spikesnap": {
+                    "description": "Determines whether spikelines are stuck to the cursor or to the closest datapoints.",
+                    "dflt": "data",
+                    "editType": "none",
+                    "role": "style",
+                    "valType": "enumerated",
+                    "values": [
+                        "data",
+                        "cursor"
+                    ]
+                },
                 "spikethickness": {
                     "description": "Sets the width (in px) of the zero line.",
                     "dflt": 3,
@@ -6745,6 +8038,38 @@
                     "editType": "ticks",
                     "role": "style",
                     "valType": "string"
+                },
+                "tickformatstops": {
+                    "items": {
+                        "tickformatstop": {
+                            "dtickrange": {
+                                "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                "editType": "ticks",
+                                "items": [
+                                    {
+                                        "editType": "ticks",
+                                        "valType": "any"
+                                    },
+                                    {
+                                        "editType": "ticks",
+                                        "valType": "any"
+                                    }
+                                ],
+                                "role": "info",
+                                "valType": "info_array"
+                            },
+                            "editType": "ticks",
+                            "role": "object",
+                            "value": {
+                                "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                "dflt": "",
+                                "editType": "ticks",
+                                "role": "style",
+                                "valType": "string"
+                            }
+                        }
+                    },
+                    "role": "object"
                 },
                 "ticklen": {
                     "description": "Sets the tick length (in px).",
@@ -7331,6 +8656,17 @@
                     "role": "style",
                     "valType": "flaglist"
                 },
+                "spikesnap": {
+                    "description": "Determines whether spikelines are stuck to the cursor or to the closest datapoints.",
+                    "dflt": "data",
+                    "editType": "none",
+                    "role": "style",
+                    "valType": "enumerated",
+                    "values": [
+                        "data",
+                        "cursor"
+                    ]
+                },
                 "spikethickness": {
                     "description": "Sets the width (in px) of the zero line.",
                     "dflt": 3,
@@ -7391,6 +8727,38 @@
                     "editType": "ticks",
                     "role": "style",
                     "valType": "string"
+                },
+                "tickformatstops": {
+                    "items": {
+                        "tickformatstop": {
+                            "dtickrange": {
+                                "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                "editType": "ticks",
+                                "items": [
+                                    {
+                                        "editType": "ticks",
+                                        "valType": "any"
+                                    },
+                                    {
+                                        "editType": "ticks",
+                                        "valType": "any"
+                                    }
+                                ],
+                                "role": "info",
+                                "valType": "info_array"
+                            },
+                            "editType": "ticks",
+                            "role": "object",
+                            "value": {
+                                "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                "dflt": "",
+                                "editType": "ticks",
+                                "role": "style",
+                                "valType": "string"
+                            }
+                        }
+                    },
+                    "role": "object"
                 },
                 "ticklen": {
                     "description": "Sets the tick length (in px).",
@@ -8054,7 +9422,7 @@
                     "valType": "number"
                 },
                 "r": {
-                    "description": "For polar chart only.Sets the radial coordinates.",
+                    "description": "For legacy polar chart only.Please switch to *scatterpolar* trace type.Sets the radial coordinates.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -8064,6 +9432,12 @@
                     "editType": "none",
                     "role": "info",
                     "valType": "string"
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
                 },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
@@ -8094,7 +9468,7 @@
                     }
                 },
                 "t": {
-                    "description": "For polar chart only.Sets the angular coordinates.",
+                    "description": "For legacy polar chart only.Please switch to *scatterpolar* trace type.Sets the angular coordinates.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -8890,6 +10264,38 @@
                             "role": "style",
                             "valType": "string"
                         },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "colorbars",
+                                        "items": [
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "colorbars",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "colorbars",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
                             "dflt": 5,
@@ -8970,7 +10376,6 @@
                         },
                         "title": {
                             "description": "Sets the title of the color bar.",
-                            "dflt": "Click to enter colorscale title",
                             "editType": "colorbars",
                             "role": "info",
                             "valType": "string"
@@ -9071,7 +10476,7 @@
                         }
                     },
                     "colorscale": {
-                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                         "editType": "calc",
                         "impliedEdits": {
                             "autocolorscale": false
@@ -9131,7 +10536,7 @@
                             "valType": "color"
                         },
                         "colorscale": {
-                            "description": "Sets the colorscale and only has an effect if `marker.line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.line.cmin` and `marker.line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                            "description": "Sets the colorscale and only has an effect if `marker.line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.line.cmin` and `marker.line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                             "editType": "calc",
                             "impliedEdits": {
                                 "autocolorscale": false
@@ -9169,6 +10574,22 @@
                             "role": "info",
                             "valType": "string"
                         }
+                    },
+                    "opacity": {
+                        "arrayOk": true,
+                        "description": "Sets the opacity of the bars.",
+                        "dflt": 1,
+                        "editType": "style",
+                        "max": 1,
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "opacitysrc": {
+                        "description": "Sets the source reference on plot.ly for  opacity .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
                     },
                     "reversescale": {
                         "description": "Has an effect only if `marker.color` is set to a numerical array. Reverses the color mapping if true (`cmin` will correspond to the last color in the array and `cmax` will correspond to the first color).",
@@ -9271,7 +10692,7 @@
                     }
                 },
                 "r": {
-                    "description": "For polar chart only.Sets the radial coordinates.",
+                    "description": "For legacy polar chart only.Please switch to *scatterpolar* trace type.Sets the radial coordinates.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -9281,6 +10702,44 @@
                     "editType": "none",
                     "role": "info",
                     "valType": "string"
+                },
+                "selected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of selected points.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of selected points.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object"
+                    },
+                    "role": "object",
+                    "textfont": {
+                        "color": {
+                            "description": "Sets the text font color of selected points.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "role": "object"
+                    }
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
                 },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
@@ -9311,7 +10770,7 @@
                     }
                 },
                 "t": {
-                    "description": "For polar chart only.Sets the angular coordinates.",
+                    "description": "For legacy polar chart only.Please switch to *scatterpolar* trace type.Sets the angular coordinates.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -9407,6 +10866,38 @@
                     "editType": "calc",
                     "role": "info",
                     "valType": "string"
+                },
+                "unselected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object"
+                    },
+                    "role": "object",
+                    "textfont": {
+                        "color": {
+                            "description": "Sets the text font color of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "role": "object"
+                    }
                 },
                 "visible": {
                     "description": "Determines whether or not this trace is visible. If *legendonly*, the trace is not drawn, but can appear as a legend item (provided that the legend itself is visible).",
@@ -9745,6 +11236,17 @@
                         "valType": "string"
                     },
                     "role": "object"
+                },
+                "hoveron": {
+                    "description": "Do the hover effects highlight individual boxes  or sample points or both?",
+                    "dflt": "boxes+points",
+                    "editType": "style",
+                    "flags": [
+                        "boxes",
+                        "points"
+                    ],
+                    "role": "info",
+                    "valType": "flaglist"
                 },
                 "ids": {
                     "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
@@ -10163,6 +11665,21 @@
                     "role": "info",
                     "valType": "string"
                 },
+                "notched": {
+                    "description": "Determines whether or not notches should be drawn.",
+                    "editType": "calcIfAutorange",
+                    "role": "style",
+                    "valType": "boolean"
+                },
+                "notchwidth": {
+                    "description": "Sets the width of the notches relative to the box' width. For example, with 0, the notches are as wide as the box(es).",
+                    "dflt": 0.25,
+                    "editType": "calcIfAutorange",
+                    "max": 0.5,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
                 "opacity": {
                     "description": "Sets the opacity of the trace.",
                     "dflt": 1,
@@ -10189,6 +11706,41 @@
                     "min": -2,
                     "role": "style",
                     "valType": "number"
+                },
+                "selected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of selected points.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of selected points.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of selected points.",
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object"
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
                 },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
@@ -10218,12 +11770,55 @@
                         "valType": "string"
                     }
                 },
+                "text": {
+                    "arrayOk": true,
+                    "description": "Sets the text elements associated with each sample value. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates. To be seen, trace `hoverinfo` must contain a *text* flag.",
+                    "dflt": "",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "textsrc": {
+                    "description": "Sets the source reference on plot.ly for  text .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
                 "type": "box",
                 "uid": {
                     "dflt": "",
                     "editType": "calc",
                     "role": "info",
                     "valType": "string"
+                },
+                "unselected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object"
                 },
                 "visible": {
                     "description": "Determines whether or not this trace is visible. If *legendonly*, the trace is not drawn, but can appear as a legend item (provided that the legend itself is visible).",
@@ -10692,6 +12287,12 @@
                     "editType": "none",
                     "role": "info",
                     "valType": "string"
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
                 },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
@@ -11209,6 +12810,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "calc",
+                                    "items": [
+                                        {
+                                            "editType": "calc",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "calc",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "calc",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "calc",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "tickmode": {
                         "dflt": "array",
                         "editType": "calc",
@@ -11702,6 +13335,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "calc",
+                                    "items": [
+                                        {
+                                            "editType": "calc",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "calc",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "calc",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "calc",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "tickmode": {
                         "dflt": "array",
                         "editType": "calc",
@@ -12029,6 +13694,12 @@
                     "role": "style",
                     "valType": "number"
                 },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
                     "dflt": true,
@@ -12346,6 +14017,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "colorbars",
+                                    "items": [
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "colorbars",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "colorbars",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
                         "dflt": 5,
@@ -12426,7 +14129,6 @@
                     },
                     "title": {
                         "description": "Sets the title of the color bar.",
-                        "dflt": "Click to enter colorscale title",
                         "editType": "colorbars",
                         "role": "info",
                         "valType": "string"
@@ -12746,6 +14448,22 @@
                             "valType": "string"
                         }
                     },
+                    "opacity": {
+                        "arrayOk": true,
+                        "description": "Sets the opacity of the locations.",
+                        "dflt": 1,
+                        "editType": "style",
+                        "max": 1,
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "opacitysrc": {
+                        "description": "Sets the source reference on plot.ly for  opacity .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
                     "role": "object"
                 },
                 "name": {
@@ -12769,6 +14487,28 @@
                     "editType": "calc",
                     "role": "style",
                     "valType": "boolean"
+                },
+                "selected": {
+                    "editType": "plot",
+                    "marker": {
+                        "editType": "plot",
+                        "opacity": {
+                            "description": "Sets the marker opacity of selected points.",
+                            "editType": "calc",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object"
+                    },
+                    "role": "object"
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
                 },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
@@ -12825,6 +14565,22 @@
                     "editType": "calc",
                     "role": "info",
                     "valType": "string"
+                },
+                "unselected": {
+                    "editType": "plot",
+                    "marker": {
+                        "editType": "plot",
+                        "opacity": {
+                            "description": "Sets the marker opacity of unselected points, applied only when a selection exists.",
+                            "editType": "calc",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object"
+                    },
+                    "role": "object"
                 },
                 "visible": {
                     "description": "Determines whether or not this trace is visible. If *legendonly*, the trace is not drawn, but can appear as a legend item (provided that the legend itself is visible).",
@@ -13118,6 +14874,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "colorbars",
+                                    "items": [
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "colorbars",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "colorbars",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
                         "dflt": 5,
@@ -13198,7 +14986,6 @@
                     },
                     "title": {
                         "description": "Sets the title of the color bar.",
-                        "dflt": "Click to enter colorscale title",
                         "editType": "colorbars",
                         "role": "info",
                         "valType": "string"
@@ -13374,6 +15161,28 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "operation": {
+                        "description": "Sets the constraint operation. *=* keeps regions equal to `value` *<* and *<=* keep regions less than `value` *>* and *>=* keep regions greater than `value` *[]*, *()*, *[)*, and *(]* keep regions inside `value[0]` to `value[1]` *][*, *)(*, *](*, *)[* keep regions outside `value[0]` to value[1]` Open vs. closed intervals make no difference to constraint display, but all versions are allowed for consistency with filter transforms.",
+                        "dflt": "=",
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "=",
+                            "<",
+                            ">=",
+                            ">",
+                            "<=",
+                            "[]",
+                            "()",
+                            "[)",
+                            "(]",
+                            "][",
+                            ")(",
+                            "](",
+                            ")["
+                        ]
+                    },
                     "role": "object",
                     "showlabels": {
                         "description": "Determines whether to label the contour lines with their values.",
@@ -13409,6 +15218,24 @@
                         },
                         "role": "style",
                         "valType": "number"
+                    },
+                    "type": {
+                        "description": "If `levels`, the data is represented as a contour plot with multiple levels displayed. If `constraint`, the data is represented as constraints with the invalid region shaded as specified by the `operation` and `value` parameters.",
+                        "dflt": "levels",
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "levels",
+                            "constraint"
+                        ]
+                    },
+                    "value": {
+                        "description": "Sets the value or values of the constraint boundary. When `operation` is set to one of the comparison values (=,<,>=,>,<=) *value* is expected to be a number. When `operation` is set to one of the interval values ([],(),[),(],][,)(,](,)[) *value* is expected to be an array of two numbers where the first is the lower bound and the second is the upper bound.",
+                        "dflt": 0,
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "any"
                     }
                 },
                 "customdata": {
@@ -13442,6 +15269,12 @@
                     },
                     "role": "info",
                     "valType": "number"
+                },
+                "fillcolor": {
+                    "description": "Sets the fill color if `contours.type` is *constraint*. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available.",
+                    "editType": "calc",
+                    "role": "style",
+                    "valType": "color"
                 },
                 "hoverinfo": {
                     "arrayOk": true,
@@ -13648,6 +15481,12 @@
                     "editType": "calc",
                     "role": "style",
                     "valType": "boolean"
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
                 },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
@@ -13869,6 +15708,13 @@
                     "impliedEdits": {},
                     "role": "info",
                     "valType": "boolean"
+                },
+                "zhoverformat": {
+                    "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. See: https://github.com/d3/d3-format/blob/master/README.md#locale_format",
+                    "dflt": "",
+                    "editType": "none",
+                    "role": "style",
+                    "valType": "string"
                 },
                 "zmax": {
                     "description": "Sets the upper bound of color domain.",
@@ -14212,6 +16058,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "colorbars",
+                                    "items": [
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "colorbars",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "colorbars",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
                         "dflt": 5,
@@ -14292,7 +16170,6 @@
                     },
                     "title": {
                         "description": "Sets the title of the color bar.",
-                        "dflt": "Click to enter colorscale title",
                         "editType": "colorbars",
                         "role": "info",
                         "valType": "string"
@@ -14401,13 +16278,6 @@
                     "role": "style",
                     "valType": "colorscale"
                 },
-                "connectgaps": {
-                    "description": "Determines whether or not gaps (i.e. {nan} or missing values) in the `z` data are filled in.",
-                    "dflt": false,
-                    "editType": "calc",
-                    "role": "info",
-                    "valType": "boolean"
-                },
                 "contours": {
                     "coloring": {
                         "description": "Determines the coloring method showing the contour values. If *fill*, coloring is done evenly between each contour level If *lines*, coloring is done on the contour lines. If *none*, no coloring is applied on this trace.",
@@ -14431,6 +16301,10 @@
                         },
                         "role": "style",
                         "valType": "number"
+                    },
+                    "impliedEdits": {
+                        "autocontour": false,
+                        "role": "object"
                     },
                     "labelfont": {
                         "color": {
@@ -14464,7 +16338,7 @@
                         "valType": "string"
                     },
                     "operation": {
-                        "description": "Sets the filter operation. *=* keeps items equal to `value` *<* keeps items less than `value` *<=* keeps items less than or equal to `value` *>* keeps items greater than `value` *>=* keeps items greater than or equal to `value` *[]* keeps items inside `value[0]` to value[1]` including both bounds` *()* keeps items inside `value[0]` to value[1]` excluding both bounds` *[)* keeps items inside `value[0]` to value[1]` including `value[0]` but excluding `value[1] *(]* keeps items inside `value[0]` to value[1]` excluding `value[0]` but including `value[1] *][* keeps items outside `value[0]` to value[1]` and equal to both bounds` *)(* keeps items outside `value[0]` to value[1]` *](* keeps items outside `value[0]` to value[1]` and equal to `value[0]` *)[* keeps items outside `value[0]` to value[1]` and equal to `value[1]`",
+                        "description": "Sets the constraint operation. *=* keeps regions equal to `value` *<* and *<=* keep regions less than `value` *>* and *>=* keep regions greater than `value` *[]*, *()*, *[)*, and *(]* keep regions inside `value[0]` to `value[1]` *][*, *)(*, *](*, *)[* keep regions outside `value[0]` to value[1]` Open vs. closed intervals make no difference to constraint display, but all versions are allowed for consistency with filter transforms.",
                         "dflt": "=",
                         "editType": "calc",
                         "role": "info",
@@ -14482,9 +16356,7 @@
                             "][",
                             ")(",
                             "](",
-                            ")[",
-                            "{}",
-                            "}{"
+                            ")["
                         ]
                     },
                     "role": "object",
@@ -14535,7 +16407,7 @@
                         ]
                     },
                     "value": {
-                        "description": "Sets the value or values by which to filter by. Values are expected to be in the same type as the data linked to *target*. When `operation` is set to one of the inequality values (=,<,>=,>,<=) *value* is expected to be a number or a string. When `operation` is set to one of the interval value ([],(),[),(],][,)(,](,)[) *value* is expected to be 2-item array where the first item is the lower bound and the second item is the upper bound. When `operation`, is set to one of the set value ({},}{) *value* is expected to be an array with as many items as the desired set elements.",
+                        "description": "Sets the value or values of the constraint boundary. When `operation` is set to one of the comparison values (=,<,>=,>,<=) *value* is expected to be a number. When `operation` is set to one of the interval values ([],(),[),(],][,)(,](,)[) *value* is expected to be an array of two numbers where the first is the lower bound and the second is the upper bound.",
                         "dflt": 0,
                         "editType": "calc",
                         "role": "info",
@@ -14575,7 +16447,7 @@
                     "valType": "number"
                 },
                 "fillcolor": {
-                    "description": "Sets the fill color. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available.",
+                    "description": "Sets the fill color if `contours.type` is *constraint*. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available.",
                     "editType": "calc",
                     "role": "style",
                     "valType": "color"
@@ -14756,19 +16628,6 @@
                         "valType": "number"
                     }
                 },
-                "mode": {
-                    "description": "The mode.",
-                    "editType": "calc",
-                    "extras": [
-                        "none"
-                    ],
-                    "flags": [
-                        "lines",
-                        "fill"
-                    ],
-                    "role": "info",
-                    "valType": "flaglist"
-                },
                 "name": {
                     "description": "Sets the trace name. The trace name appear as the legend item and on hover.",
                     "editType": "style",
@@ -14798,6 +16657,12 @@
                     "editType": "calc",
                     "role": "style",
                     "valType": "boolean"
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
                 },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
@@ -15159,6 +17024,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "colorbars",
+                                    "items": [
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "colorbars",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "colorbars",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
                         "dflt": 5,
@@ -15239,7 +17136,6 @@
                     },
                     "title": {
                         "description": "Sets the title of the color bar.",
-                        "dflt": "Click to enter colorscale title",
                         "editType": "colorbars",
                         "role": "info",
                         "valType": "string"
@@ -15543,6 +17439,12 @@
                     "role": "style",
                     "valType": "boolean"
                 },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
                     "dflt": true,
@@ -15779,6 +17681,13 @@
                     "impliedEdits": {},
                     "role": "info",
                     "valType": "boolean"
+                },
+                "zhoverformat": {
+                    "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. See: https://github.com/d3/d3-format/blob/master/README.md#locale_format",
+                    "dflt": "",
+                    "editType": "none",
+                    "role": "style",
+                    "valType": "string"
                 },
                 "zmax": {
                     "description": "Sets the upper bound of color domain.",
@@ -16050,6 +17959,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "calc",
+                                    "items": [
+                                        {
+                                            "editType": "calc",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "calc",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "calc",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "calc",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
                         "dflt": 5,
@@ -16130,7 +18071,6 @@
                     },
                     "title": {
                         "description": "Sets the title of the color bar.",
-                        "dflt": "Click to enter colorscale title",
                         "editType": "calc",
                         "role": "info",
                         "valType": "string"
@@ -16426,6 +18366,12 @@
                     "editType": "calc",
                     "role": "style",
                     "valType": "boolean"
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
                 },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
@@ -17370,6 +19316,38 @@
                             "role": "style",
                             "valType": "string"
                         },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "colorbars",
+                                        "items": [
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "colorbars",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "colorbars",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
                             "dflt": 5,
@@ -17450,7 +19428,6 @@
                         },
                         "title": {
                             "description": "Sets the title of the color bar.",
-                            "dflt": "Click to enter colorscale title",
                             "editType": "colorbars",
                             "role": "info",
                             "valType": "string"
@@ -17551,7 +19528,7 @@
                         }
                     },
                     "colorscale": {
-                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                         "editType": "calc",
                         "impliedEdits": {
                             "autocolorscale": false
@@ -17611,7 +19588,7 @@
                             "valType": "color"
                         },
                         "colorscale": {
-                            "description": "Sets the colorscale and only has an effect if `marker.line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.line.cmin` and `marker.line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                            "description": "Sets the colorscale and only has an effect if `marker.line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.line.cmin` and `marker.line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                             "editType": "calc",
                             "impliedEdits": {
                                 "autocolorscale": false
@@ -17649,6 +19626,22 @@
                             "role": "info",
                             "valType": "string"
                         }
+                    },
+                    "opacity": {
+                        "arrayOk": true,
+                        "description": "Sets the opacity of the bars.",
+                        "dflt": 1,
+                        "editType": "style",
+                        "max": 1,
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "opacitysrc": {
+                        "description": "Sets the source reference on plot.ly for  opacity .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
                     },
                     "reversescale": {
                         "description": "Has an effect only if `marker.color` is set to a numerical array. Reverses the color mapping if true (`cmin` will correspond to the last color in the array and `cmax` will correspond to the first color).",
@@ -17707,6 +19700,44 @@
                         "h"
                     ]
                 },
+                "selected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of selected points.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of selected points.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object"
+                    },
+                    "role": "object",
+                    "textfont": {
+                        "color": {
+                            "description": "Sets the text font color of selected points.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "role": "object"
+                    }
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
                     "dflt": true,
@@ -17755,6 +19786,38 @@
                     "editType": "calc",
                     "role": "info",
                     "valType": "string"
+                },
+                "unselected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object"
+                    },
+                    "role": "object",
+                    "textfont": {
+                        "color": {
+                            "description": "Sets the text font color of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "role": "object"
+                    }
                 },
                 "visible": {
                     "description": "Determines whether or not this trace is visible. If *legendonly*, the trace is not drawn, but can appear as a legend item (provided that the legend itself is visible).",
@@ -18224,6 +20287,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "colorbars",
+                                    "items": [
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "colorbars",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "colorbars",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
                         "dflt": 5,
@@ -18304,7 +20399,6 @@
                     },
                     "title": {
                         "description": "Sets the title of the color bar.",
-                        "dflt": "Click to enter colorscale title",
                         "editType": "colorbars",
                         "role": "info",
                         "valType": "string"
@@ -18641,6 +20735,12 @@
                     "role": "style",
                     "valType": "boolean"
                 },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
                     "dflt": true,
@@ -18888,6 +20988,13 @@
                     "impliedEdits": {},
                     "role": "info",
                     "valType": "boolean"
+                },
+                "zhoverformat": {
+                    "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. See: https://github.com/d3/d3-format/blob/master/README.md#locale_format",
+                    "dflt": "",
+                    "editType": "none",
+                    "role": "style",
+                    "valType": "string"
                 },
                 "zmax": {
                     "description": "Sets the upper bound of color domain.",
@@ -19184,6 +21291,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "colorbars",
+                                    "items": [
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "colorbars",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "colorbars",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
                         "dflt": 5,
@@ -19264,7 +21403,6 @@
                     },
                     "title": {
                         "description": "Sets the title of the color bar.",
-                        "dflt": "Click to enter colorscale title",
                         "editType": "colorbars",
                         "role": "info",
                         "valType": "string"
@@ -19433,6 +21571,28 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "operation": {
+                        "description": "Sets the constraint operation. *=* keeps regions equal to `value` *<* and *<=* keep regions less than `value` *>* and *>=* keep regions greater than `value` *[]*, *()*, *[)*, and *(]* keep regions inside `value[0]` to `value[1]` *][*, *)(*, *](*, *)[* keep regions outside `value[0]` to value[1]` Open vs. closed intervals make no difference to constraint display, but all versions are allowed for consistency with filter transforms.",
+                        "dflt": "=",
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "=",
+                            "<",
+                            ">=",
+                            ">",
+                            "<=",
+                            "[]",
+                            "()",
+                            "[)",
+                            "(]",
+                            "][",
+                            ")(",
+                            "](",
+                            ")["
+                        ]
+                    },
                     "role": "object",
                     "showlabels": {
                         "description": "Determines whether to label the contour lines with their values.",
@@ -19468,6 +21628,24 @@
                         },
                         "role": "style",
                         "valType": "number"
+                    },
+                    "type": {
+                        "description": "If `levels`, the data is represented as a contour plot with multiple levels displayed. If `constraint`, the data is represented as constraints with the invalid region shaded as specified by the `operation` and `value` parameters.",
+                        "dflt": "levels",
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "levels",
+                            "constraint"
+                        ]
+                    },
+                    "value": {
+                        "description": "Sets the value or values of the constraint boundary. When `operation` is set to one of the comparison values (=,<,>=,>,<=) *value* is expected to be a number. When `operation` is set to one of the interval values ([],(),[),(],][,)(,](,)[) *value* is expected to be an array of two numbers where the first is the lower bound and the second is the upper bound.",
+                        "dflt": 0,
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "any"
                     }
                 },
                 "customdata": {
@@ -19748,6 +21926,12 @@
                     "role": "style",
                     "valType": "boolean"
                 },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
                     "dflt": true,
@@ -19979,6 +22163,13 @@
                     "impliedEdits": {},
                     "role": "info",
                     "valType": "boolean"
+                },
+                "zhoverformat": {
+                    "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. See: https://github.com/d3/d3-format/blob/master/README.md#locale_format",
+                    "dflt": "",
+                    "editType": "none",
+                    "role": "style",
+                    "valType": "string"
                 },
                 "zmax": {
                     "description": "Sets the upper bound of color domain.",
@@ -20280,6 +22471,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "colorbars",
+                                    "items": [
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "colorbars",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "colorbars",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
                         "dflt": 5,
@@ -20360,7 +22583,6 @@
                     },
                     "title": {
                         "description": "Sets the title of the color bar.",
-                        "dflt": "Click to enter colorscale title",
                         "editType": "colorbars",
                         "role": "info",
                         "valType": "string"
@@ -20461,7 +22683,7 @@
                     }
                 },
                 "colorscale": {
-                    "description": "Sets the colorscale and only has an effect if `color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `cmin` and `cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                    "description": "Sets the colorscale and only has an effect if `color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `cmin` and `cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                     "editType": "calc",
                     "impliedEdits": {
                         "autocolorscale": false
@@ -20543,7 +22765,7 @@
                     "arrayOk": true,
                     "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
-                    "editType": "none",
+                    "editType": "calc",
                     "extras": [
                         "all",
                         "none",
@@ -20848,6 +23070,12 @@
                     "role": "info",
                     "valType": "subplotid"
                 },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
                     "dflt": true,
@@ -20882,6 +23110,20 @@
                         "strict": true,
                         "valType": "string"
                     }
+                },
+                "text": {
+                    "arrayOk": true,
+                    "description": "Sets the text elements associated with the vertices. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.",
+                    "dflt": "",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "textsrc": {
+                    "description": "Sets the source reference on plot.ly for  text .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
                 },
                 "type": "mesh3d",
                 "uid": {
@@ -21374,6 +23616,12 @@
                     "role": "info",
                     "valType": "string"
                 },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
                     "dflt": true,
@@ -21617,7 +23865,7 @@
                     "editType": "calc",
                     "role": "object",
                     "x": {
-                        "description": "Sets the horizontal domain of this `parcoords` trace (in plot fraction).",
+                        "description": "Sets the horizontal domain of this parcoords trace (in plot fraction).",
                         "dflt": [
                             0,
                             1
@@ -21625,13 +23873,11 @@
                         "editType": "calc",
                         "items": [
                             {
-                                "editType": "calc",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
                             },
                             {
-                                "editType": "calc",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
@@ -21641,7 +23887,7 @@
                         "valType": "info_array"
                     },
                     "y": {
-                        "description": "Sets the vertical domain of this `parcoords` trace (in plot fraction).",
+                        "description": "Sets the vertical domain of this parcoords trace (in plot fraction).",
                         "dflt": [
                             0,
                             1
@@ -21649,13 +23895,11 @@
                         "editType": "calc",
                         "items": [
                             {
-                                "editType": "calc",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
                             },
                             {
-                                "editType": "calc",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
@@ -22084,6 +24328,38 @@
                             "role": "style",
                             "valType": "string"
                         },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "colorbars",
+                                        "items": [
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "colorbars",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "colorbars",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
                             "dflt": 5,
@@ -22164,7 +24440,6 @@
                         },
                         "title": {
                             "description": "Sets the title of the color bar.",
-                            "dflt": "Click to enter colorscale title",
                             "editType": "colorbars",
                             "role": "info",
                             "valType": "string"
@@ -22265,7 +24540,7 @@
                         }
                     },
                     "colorscale": {
-                        "description": "Sets the colorscale and only has an effect if `line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `line.cmin` and `line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                        "description": "Sets the colorscale and only has an effect if `line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `line.cmin` and `line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                         "dflt": [
                             [
                                 0,
@@ -22405,6 +24680,12 @@
                         "valType": "number"
                     }
                 },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
                     "dflt": true,
@@ -22525,13 +24806,11 @@
                         "editType": "calc",
                         "items": [
                             {
-                                "editType": "calc",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
                             },
                             {
-                                "editType": "calc",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
@@ -22549,13 +24828,11 @@
                         "editType": "calc",
                         "items": [
                             {
-                                "editType": "calc",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
                             },
                             {
-                                "editType": "calc",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
@@ -22747,7 +25024,7 @@
                     "valType": "number"
                 },
                 "labels": {
-                    "description": "Sets the sector labels.",
+                    "description": "Sets the sector labels. If `labels` entries are duplicated, we sum associated `values` or simply count occurrences if `values` is not provided. For other array attributes (including color) we use the first non-empty entry among all occurrences of the label.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -22885,6 +25162,12 @@
                     "role": "info",
                     "valType": "string"
                 },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
                     "dflt": true,
@@ -22999,7 +25282,7 @@
                     "valType": "string"
                 },
                 "values": {
-                    "description": "Sets the values of the sectors of this pie chart.",
+                    "description": "Sets the values of the sectors of this pie chart. If omitted, we count occurrences of each label.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -23280,6 +25563,12 @@
                     "role": "style",
                     "valType": "number"
                 },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
                     "dflt": true,
@@ -23310,7 +25599,7 @@
                 },
                 "text": {
                     "arrayOk": true,
-                    "description": "Sets text elements associated with each (x,y) pair to appear on hover. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates.",
+                    "description": "Sets text elements associated with each (x,y) pair. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.",
                     "dflt": "",
                     "editType": "calc",
                     "role": "info",
@@ -23451,7 +25740,7 @@
                     "editType": "calc",
                     "role": "object",
                     "x": {
-                        "description": "Sets the horizontal domain of this `sankey` trace (in plot fraction).",
+                        "description": "Sets the horizontal domain of this sankey trace (in plot fraction).",
                         "dflt": [
                             0,
                             1
@@ -23475,7 +25764,7 @@
                         "valType": "info_array"
                     },
                     "y": {
-                        "description": "Sets the vertical domain of this `sankey` trace (in plot fraction).",
+                        "description": "Sets the vertical domain of this sankey trace (in plot fraction).",
                         "dflt": [
                             0,
                             1
@@ -23843,6 +26132,12 @@
                         "v",
                         "h"
                     ]
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
                 },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
@@ -24723,6 +27018,38 @@
                             "role": "style",
                             "valType": "string"
                         },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "colorbars",
+                                        "items": [
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "colorbars",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "colorbars",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
                             "dflt": 5,
@@ -24803,7 +27130,6 @@
                         },
                         "title": {
                             "description": "Sets the title of the color bar.",
-                            "dflt": "Click to enter colorscale title",
                             "editType": "colorbars",
                             "role": "info",
                             "valType": "string"
@@ -24904,7 +27230,7 @@
                         }
                     },
                     "colorscale": {
-                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                         "editType": "calc",
                         "impliedEdits": {
                             "autocolorscale": false
@@ -25001,7 +27327,7 @@
                             "valType": "color"
                         },
                         "colorscale": {
-                            "description": "Sets the colorscale and only has an effect if `marker.line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.line.cmin` and `marker.line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                            "description": "Sets the colorscale and only has an effect if `marker.line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.line.cmin` and `marker.line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                             "editType": "calc",
                             "impliedEdits": {
                                 "autocolorscale": false
@@ -25449,7 +27775,7 @@
                     "valType": "number"
                 },
                 "r": {
-                    "description": "For polar chart only.Sets the radial coordinates.",
+                    "description": "For legacy polar chart only.Please switch to *scatterpolar* trace type.Sets the radial coordinates.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -25459,6 +27785,51 @@
                     "editType": "none",
                     "role": "info",
                     "valType": "string"
+                },
+                "selected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of selected points.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of selected points.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of selected points.",
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object",
+                    "textfont": {
+                        "color": {
+                            "description": "Sets the text font color of selected points.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "role": "object"
+                    }
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
                 },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
@@ -25489,7 +27860,7 @@
                     }
                 },
                 "t": {
-                    "description": "For polar chart only.Sets the angular coordinates.",
+                    "description": "For legacy polar chart only.Please switch to *scatterpolar* trace type.Sets the angular coordinates.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -25590,6 +27961,45 @@
                     "editType": "calc",
                     "role": "info",
                     "valType": "string"
+                },
+                "unselected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object",
+                    "textfont": {
+                        "color": {
+                            "description": "Sets the text font color of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "role": "object"
+                    }
                 },
                 "visible": {
                     "description": "Determines whether or not this trace is visible. If *legendonly*, the trace is not drawn, but can appear as a legend item (provided that the legend itself is visible).",
@@ -26098,7 +28508,7 @@
                     "arrayOk": true,
                     "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
-                    "editType": "none",
+                    "editType": "calc",
                     "extras": [
                         "all",
                         "none",
@@ -26287,7 +28697,7 @@
                         "valType": "color"
                     },
                     "colorscale": {
-                        "description": "Sets the colorscale and only has an effect if `line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `line.cmin` and `line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                        "description": "Sets the colorscale and only has an effect if `line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `line.cmin` and `line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                         "editType": "calc",
                         "impliedEdits": {
                             "autocolorscale": false
@@ -26602,6 +29012,38 @@
                             "role": "style",
                             "valType": "string"
                         },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "calc",
+                                        "items": [
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "calc",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "calc",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
                             "dflt": 5,
@@ -26682,7 +29124,6 @@
                         },
                         "title": {
                             "description": "Sets the title of the color bar.",
-                            "dflt": "Click to enter colorscale title",
                             "editType": "calc",
                             "role": "info",
                             "valType": "string"
@@ -26783,7 +29224,7 @@
                         }
                     },
                     "colorscale": {
-                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                         "editType": "calc",
                         "impliedEdits": {
                             "autocolorscale": false
@@ -26843,7 +29284,7 @@
                             "valType": "color"
                         },
                         "colorscale": {
-                            "description": "Sets the colorscale and only has an effect if `marker.line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.line.cmin` and `marker.line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                            "description": "Sets the colorscale and only has an effect if `marker.line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.line.cmin` and `marker.line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                             "editType": "calc",
                             "impliedEdits": {
                                 "autocolorscale": false
@@ -27092,6 +29533,12 @@
                     "editType": "calc+clearAxisTypes",
                     "role": "info",
                     "valType": "subplotid"
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
                 },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
@@ -27887,6 +30334,38 @@
                             "role": "style",
                             "valType": "string"
                         },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "colorbars",
+                                        "items": [
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "colorbars",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "colorbars",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
                             "dflt": 5,
@@ -27967,7 +30446,6 @@
                         },
                         "title": {
                             "description": "Sets the title of the color bar.",
-                            "dflt": "Click to enter colorscale title",
                             "editType": "colorbars",
                             "role": "info",
                             "valType": "string"
@@ -28068,7 +30546,7 @@
                         }
                     },
                     "colorscale": {
-                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                         "editType": "calc",
                         "impliedEdits": {
                             "autocolorscale": false
@@ -28165,7 +30643,7 @@
                             "valType": "color"
                         },
                         "colorscale": {
-                            "description": "Sets the colorscale and only has an effect if `color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `cmin` and `cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                            "description": "Sets the colorscale and only has an effect if `color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `cmin` and `cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                             "editType": "calc",
                             "impliedEdits": {
                                 "autocolorscale": false
@@ -28613,6 +31091,51 @@
                     "role": "style",
                     "valType": "number"
                 },
+                "selected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of selected points.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of selected points.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of selected points.",
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object",
+                    "textfont": {
+                        "color": {
+                            "description": "Sets the text font color of selected points.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "role": "object"
+                    }
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
                     "dflt": true,
@@ -28731,6 +31254,45 @@
                     "editType": "calc",
                     "role": "info",
                     "valType": "string"
+                },
+                "unselected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object",
+                    "textfont": {
+                        "color": {
+                            "description": "Sets the text font color of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "role": "object"
+                    }
                 },
                 "visible": {
                     "description": "Determines whether or not this trace is visible. If *legendonly*, the trace is not drawn, but can appear as a legend item (provided that the legend itself is visible).",
@@ -29299,6 +31861,38 @@
                             "role": "style",
                             "valType": "string"
                         },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "calc",
+                                        "items": [
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "calc",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "calc",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
                             "dflt": 5,
@@ -29379,7 +31973,6 @@
                         },
                         "title": {
                             "description": "Sets the title of the color bar.",
-                            "dflt": "Click to enter colorscale title",
                             "editType": "calc",
                             "role": "info",
                             "valType": "string"
@@ -29480,7 +32073,7 @@
                         }
                     },
                     "colorscale": {
-                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                         "editType": "calc",
                         "impliedEdits": {
                             "autocolorscale": false
@@ -29577,7 +32170,7 @@
                             "valType": "color"
                         },
                         "colorscale": {
-                            "description": "Sets the colorscale and only has an effect if `marker.line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.line.cmin` and `marker.line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                            "description": "Sets the colorscale and only has an effect if `marker.line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.line.cmin` and `marker.line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                             "editType": "calc",
                             "impliedEdits": {
                                 "autocolorscale": false
@@ -30017,6 +32610,51 @@
                     "role": "style",
                     "valType": "number"
                 },
+                "selected": {
+                    "editType": "calc",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of selected points.",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "calc",
+                        "opacity": {
+                            "description": "Sets the marker opacity of selected points.",
+                            "editType": "calc",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of selected points.",
+                            "editType": "calc",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object",
+                    "textfont": {
+                        "color": {
+                            "description": "Sets the text font color of selected points.",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "calc",
+                        "role": "object"
+                    }
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
                     "dflt": true,
@@ -30135,6 +32773,45 @@
                     "editType": "calc",
                     "role": "info",
                     "valType": "string"
+                },
+                "unselected": {
+                    "editType": "calc",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of unselected points, applied only when a selection exists.",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "calc",
+                        "opacity": {
+                            "description": "Sets the marker opacity of unselected points, applied only when a selection exists.",
+                            "editType": "calc",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of unselected points, applied only when a selection exists.",
+                            "editType": "calc",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object",
+                    "textfont": {
+                        "color": {
+                            "description": "Sets the text font color of unselected points, applied only when a selection exists.",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "calc",
+                        "role": "object"
+                    }
                 },
                 "visible": {
                     "description": "Determines whether or not this trace is visible. If *legendonly*, the trace is not drawn, but can appear as a legend item (provided that the legend itself is visible).",
@@ -30440,7 +33117,11 @@
                     "values": [
                         "none",
                         "tozeroy",
-                        "tozerox"
+                        "tozerox",
+                        "tonexty",
+                        "tonextx",
+                        "toself",
+                        "tonext"
                     ]
                 },
                 "fillcolor": {
@@ -30563,6 +33244,16 @@
                         "valType": "string"
                     },
                     "role": "object"
+                },
+                "hoveron": {
+                    "description": "Do the hover effects highlight individual points (markers or line points) or do they highlight filled regions? If the fill is *toself* or *tonext* and there are no markers or text, then the default is *fills*, otherwise it is *points*.",
+                    "editType": "calc",
+                    "flags": [
+                        "points",
+                        "fills"
+                    ],
+                    "role": "info",
+                    "valType": "flaglist"
                 },
                 "ids": {
                     "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
@@ -30877,6 +33568,38 @@
                             "role": "style",
                             "valType": "string"
                         },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "calc",
+                                        "items": [
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "calc",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "calc",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
                             "dflt": 5,
@@ -30957,7 +33680,6 @@
                         },
                         "title": {
                             "description": "Sets the title of the color bar.",
-                            "dflt": "Click to enter colorscale title",
                             "editType": "calc",
                             "role": "info",
                             "valType": "string"
@@ -31058,7 +33780,7 @@
                         }
                     },
                     "colorscale": {
-                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                         "editType": "calc",
                         "impliedEdits": {
                             "autocolorscale": false
@@ -31118,7 +33840,7 @@
                             "valType": "color"
                         },
                         "colorscale": {
-                            "description": "Sets the colorscale and only has an effect if `marker.line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.line.cmin` and `marker.line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                            "description": "Sets the colorscale and only has an effect if `marker.line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.line.cmin` and `marker.line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                             "editType": "calc",
                             "impliedEdits": {
                                 "autocolorscale": false
@@ -31229,68 +33951,296 @@
                     },
                     "symbol": {
                         "arrayOk": true,
-                        "description": "Sets the marker symbol type.",
+                        "description": "Sets the marker symbol type. Adding 100 is equivalent to appending *-open* to a symbol name. Adding 200 is equivalent to appending *-dot* to a symbol name. Adding 300 is equivalent to appending *-open-dot* or *dot-open* to a symbol name.",
                         "dflt": "circle",
                         "editType": "calc",
                         "role": "style",
                         "valType": "enumerated",
                         "values": [
+                            0,
                             "circle",
-                            "square",
-                            "diamond",
-                            "cross",
-                            "x",
-                            "triangle-up",
-                            "triangle-down",
-                            "triangle-left",
-                            "triangle-right",
-                            "triangle-ne",
-                            "triangle-nw",
-                            "triangle-se",
-                            "triangle-sw",
-                            "pentagon",
-                            "hexagon",
-                            "hexagon2",
-                            "star",
-                            "diamond-tall",
-                            "bowtie",
-                            "diamond-x",
-                            "cross-thin",
-                            "asterisk",
-                            "y-up",
-                            "y-down",
-                            "line-ew",
-                            "line-ns",
+                            100,
                             "circle-open",
+                            200,
+                            "circle-dot",
+                            300,
+                            "circle-open-dot",
+                            1,
+                            "square",
+                            101,
                             "square-open",
+                            201,
+                            "square-dot",
+                            301,
+                            "square-open-dot",
+                            2,
+                            "diamond",
+                            102,
                             "diamond-open",
+                            202,
+                            "diamond-dot",
+                            302,
+                            "diamond-open-dot",
+                            3,
+                            "cross",
+                            103,
                             "cross-open",
+                            203,
+                            "cross-dot",
+                            303,
+                            "cross-open-dot",
+                            4,
+                            "x",
+                            104,
                             "x-open",
+                            204,
+                            "x-dot",
+                            304,
+                            "x-open-dot",
+                            5,
+                            "triangle-up",
+                            105,
                             "triangle-up-open",
+                            205,
+                            "triangle-up-dot",
+                            305,
+                            "triangle-up-open-dot",
+                            6,
+                            "triangle-down",
+                            106,
                             "triangle-down-open",
+                            206,
+                            "triangle-down-dot",
+                            306,
+                            "triangle-down-open-dot",
+                            7,
+                            "triangle-left",
+                            107,
                             "triangle-left-open",
+                            207,
+                            "triangle-left-dot",
+                            307,
+                            "triangle-left-open-dot",
+                            8,
+                            "triangle-right",
+                            108,
                             "triangle-right-open",
+                            208,
+                            "triangle-right-dot",
+                            308,
+                            "triangle-right-open-dot",
+                            9,
+                            "triangle-ne",
+                            109,
                             "triangle-ne-open",
-                            "triangle-nw-open",
+                            209,
+                            "triangle-ne-dot",
+                            309,
+                            "triangle-ne-open-dot",
+                            10,
+                            "triangle-se",
+                            110,
                             "triangle-se-open",
+                            210,
+                            "triangle-se-dot",
+                            310,
+                            "triangle-se-open-dot",
+                            11,
+                            "triangle-sw",
+                            111,
                             "triangle-sw-open",
+                            211,
+                            "triangle-sw-dot",
+                            311,
+                            "triangle-sw-open-dot",
+                            12,
+                            "triangle-nw",
+                            112,
+                            "triangle-nw-open",
+                            212,
+                            "triangle-nw-dot",
+                            312,
+                            "triangle-nw-open-dot",
+                            13,
+                            "pentagon",
+                            113,
                             "pentagon-open",
+                            213,
+                            "pentagon-dot",
+                            313,
+                            "pentagon-open-dot",
+                            14,
+                            "hexagon",
+                            114,
                             "hexagon-open",
+                            214,
+                            "hexagon-dot",
+                            314,
+                            "hexagon-open-dot",
+                            15,
+                            "hexagon2",
+                            115,
                             "hexagon2-open",
+                            215,
+                            "hexagon2-dot",
+                            315,
+                            "hexagon2-open-dot",
+                            16,
+                            "octagon",
+                            116,
+                            "octagon-open",
+                            216,
+                            "octagon-dot",
+                            316,
+                            "octagon-open-dot",
+                            17,
+                            "star",
+                            117,
                             "star-open",
+                            217,
+                            "star-dot",
+                            317,
+                            "star-open-dot",
+                            18,
+                            "hexagram",
+                            118,
+                            "hexagram-open",
+                            218,
+                            "hexagram-dot",
+                            318,
+                            "hexagram-open-dot",
+                            19,
+                            "star-triangle-up",
+                            119,
+                            "star-triangle-up-open",
+                            219,
+                            "star-triangle-up-dot",
+                            319,
+                            "star-triangle-up-open-dot",
+                            20,
+                            "star-triangle-down",
+                            120,
+                            "star-triangle-down-open",
+                            220,
+                            "star-triangle-down-dot",
+                            320,
+                            "star-triangle-down-open-dot",
+                            21,
+                            "star-square",
+                            121,
+                            "star-square-open",
+                            221,
+                            "star-square-dot",
+                            321,
+                            "star-square-open-dot",
+                            22,
+                            "star-diamond",
+                            122,
+                            "star-diamond-open",
+                            222,
+                            "star-diamond-dot",
+                            322,
+                            "star-diamond-open-dot",
+                            23,
+                            "diamond-tall",
+                            123,
                             "diamond-tall-open",
+                            223,
+                            "diamond-tall-dot",
+                            323,
+                            "diamond-tall-open-dot",
+                            24,
+                            "diamond-wide",
+                            124,
+                            "diamond-wide-open",
+                            224,
+                            "diamond-wide-dot",
+                            324,
+                            "diamond-wide-open-dot",
+                            25,
+                            "hourglass",
+                            125,
+                            "hourglass-open",
+                            26,
+                            "bowtie",
+                            126,
                             "bowtie-open",
-                            "diamond-x-open",
-                            "cross-thin-open",
-                            "asterisk-open",
-                            "y-up-open",
-                            "y-down-open",
-                            "line-ew-open",
-                            "line-ns-open",
+                            27,
+                            "circle-cross",
+                            127,
                             "circle-cross-open",
+                            28,
+                            "circle-x",
+                            128,
                             "circle-x-open",
+                            29,
+                            "square-cross",
+                            129,
                             "square-cross-open",
-                            "square-x-open"
+                            30,
+                            "square-x",
+                            130,
+                            "square-x-open",
+                            31,
+                            "diamond-cross",
+                            131,
+                            "diamond-cross-open",
+                            32,
+                            "diamond-x",
+                            132,
+                            "diamond-x-open",
+                            33,
+                            "cross-thin",
+                            133,
+                            "cross-thin-open",
+                            34,
+                            "x-thin",
+                            134,
+                            "x-thin-open",
+                            35,
+                            "asterisk",
+                            135,
+                            "asterisk-open",
+                            36,
+                            "hash",
+                            136,
+                            "hash-open",
+                            236,
+                            "hash-dot",
+                            336,
+                            "hash-open-dot",
+                            37,
+                            "y-up",
+                            137,
+                            "y-up-open",
+                            38,
+                            "y-down",
+                            138,
+                            "y-down-open",
+                            39,
+                            "y-left",
+                            139,
+                            "y-left-open",
+                            40,
+                            "y-right",
+                            140,
+                            "y-right-open",
+                            41,
+                            "line-ew",
+                            141,
+                            "line-ew-open",
+                            42,
+                            "line-ns",
+                            142,
+                            "line-ns-open",
+                            43,
+                            "line-ne",
+                            143,
+                            "line-ne-open",
+                            44,
+                            "line-nw",
+                            144,
+                            "line-nw-open"
                         ]
                     },
                     "symbolsrc": {
@@ -31322,11 +34272,46 @@
                 "opacity": {
                     "description": "Sets the opacity of the trace.",
                     "dflt": 1,
-                    "editType": "style",
+                    "editType": "calc",
                     "max": 1,
                     "min": 0,
                     "role": "style",
                     "valType": "number"
+                },
+                "selected": {
+                    "editType": "calc",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of selected points.",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "calc",
+                        "opacity": {
+                            "description": "Sets the marker opacity of selected points.",
+                            "editType": "calc",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of selected points.",
+                            "editType": "calc",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object"
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
                 },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
@@ -31376,6 +34361,35 @@
                     "editType": "calc",
                     "role": "info",
                     "valType": "string"
+                },
+                "unselected": {
+                    "editType": "calc",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of unselected points, applied only when a selection exists.",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "calc",
+                        "opacity": {
+                            "description": "Sets the marker opacity of unselected points, applied only when a selection exists.",
+                            "editType": "calc",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of unselected points, applied only when a selection exists.",
+                            "editType": "calc",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object"
                 },
                 "visible": {
                     "description": "Determines whether or not this trace is visible. If *legendonly*, the trace is not drawn, but can appear as a legend item (provided that the legend itself is visible).",
@@ -31493,7 +34507,8 @@
                 }
             },
             "meta": {
-                "description": "The data visualized as scatter point or lines is set in `x` and `y` using the WebGl plotting engine. Bubble charts are achieved by setting `marker.size` and/or `marker.color` to a numerical arrays."
+                "description": "The data visualized as scatter point or lines is set in `x` and `y` using the WebGL plotting engine. Bubble charts are achieved by setting `marker.size` and/or `marker.color` to a numerical arrays.",
+                "hrName": "scatter_gl"
             }
         },
         "scattermapbox": {
@@ -31985,6 +35000,38 @@
                             "role": "style",
                             "valType": "string"
                         },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "calc",
+                                        "items": [
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "calc",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "calc",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
                             "dflt": 5,
@@ -32065,7 +35112,6 @@
                         },
                         "title": {
                             "description": "Sets the title of the color bar.",
-                            "dflt": "Click to enter colorscale title",
                             "editType": "calc",
                             "role": "info",
                             "valType": "string"
@@ -32166,7 +35212,7 @@
                         }
                     },
                     "colorscale": {
-                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                         "editType": "calc",
                         "impliedEdits": {
                             "autocolorscale": false
@@ -32297,6 +35343,28 @@
                     "role": "style",
                     "valType": "number"
                 },
+                "selected": {
+                    "editType": "calc",
+                    "marker": {
+                        "editType": "calc",
+                        "opacity": {
+                            "description": "Sets the marker opacity of selected points.",
+                            "editType": "calc",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object"
+                    },
+                    "role": "object"
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
                     "dflt": true,
@@ -32397,6 +35465,22 @@
                     "role": "info",
                     "valType": "string"
                 },
+                "unselected": {
+                    "editType": "calc",
+                    "marker": {
+                        "editType": "calc",
+                        "opacity": {
+                            "description": "Sets the marker opacity of unselected points, applied only when a selection exists.",
+                            "editType": "calc",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object"
+                    },
+                    "role": "object"
+                },
                 "visible": {
                     "description": "Determines whether or not this trace is visible. If *legendonly*, the trace is not drawn, but can appear as a legend item (provided that the legend itself is visible).",
                     "dflt": true,
@@ -32413,6 +35497,2930 @@
             "meta": {
                 "description": "The data visualized as scatter point, lines or marker symbols on a Mapbox GL geographic map is provided by longitude/latitude pairs in `lon` and `lat`.",
                 "hrName": "scatter_mapbox"
+            }
+        },
+        "scatterpolar": {
+            "attributes": {
+                "cliponaxis": {
+                    "description": "Determines whether or not markers and text nodes are clipped about the subplot axes. To show markers and text nodes above axis lines and tick labels, make sure to set `xaxis.layer` and `yaxis.layer` to *below traces*.",
+                    "dflt": false,
+                    "editType": "plot",
+                    "role": "info",
+                    "valType": "boolean"
+                },
+                "connectgaps": {
+                    "description": "Determines whether or not gaps (i.e. {nan} or missing values) in the provided data arrays are connected.",
+                    "dflt": false,
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "boolean"
+                },
+                "customdata": {
+                    "description": "Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements",
+                    "editType": "calc",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "customdatasrc": {
+                    "description": "Sets the source reference on plot.ly for  customdata .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "fill": {
+                    "description": "Sets the area to fill with a solid color. Use with `fillcolor` if not *none*. scatterpolar has a subset of the options available to scatter. *toself* connects the endpoints of the trace (or each segment of the trace if it has gaps) into a closed shape. *tonext* fills the space between two traces if one completely encloses the other (eg consecutive contour lines), and behaves like *toself* if there is no trace before it. *tonext* should not be used if one trace does not enclose the other.",
+                    "dflt": "none",
+                    "editType": "calc",
+                    "role": "style",
+                    "valType": "enumerated",
+                    "values": [
+                        "none",
+                        "toself",
+                        "tonext"
+                    ]
+                },
+                "fillcolor": {
+                    "description": "Sets the fill color. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available.",
+                    "editType": "style",
+                    "role": "style",
+                    "valType": "color"
+                },
+                "hoverinfo": {
+                    "arrayOk": true,
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+                    "dflt": "all",
+                    "editType": "none",
+                    "extras": [
+                        "all",
+                        "none",
+                        "skip"
+                    ],
+                    "flags": [
+                        "r",
+                        "theta",
+                        "text",
+                        "name",
+                        "name"
+                    ],
+                    "role": "info",
+                    "valType": "flaglist"
+                },
+                "hoverinfosrc": {
+                    "description": "Sets the source reference on plot.ly for  hoverinfo .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "hoverlabel": {
+                    "bgcolor": {
+                        "arrayOk": true,
+                        "description": "Sets the background color of the hover labels for this trace",
+                        "editType": "none",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "bgcolorsrc": {
+                        "description": "Sets the source reference on plot.ly for  bgcolor .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "bordercolor": {
+                        "arrayOk": true,
+                        "description": "Sets the border color of the hover labels for this trace.",
+                        "editType": "none",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "bordercolorsrc": {
+                        "description": "Sets the source reference on plot.ly for  bordercolor .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "editType": "calc",
+                    "font": {
+                        "color": {
+                            "arrayOk": true,
+                            "editType": "none",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "colorsrc": {
+                            "description": "Sets the source reference on plot.ly for  color .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        },
+                        "description": "Sets the font used in hover labels.",
+                        "editType": "none",
+                        "family": {
+                            "arrayOk": true,
+                            "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                            "editType": "none",
+                            "noBlank": true,
+                            "role": "style",
+                            "strict": true,
+                            "valType": "string"
+                        },
+                        "familysrc": {
+                            "description": "Sets the source reference on plot.ly for  family .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        },
+                        "role": "object",
+                        "size": {
+                            "arrayOk": true,
+                            "editType": "none",
+                            "min": 1,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "sizesrc": {
+                            "description": "Sets the source reference on plot.ly for  size .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        }
+                    },
+                    "namelength": {
+                        "arrayOk": true,
+                        "description": "Sets the length (in number of characters) of the trace name in the hover labels for this trace. -1 shows the whole name regardless of length. 0-3 shows the first 0-3 characters, and an integer >3 will show the whole name if it is less than that many characters, but if it is longer, will truncate to `namelength - 3` characters and add an ellipsis.",
+                        "editType": "none",
+                        "min": -1,
+                        "role": "style",
+                        "valType": "integer"
+                    },
+                    "namelengthsrc": {
+                        "description": "Sets the source reference on plot.ly for  namelength .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "role": "object"
+                },
+                "hoveron": {
+                    "description": "Do the hover effects highlight individual points (markers or line points) or do they highlight filled regions? If the fill is *toself* or *tonext* and there are no markers or text, then the default is *fills*, otherwise it is *points*.",
+                    "editType": "style",
+                    "flags": [
+                        "points",
+                        "fills"
+                    ],
+                    "role": "info",
+                    "valType": "flaglist"
+                },
+                "hovertext": {
+                    "arrayOk": true,
+                    "description": "Sets hover text elements associated with each (x,y) pair. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates. To be seen, trace `hoverinfo` must contain a *text* flag.",
+                    "dflt": "",
+                    "editType": "style",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "hovertextsrc": {
+                    "description": "Sets the source reference on plot.ly for  hovertext .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "ids": {
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "editType": "calc",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "idssrc": {
+                    "description": "Sets the source reference on plot.ly for  ids .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "legendgroup": {
+                    "description": "Sets the legend group for this trace. Traces part of the same legend group hide/show at the same time when toggling legend items.",
+                    "dflt": "",
+                    "editType": "style",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "line": {
+                    "color": {
+                        "description": "Sets the line color.",
+                        "editType": "style",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "dash": {
+                        "description": "Sets the dash style of lines. Set to a dash type string (*solid*, *dot*, *dash*, *longdash*, *dashdot*, or *longdashdot*) or a dash length list in px (eg *5px,10px,2px,2px*).",
+                        "dflt": "solid",
+                        "editType": "style",
+                        "role": "style",
+                        "valType": "string",
+                        "values": [
+                            "solid",
+                            "dot",
+                            "dash",
+                            "longdash",
+                            "dashdot",
+                            "longdashdot"
+                        ]
+                    },
+                    "editType": "calc",
+                    "role": "object",
+                    "shape": {
+                        "description": "Determines the line shape. With *spline* the lines are drawn using spline interpolation. The other available values correspond to step-wise line shapes.",
+                        "dflt": "linear",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "enumerated",
+                        "values": [
+                            "linear",
+                            "spline"
+                        ]
+                    },
+                    "smoothing": {
+                        "description": "Has an effect only if `shape` is set to *spline* Sets the amount of smoothing. *0* corresponds to no smoothing (equivalent to a *linear* shape).",
+                        "dflt": 1,
+                        "editType": "plot",
+                        "max": 1.3,
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "width": {
+                        "description": "Sets the line width (in px).",
+                        "dflt": 2,
+                        "editType": "style",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    }
+                },
+                "marker": {
+                    "autocolorscale": {
+                        "description": "Has an effect only if `marker.color` is set to a numerical array. Determines whether the colorscale is a default palette (`autocolorscale: true`) or the palette determined by `marker.colorscale`. In case `colorscale` is unspecified or `autocolorscale` is true, the default  palette will be chosen according to whether numbers in the `color` array are all positive, all negative or mixed.",
+                        "dflt": true,
+                        "editType": "calc",
+                        "impliedEdits": {},
+                        "role": "style",
+                        "valType": "boolean"
+                    },
+                    "cauto": {
+                        "description": "Has an effect only if `marker.color` is set to a numerical array and `cmin`, `cmax` are set by the user. In this case, it controls whether the range of colors in `colorscale` is mapped to the range of values in the `color` array (`cauto: true`), or the `cmin`/`cmax` values (`cauto: false`). Defaults to `false` when `cmin`, `cmax` are set by the user.",
+                        "dflt": true,
+                        "editType": "calc",
+                        "impliedEdits": {},
+                        "role": "info",
+                        "valType": "boolean"
+                    },
+                    "cmax": {
+                        "description": "Has an effect only if `marker.color` is set to a numerical array. Sets the upper bound of the color domain. Value should be associated to the `marker.color` array index, and if set, `marker.cmin` must be set as well.",
+                        "dflt": null,
+                        "editType": "plot",
+                        "impliedEdits": {
+                            "cauto": false
+                        },
+                        "role": "info",
+                        "valType": "number"
+                    },
+                    "cmin": {
+                        "description": "Has an effect only if `marker.color` is set to a numerical array. Sets the lower bound of the color domain. Value should be associated to the `marker.color` array index, and if set, `marker.cmax` must be set as well.",
+                        "dflt": null,
+                        "editType": "plot",
+                        "impliedEdits": {
+                            "cauto": false
+                        },
+                        "role": "info",
+                        "valType": "number"
+                    },
+                    "color": {
+                        "arrayOk": true,
+                        "description": "Sets the marker color. It accepts either a specific color or an array of numbers that are mapped to the colorscale relative to the max and min values of the array or relative to `cmin` and `cmax` if set.",
+                        "editType": "style",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "colorbar": {
+                        "bgcolor": {
+                            "description": "Sets the color of padded area.",
+                            "dflt": "rgba(0,0,0,0)",
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "bordercolor": {
+                            "description": "Sets the axis line color.",
+                            "dflt": "#444",
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "borderwidth": {
+                            "description": "Sets the width (in px) or the border enclosing this color bar.",
+                            "dflt": 0,
+                            "editType": "colorbars",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "dtick": {
+                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                            "editType": "colorbars",
+                            "impliedEdits": {
+                                "tickmode": "linear"
+                            },
+                            "role": "style",
+                            "valType": "any"
+                        },
+                        "editType": "colorbars",
+                        "exponentformat": {
+                            "description": "Determines a formatting rule for the tick exponents. For example, consider the number 1,000,000,000. If *none*, it appears as 1,000,000,000. If *e*, 1e+9. If *E*, 1E+9. If *power*, 1x10^9 (with 9 in a super script). If *SI*, 1G. If *B*, 1B.",
+                            "dflt": "B",
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "none",
+                                "e",
+                                "E",
+                                "power",
+                                "SI",
+                                "B"
+                            ]
+                        },
+                        "len": {
+                            "description": "Sets the length of the color bar This measure excludes the padding of both ends. That is, the color bar length is this length minus the padding on both ends.",
+                            "dflt": 1,
+                            "editType": "colorbars",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "lenmode": {
+                            "description": "Determines whether this color bar's length (i.e. the measure in the color variation direction) is set in units of plot *fraction* or in *pixels. Use `len` to set the value.",
+                            "dflt": "fraction",
+                            "editType": "colorbars",
+                            "role": "info",
+                            "valType": "enumerated",
+                            "values": [
+                                "fraction",
+                                "pixels"
+                            ]
+                        },
+                        "nticks": {
+                            "description": "Specifies the maximum number of ticks for the particular axis. The actual number of ticks will be chosen automatically to be less than or equal to `nticks`. Has an effect only if `tickmode` is set to *auto*.",
+                            "dflt": 0,
+                            "editType": "colorbars",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "integer"
+                        },
+                        "outlinecolor": {
+                            "description": "Sets the axis line color.",
+                            "dflt": "#444",
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "outlinewidth": {
+                            "description": "Sets the width (in px) of the axis line.",
+                            "dflt": 1,
+                            "editType": "colorbars",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "separatethousands": {
+                            "description": "If \"true\", even 4-digit integers are separated",
+                            "dflt": false,
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "boolean"
+                        },
+                        "showexponent": {
+                            "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
+                            "dflt": "all",
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "all",
+                                "first",
+                                "last",
+                                "none"
+                            ]
+                        },
+                        "showticklabels": {
+                            "description": "Determines whether or not the tick labels are drawn.",
+                            "dflt": true,
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "boolean"
+                        },
+                        "showtickprefix": {
+                            "description": "If *all*, all tick labels are displayed with a prefix. If *first*, only the first tick is displayed with a prefix. If *last*, only the last tick is displayed with a suffix. If *none*, tick prefixes are hidden.",
+                            "dflt": "all",
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "all",
+                                "first",
+                                "last",
+                                "none"
+                            ]
+                        },
+                        "showticksuffix": {
+                            "description": "Same as `showtickprefix` but for tick suffixes.",
+                            "dflt": "all",
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "all",
+                                "first",
+                                "last",
+                                "none"
+                            ]
+                        },
+                        "thickness": {
+                            "description": "Sets the thickness of the color bar This measure excludes the size of the padding, ticks and labels.",
+                            "dflt": 30,
+                            "editType": "colorbars",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "thicknessmode": {
+                            "description": "Determines whether this color bar's thickness (i.e. the measure in the constant color direction) is set in units of plot *fraction* or in *pixels*. Use `thickness` to set the value.",
+                            "dflt": "pixels",
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "fraction",
+                                "pixels"
+                            ]
+                        },
+                        "tick0": {
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                            "editType": "colorbars",
+                            "impliedEdits": {
+                                "tickmode": "linear"
+                            },
+                            "role": "style",
+                            "valType": "any"
+                        },
+                        "tickangle": {
+                            "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
+                            "dflt": "auto",
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "angle"
+                        },
+                        "tickcolor": {
+                            "description": "Sets the tick color.",
+                            "dflt": "#444",
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "tickfont": {
+                            "color": {
+                                "editType": "colorbars",
+                                "role": "style",
+                                "valType": "color"
+                            },
+                            "description": "Sets the color bar's tick label font",
+                            "editType": "colorbars",
+                            "family": {
+                                "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                                "editType": "colorbars",
+                                "noBlank": true,
+                                "role": "style",
+                                "strict": true,
+                                "valType": "string"
+                            },
+                            "role": "object",
+                            "size": {
+                                "editType": "colorbars",
+                                "min": 1,
+                                "role": "style",
+                                "valType": "number"
+                            }
+                        },
+                        "tickformat": {
+                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                            "dflt": "",
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "string"
+                        },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "colorbars",
+                                        "items": [
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "colorbars",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "colorbars",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
+                        "ticklen": {
+                            "description": "Sets the tick length (in px).",
+                            "dflt": 5,
+                            "editType": "colorbars",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "tickmode": {
+                            "description": "Sets the tick mode for this axis. If *auto*, the number of ticks is set via `nticks`. If *linear*, the placement of the ticks is determined by a starting position `tick0` and a tick step `dtick` (*linear* is the default value if `tick0` and `dtick` are provided). If *array*, the placement of the ticks is set via `tickvals` and the tick text is `ticktext`. (*array* is the default value if `tickvals` is provided).",
+                            "editType": "colorbars",
+                            "impliedEdits": {},
+                            "role": "info",
+                            "valType": "enumerated",
+                            "values": [
+                                "auto",
+                                "linear",
+                                "array"
+                            ]
+                        },
+                        "tickprefix": {
+                            "description": "Sets a tick label prefix.",
+                            "dflt": "",
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "string"
+                        },
+                        "ticks": {
+                            "description": "Determines whether ticks are drawn or not. If **, this axis' ticks are not drawn. If *outside* (*inside*), this axis' are drawn outside (inside) the axis lines.",
+                            "dflt": "",
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "outside",
+                                "inside",
+                                ""
+                            ]
+                        },
+                        "ticksuffix": {
+                            "description": "Sets a tick label suffix.",
+                            "dflt": "",
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "string"
+                        },
+                        "ticktext": {
+                            "description": "Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.",
+                            "editType": "colorbars",
+                            "role": "data",
+                            "valType": "data_array"
+                        },
+                        "ticktextsrc": {
+                            "description": "Sets the source reference on plot.ly for  ticktext .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        },
+                        "tickvals": {
+                            "description": "Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.",
+                            "editType": "colorbars",
+                            "role": "data",
+                            "valType": "data_array"
+                        },
+                        "tickvalssrc": {
+                            "description": "Sets the source reference on plot.ly for  tickvals .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        },
+                        "tickwidth": {
+                            "description": "Sets the tick width (in px).",
+                            "dflt": 1,
+                            "editType": "colorbars",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "title": {
+                            "description": "Sets the title of the color bar.",
+                            "editType": "colorbars",
+                            "role": "info",
+                            "valType": "string"
+                        },
+                        "titlefont": {
+                            "color": {
+                                "editType": "colorbars",
+                                "role": "style",
+                                "valType": "color"
+                            },
+                            "description": "Sets this color bar's title font.",
+                            "editType": "colorbars",
+                            "family": {
+                                "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                                "editType": "colorbars",
+                                "noBlank": true,
+                                "role": "style",
+                                "strict": true,
+                                "valType": "string"
+                            },
+                            "role": "object",
+                            "size": {
+                                "editType": "colorbars",
+                                "min": 1,
+                                "role": "style",
+                                "valType": "number"
+                            }
+                        },
+                        "titleside": {
+                            "description": "Determines the location of the colorbar title with respect to the color bar.",
+                            "dflt": "top",
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "right",
+                                "top",
+                                "bottom"
+                            ]
+                        },
+                        "x": {
+                            "description": "Sets the x position of the color bar (in plot fraction).",
+                            "dflt": 1.02,
+                            "editType": "colorbars",
+                            "max": 3,
+                            "min": -2,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "xanchor": {
+                            "description": "Sets this color bar's horizontal position anchor. This anchor binds the `x` position to the *left*, *center* or *right* of the color bar.",
+                            "dflt": "left",
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "left",
+                                "center",
+                                "right"
+                            ]
+                        },
+                        "xpad": {
+                            "description": "Sets the amount of padding (in px) along the x direction.",
+                            "dflt": 10,
+                            "editType": "colorbars",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "y": {
+                            "description": "Sets the y position of the color bar (in plot fraction).",
+                            "dflt": 0.5,
+                            "editType": "colorbars",
+                            "max": 3,
+                            "min": -2,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "yanchor": {
+                            "description": "Sets this color bar's vertical position anchor This anchor binds the `y` position to the *top*, *middle* or *bottom* of the color bar.",
+                            "dflt": "middle",
+                            "editType": "colorbars",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "top",
+                                "middle",
+                                "bottom"
+                            ]
+                        },
+                        "ypad": {
+                            "description": "Sets the amount of padding (in px) along the y direction.",
+                            "dflt": 10,
+                            "editType": "colorbars",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "colorscale": {
+                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
+                        "editType": "calc",
+                        "impliedEdits": {
+                            "autocolorscale": false
+                        },
+                        "role": "style",
+                        "valType": "colorscale"
+                    },
+                    "colorsrc": {
+                        "description": "Sets the source reference on plot.ly for  color .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "editType": "calc",
+                    "gradient": {
+                        "color": {
+                            "arrayOk": true,
+                            "description": "Sets the final color of the gradient fill: the center color for radial, the right for horizontal, or the bottom for vertical.",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "colorsrc": {
+                            "description": "Sets the source reference on plot.ly for  color .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        },
+                        "editType": "calc",
+                        "role": "object",
+                        "type": {
+                            "arrayOk": true,
+                            "description": "Sets the type of gradient used to fill the markers",
+                            "dflt": "none",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "radial",
+                                "horizontal",
+                                "vertical",
+                                "none"
+                            ]
+                        },
+                        "typesrc": {
+                            "description": "Sets the source reference on plot.ly for  type .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        }
+                    },
+                    "line": {
+                        "autocolorscale": {
+                            "description": "Has an effect only if `marker.line.color` is set to a numerical array. Determines whether the colorscale is a default palette (`autocolorscale: true`) or the palette determined by `marker.line.colorscale`. In case `colorscale` is unspecified or `autocolorscale` is true, the default  palette will be chosen according to whether numbers in the `color` array are all positive, all negative or mixed.",
+                            "dflt": true,
+                            "editType": "calc",
+                            "impliedEdits": {},
+                            "role": "style",
+                            "valType": "boolean"
+                        },
+                        "cauto": {
+                            "description": "Has an effect only if `marker.line.color` is set to a numerical array and `cmin`, `cmax` are set by the user. In this case, it controls whether the range of colors in `colorscale` is mapped to the range of values in the `color` array (`cauto: true`), or the `cmin`/`cmax` values (`cauto: false`). Defaults to `false` when `cmin`, `cmax` are set by the user.",
+                            "dflt": true,
+                            "editType": "calc",
+                            "impliedEdits": {},
+                            "role": "info",
+                            "valType": "boolean"
+                        },
+                        "cmax": {
+                            "description": "Has an effect only if `marker.line.color` is set to a numerical array. Sets the upper bound of the color domain. Value should be associated to the `marker.line.color` array index, and if set, `marker.line.cmin` must be set as well.",
+                            "dflt": null,
+                            "editType": "plot",
+                            "impliedEdits": {
+                                "cauto": false
+                            },
+                            "role": "info",
+                            "valType": "number"
+                        },
+                        "cmin": {
+                            "description": "Has an effect only if `marker.line.color` is set to a numerical array. Sets the lower bound of the color domain. Value should be associated to the `marker.line.color` array index, and if set, `marker.line.cmax` must be set as well.",
+                            "dflt": null,
+                            "editType": "plot",
+                            "impliedEdits": {
+                                "cauto": false
+                            },
+                            "role": "info",
+                            "valType": "number"
+                        },
+                        "color": {
+                            "arrayOk": true,
+                            "description": "Sets the marker.line color. It accepts either a specific color or an array of numbers that are mapped to the colorscale relative to the max and min values of the array or relative to `cmin` and `cmax` if set.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "colorscale": {
+                            "description": "Sets the colorscale and only has an effect if `marker.line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.line.cmin` and `marker.line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
+                            "editType": "calc",
+                            "impliedEdits": {
+                                "autocolorscale": false
+                            },
+                            "role": "style",
+                            "valType": "colorscale"
+                        },
+                        "colorsrc": {
+                            "description": "Sets the source reference on plot.ly for  color .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        },
+                        "editType": "calc",
+                        "reversescale": {
+                            "description": "Has an effect only if `marker.line.color` is set to a numerical array. Reverses the color mapping if true (`cmin` will correspond to the last color in the array and `cmax` will correspond to the first color).",
+                            "dflt": false,
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "boolean"
+                        },
+                        "role": "object",
+                        "width": {
+                            "arrayOk": true,
+                            "description": "Sets the width (in px) of the lines bounding the marker points.",
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "widthsrc": {
+                            "description": "Sets the source reference on plot.ly for  width .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        }
+                    },
+                    "maxdisplayed": {
+                        "description": "Sets a maximum number of points to be drawn on the graph. *0* corresponds to no limit.",
+                        "dflt": 0,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "opacity": {
+                        "arrayOk": true,
+                        "description": "Sets the marker opacity.",
+                        "editType": "style",
+                        "max": 1,
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "opacitysrc": {
+                        "description": "Sets the source reference on plot.ly for  opacity .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "reversescale": {
+                        "description": "Has an effect only if `marker.color` is set to a numerical array. Reverses the color mapping if true (`cmin` will correspond to the last color in the array and `cmax` will correspond to the first color).",
+                        "dflt": false,
+                        "editType": "calc",
+                        "role": "style",
+                        "valType": "boolean"
+                    },
+                    "role": "object",
+                    "showscale": {
+                        "description": "Has an effect only if `marker.color` is set to a numerical array. Determines whether or not a colorbar is displayed.",
+                        "dflt": false,
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "boolean"
+                    },
+                    "size": {
+                        "arrayOk": true,
+                        "description": "Sets the marker size (in px).",
+                        "dflt": 6,
+                        "editType": "calcIfAutorange",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "sizemin": {
+                        "description": "Has an effect only if `marker.size` is set to a numerical array. Sets the minimum size (in px) of the rendered marker points.",
+                        "dflt": 0,
+                        "editType": "calc",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "sizemode": {
+                        "description": "Has an effect only if `marker.size` is set to a numerical array. Sets the rule for which the data in `size` is converted to pixels.",
+                        "dflt": "diameter",
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "diameter",
+                            "area"
+                        ]
+                    },
+                    "sizeref": {
+                        "description": "Has an effect only if `marker.size` is set to a numerical array. Sets the scale factor used to determine the rendered size of marker points. Use with `sizemin` and `sizemode`.",
+                        "dflt": 1,
+                        "editType": "calc",
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "sizesrc": {
+                        "description": "Sets the source reference on plot.ly for  size .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "symbol": {
+                        "arrayOk": true,
+                        "description": "Sets the marker symbol type. Adding 100 is equivalent to appending *-open* to a symbol name. Adding 200 is equivalent to appending *-dot* to a symbol name. Adding 300 is equivalent to appending *-open-dot* or *dot-open* to a symbol name.",
+                        "dflt": "circle",
+                        "editType": "style",
+                        "role": "style",
+                        "valType": "enumerated",
+                        "values": [
+                            0,
+                            "circle",
+                            100,
+                            "circle-open",
+                            200,
+                            "circle-dot",
+                            300,
+                            "circle-open-dot",
+                            1,
+                            "square",
+                            101,
+                            "square-open",
+                            201,
+                            "square-dot",
+                            301,
+                            "square-open-dot",
+                            2,
+                            "diamond",
+                            102,
+                            "diamond-open",
+                            202,
+                            "diamond-dot",
+                            302,
+                            "diamond-open-dot",
+                            3,
+                            "cross",
+                            103,
+                            "cross-open",
+                            203,
+                            "cross-dot",
+                            303,
+                            "cross-open-dot",
+                            4,
+                            "x",
+                            104,
+                            "x-open",
+                            204,
+                            "x-dot",
+                            304,
+                            "x-open-dot",
+                            5,
+                            "triangle-up",
+                            105,
+                            "triangle-up-open",
+                            205,
+                            "triangle-up-dot",
+                            305,
+                            "triangle-up-open-dot",
+                            6,
+                            "triangle-down",
+                            106,
+                            "triangle-down-open",
+                            206,
+                            "triangle-down-dot",
+                            306,
+                            "triangle-down-open-dot",
+                            7,
+                            "triangle-left",
+                            107,
+                            "triangle-left-open",
+                            207,
+                            "triangle-left-dot",
+                            307,
+                            "triangle-left-open-dot",
+                            8,
+                            "triangle-right",
+                            108,
+                            "triangle-right-open",
+                            208,
+                            "triangle-right-dot",
+                            308,
+                            "triangle-right-open-dot",
+                            9,
+                            "triangle-ne",
+                            109,
+                            "triangle-ne-open",
+                            209,
+                            "triangle-ne-dot",
+                            309,
+                            "triangle-ne-open-dot",
+                            10,
+                            "triangle-se",
+                            110,
+                            "triangle-se-open",
+                            210,
+                            "triangle-se-dot",
+                            310,
+                            "triangle-se-open-dot",
+                            11,
+                            "triangle-sw",
+                            111,
+                            "triangle-sw-open",
+                            211,
+                            "triangle-sw-dot",
+                            311,
+                            "triangle-sw-open-dot",
+                            12,
+                            "triangle-nw",
+                            112,
+                            "triangle-nw-open",
+                            212,
+                            "triangle-nw-dot",
+                            312,
+                            "triangle-nw-open-dot",
+                            13,
+                            "pentagon",
+                            113,
+                            "pentagon-open",
+                            213,
+                            "pentagon-dot",
+                            313,
+                            "pentagon-open-dot",
+                            14,
+                            "hexagon",
+                            114,
+                            "hexagon-open",
+                            214,
+                            "hexagon-dot",
+                            314,
+                            "hexagon-open-dot",
+                            15,
+                            "hexagon2",
+                            115,
+                            "hexagon2-open",
+                            215,
+                            "hexagon2-dot",
+                            315,
+                            "hexagon2-open-dot",
+                            16,
+                            "octagon",
+                            116,
+                            "octagon-open",
+                            216,
+                            "octagon-dot",
+                            316,
+                            "octagon-open-dot",
+                            17,
+                            "star",
+                            117,
+                            "star-open",
+                            217,
+                            "star-dot",
+                            317,
+                            "star-open-dot",
+                            18,
+                            "hexagram",
+                            118,
+                            "hexagram-open",
+                            218,
+                            "hexagram-dot",
+                            318,
+                            "hexagram-open-dot",
+                            19,
+                            "star-triangle-up",
+                            119,
+                            "star-triangle-up-open",
+                            219,
+                            "star-triangle-up-dot",
+                            319,
+                            "star-triangle-up-open-dot",
+                            20,
+                            "star-triangle-down",
+                            120,
+                            "star-triangle-down-open",
+                            220,
+                            "star-triangle-down-dot",
+                            320,
+                            "star-triangle-down-open-dot",
+                            21,
+                            "star-square",
+                            121,
+                            "star-square-open",
+                            221,
+                            "star-square-dot",
+                            321,
+                            "star-square-open-dot",
+                            22,
+                            "star-diamond",
+                            122,
+                            "star-diamond-open",
+                            222,
+                            "star-diamond-dot",
+                            322,
+                            "star-diamond-open-dot",
+                            23,
+                            "diamond-tall",
+                            123,
+                            "diamond-tall-open",
+                            223,
+                            "diamond-tall-dot",
+                            323,
+                            "diamond-tall-open-dot",
+                            24,
+                            "diamond-wide",
+                            124,
+                            "diamond-wide-open",
+                            224,
+                            "diamond-wide-dot",
+                            324,
+                            "diamond-wide-open-dot",
+                            25,
+                            "hourglass",
+                            125,
+                            "hourglass-open",
+                            26,
+                            "bowtie",
+                            126,
+                            "bowtie-open",
+                            27,
+                            "circle-cross",
+                            127,
+                            "circle-cross-open",
+                            28,
+                            "circle-x",
+                            128,
+                            "circle-x-open",
+                            29,
+                            "square-cross",
+                            129,
+                            "square-cross-open",
+                            30,
+                            "square-x",
+                            130,
+                            "square-x-open",
+                            31,
+                            "diamond-cross",
+                            131,
+                            "diamond-cross-open",
+                            32,
+                            "diamond-x",
+                            132,
+                            "diamond-x-open",
+                            33,
+                            "cross-thin",
+                            133,
+                            "cross-thin-open",
+                            34,
+                            "x-thin",
+                            134,
+                            "x-thin-open",
+                            35,
+                            "asterisk",
+                            135,
+                            "asterisk-open",
+                            36,
+                            "hash",
+                            136,
+                            "hash-open",
+                            236,
+                            "hash-dot",
+                            336,
+                            "hash-open-dot",
+                            37,
+                            "y-up",
+                            137,
+                            "y-up-open",
+                            38,
+                            "y-down",
+                            138,
+                            "y-down-open",
+                            39,
+                            "y-left",
+                            139,
+                            "y-left-open",
+                            40,
+                            "y-right",
+                            140,
+                            "y-right-open",
+                            41,
+                            "line-ew",
+                            141,
+                            "line-ew-open",
+                            42,
+                            "line-ns",
+                            142,
+                            "line-ns-open",
+                            43,
+                            "line-ne",
+                            143,
+                            "line-ne-open",
+                            44,
+                            "line-nw",
+                            144,
+                            "line-nw-open"
+                        ]
+                    },
+                    "symbolsrc": {
+                        "description": "Sets the source reference on plot.ly for  symbol .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    }
+                },
+                "mode": {
+                    "description": "Determines the drawing mode for this scatter trace. If the provided `mode` includes *text* then the `text` elements appear at the coordinates. Otherwise, the `text` elements appear on hover. If there are less than 20 points, then the default is *lines+markers*. Otherwise, *lines*.",
+                    "editType": "calc",
+                    "extras": [
+                        "none"
+                    ],
+                    "flags": [
+                        "lines",
+                        "markers",
+                        "text"
+                    ],
+                    "role": "info",
+                    "valType": "flaglist"
+                },
+                "name": {
+                    "description": "Sets the trace name. The trace name appear as the legend item and on hover.",
+                    "editType": "style",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "opacity": {
+                    "description": "Sets the opacity of the trace.",
+                    "dflt": 1,
+                    "editType": "style",
+                    "max": 1,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "r": {
+                    "description": "Sets the radial coordinates",
+                    "editType": "calc+clearAxisTypes",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "rsrc": {
+                    "description": "Sets the source reference on plot.ly for  r .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "selected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of selected points.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of selected points.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of selected points.",
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object",
+                    "textfont": {
+                        "color": {
+                            "description": "Sets the text font color of selected points.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "role": "object"
+                    }
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
+                "showlegend": {
+                    "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
+                    "dflt": true,
+                    "editType": "style",
+                    "role": "info",
+                    "valType": "boolean"
+                },
+                "stream": {
+                    "editType": "calc",
+                    "maxpoints": {
+                        "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "editType": "calc",
+                        "max": 10000,
+                        "min": 0,
+                        "role": "info",
+                        "valType": "number"
+                    },
+                    "role": "object",
+                    "token": {
+                        "description": "The stream id number links a data trace on a plot with a stream. See https://plot.ly/settings for more details.",
+                        "editType": "calc",
+                        "noBlank": true,
+                        "role": "info",
+                        "strict": true,
+                        "valType": "string"
+                    }
+                },
+                "subplot": {
+                    "description": "Sets a reference between this trace's data coordinates and a polar subplot. If *polar* (the default value), the data refer to `layout.polar`. If *polar2*, the data refer to `layout.polar2`, and so on.",
+                    "dflt": "polar",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "subplotid"
+                },
+                "text": {
+                    "arrayOk": true,
+                    "description": "Sets text elements associated with each (x,y) pair. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.",
+                    "dflt": "",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "textfont": {
+                    "color": {
+                        "arrayOk": true,
+                        "editType": "style",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "colorsrc": {
+                        "description": "Sets the source reference on plot.ly for  color .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "description": "Sets the text font.",
+                    "editType": "calc",
+                    "family": {
+                        "arrayOk": true,
+                        "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                        "editType": "calc",
+                        "noBlank": true,
+                        "role": "style",
+                        "strict": true,
+                        "valType": "string"
+                    },
+                    "familysrc": {
+                        "description": "Sets the source reference on plot.ly for  family .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "role": "object",
+                    "size": {
+                        "arrayOk": true,
+                        "editType": "calc",
+                        "min": 1,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "sizesrc": {
+                        "description": "Sets the source reference on plot.ly for  size .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    }
+                },
+                "textposition": {
+                    "arrayOk": true,
+                    "description": "Sets the positions of the `text` elements with respects to the (x,y) coordinates.",
+                    "dflt": "middle center",
+                    "editType": "calc",
+                    "role": "style",
+                    "valType": "enumerated",
+                    "values": [
+                        "top left",
+                        "top center",
+                        "top right",
+                        "middle left",
+                        "middle center",
+                        "middle right",
+                        "bottom left",
+                        "bottom center",
+                        "bottom right"
+                    ]
+                },
+                "textpositionsrc": {
+                    "description": "Sets the source reference on plot.ly for  textposition .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "textsrc": {
+                    "description": "Sets the source reference on plot.ly for  text .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "theta": {
+                    "description": "Sets the angular coordinates",
+                    "editType": "calc+clearAxisTypes",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "thetasrc": {
+                    "description": "Sets the source reference on plot.ly for  theta .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "thetaunit": {
+                    "description": "Sets the unit of input *theta* values. Has an effect only when on *linear* angular axes.",
+                    "dflt": "degrees",
+                    "editType": "calc+clearAxisTypes",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        "radians",
+                        "degrees",
+                        "gradians"
+                    ]
+                },
+                "type": "scatterpolar",
+                "uid": {
+                    "dflt": "",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "unselected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object",
+                    "textfont": {
+                        "color": {
+                            "description": "Sets the text font color of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "role": "object"
+                    }
+                },
+                "visible": {
+                    "description": "Determines whether or not this trace is visible. If *legendonly*, the trace is not drawn, but can appear as a legend item (provided that the legend itself is visible).",
+                    "dflt": true,
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        true,
+                        false,
+                        "legendonly"
+                    ]
+                }
+            },
+            "meta": {
+                "description": "The scatterpolar trace type encompasses line charts, scatter charts, text charts, and bubble charts in polar coordinates. The data visualized as scatter point or lines is set in `r` (radial) and `theta` (angular) coordinates Text (appearing either on the chart or on hover only) is via `text`. Bubble charts are achieved by setting `marker.size` and/or `marker.color` to numerical arrays.",
+                "hrName": "scatter_polar"
+            }
+        },
+        "scatterpolargl": {
+            "attributes": {
+                "connectgaps": {
+                    "description": "Determines whether or not gaps (i.e. {nan} or missing values) in the provided data arrays are connected.",
+                    "dflt": false,
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "boolean"
+                },
+                "customdata": {
+                    "description": "Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements",
+                    "editType": "calc",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "customdatasrc": {
+                    "description": "Sets the source reference on plot.ly for  customdata .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "fill": {
+                    "description": "Sets the area to fill with a solid color. Use with `fillcolor` if not *none*. *tozerox* and *tozeroy* fill to x=0 and y=0 respectively. *tonextx* and *tonexty* fill between the endpoints of this trace and the endpoints of the trace before it, connecting those endpoints with straight lines (to make a stacked area graph); if there is no trace before it, they behave like *tozerox* and *tozeroy*. *toself* connects the endpoints of the trace (or each segment of the trace if it has gaps) into a closed shape. *tonext* fills the space between two traces if one completely encloses the other (eg consecutive contour lines), and behaves like *toself* if there is no trace before it. *tonext* should not be used if one trace does not enclose the other.",
+                    "dflt": "none",
+                    "editType": "calc",
+                    "role": "style",
+                    "valType": "enumerated",
+                    "values": [
+                        "none",
+                        "tozeroy",
+                        "tozerox",
+                        "tonexty",
+                        "tonextx",
+                        "toself",
+                        "tonext"
+                    ]
+                },
+                "fillcolor": {
+                    "description": "Sets the fill color. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available.",
+                    "editType": "calc",
+                    "role": "style",
+                    "valType": "color"
+                },
+                "hoverinfo": {
+                    "arrayOk": true,
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+                    "dflt": "all",
+                    "editType": "none",
+                    "extras": [
+                        "all",
+                        "none",
+                        "skip"
+                    ],
+                    "flags": [
+                        "r",
+                        "theta",
+                        "text",
+                        "name",
+                        "name"
+                    ],
+                    "role": "info",
+                    "valType": "flaglist"
+                },
+                "hoverinfosrc": {
+                    "description": "Sets the source reference on plot.ly for  hoverinfo .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "hoverlabel": {
+                    "bgcolor": {
+                        "arrayOk": true,
+                        "description": "Sets the background color of the hover labels for this trace",
+                        "editType": "none",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "bgcolorsrc": {
+                        "description": "Sets the source reference on plot.ly for  bgcolor .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "bordercolor": {
+                        "arrayOk": true,
+                        "description": "Sets the border color of the hover labels for this trace.",
+                        "editType": "none",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "bordercolorsrc": {
+                        "description": "Sets the source reference on plot.ly for  bordercolor .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "editType": "calc",
+                    "font": {
+                        "color": {
+                            "arrayOk": true,
+                            "editType": "none",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "colorsrc": {
+                            "description": "Sets the source reference on plot.ly for  color .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        },
+                        "description": "Sets the font used in hover labels.",
+                        "editType": "none",
+                        "family": {
+                            "arrayOk": true,
+                            "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                            "editType": "none",
+                            "noBlank": true,
+                            "role": "style",
+                            "strict": true,
+                            "valType": "string"
+                        },
+                        "familysrc": {
+                            "description": "Sets the source reference on plot.ly for  family .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        },
+                        "role": "object",
+                        "size": {
+                            "arrayOk": true,
+                            "editType": "none",
+                            "min": 1,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "sizesrc": {
+                            "description": "Sets the source reference on plot.ly for  size .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        }
+                    },
+                    "namelength": {
+                        "arrayOk": true,
+                        "description": "Sets the length (in number of characters) of the trace name in the hover labels for this trace. -1 shows the whole name regardless of length. 0-3 shows the first 0-3 characters, and an integer >3 will show the whole name if it is less than that many characters, but if it is longer, will truncate to `namelength - 3` characters and add an ellipsis.",
+                        "editType": "none",
+                        "min": -1,
+                        "role": "style",
+                        "valType": "integer"
+                    },
+                    "namelengthsrc": {
+                        "description": "Sets the source reference on plot.ly for  namelength .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "role": "object"
+                },
+                "hoveron": {
+                    "description": "Do the hover effects highlight individual points (markers or line points) or do they highlight filled regions? If the fill is *toself* or *tonext* and there are no markers or text, then the default is *fills*, otherwise it is *points*.",
+                    "editType": "style",
+                    "flags": [
+                        "points",
+                        "fills"
+                    ],
+                    "role": "info",
+                    "valType": "flaglist"
+                },
+                "ids": {
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "editType": "calc",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "idssrc": {
+                    "description": "Sets the source reference on plot.ly for  ids .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "legendgroup": {
+                    "description": "Sets the legend group for this trace. Traces part of the same legend group hide/show at the same time when toggling legend items.",
+                    "dflt": "",
+                    "editType": "style",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "line": {
+                    "color": {
+                        "description": "Sets the line color.",
+                        "editType": "calc",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "dash": {
+                        "description": "Sets the style of the lines.",
+                        "dflt": "solid",
+                        "editType": "calc",
+                        "role": "style",
+                        "valType": "enumerated",
+                        "values": [
+                            "solid",
+                            "dot",
+                            "dash",
+                            "longdash",
+                            "dashdot",
+                            "longdashdot"
+                        ]
+                    },
+                    "editType": "calc",
+                    "role": "object",
+                    "width": {
+                        "description": "Sets the line width (in px).",
+                        "dflt": 2,
+                        "editType": "calc",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    }
+                },
+                "marker": {
+                    "autocolorscale": {
+                        "description": "Has an effect only if `marker.color` is set to a numerical array. Determines whether the colorscale is a default palette (`autocolorscale: true`) or the palette determined by `marker.colorscale`. In case `colorscale` is unspecified or `autocolorscale` is true, the default  palette will be chosen according to whether numbers in the `color` array are all positive, all negative or mixed.",
+                        "dflt": true,
+                        "editType": "calc",
+                        "impliedEdits": {},
+                        "role": "style",
+                        "valType": "boolean"
+                    },
+                    "cauto": {
+                        "description": "Has an effect only if `marker.color` is set to a numerical array and `cmin`, `cmax` are set by the user. In this case, it controls whether the range of colors in `colorscale` is mapped to the range of values in the `color` array (`cauto: true`), or the `cmin`/`cmax` values (`cauto: false`). Defaults to `false` when `cmin`, `cmax` are set by the user.",
+                        "dflt": true,
+                        "editType": "calc",
+                        "impliedEdits": {},
+                        "role": "info",
+                        "valType": "boolean"
+                    },
+                    "cmax": {
+                        "description": "Has an effect only if `marker.color` is set to a numerical array. Sets the upper bound of the color domain. Value should be associated to the `marker.color` array index, and if set, `marker.cmin` must be set as well.",
+                        "dflt": null,
+                        "editType": "calc",
+                        "impliedEdits": {
+                            "cauto": false
+                        },
+                        "role": "info",
+                        "valType": "number"
+                    },
+                    "cmin": {
+                        "description": "Has an effect only if `marker.color` is set to a numerical array. Sets the lower bound of the color domain. Value should be associated to the `marker.color` array index, and if set, `marker.cmax` must be set as well.",
+                        "dflt": null,
+                        "editType": "calc",
+                        "impliedEdits": {
+                            "cauto": false
+                        },
+                        "role": "info",
+                        "valType": "number"
+                    },
+                    "color": {
+                        "arrayOk": true,
+                        "description": "Sets the marker color. It accepts either a specific color or an array of numbers that are mapped to the colorscale relative to the max and min values of the array or relative to `cmin` and `cmax` if set.",
+                        "editType": "calc",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "colorbar": {
+                        "bgcolor": {
+                            "description": "Sets the color of padded area.",
+                            "dflt": "rgba(0,0,0,0)",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "bordercolor": {
+                            "description": "Sets the axis line color.",
+                            "dflt": "#444",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "borderwidth": {
+                            "description": "Sets the width (in px) or the border enclosing this color bar.",
+                            "dflt": 0,
+                            "editType": "calc",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "dtick": {
+                            "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
+                            "editType": "calc",
+                            "impliedEdits": {
+                                "tickmode": "linear"
+                            },
+                            "role": "style",
+                            "valType": "any"
+                        },
+                        "editType": "calc",
+                        "exponentformat": {
+                            "description": "Determines a formatting rule for the tick exponents. For example, consider the number 1,000,000,000. If *none*, it appears as 1,000,000,000. If *e*, 1e+9. If *E*, 1E+9. If *power*, 1x10^9 (with 9 in a super script). If *SI*, 1G. If *B*, 1B.",
+                            "dflt": "B",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "none",
+                                "e",
+                                "E",
+                                "power",
+                                "SI",
+                                "B"
+                            ]
+                        },
+                        "len": {
+                            "description": "Sets the length of the color bar This measure excludes the padding of both ends. That is, the color bar length is this length minus the padding on both ends.",
+                            "dflt": 1,
+                            "editType": "calc",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "lenmode": {
+                            "description": "Determines whether this color bar's length (i.e. the measure in the color variation direction) is set in units of plot *fraction* or in *pixels. Use `len` to set the value.",
+                            "dflt": "fraction",
+                            "editType": "calc",
+                            "role": "info",
+                            "valType": "enumerated",
+                            "values": [
+                                "fraction",
+                                "pixels"
+                            ]
+                        },
+                        "nticks": {
+                            "description": "Specifies the maximum number of ticks for the particular axis. The actual number of ticks will be chosen automatically to be less than or equal to `nticks`. Has an effect only if `tickmode` is set to *auto*.",
+                            "dflt": 0,
+                            "editType": "calc",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "integer"
+                        },
+                        "outlinecolor": {
+                            "description": "Sets the axis line color.",
+                            "dflt": "#444",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "outlinewidth": {
+                            "description": "Sets the width (in px) of the axis line.",
+                            "dflt": 1,
+                            "editType": "calc",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "separatethousands": {
+                            "description": "If \"true\", even 4-digit integers are separated",
+                            "dflt": false,
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "boolean"
+                        },
+                        "showexponent": {
+                            "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
+                            "dflt": "all",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "all",
+                                "first",
+                                "last",
+                                "none"
+                            ]
+                        },
+                        "showticklabels": {
+                            "description": "Determines whether or not the tick labels are drawn.",
+                            "dflt": true,
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "boolean"
+                        },
+                        "showtickprefix": {
+                            "description": "If *all*, all tick labels are displayed with a prefix. If *first*, only the first tick is displayed with a prefix. If *last*, only the last tick is displayed with a suffix. If *none*, tick prefixes are hidden.",
+                            "dflt": "all",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "all",
+                                "first",
+                                "last",
+                                "none"
+                            ]
+                        },
+                        "showticksuffix": {
+                            "description": "Same as `showtickprefix` but for tick suffixes.",
+                            "dflt": "all",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "all",
+                                "first",
+                                "last",
+                                "none"
+                            ]
+                        },
+                        "thickness": {
+                            "description": "Sets the thickness of the color bar This measure excludes the size of the padding, ticks and labels.",
+                            "dflt": 30,
+                            "editType": "calc",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "thicknessmode": {
+                            "description": "Determines whether this color bar's thickness (i.e. the measure in the constant color direction) is set in units of plot *fraction* or in *pixels*. Use `thickness` to set the value.",
+                            "dflt": "pixels",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "fraction",
+                                "pixels"
+                            ]
+                        },
+                        "tick0": {
+                            "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
+                            "editType": "calc",
+                            "impliedEdits": {
+                                "tickmode": "linear"
+                            },
+                            "role": "style",
+                            "valType": "any"
+                        },
+                        "tickangle": {
+                            "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
+                            "dflt": "auto",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "angle"
+                        },
+                        "tickcolor": {
+                            "description": "Sets the tick color.",
+                            "dflt": "#444",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "tickfont": {
+                            "color": {
+                                "editType": "calc",
+                                "role": "style",
+                                "valType": "color"
+                            },
+                            "description": "Sets the color bar's tick label font",
+                            "editType": "calc",
+                            "family": {
+                                "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                                "editType": "calc",
+                                "noBlank": true,
+                                "role": "style",
+                                "strict": true,
+                                "valType": "string"
+                            },
+                            "role": "object",
+                            "size": {
+                                "editType": "calc",
+                                "min": 1,
+                                "role": "style",
+                                "valType": "number"
+                            }
+                        },
+                        "tickformat": {
+                            "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
+                            "dflt": "",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "string"
+                        },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "calc",
+                                        "items": [
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "calc",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "calc",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
+                        "ticklen": {
+                            "description": "Sets the tick length (in px).",
+                            "dflt": 5,
+                            "editType": "calc",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "tickmode": {
+                            "description": "Sets the tick mode for this axis. If *auto*, the number of ticks is set via `nticks`. If *linear*, the placement of the ticks is determined by a starting position `tick0` and a tick step `dtick` (*linear* is the default value if `tick0` and `dtick` are provided). If *array*, the placement of the ticks is set via `tickvals` and the tick text is `ticktext`. (*array* is the default value if `tickvals` is provided).",
+                            "editType": "calc",
+                            "impliedEdits": {},
+                            "role": "info",
+                            "valType": "enumerated",
+                            "values": [
+                                "auto",
+                                "linear",
+                                "array"
+                            ]
+                        },
+                        "tickprefix": {
+                            "description": "Sets a tick label prefix.",
+                            "dflt": "",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "string"
+                        },
+                        "ticks": {
+                            "description": "Determines whether ticks are drawn or not. If **, this axis' ticks are not drawn. If *outside* (*inside*), this axis' are drawn outside (inside) the axis lines.",
+                            "dflt": "",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "outside",
+                                "inside",
+                                ""
+                            ]
+                        },
+                        "ticksuffix": {
+                            "description": "Sets a tick label suffix.",
+                            "dflt": "",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "string"
+                        },
+                        "ticktext": {
+                            "description": "Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.",
+                            "editType": "calc",
+                            "role": "data",
+                            "valType": "data_array"
+                        },
+                        "ticktextsrc": {
+                            "description": "Sets the source reference on plot.ly for  ticktext .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        },
+                        "tickvals": {
+                            "description": "Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.",
+                            "editType": "calc",
+                            "role": "data",
+                            "valType": "data_array"
+                        },
+                        "tickvalssrc": {
+                            "description": "Sets the source reference on plot.ly for  tickvals .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        },
+                        "tickwidth": {
+                            "description": "Sets the tick width (in px).",
+                            "dflt": 1,
+                            "editType": "calc",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "title": {
+                            "description": "Sets the title of the color bar.",
+                            "editType": "calc",
+                            "role": "info",
+                            "valType": "string"
+                        },
+                        "titlefont": {
+                            "color": {
+                                "editType": "calc",
+                                "role": "style",
+                                "valType": "color"
+                            },
+                            "description": "Sets this color bar's title font.",
+                            "editType": "calc",
+                            "family": {
+                                "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                                "editType": "calc",
+                                "noBlank": true,
+                                "role": "style",
+                                "strict": true,
+                                "valType": "string"
+                            },
+                            "role": "object",
+                            "size": {
+                                "editType": "calc",
+                                "min": 1,
+                                "role": "style",
+                                "valType": "number"
+                            }
+                        },
+                        "titleside": {
+                            "description": "Determines the location of the colorbar title with respect to the color bar.",
+                            "dflt": "top",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "right",
+                                "top",
+                                "bottom"
+                            ]
+                        },
+                        "x": {
+                            "description": "Sets the x position of the color bar (in plot fraction).",
+                            "dflt": 1.02,
+                            "editType": "calc",
+                            "max": 3,
+                            "min": -2,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "xanchor": {
+                            "description": "Sets this color bar's horizontal position anchor. This anchor binds the `x` position to the *left*, *center* or *right* of the color bar.",
+                            "dflt": "left",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "left",
+                                "center",
+                                "right"
+                            ]
+                        },
+                        "xpad": {
+                            "description": "Sets the amount of padding (in px) along the x direction.",
+                            "dflt": 10,
+                            "editType": "calc",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "y": {
+                            "description": "Sets the y position of the color bar (in plot fraction).",
+                            "dflt": 0.5,
+                            "editType": "calc",
+                            "max": 3,
+                            "min": -2,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "yanchor": {
+                            "description": "Sets this color bar's vertical position anchor This anchor binds the `y` position to the *top*, *middle* or *bottom* of the color bar.",
+                            "dflt": "middle",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "top",
+                                "middle",
+                                "bottom"
+                            ]
+                        },
+                        "ypad": {
+                            "description": "Sets the amount of padding (in px) along the y direction.",
+                            "dflt": 10,
+                            "editType": "calc",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "colorscale": {
+                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
+                        "editType": "calc",
+                        "impliedEdits": {
+                            "autocolorscale": false
+                        },
+                        "role": "style",
+                        "valType": "colorscale"
+                    },
+                    "colorsrc": {
+                        "description": "Sets the source reference on plot.ly for  color .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "editType": "calc",
+                    "line": {
+                        "autocolorscale": {
+                            "description": "Has an effect only if `marker.line.color` is set to a numerical array. Determines whether the colorscale is a default palette (`autocolorscale: true`) or the palette determined by `marker.line.colorscale`. In case `colorscale` is unspecified or `autocolorscale` is true, the default  palette will be chosen according to whether numbers in the `color` array are all positive, all negative or mixed.",
+                            "dflt": true,
+                            "editType": "calc",
+                            "impliedEdits": {},
+                            "role": "style",
+                            "valType": "boolean"
+                        },
+                        "cauto": {
+                            "description": "Has an effect only if `marker.line.color` is set to a numerical array and `cmin`, `cmax` are set by the user. In this case, it controls whether the range of colors in `colorscale` is mapped to the range of values in the `color` array (`cauto: true`), or the `cmin`/`cmax` values (`cauto: false`). Defaults to `false` when `cmin`, `cmax` are set by the user.",
+                            "dflt": true,
+                            "editType": "calc",
+                            "impliedEdits": {},
+                            "role": "info",
+                            "valType": "boolean"
+                        },
+                        "cmax": {
+                            "description": "Has an effect only if `marker.line.color` is set to a numerical array. Sets the upper bound of the color domain. Value should be associated to the `marker.line.color` array index, and if set, `marker.line.cmin` must be set as well.",
+                            "dflt": null,
+                            "editType": "calc",
+                            "impliedEdits": {
+                                "cauto": false
+                            },
+                            "role": "info",
+                            "valType": "number"
+                        },
+                        "cmin": {
+                            "description": "Has an effect only if `marker.line.color` is set to a numerical array. Sets the lower bound of the color domain. Value should be associated to the `marker.line.color` array index, and if set, `marker.line.cmax` must be set as well.",
+                            "dflt": null,
+                            "editType": "calc",
+                            "impliedEdits": {
+                                "cauto": false
+                            },
+                            "role": "info",
+                            "valType": "number"
+                        },
+                        "color": {
+                            "arrayOk": true,
+                            "description": "Sets the marker.line color. It accepts either a specific color or an array of numbers that are mapped to the colorscale relative to the max and min values of the array or relative to `cmin` and `cmax` if set.",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "colorscale": {
+                            "description": "Sets the colorscale and only has an effect if `marker.line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.line.cmin` and `marker.line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
+                            "editType": "calc",
+                            "impliedEdits": {
+                                "autocolorscale": false
+                            },
+                            "role": "style",
+                            "valType": "colorscale"
+                        },
+                        "colorsrc": {
+                            "description": "Sets the source reference on plot.ly for  color .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        },
+                        "editType": "calc",
+                        "reversescale": {
+                            "description": "Has an effect only if `marker.line.color` is set to a numerical array. Reverses the color mapping if true (`cmin` will correspond to the last color in the array and `cmax` will correspond to the first color).",
+                            "dflt": false,
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "boolean"
+                        },
+                        "role": "object",
+                        "width": {
+                            "arrayOk": true,
+                            "description": "Sets the width (in px) of the lines bounding the marker points.",
+                            "editType": "calc",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "widthsrc": {
+                            "description": "Sets the source reference on plot.ly for  width .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        }
+                    },
+                    "opacity": {
+                        "arrayOk": true,
+                        "description": "Sets the marker opacity.",
+                        "editType": "calc",
+                        "max": 1,
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "opacitysrc": {
+                        "description": "Sets the source reference on plot.ly for  opacity .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "reversescale": {
+                        "description": "Has an effect only if `marker.color` is set to a numerical array. Reverses the color mapping if true (`cmin` will correspond to the last color in the array and `cmax` will correspond to the first color).",
+                        "dflt": false,
+                        "editType": "calc",
+                        "role": "style",
+                        "valType": "boolean"
+                    },
+                    "role": "object",
+                    "showscale": {
+                        "description": "Has an effect only if `marker.color` is set to a numerical array. Determines whether or not a colorbar is displayed.",
+                        "dflt": false,
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "boolean"
+                    },
+                    "size": {
+                        "arrayOk": true,
+                        "description": "Sets the marker size (in px).",
+                        "dflt": 6,
+                        "editType": "calc",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "sizemin": {
+                        "description": "Has an effect only if `marker.size` is set to a numerical array. Sets the minimum size (in px) of the rendered marker points.",
+                        "dflt": 0,
+                        "editType": "calc",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "sizemode": {
+                        "description": "Has an effect only if `marker.size` is set to a numerical array. Sets the rule for which the data in `size` is converted to pixels.",
+                        "dflt": "diameter",
+                        "editType": "calc",
+                        "role": "info",
+                        "valType": "enumerated",
+                        "values": [
+                            "diameter",
+                            "area"
+                        ]
+                    },
+                    "sizeref": {
+                        "description": "Has an effect only if `marker.size` is set to a numerical array. Sets the scale factor used to determine the rendered size of marker points. Use with `sizemin` and `sizemode`.",
+                        "dflt": 1,
+                        "editType": "calc",
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "sizesrc": {
+                        "description": "Sets the source reference on plot.ly for  size .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "symbol": {
+                        "arrayOk": true,
+                        "description": "Sets the marker symbol type. Adding 100 is equivalent to appending *-open* to a symbol name. Adding 200 is equivalent to appending *-dot* to a symbol name. Adding 300 is equivalent to appending *-open-dot* or *dot-open* to a symbol name.",
+                        "dflt": "circle",
+                        "editType": "calc",
+                        "role": "style",
+                        "valType": "enumerated",
+                        "values": [
+                            0,
+                            "circle",
+                            100,
+                            "circle-open",
+                            200,
+                            "circle-dot",
+                            300,
+                            "circle-open-dot",
+                            1,
+                            "square",
+                            101,
+                            "square-open",
+                            201,
+                            "square-dot",
+                            301,
+                            "square-open-dot",
+                            2,
+                            "diamond",
+                            102,
+                            "diamond-open",
+                            202,
+                            "diamond-dot",
+                            302,
+                            "diamond-open-dot",
+                            3,
+                            "cross",
+                            103,
+                            "cross-open",
+                            203,
+                            "cross-dot",
+                            303,
+                            "cross-open-dot",
+                            4,
+                            "x",
+                            104,
+                            "x-open",
+                            204,
+                            "x-dot",
+                            304,
+                            "x-open-dot",
+                            5,
+                            "triangle-up",
+                            105,
+                            "triangle-up-open",
+                            205,
+                            "triangle-up-dot",
+                            305,
+                            "triangle-up-open-dot",
+                            6,
+                            "triangle-down",
+                            106,
+                            "triangle-down-open",
+                            206,
+                            "triangle-down-dot",
+                            306,
+                            "triangle-down-open-dot",
+                            7,
+                            "triangle-left",
+                            107,
+                            "triangle-left-open",
+                            207,
+                            "triangle-left-dot",
+                            307,
+                            "triangle-left-open-dot",
+                            8,
+                            "triangle-right",
+                            108,
+                            "triangle-right-open",
+                            208,
+                            "triangle-right-dot",
+                            308,
+                            "triangle-right-open-dot",
+                            9,
+                            "triangle-ne",
+                            109,
+                            "triangle-ne-open",
+                            209,
+                            "triangle-ne-dot",
+                            309,
+                            "triangle-ne-open-dot",
+                            10,
+                            "triangle-se",
+                            110,
+                            "triangle-se-open",
+                            210,
+                            "triangle-se-dot",
+                            310,
+                            "triangle-se-open-dot",
+                            11,
+                            "triangle-sw",
+                            111,
+                            "triangle-sw-open",
+                            211,
+                            "triangle-sw-dot",
+                            311,
+                            "triangle-sw-open-dot",
+                            12,
+                            "triangle-nw",
+                            112,
+                            "triangle-nw-open",
+                            212,
+                            "triangle-nw-dot",
+                            312,
+                            "triangle-nw-open-dot",
+                            13,
+                            "pentagon",
+                            113,
+                            "pentagon-open",
+                            213,
+                            "pentagon-dot",
+                            313,
+                            "pentagon-open-dot",
+                            14,
+                            "hexagon",
+                            114,
+                            "hexagon-open",
+                            214,
+                            "hexagon-dot",
+                            314,
+                            "hexagon-open-dot",
+                            15,
+                            "hexagon2",
+                            115,
+                            "hexagon2-open",
+                            215,
+                            "hexagon2-dot",
+                            315,
+                            "hexagon2-open-dot",
+                            16,
+                            "octagon",
+                            116,
+                            "octagon-open",
+                            216,
+                            "octagon-dot",
+                            316,
+                            "octagon-open-dot",
+                            17,
+                            "star",
+                            117,
+                            "star-open",
+                            217,
+                            "star-dot",
+                            317,
+                            "star-open-dot",
+                            18,
+                            "hexagram",
+                            118,
+                            "hexagram-open",
+                            218,
+                            "hexagram-dot",
+                            318,
+                            "hexagram-open-dot",
+                            19,
+                            "star-triangle-up",
+                            119,
+                            "star-triangle-up-open",
+                            219,
+                            "star-triangle-up-dot",
+                            319,
+                            "star-triangle-up-open-dot",
+                            20,
+                            "star-triangle-down",
+                            120,
+                            "star-triangle-down-open",
+                            220,
+                            "star-triangle-down-dot",
+                            320,
+                            "star-triangle-down-open-dot",
+                            21,
+                            "star-square",
+                            121,
+                            "star-square-open",
+                            221,
+                            "star-square-dot",
+                            321,
+                            "star-square-open-dot",
+                            22,
+                            "star-diamond",
+                            122,
+                            "star-diamond-open",
+                            222,
+                            "star-diamond-dot",
+                            322,
+                            "star-diamond-open-dot",
+                            23,
+                            "diamond-tall",
+                            123,
+                            "diamond-tall-open",
+                            223,
+                            "diamond-tall-dot",
+                            323,
+                            "diamond-tall-open-dot",
+                            24,
+                            "diamond-wide",
+                            124,
+                            "diamond-wide-open",
+                            224,
+                            "diamond-wide-dot",
+                            324,
+                            "diamond-wide-open-dot",
+                            25,
+                            "hourglass",
+                            125,
+                            "hourglass-open",
+                            26,
+                            "bowtie",
+                            126,
+                            "bowtie-open",
+                            27,
+                            "circle-cross",
+                            127,
+                            "circle-cross-open",
+                            28,
+                            "circle-x",
+                            128,
+                            "circle-x-open",
+                            29,
+                            "square-cross",
+                            129,
+                            "square-cross-open",
+                            30,
+                            "square-x",
+                            130,
+                            "square-x-open",
+                            31,
+                            "diamond-cross",
+                            131,
+                            "diamond-cross-open",
+                            32,
+                            "diamond-x",
+                            132,
+                            "diamond-x-open",
+                            33,
+                            "cross-thin",
+                            133,
+                            "cross-thin-open",
+                            34,
+                            "x-thin",
+                            134,
+                            "x-thin-open",
+                            35,
+                            "asterisk",
+                            135,
+                            "asterisk-open",
+                            36,
+                            "hash",
+                            136,
+                            "hash-open",
+                            236,
+                            "hash-dot",
+                            336,
+                            "hash-open-dot",
+                            37,
+                            "y-up",
+                            137,
+                            "y-up-open",
+                            38,
+                            "y-down",
+                            138,
+                            "y-down-open",
+                            39,
+                            "y-left",
+                            139,
+                            "y-left-open",
+                            40,
+                            "y-right",
+                            140,
+                            "y-right-open",
+                            41,
+                            "line-ew",
+                            141,
+                            "line-ew-open",
+                            42,
+                            "line-ns",
+                            142,
+                            "line-ns-open",
+                            43,
+                            "line-ne",
+                            143,
+                            "line-ne-open",
+                            44,
+                            "line-nw",
+                            144,
+                            "line-nw-open"
+                        ]
+                    },
+                    "symbolsrc": {
+                        "description": "Sets the source reference on plot.ly for  symbol .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    }
+                },
+                "mode": {
+                    "description": "Determines the drawing mode for this scatter trace. If the provided `mode` includes *text* then the `text` elements appear at the coordinates. Otherwise, the `text` elements appear on hover. If there are less than 20 points, then the default is *lines+markers*. Otherwise, *lines*.",
+                    "editType": "calc",
+                    "extras": [
+                        "none"
+                    ],
+                    "flags": [
+                        "lines",
+                        "markers",
+                        "text"
+                    ],
+                    "role": "info",
+                    "valType": "flaglist"
+                },
+                "name": {
+                    "description": "Sets the trace name. The trace name appear as the legend item and on hover.",
+                    "editType": "style",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "opacity": {
+                    "description": "Sets the opacity of the trace.",
+                    "dflt": 1,
+                    "editType": "style",
+                    "max": 1,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "r": {
+                    "description": "Sets the radial coordinates",
+                    "editType": "calc+clearAxisTypes",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "rsrc": {
+                    "description": "Sets the source reference on plot.ly for  r .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "selected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of selected points.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of selected points.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of selected points.",
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object",
+                    "textfont": {
+                        "color": {
+                            "description": "Sets the text font color of selected points.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "role": "object"
+                    }
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
+                "showlegend": {
+                    "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
+                    "dflt": true,
+                    "editType": "style",
+                    "role": "info",
+                    "valType": "boolean"
+                },
+                "stream": {
+                    "editType": "calc",
+                    "maxpoints": {
+                        "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "editType": "calc",
+                        "max": 10000,
+                        "min": 0,
+                        "role": "info",
+                        "valType": "number"
+                    },
+                    "role": "object",
+                    "token": {
+                        "description": "The stream id number links a data trace on a plot with a stream. See https://plot.ly/settings for more details.",
+                        "editType": "calc",
+                        "noBlank": true,
+                        "role": "info",
+                        "strict": true,
+                        "valType": "string"
+                    }
+                },
+                "subplot": {
+                    "description": "Sets a reference between this trace's data coordinates and a polar subplot. If *polar* (the default value), the data refer to `layout.polar`. If *polar2*, the data refer to `layout.polar2`, and so on.",
+                    "dflt": "polar",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "subplotid"
+                },
+                "text": {
+                    "arrayOk": true,
+                    "description": "Sets text elements associated with each (x,y) pair. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.",
+                    "dflt": "",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "textsrc": {
+                    "description": "Sets the source reference on plot.ly for  text .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "theta": {
+                    "description": "Sets the angular coordinates",
+                    "editType": "calc+clearAxisTypes",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "thetasrc": {
+                    "description": "Sets the source reference on plot.ly for  theta .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "thetaunit": {
+                    "description": "Sets the unit of input *theta* values. Has an effect only when on *linear* angular axes.",
+                    "dflt": "degrees",
+                    "editType": "calc+clearAxisTypes",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        "radians",
+                        "degrees",
+                        "gradians"
+                    ]
+                },
+                "type": "scatterpolargl",
+                "uid": {
+                    "dflt": "",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "unselected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object",
+                    "textfont": {
+                        "color": {
+                            "description": "Sets the text font color of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "role": "object"
+                    }
+                },
+                "visible": {
+                    "description": "Determines whether or not this trace is visible. If *legendonly*, the trace is not drawn, but can appear as a legend item (provided that the legend itself is visible).",
+                    "dflt": true,
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        true,
+                        false,
+                        "legendonly"
+                    ]
+                }
+            },
+            "meta": {
+                "description": "The scatterpolargl trace type encompasses line charts, scatter charts, and bubble charts in polar coordinates using the WebGL plotting engine. The data visualized as scatter point or lines is set in `r` (radial) and `theta` (angular) coordinates Bubble charts are achieved by setting `marker.size` and/or `marker.color` to numerical arrays.",
+                "hrName": "scatter_polar_gl"
             }
         },
         "scatterternary": {
@@ -32969,6 +38977,38 @@
                             "role": "style",
                             "valType": "string"
                         },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "colorbars",
+                                        "items": [
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "colorbars",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "colorbars",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
                             "dflt": 5,
@@ -33049,7 +39089,6 @@
                         },
                         "title": {
                             "description": "Sets the title of the color bar.",
-                            "dflt": "Click to enter colorscale title",
                             "editType": "colorbars",
                             "role": "info",
                             "valType": "string"
@@ -33150,7 +39189,7 @@
                         }
                     },
                     "colorscale": {
-                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                        "description": "Sets the colorscale and only has an effect if `marker.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.cmin` and `marker.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                         "editType": "calc",
                         "impliedEdits": {
                             "autocolorscale": false
@@ -33247,7 +39286,7 @@
                             "valType": "color"
                         },
                         "colorscale": {
-                            "description": "Sets the colorscale and only has an effect if `marker.line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.line.cmin` and `marker.line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis",
+                            "description": "Sets the colorscale and only has an effect if `marker.line.color` is set to a numerical array. The colorscale must be an array containing arrays mapping a normalized value to an rgb, rgba, hex, hsl, hsv, or named color string. At minimum, a mapping for the lowest (0) and highest (1) values are required. For example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To control the bounds of the colorscale in color space, use `marker.line.cmin` and `marker.line.cmax`. Alternatively, `colorscale` may be a palette name string of the following list: Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis, Cividis",
                             "editType": "calc",
                             "impliedEdits": {
                                 "autocolorscale": false
@@ -33695,6 +39734,51 @@
                     "role": "style",
                     "valType": "number"
                 },
+                "selected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of selected points.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of selected points.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of selected points.",
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object",
+                    "textfont": {
+                        "color": {
+                            "description": "Sets the text font color of selected points.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "role": "object"
+                    }
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
                     "dflt": true,
@@ -33828,6 +39912,45 @@
                     "editType": "calc",
                     "role": "info",
                     "valType": "string"
+                },
+                "unselected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object",
+                    "textfont": {
+                        "color": {
+                            "description": "Sets the text font color of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "role": "object"
+                    }
                 },
                 "visible": {
                     "description": "Determines whether or not this trace is visible. If *legendonly*, the trace is not drawn, but can appear as a legend item (provided that the legend itself is visible).",
@@ -34132,6 +40255,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "calc",
+                                    "items": [
+                                        {
+                                            "editType": "calc",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "calc",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "calc",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "calc",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
                         "dflt": 5,
@@ -34212,7 +40367,6 @@
                     },
                     "title": {
                         "description": "Sets the title of the color bar.",
-                        "dflt": "Click to enter colorscale title",
                         "editType": "calc",
                         "role": "info",
                         "valType": "string"
@@ -34594,7 +40748,7 @@
                     "arrayOk": true,
                     "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
                     "dflt": "all",
-                    "editType": "none",
+                    "editType": "calc",
                     "extras": [
                         "all",
                         "none",
@@ -34833,6 +40987,12 @@
                     "role": "info",
                     "valType": "subplotid"
                 },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
                     "dflt": true,
@@ -34881,10 +41041,12 @@
                     "valType": "string"
                 },
                 "text": {
-                    "description": "Sets the text elements associated with each z value.",
+                    "arrayOk": true,
+                    "description": "Sets the text elements associated with each z value. If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.",
+                    "dflt": "",
                     "editType": "calc",
-                    "role": "data",
-                    "valType": "data_array"
+                    "role": "info",
+                    "valType": "string"
                 },
                 "textsrc": {
                     "description": "Sets the source reference on plot.ly for  text .",
@@ -35248,7 +41410,7 @@
                     "editType": "calc",
                     "role": "object",
                     "x": {
-                        "description": "Sets the horizontal domain of this `table` trace (in plot fraction).",
+                        "description": "Sets the horizontal domain of this table trace (in plot fraction).",
                         "dflt": [
                             0,
                             1
@@ -35272,7 +41434,7 @@
                         "valType": "info_array"
                     },
                     "y": {
-                        "description": "Sets the vertical domain of this `table` trace (in plot fraction).",
+                        "description": "Sets the vertical domain of this table trace (in plot fraction).",
                         "dflt": [
                             0,
                             1
@@ -35623,6 +41785,12 @@
                     "role": "style",
                     "valType": "number"
                 },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
                 "showlegend": {
                     "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
                     "dflt": true,
@@ -35673,6 +41841,956 @@
             },
             "meta": {
                 "description": "Table view for detailed data viewing. The data are arranged in a grid of rows and columns. Most styling can be specified for columns, rows or individual cells. Table is using a column-major order, ie. the grid is represented as a vector of column vectors."
+            }
+        },
+        "violin": {
+            "attributes": {
+                "bandwidth": {
+                    "description": "Sets the bandwidth used to compute the kernel density estimate. By default, the bandwidth is determined by Silverman's rule of thumb.",
+                    "editType": "calc",
+                    "min": 0,
+                    "role": "info",
+                    "valType": "number"
+                },
+                "box": {
+                    "editType": "plot",
+                    "fillcolor": {
+                        "description": "Sets the inner box plot fill color.",
+                        "editType": "style",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "line": {
+                        "color": {
+                            "description": "Sets the inner box plot bounding line color.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "role": "object",
+                        "width": {
+                            "description": "Sets the inner box plot bounding line width.",
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object",
+                    "visible": {
+                        "description": "Determines if an miniature box plot is drawn inside the violins. ",
+                        "dflt": false,
+                        "editType": "plot",
+                        "role": "info",
+                        "valType": "boolean"
+                    },
+                    "width": {
+                        "description": "Sets the width of the inner box plots relative to the violins' width. For example, with 1, the inner box plots are as wide as the violins.",
+                        "dflt": 0.25,
+                        "editType": "plot",
+                        "max": 1,
+                        "min": 0,
+                        "role": "info",
+                        "valType": "number"
+                    }
+                },
+                "customdata": {
+                    "description": "Assigns extra data each datum. This may be useful when listening to hover, click and selection events. Note that, *scatter* traces also appends customdata items in the markers DOM elements",
+                    "editType": "calc",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "customdatasrc": {
+                    "description": "Sets the source reference on plot.ly for  customdata .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "fillcolor": {
+                    "description": "Sets the fill color. Defaults to a half-transparent variant of the line color, marker color, or marker line color, whichever is available.",
+                    "editType": "style",
+                    "role": "style",
+                    "valType": "color"
+                },
+                "hoverinfo": {
+                    "arrayOk": true,
+                    "description": "Determines which trace information appear on hover. If `none` or `skip` are set, no information is displayed upon hovering. But, if `none` is set, click and hover events are still fired.",
+                    "dflt": "all",
+                    "editType": "none",
+                    "extras": [
+                        "all",
+                        "none",
+                        "skip"
+                    ],
+                    "flags": [
+                        "x",
+                        "y",
+                        "z",
+                        "text",
+                        "name"
+                    ],
+                    "role": "info",
+                    "valType": "flaglist"
+                },
+                "hoverinfosrc": {
+                    "description": "Sets the source reference on plot.ly for  hoverinfo .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "hoverlabel": {
+                    "bgcolor": {
+                        "arrayOk": true,
+                        "description": "Sets the background color of the hover labels for this trace",
+                        "editType": "none",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "bgcolorsrc": {
+                        "description": "Sets the source reference on plot.ly for  bgcolor .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "bordercolor": {
+                        "arrayOk": true,
+                        "description": "Sets the border color of the hover labels for this trace.",
+                        "editType": "none",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "bordercolorsrc": {
+                        "description": "Sets the source reference on plot.ly for  bordercolor .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "editType": "calc",
+                    "font": {
+                        "color": {
+                            "arrayOk": true,
+                            "editType": "none",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "colorsrc": {
+                            "description": "Sets the source reference on plot.ly for  color .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        },
+                        "description": "Sets the font used in hover labels.",
+                        "editType": "none",
+                        "family": {
+                            "arrayOk": true,
+                            "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
+                            "editType": "none",
+                            "noBlank": true,
+                            "role": "style",
+                            "strict": true,
+                            "valType": "string"
+                        },
+                        "familysrc": {
+                            "description": "Sets the source reference on plot.ly for  family .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        },
+                        "role": "object",
+                        "size": {
+                            "arrayOk": true,
+                            "editType": "none",
+                            "min": 1,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "sizesrc": {
+                            "description": "Sets the source reference on plot.ly for  size .",
+                            "editType": "none",
+                            "role": "info",
+                            "valType": "string"
+                        }
+                    },
+                    "namelength": {
+                        "arrayOk": true,
+                        "description": "Sets the length (in number of characters) of the trace name in the hover labels for this trace. -1 shows the whole name regardless of length. 0-3 shows the first 0-3 characters, and an integer >3 will show the whole name if it is less than that many characters, but if it is longer, will truncate to `namelength - 3` characters and add an ellipsis.",
+                        "editType": "none",
+                        "min": -1,
+                        "role": "style",
+                        "valType": "integer"
+                    },
+                    "namelengthsrc": {
+                        "description": "Sets the source reference on plot.ly for  namelength .",
+                        "editType": "none",
+                        "role": "info",
+                        "valType": "string"
+                    },
+                    "role": "object"
+                },
+                "hoveron": {
+                    "description": "Do the hover effects highlight individual violins or sample points or the kernel density estimate or any combination of them?",
+                    "dflt": "violins+points+kde",
+                    "editType": "style",
+                    "extras": [
+                        "all"
+                    ],
+                    "flags": [
+                        "violins",
+                        "points",
+                        "kde"
+                    ],
+                    "role": "info",
+                    "valType": "flaglist"
+                },
+                "ids": {
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "editType": "calc",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "idssrc": {
+                    "description": "Sets the source reference on plot.ly for  ids .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "jitter": {
+                    "description": "Sets the amount of jitter in the sample points drawn. If *0*, the sample points align along the distribution axis. If *1*, the sample points are drawn in a random jitter of width equal to the width of the violins.",
+                    "editType": "calcIfAutorange",
+                    "max": 1,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "legendgroup": {
+                    "description": "Sets the legend group for this trace. Traces part of the same legend group hide/show at the same time when toggling legend items.",
+                    "dflt": "",
+                    "editType": "style",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "line": {
+                    "color": {
+                        "description": "Sets the color of line bounding the violin(s).",
+                        "editType": "style",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "editType": "plot",
+                    "role": "object",
+                    "width": {
+                        "description": "Sets the width (in px) of line bounding the violin(s).",
+                        "dflt": 2,
+                        "editType": "style",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    }
+                },
+                "marker": {
+                    "color": {
+                        "arrayOk": false,
+                        "description": "Sets the marker color. It accepts either a specific color or an array of numbers that are mapped to the colorscale relative to the max and min values of the array or relative to `cmin` and `cmax` if set.",
+                        "editType": "style",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "editType": "plot",
+                    "line": {
+                        "color": {
+                            "arrayOk": false,
+                            "description": "Sets the marker.line color. It accepts either a specific color or an array of numbers that are mapped to the colorscale relative to the max and min values of the array or relative to `cmin` and `cmax` if set.",
+                            "dflt": "#444",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "outliercolor": {
+                            "description": "Sets the border line color of the outlier sample points. Defaults to marker.color",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "outlierwidth": {
+                            "description": "Sets the border line width (in px) of the outlier sample points.",
+                            "dflt": 1,
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "width": {
+                            "arrayOk": false,
+                            "description": "Sets the width (in px) of the lines bounding the marker points.",
+                            "dflt": 0,
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "opacity": {
+                        "arrayOk": false,
+                        "description": "Sets the marker opacity.",
+                        "dflt": 1,
+                        "editType": "style",
+                        "max": 1,
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "outliercolor": {
+                        "description": "Sets the color of the outlier sample points.",
+                        "dflt": "rgba(0, 0, 0, 0)",
+                        "editType": "style",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "role": "object",
+                    "size": {
+                        "arrayOk": false,
+                        "description": "Sets the marker size (in px).",
+                        "dflt": 6,
+                        "editType": "calcIfAutorange",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    },
+                    "symbol": {
+                        "arrayOk": false,
+                        "description": "Sets the marker symbol type. Adding 100 is equivalent to appending *-open* to a symbol name. Adding 200 is equivalent to appending *-dot* to a symbol name. Adding 300 is equivalent to appending *-open-dot* or *dot-open* to a symbol name.",
+                        "dflt": "circle",
+                        "editType": "plot",
+                        "role": "style",
+                        "valType": "enumerated",
+                        "values": [
+                            0,
+                            "circle",
+                            100,
+                            "circle-open",
+                            200,
+                            "circle-dot",
+                            300,
+                            "circle-open-dot",
+                            1,
+                            "square",
+                            101,
+                            "square-open",
+                            201,
+                            "square-dot",
+                            301,
+                            "square-open-dot",
+                            2,
+                            "diamond",
+                            102,
+                            "diamond-open",
+                            202,
+                            "diamond-dot",
+                            302,
+                            "diamond-open-dot",
+                            3,
+                            "cross",
+                            103,
+                            "cross-open",
+                            203,
+                            "cross-dot",
+                            303,
+                            "cross-open-dot",
+                            4,
+                            "x",
+                            104,
+                            "x-open",
+                            204,
+                            "x-dot",
+                            304,
+                            "x-open-dot",
+                            5,
+                            "triangle-up",
+                            105,
+                            "triangle-up-open",
+                            205,
+                            "triangle-up-dot",
+                            305,
+                            "triangle-up-open-dot",
+                            6,
+                            "triangle-down",
+                            106,
+                            "triangle-down-open",
+                            206,
+                            "triangle-down-dot",
+                            306,
+                            "triangle-down-open-dot",
+                            7,
+                            "triangle-left",
+                            107,
+                            "triangle-left-open",
+                            207,
+                            "triangle-left-dot",
+                            307,
+                            "triangle-left-open-dot",
+                            8,
+                            "triangle-right",
+                            108,
+                            "triangle-right-open",
+                            208,
+                            "triangle-right-dot",
+                            308,
+                            "triangle-right-open-dot",
+                            9,
+                            "triangle-ne",
+                            109,
+                            "triangle-ne-open",
+                            209,
+                            "triangle-ne-dot",
+                            309,
+                            "triangle-ne-open-dot",
+                            10,
+                            "triangle-se",
+                            110,
+                            "triangle-se-open",
+                            210,
+                            "triangle-se-dot",
+                            310,
+                            "triangle-se-open-dot",
+                            11,
+                            "triangle-sw",
+                            111,
+                            "triangle-sw-open",
+                            211,
+                            "triangle-sw-dot",
+                            311,
+                            "triangle-sw-open-dot",
+                            12,
+                            "triangle-nw",
+                            112,
+                            "triangle-nw-open",
+                            212,
+                            "triangle-nw-dot",
+                            312,
+                            "triangle-nw-open-dot",
+                            13,
+                            "pentagon",
+                            113,
+                            "pentagon-open",
+                            213,
+                            "pentagon-dot",
+                            313,
+                            "pentagon-open-dot",
+                            14,
+                            "hexagon",
+                            114,
+                            "hexagon-open",
+                            214,
+                            "hexagon-dot",
+                            314,
+                            "hexagon-open-dot",
+                            15,
+                            "hexagon2",
+                            115,
+                            "hexagon2-open",
+                            215,
+                            "hexagon2-dot",
+                            315,
+                            "hexagon2-open-dot",
+                            16,
+                            "octagon",
+                            116,
+                            "octagon-open",
+                            216,
+                            "octagon-dot",
+                            316,
+                            "octagon-open-dot",
+                            17,
+                            "star",
+                            117,
+                            "star-open",
+                            217,
+                            "star-dot",
+                            317,
+                            "star-open-dot",
+                            18,
+                            "hexagram",
+                            118,
+                            "hexagram-open",
+                            218,
+                            "hexagram-dot",
+                            318,
+                            "hexagram-open-dot",
+                            19,
+                            "star-triangle-up",
+                            119,
+                            "star-triangle-up-open",
+                            219,
+                            "star-triangle-up-dot",
+                            319,
+                            "star-triangle-up-open-dot",
+                            20,
+                            "star-triangle-down",
+                            120,
+                            "star-triangle-down-open",
+                            220,
+                            "star-triangle-down-dot",
+                            320,
+                            "star-triangle-down-open-dot",
+                            21,
+                            "star-square",
+                            121,
+                            "star-square-open",
+                            221,
+                            "star-square-dot",
+                            321,
+                            "star-square-open-dot",
+                            22,
+                            "star-diamond",
+                            122,
+                            "star-diamond-open",
+                            222,
+                            "star-diamond-dot",
+                            322,
+                            "star-diamond-open-dot",
+                            23,
+                            "diamond-tall",
+                            123,
+                            "diamond-tall-open",
+                            223,
+                            "diamond-tall-dot",
+                            323,
+                            "diamond-tall-open-dot",
+                            24,
+                            "diamond-wide",
+                            124,
+                            "diamond-wide-open",
+                            224,
+                            "diamond-wide-dot",
+                            324,
+                            "diamond-wide-open-dot",
+                            25,
+                            "hourglass",
+                            125,
+                            "hourglass-open",
+                            26,
+                            "bowtie",
+                            126,
+                            "bowtie-open",
+                            27,
+                            "circle-cross",
+                            127,
+                            "circle-cross-open",
+                            28,
+                            "circle-x",
+                            128,
+                            "circle-x-open",
+                            29,
+                            "square-cross",
+                            129,
+                            "square-cross-open",
+                            30,
+                            "square-x",
+                            130,
+                            "square-x-open",
+                            31,
+                            "diamond-cross",
+                            131,
+                            "diamond-cross-open",
+                            32,
+                            "diamond-x",
+                            132,
+                            "diamond-x-open",
+                            33,
+                            "cross-thin",
+                            133,
+                            "cross-thin-open",
+                            34,
+                            "x-thin",
+                            134,
+                            "x-thin-open",
+                            35,
+                            "asterisk",
+                            135,
+                            "asterisk-open",
+                            36,
+                            "hash",
+                            136,
+                            "hash-open",
+                            236,
+                            "hash-dot",
+                            336,
+                            "hash-open-dot",
+                            37,
+                            "y-up",
+                            137,
+                            "y-up-open",
+                            38,
+                            "y-down",
+                            138,
+                            "y-down-open",
+                            39,
+                            "y-left",
+                            139,
+                            "y-left-open",
+                            40,
+                            "y-right",
+                            140,
+                            "y-right-open",
+                            41,
+                            "line-ew",
+                            141,
+                            "line-ew-open",
+                            42,
+                            "line-ns",
+                            142,
+                            "line-ns-open",
+                            43,
+                            "line-ne",
+                            143,
+                            "line-ne-open",
+                            44,
+                            "line-nw",
+                            144,
+                            "line-nw-open"
+                        ]
+                    }
+                },
+                "meanline": {
+                    "color": {
+                        "description": "Sets the mean line color.",
+                        "editType": "style",
+                        "role": "style",
+                        "valType": "color"
+                    },
+                    "editType": "plot",
+                    "role": "object",
+                    "visible": {
+                        "description": "Determines if a line corresponding to the sample's mean is shown inside the violins. If `box.visible` is turned on, the mean line is drawn inside the inner box. Otherwise, the mean line is drawn from one side of the violin to other.",
+                        "dflt": false,
+                        "editType": "plot",
+                        "role": "info",
+                        "valType": "boolean"
+                    },
+                    "width": {
+                        "description": "Sets the mean line width.",
+                        "editType": "style",
+                        "min": 0,
+                        "role": "style",
+                        "valType": "number"
+                    }
+                },
+                "name": {
+                    "description": "Sets the trace name. The trace name appear as the legend item and on hover. For box traces, the name will also be used for the position coordinate, if `x` and `x0` (`y` and `y0` if horizontal) are missing and the position axis is categorical",
+                    "editType": "calc+clearAxisTypes",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "opacity": {
+                    "description": "Sets the opacity of the trace.",
+                    "dflt": 1,
+                    "editType": "style",
+                    "max": 1,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "orientation": {
+                    "description": "Sets the orientation of the violin(s). If *v* (*h*), the distribution is visualized along the vertical (horizontal).",
+                    "editType": "calc+clearAxisTypes",
+                    "role": "style",
+                    "valType": "enumerated",
+                    "values": [
+                        "v",
+                        "h"
+                    ]
+                },
+                "pointpos": {
+                    "description": "Sets the position of the sample points in relation to the violins. If *0*, the sample points are places over the center of the violins. Positive (negative) values correspond to positions to the right (left) for vertical violins and above (below) for horizontal violins.",
+                    "editType": "calcIfAutorange",
+                    "max": 2,
+                    "min": -2,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "points": {
+                    "description": "If *outliers*, only the sample points lying outside the whiskers are shown If *suspectedoutliers*, the outlier points are shown and points either less than 4*Q1-3*Q3 or greater than 4*Q3-3*Q1 are highlighted (see `outliercolor`) If *all*, all sample points are shown If *false*, only the violins are shown with no sample points",
+                    "dflt": "outliers",
+                    "editType": "calcIfAutorange",
+                    "role": "style",
+                    "valType": "enumerated",
+                    "values": [
+                        "all",
+                        "outliers",
+                        "suspectedoutliers",
+                        false
+                    ]
+                },
+                "scalegroup": {
+                    "description": "If there are multiple violins that should be sized according to to some metric (see `scalemode`), link them by providing a non-empty group id here shared by every trace in the same group.",
+                    "dflt": "",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "scalemode": {
+                    "description": "Sets the metric by which the width of each violin is determined.*width* means each violin has the same (max) width*count* means the violins are scaled by the number of sample points makingup each violin.",
+                    "dflt": "width",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        "width",
+                        "count"
+                    ]
+                },
+                "selected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of selected points.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of selected points.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of selected points.",
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object"
+                },
+                "selectedpoints": {
+                    "description": "Array containing integer indices of selected points. Has an effect only for traces that support selections. Note that an empty array means an empty selection where the `unselected` are turned on for all points, whereas, any other non-array values means no selection all where the `selected` and `unselected` styles have no effect.",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "any"
+                },
+                "showlegend": {
+                    "description": "Determines whether or not an item corresponding to this trace is shown in the legend.",
+                    "dflt": true,
+                    "editType": "style",
+                    "role": "info",
+                    "valType": "boolean"
+                },
+                "side": {
+                    "description": "Determines on which side of the position value the density function making up one half of a violin is plotted. Useful when comparing two violin traces under *overlay* mode, where one trace has `side` set to *positive* and the other to *negative*.",
+                    "dflt": "both",
+                    "editType": "plot",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        "both",
+                        "positive",
+                        "negative"
+                    ]
+                },
+                "span": {
+                    "description": "Sets the span in data space for which the density function will be computed. Has an effect only when `spanmode` is set to *manual*.",
+                    "editType": "calc",
+                    "items": [
+                        {
+                            "editType": "calc",
+                            "valType": "any"
+                        },
+                        {
+                            "editType": "calc",
+                            "valType": "any"
+                        }
+                    ],
+                    "role": "info",
+                    "valType": "info_array"
+                },
+                "spanmode": {
+                    "description": "Sets the method by which the span in data space where the density function will be computed. *soft* means the span goes from the sample's minimum value minus two bandwidths to the sample's maximum value plus two bandwidths. *hard* means the span goes from the sample's minimum to its maximum value. For custom span settings, use mode *manual* and fill in the `span` attribute.",
+                    "dflt": "soft",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        "soft",
+                        "hard",
+                        "manual"
+                    ]
+                },
+                "stream": {
+                    "editType": "calc",
+                    "maxpoints": {
+                        "description": "Sets the maximum number of points to keep on the plots from an incoming stream. If `maxpoints` is set to *50*, only the newest 50 points will be displayed on the plot.",
+                        "dflt": 500,
+                        "editType": "calc",
+                        "max": 10000,
+                        "min": 0,
+                        "role": "info",
+                        "valType": "number"
+                    },
+                    "role": "object",
+                    "token": {
+                        "description": "The stream id number links a data trace on a plot with a stream. See https://plot.ly/settings for more details.",
+                        "editType": "calc",
+                        "noBlank": true,
+                        "role": "info",
+                        "strict": true,
+                        "valType": "string"
+                    }
+                },
+                "text": {
+                    "arrayOk": true,
+                    "description": "Sets the text elements associated with each sample value. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates. To be seen, trace `hoverinfo` must contain a *text* flag.",
+                    "dflt": "",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "textsrc": {
+                    "description": "Sets the source reference on plot.ly for  text .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "type": "violin",
+                "uid": {
+                    "dflt": "",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "unselected": {
+                    "editType": "style",
+                    "marker": {
+                        "color": {
+                            "description": "Sets the marker color of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "role": "style",
+                            "valType": "color"
+                        },
+                        "editType": "style",
+                        "opacity": {
+                            "description": "Sets the marker opacity of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "max": 1,
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        },
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of unselected points, applied only when a selection exists.",
+                            "editType": "style",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
+                    },
+                    "role": "object"
+                },
+                "visible": {
+                    "description": "Determines whether or not this trace is visible. If *legendonly*, the trace is not drawn, but can appear as a legend item (provided that the legend itself is visible).",
+                    "dflt": true,
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        true,
+                        false,
+                        "legendonly"
+                    ]
+                },
+                "x": {
+                    "description": "Sets the x sample data or coordinates. See overview for more info.",
+                    "editType": "calc+clearAxisTypes",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "x0": {
+                    "description": "Sets the x coordinate of the box. See overview for more info.",
+                    "editType": "calc+clearAxisTypes",
+                    "role": "info",
+                    "valType": "any"
+                },
+                "xaxis": {
+                    "description": "Sets a reference between this trace's x coordinates and a 2D cartesian x axis. If *x* (the default value), the x coordinates refer to `layout.xaxis`. If *x2*, the x coordinates refer to `layout.xaxis2`, and so on.",
+                    "dflt": "x",
+                    "editType": "calc+clearAxisTypes",
+                    "role": "info",
+                    "valType": "subplotid"
+                },
+                "xsrc": {
+                    "description": "Sets the source reference on plot.ly for  x .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "y": {
+                    "description": "Sets the y sample data or coordinates. See overview for more info.",
+                    "editType": "calc+clearAxisTypes",
+                    "role": "data",
+                    "valType": "data_array"
+                },
+                "y0": {
+                    "description": "Sets the y coordinate of the box. See overview for more info.",
+                    "editType": "calc+clearAxisTypes",
+                    "role": "info",
+                    "valType": "any"
+                },
+                "yaxis": {
+                    "description": "Sets a reference between this trace's y coordinates and a 2D cartesian y axis. If *y* (the default value), the y coordinates refer to `layout.yaxis`. If *y2*, the y coordinates refer to `layout.xaxis2`, and so on.",
+                    "dflt": "y",
+                    "editType": "calc+clearAxisTypes",
+                    "role": "info",
+                    "valType": "subplotid"
+                },
+                "ysrc": {
+                    "description": "Sets the source reference on plot.ly for  y .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
+                }
+            },
+            "layoutAttributes": {
+                "violingap": {
+                    "description": "Sets the gap (in plot fraction) between violins of adjacent location coordinates.",
+                    "dflt": 0.3,
+                    "editType": "calc",
+                    "max": 1,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "violingroupgap": {
+                    "description": "Sets the gap (in plot fraction) between violins of the same location coordinate.",
+                    "dflt": 0.3,
+                    "editType": "calc",
+                    "max": 1,
+                    "min": 0,
+                    "role": "style",
+                    "valType": "number"
+                },
+                "violinmode": {
+                    "description": "Determines how violins at the same location coordinate are displayed on the graph. If *group*, the violins are plotted next to one another centered around the shared location. If *overlay*, the violins are plotted over one another, you might need to set *opacity* to see them multiple violins.",
+                    "dflt": "overlay",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        "group",
+                        "overlay"
+                    ]
+                }
+            },
+            "meta": {
+                "description": "In vertical (horizontal) violin plots, statistics are computed using `y` (`x`) values. By supplying an `x` (`y`) array, one violin per distinct x (y) value is drawn If no `x` (`y`) {array} is provided, a single violin is drawn. That violin position is then positioned with with `name` or with `x0` (`y0`) if provided."
             }
         }
     },
@@ -35772,7 +42890,7 @@
                     "valType": "boolean"
                 },
                 "operation": {
-                    "description": "Sets the filter operation. *=* keeps items equal to `value` *!=* keeps items not equal to `value` *<* keeps items less than `value` *<=* keeps items less than or equal to `value` *>* keeps items greater than `value` *>=* keeps items greater than or equal to `value` *[]* keeps items inside `value[0]` to value[1]` including both bounds` *()* keeps items inside `value[0]` to value[1]` excluding both bounds` *[)* keeps items inside `value[0]` to value[1]` including `value[0]` but excluding `value[1] *(]* keeps items inside `value[0]` to value[1]` excluding `value[0]` but including `value[1] *][* keeps items outside `value[0]` to value[1]` and equal to both bounds` *)(* keeps items outside `value[0]` to value[1]` *](* keeps items outside `value[0]` to value[1]` and equal to `value[0]` *)[* keeps items outside `value[0]` to value[1]` and equal to `value[1]` *{}* keeps items present in a set of values *}{* keeps items not present in a set of values",
+                    "description": "Sets the filter operation. *=* keeps items equal to `value` *!=* keeps items not equal to `value` *<* keeps items less than `value` *<=* keeps items less than or equal to `value` *>* keeps items greater than `value` *>=* keeps items greater than or equal to `value` *[]* keeps items inside `value[0]` to `value[1]` including both bounds *()* keeps items inside `value[0]` to `value[1]` excluding both bounds *[)* keeps items inside `value[0]` to `value[1]` including `value[0]` but excluding `value[1] *(]* keeps items inside `value[0]` to `value[1]` excluding `value[0]` but including `value[1] *][* keeps items outside `value[0]` to `value[1]` and equal to both bounds *)(* keeps items outside `value[0]` to `value[1]` *](* keeps items outside `value[0]` to `value[1]` and equal to `value[0]` *)[* keeps items outside `value[0]` to `value[1]` and equal to `value[1]` *{}* keeps items present in a set of values *}{* keeps items not present in a set of values",
                     "dflt": "=",
                     "editType": "calc",
                     "role": "info",

--- a/plotly/tests/test_core/test_graph_objs/test_graph_objs_tools.py
+++ b/plotly/tests/test_core/test_graph_objs/test_graph_objs_tools.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 
 from plotly import graph_reference as gr
 from plotly.graph_objs import graph_objs_tools as got
+from plotly import graph_objs as go
 
 
 class TestGetHelp(TestCase):
@@ -30,3 +31,183 @@ class TestGetHelp(TestCase):
                 got.get_help(object_name, attribute=fake_attribute)
         except:
             self.fail(msg=msg)
+
+
+class TestKeyParts(TestCase):
+    def test_without_underscore_attr(self):
+        assert got._key_parts("foo") == ["foo"]
+        assert got._key_parts("foo_bar") == ["foo", "bar"]
+        assert got._key_parts("foo_bar_baz") == ["foo", "bar", "baz"]
+
+    def test_traililng_underscore_attr(self):
+        assert got._key_parts("foo_error_x") == ["foo", "error_x"]
+        assert got._key_parts("foo_bar_error_x") == ["foo", "bar", "error_x"]
+        assert got._key_parts("foo_bar_baz_error_x") == ["foo", "bar", "baz", "error_x"]
+
+    def test_leading_underscore_attr(self):
+        assert got._key_parts("error_x_foo") == ["error_x", "foo"]
+        assert got._key_parts("error_x_foo_bar") == ["error_x", "foo", "bar"]
+        assert got._key_parts("error_x_foo_bar_baz") == ["error_x", "foo", "bar", "baz"]
+
+
+class TestUnderscoreMagicDictObj(TestCase):
+
+    def test_can_split_string_key_into_parts(self):
+        obj1 = {}
+        obj2 = {}
+        got._underscore_magic("marker_line_width", 42, obj1)
+        got._underscore_magic(["marker", "line", "width"], 42, obj2)
+        want = {"marker": {"line": {"width": 42}}}
+        assert obj1 == obj2 == want
+
+    def test_will_make_tree_with_empty_dict_val(self):
+        obj = {}
+        got._underscore_magic("marker_colorbar_tickfont", {}, obj)
+        assert obj == {"marker": {"colorbar": {"tickfont": {}}}}
+
+    def test_can_set_at_depths_1to4(self):
+        # 1 level
+        obj = {}
+        got._underscore_magic("opacity", 0.9, obj)
+        assert obj == {"opacity": 0.9}
+
+        # 2 levels
+        got._underscore_magic("line_width", 10, obj)
+        assert obj == {"opacity": 0.9, "line": {"width": 10}}
+
+        # 3 levels
+        got._underscore_magic("hoverinfo_font_family", "Times", obj)
+        want = {
+            "opacity": 0.9,
+            "line": {"width": 10},
+            "hoverinfo": {"font": {"family": "Times"}}
+        }
+        assert obj == want
+
+        # 4 levels
+        got._underscore_magic("marker_colorbar_tickfont_family", "Times", obj)
+        want = {
+            "opacity": 0.9,
+            "line": {"width": 10},
+            "hoverinfo": {"font": {"family": "Times"}},
+            "marker": {"colorbar": {"tickfont": {"family": "Times"}}},
+        }
+        assert obj == want
+
+    def test_does_not_displace_existing_fields(self):
+        obj = {}
+        got._underscore_magic("marker_size", 10, obj)
+        got._underscore_magic("marker_line_width", 0.4, obj)
+        assert obj == {"marker": {"size": 10, "line": {"width": 0.4}}}
+
+    def test_doesnt_mess_up_underscore_attrs(self):
+        obj = {}
+        got._underscore_magic("error_x_color", "red", obj)
+        got._underscore_magic("error_x_width", 4, obj)
+        assert obj == {"error_x": {"color": "red", "width": 4}}
+
+
+class TestUnderscoreMagicPlotlyDictObj(TestCase):
+
+    def test_can_split_string_key_into_parts(self):
+        obj1 = go.Scatter()
+        obj2 = go.Scatter()
+        got._underscore_magic("marker_line_width", 42, obj1)
+        got._underscore_magic(["marker", "line", "width"], 42, obj2)
+        want = go.Scatter({"marker": {"line": {"width": 42}}})
+        assert obj1 == obj2 == want
+
+    def test_will_make_tree_with_empty_dict_val(self):
+        obj = go.Scatter()
+        got._underscore_magic("marker_colorbar_tickfont", {}, obj)
+        want = go.Scatter({"marker": {"colorbar": {"tickfont": {}}}})
+        assert obj == want
+
+    def test_can_set_at_depths_1to4(self):
+        # 1 level
+        obj = go.Scatter()
+        got._underscore_magic("opacity", 0.9, obj)
+        assert obj == go.Scatter({"type": "scatter", "opacity": 0.9})
+
+        # 2 levels
+        got._underscore_magic("line_width", 10, obj)
+        assert obj == go.Scatter({"opacity": 0.9, "line": {"width": 10}})
+
+        # 3 levels
+        got._underscore_magic("hoverinfo_font_family", "Times", obj)
+        want = go.Scatter({
+            "opacity": 0.9,
+            "line": {"width": 10},
+            "hoverinfo": {"font": {"family": "Times"}}
+        })
+        assert obj == want
+
+        # 4 levels
+        got._underscore_magic("marker_colorbar_tickfont_family", "Times", obj)
+        want = go.Scatter({
+            "opacity": 0.9,
+            "line": {"width": 10},
+            "hoverinfo": {"font": {"family": "Times"}},
+            "marker": {"colorbar": {"tickfont": {"family": "Times"}}},
+        })
+        assert obj == want
+
+    def test_does_not_displace_existing_fields(self):
+        obj = go.Scatter()
+        got._underscore_magic("marker_size", 10, obj)
+        got._underscore_magic("marker_line_width", 0.4, obj)
+        assert obj == go.Scatter({"marker": {"size": 10, "line": {"width": 0.4}}})
+
+    def test_doesnt_mess_up_underscore_attrs(self):
+        obj = go.Scatter()
+        got._underscore_magic("error_x_color", "red", obj)
+        got._underscore_magic("error_x_width", 4, obj)
+        assert obj == go.Scatter({"error_x": {"color": "red", "width": 4}})
+
+
+class TestAttr(TestCase):
+    def test_with_no_positional_argument(self):
+        have = got.attr(
+            opacity=0.9, line_width=10,
+            hoverinfo_font_family="Times",
+            marker_colorbar_tickfont_size=10
+        )
+        want = {
+            "opacity": 0.9,
+            "line": {"width": 10},
+            "hoverinfo": {"font": {"family": "Times"}},
+            "marker": {"colorbar": {"tickfont": {"size": 10}}},
+        }
+        assert have == want
+
+    def test_with_dict_positional_argument(self):
+        have = {"x": [1, 2, 3, 4, 5]}
+        got.attr(have,
+            opacity=0.9, line_width=10,
+            hoverinfo_font_family="Times",
+            marker_colorbar_tickfont_size=10
+        )
+        want = {
+            "x": [1, 2, 3, 4, 5],
+            "opacity": 0.9,
+            "line": {"width": 10},
+            "hoverinfo": {"font": {"family": "Times"}},
+            "marker": {"colorbar": {"tickfont": {"size": 10}}},
+        }
+        assert have == want
+
+    def test_with_PlotlyDict_positional_argument(self):
+        have = go.Scatter({"x": [1, 2, 3, 4, 5]})
+        got.attr(have,
+            opacity=0.9, line_width=10,
+            hoverinfo_font_family="Times",
+            marker_colorbar_tickfont_size=10
+        )
+        want = go.Scatter({
+            "x": [1, 2, 3, 4, 5],
+            "opacity": 0.9,
+            "line": {"width": 10},
+            "hoverinfo": {"font": {"family": "Times"}},
+            "marker": {"colorbar": {"tickfont": {"size": 10}}},
+        })
+        assert have == want


### PR DESCRIPTION
This is a request for comments for brining some features of the [plotly Julia library](https://github.com/sglyon/PlotlyJS.jl) over to the python side.

The two main features are:

1. The ability to use "magic underscore"  notation to set nested properties. For example, if I wanted to set `marker.line.color` to red I could do `marker_line_color="red"` instead of `"marker": {"line": {"color": "red"}}`. This is enabled for keyword arguments to the `update` method of all subclasses of `PlotlyDict`
2. A new function `attr` that allows you to apply the magic underscore notation to groups of nested arguments. For example, if I wanted to set  "marker.symbol" to "star" and "marker.line.width" to 3 I could to `marker=attr(symbol="star", line_width=3)`. When I originally wrote this for Julia, the goal was to make it easier to create nested sets of attributes because doing so with Julia's dict notation is cumbersome. Because my goal was convenience in setting `attr`ibutes, I chose the name `attr`, but I am 100% open to alternative suggestions for that name.

The semantics of the magic underscore notation are such that if a parent property already exists, its children are not lost when adding another child. (meaning if "marker.symbol" already exists on the trace, then trying to set "marker_line_color" would just add "line.color" within the existing "marker" tree). 

Also the code is "smart" about dealing with attributes that have underscores in their name. If you tried to do `error_x_color` it would create a node `error_x` with a child node `color`.

The tests are fairly comprehensive and show how this works.

I'd love to hear what people think and if this is something you want in plotly.py.

If this is something that can be accepted here, I will take the time to update docstrings for `PlotlyDict.update` to make it clear what the magic underscore notation is as well as document the `attr` function.