### PR TITLE
Revert "Remove whitespace. Remove unused variable j."

### DIFF
--- a/plotly/colors.py
+++ b/plotly/colors.py
@@ -224,7 +224,7 @@ def validate_colors(colors):
         colors_list = colors
 
     # Validate colors in colors_list
-    for each_color in colors_list:
+    for j, each_color in enumerate(colors_list):
         if 'rgb' in each_color:
             each_color = color_parser(
                 each_color, unlabel_rgb
@@ -401,10 +401,10 @@ def validate_scale_values(scale):
         )
 
     if not all(x < y for x, y in zip(scale, scale[1:])):
-        raise exceptions.PlotlyError(
-            "'scale' must be a list that contains a strictly increasing "
-            "sequence of numbers."
-        )
+            raise exceptions.PlotlyError(
+                "'scale' must be a list that contains a strictly increasing "
+                "sequence of numbers."
+            )
 
 
 def make_colorscale(colors, scale=None):
@@ -553,7 +553,7 @@ def label_rgb(colors):
     """
     Takes tuple (a, b, c) and returns an rgb color 'rgb(a, b, c)'
     """
-    return 'rgb(%s, %s, %s)' % (colors[0], colors[1], colors[2])
+    return ('rgb(%s, %s, %s)' % (colors[0], colors[1], colors[2]))
 
 
 def unlabel_rgb(colors):

--- a/plotly/dashboard_objs/dashboard_objs.py
+++ b/plotly/dashboard_objs/dashboard_objs.py
@@ -62,7 +62,6 @@ def _container(box_1=None, box_2=None, size=MASTER_HEIGHT,
     }
     return container
 
-
 dashboard_html = ("""
 <!DOCTYPE HTML>
 <html>
@@ -274,7 +273,7 @@ class Dashboard(dict):
         self['layout']['sizeUnit'] = 'px'
 
         for path in all_paths:
-            if path:
+            if len(path) != 0:
                 if self._path_to_box(path)['type'] == 'split':
                     self._path_to_box(path)['size'] = 50
                     self._path_to_box(path)['sizeUnit'] = '%'

--- a/plotly/figure_factory/_annotated_heatmap.py
+++ b/plotly/figure_factory/_annotated_heatmap.py
@@ -180,8 +180,8 @@ class _AnnotatedHeatmap(object):
                 max_col = map(int,
                               self.colorscale[-1][1].strip('rgb()').split(','))
             elif '#' in self.colorscale[0][1]:
-                min_col = utils.hex_to_rgb(self.colorscale[0][1])
-                max_col = utils.hex_to_rgb(self.colorscale[-1][1])
+                    min_col = utils.hex_to_rgb(self.colorscale[0][1])
+                    max_col = utils.hex_to_rgb(self.colorscale[-1][1])
             else:
                 min_col = [255, 255, 255]
                 max_col = [255, 255, 255]

--- a/plotly/figure_factory/_dendrogram.py
+++ b/plotly/figure_factory/_dendrogram.py
@@ -124,10 +124,10 @@ class _Dendrogram(object):
             distfun = scs.distance.pdist
 
         (dd_traces, xvals, yvals,
-         ordered_labels, leaves) = self.get_dendrogram_traces(X, colorscale,
-                                                              distfun,
-                                                              linkagefun,
-                                                              hovertext)
+            ordered_labels, leaves) = self.get_dendrogram_traces(X, colorscale,
+                                                                 distfun,
+                                                                 linkagefun, 
+                                                                 hovertext)
 
         self.labels = ordered_labels
         self.leaves = leaves
@@ -193,17 +193,17 @@ class _Dendrogram(object):
 
         """
         axis_defaults = {
-            'type': 'linear',
-            'ticks': 'outside',
-            'mirror': 'allticks',
-            'rangemode': 'tozero',
-            'showticklabels': True,
-            'zeroline': False,
-            'showgrid': False,
-            'showline': True,
+                'type': 'linear',
+                'ticks': 'outside',
+                'mirror': 'allticks',
+                'rangemode': 'tozero',
+                'showticklabels': True,
+                'zeroline': False,
+                'showgrid': False,
+                'showline': True,
             }
 
-        if self.labels:
+        if len(self.labels) != 0:
             axis_key_labels = self.xaxis
             if self.orientation in ['left', 'right']:
                 axis_key_labels = self.yaxis

--- a/plotly/figure_factory/_facet_grid.py
+++ b/plotly/figure_factory/_facet_grid.py
@@ -149,12 +149,12 @@ def _add_shapes_to_fig(fig, annot_rect_color, flipped_rows=False,
     for key in fig['layout'].keys():
         if 'axis' in key and fig['layout'][key]['domain'] != [0.0, 1.0]:
             shape = {
-                'fillcolor': annot_rect_color,
-                'layer': 'below',
-                'line': {'color': annot_rect_color, 'width': 1},
-                'type': 'rect',
-                'xref': 'paper',
-                'yref': 'paper'
+               'fillcolor': annot_rect_color,
+               'layer': 'below',
+               'line': {'color': annot_rect_color, 'width': 1},
+               'type': 'rect',
+               'xref': 'paper',
+               'yref': 'paper'
             }
 
             if 'xaxis' in key:
@@ -1052,7 +1052,7 @@ def create_facet_grid(df, x=None, y=None, facet_row=None, facet_col=None,
         min_ranges = []
         max_ranges = []
         for trace in fig['data']:
-            if trace[x_y] is not None and trace[x_y]:
+            if trace[x_y] is not None and len(trace[x_y]) > 0:
                 min_ranges.append(min(trace[x_y]))
                 max_ranges.append(max(trace[x_y]))
         while None in min_ranges:

--- a/plotly/figure_factory/_scatterplot.py
+++ b/plotly/figure_factory/_scatterplot.py
@@ -206,8 +206,8 @@ def scatterplot(dataframe, headers, diag, size, height, width, title,
 
 
 def scatterplot_dict(dataframe, headers, diag, size,
-                     height, width, title, index, index_vals,
-                     endpts, colormap, colormap_type, **kwargs):
+                      height, width, title, index, index_vals,
+                      endpts, colormap, colormap_type, **kwargs):
     """
     Refer to FigureFactory.create_scatterplotmatrix() for docstring
 

--- a/plotly/figure_factory/utils.py
+++ b/plotly/figure_factory/utils.py
@@ -421,10 +421,10 @@ def validate_scale_values(scale):
         )
 
     if not all(x < y for x, y in zip(scale, scale[1:])):
-        raise exceptions.PlotlyError(
-            "'scale' must be a list that contains a strictly increasing "
-            "sequence of numbers."
-        )
+            raise exceptions.PlotlyError(
+                "'scale' must be a list that contains a strictly increasing "
+                "sequence of numbers."
+            )
 
 
 def validate_colorscale(colorscale):

--- a/plotly/graph_objs/graph_objs.py
+++ b/plotly/graph_objs/graph_objs.py
@@ -886,11 +886,11 @@ class Box(PlotlyDict):
     Valid attributes for 'box' at path [] under parents ():
     
         ['boxmean', 'boxpoints', 'customdata', 'customdatasrc', 'fillcolor',
-        'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc', 'jitter',
-        'legendgroup', 'line', 'marker', 'name', 'opacity', 'orientation',
-        'pointpos', 'showlegend', 'stream', 'type', 'uid', 'visible',
-        'whiskerwidth', 'x', 'x0', 'xaxis', 'xcalendar', 'xsrc', 'y', 'y0',
-        'yaxis', 'ycalendar', 'ysrc']
+        'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'hoveron', 'ids', 'idssrc',
+        'jitter', 'legendgroup', 'line', 'marker', 'name', 'opacity',
+        'orientation', 'pointpos', 'showlegend', 'stream', 'text', 'textsrc',
+        'type', 'uid', 'visible', 'whiskerwidth', 'x', 'x0', 'xaxis',
+        'xcalendar', 'xsrc', 'y', 'y0', 'yaxis', 'ycalendar', 'ysrc']
     
     Run `<box-object>.help('attribute')` on any of the above.
     '<box-object>' is the object at []
@@ -960,11 +960,11 @@ class ColorBar(PlotlyDict):
         'len', 'lenmode', 'nticks', 'outlinecolor', 'outlinewidth',
         'separatethousands', 'showexponent', 'showticklabels',
         'showtickprefix', 'showticksuffix', 'thickness', 'thicknessmode',
-        'tick0', 'tickangle', 'tickcolor', 'tickfont', 'tickformat', 'ticklen',
-        'tickmode', 'tickprefix', 'ticks', 'ticksuffix', 'ticktext',
-        'ticktextsrc', 'tickvals', 'tickvalssrc', 'tickwidth', 'title',
-        'titlefont', 'titleside', 'x', 'xanchor', 'xpad', 'y', 'yanchor',
-        'ypad']
+        'tick0', 'tickangle', 'tickcolor', 'tickfont', 'tickformat',
+        'tickformatstops', 'ticklen', 'tickmode', 'tickprefix', 'ticks',
+        'ticksuffix', 'ticktext', 'ticktextsrc', 'tickvals', 'tickvalssrc',
+        'tickwidth', 'title', 'titlefont', 'titleside', 'x', 'xanchor', 'xpad',
+        'y', 'yanchor', 'ypad']
     
     Run `<colorbar-object>.help('attribute')` on any of the above.
     '<colorbar-object>' is the object at []
@@ -984,7 +984,7 @@ class Contour(PlotlyDict):
         'showlegend', 'showscale', 'stream', 'text', 'textsrc', 'transpose',
         'type', 'uid', 'visible', 'x', 'x0', 'xaxis', 'xcalendar', 'xsrc',
         'xtype', 'y', 'y0', 'yaxis', 'ycalendar', 'ysrc', 'ytype', 'z',
-        'zauto', 'zmax', 'zmin', 'zsrc']
+        'zauto', 'zhoverformat', 'zmax', 'zmin', 'zsrc']
     
     Run `<contour-object>.help('attribute')` on any of the above.
     '<contour-object>' is the object at []
@@ -1331,7 +1331,8 @@ class Heatmap(PlotlyDict):
         'reversescale', 'showlegend', 'showscale', 'stream', 'text', 'textsrc',
         'transpose', 'type', 'uid', 'visible', 'x', 'x0', 'xaxis', 'xcalendar',
         'xgap', 'xsrc', 'xtype', 'y', 'y0', 'yaxis', 'ycalendar', 'ygap',
-        'ysrc', 'ytype', 'z', 'zauto', 'zmax', 'zmin', 'zsmooth', 'zsrc']
+        'ysrc', 'ytype', 'z', 'zauto', 'zhoverformat', 'zmax', 'zmin',
+        'zsmooth', 'zsrc']
     
     Run `<heatmap-object>.help('attribute')` on any of the above.
     '<heatmap-object>' is the object at []
@@ -1387,7 +1388,8 @@ class Histogram2d(PlotlyDict):
         'name', 'nbinsx', 'nbinsy', 'opacity', 'reversescale', 'showlegend',
         'showscale', 'stream', 'type', 'uid', 'visible', 'x', 'xaxis', 'xbins',
         'xcalendar', 'xgap', 'xsrc', 'y', 'yaxis', 'ybins', 'ycalendar',
-        'ygap', 'ysrc', 'z', 'zauto', 'zmax', 'zmin', 'zsmooth', 'zsrc']
+        'ygap', 'ysrc', 'z', 'zauto', 'zhoverformat', 'zmax', 'zmin',
+        'zsmooth', 'zsrc']
     
     Run `<histogram2d-object>.help('attribute')` on any of the above.
     '<histogram2d-object>' is the object at []
@@ -1407,7 +1409,7 @@ class Histogram2dContour(PlotlyDict):
         'ncontours', 'opacity', 'reversescale', 'showlegend', 'showscale',
         'stream', 'type', 'uid', 'visible', 'x', 'xaxis', 'xbins', 'xcalendar',
         'xsrc', 'y', 'yaxis', 'ybins', 'ycalendar', 'ysrc', 'z', 'zauto',
-        'zmax', 'zmin', 'zsrc']
+        'zhoverformat', 'zmax', 'zmin', 'zsrc']
     
     Run `<histogram2dcontour-object>.help('attribute')` on any of the above.
     '<histogram2dcontour-object>' is the object at []
@@ -1427,7 +1429,7 @@ class Histogram2dcontour(PlotlyDict):
         'ncontours', 'opacity', 'reversescale', 'showlegend', 'showscale',
         'stream', 'type', 'uid', 'visible', 'x', 'xaxis', 'xbins', 'xcalendar',
         'xsrc', 'y', 'yaxis', 'ybins', 'ycalendar', 'ysrc', 'z', 'zauto',
-        'zmax', 'zmin', 'zsrc']
+        'zhoverformat', 'zmax', 'zmin', 'zsrc']
     
     Run `<histogram2dcontour-object>.help('attribute')` on any of the above.
     '<histogram2dcontour-object>' is the object at []
@@ -1446,7 +1448,7 @@ class Layout(PlotlyDict):
         'hiddenlabelssrc', 'hidesources', 'hoverlabel', 'hovermode', 'images',
         'legend', 'mapbox', 'margin', 'orientation', 'paper_bgcolor',
         'plot_bgcolor', 'radialaxis', 'scene', 'separators', 'shapes',
-        'showlegend', 'sliders', 'smith', 'ternary', 'title', 'titlefont',
+        'showlegend', 'sliders', 'ternary', 'title', 'titlefont',
         'updatemenus', 'width', 'xaxis', 'yaxis']
     
     Run `<layout-object>.help('attribute')` on any of the above.
@@ -1854,10 +1856,11 @@ class XAxis(PlotlyDict):
         'showexponent', 'showgrid', 'showline', 'showspikes', 'showticklabels',
         'showtickprefix', 'showticksuffix', 'side', 'spikecolor', 'spikedash',
         'spikemode', 'spikesides', 'spikethickness', 'tick0', 'tickangle',
-        'tickcolor', 'tickfont', 'tickformat', 'ticklen', 'tickmode',
-        'tickprefix', 'ticks', 'ticksuffix', 'ticktext', 'ticktextsrc',
-        'tickvals', 'tickvalssrc', 'tickwidth', 'title', 'titlefont', 'type',
-        'visible', 'zeroline', 'zerolinecolor', 'zerolinewidth']
+        'tickcolor', 'tickfont', 'tickformat', 'tickformatstops', 'ticklen',
+        'tickmode', 'tickprefix', 'ticks', 'ticksuffix', 'ticktext',
+        'ticktextsrc', 'tickvals', 'tickvalssrc', 'tickwidth', 'title',
+        'titlefont', 'type', 'visible', 'zeroline', 'zerolinecolor',
+        'zerolinewidth']
     
     Run `<xaxis-object>.help('attribute')` on any of the above.
     '<xaxis-object>' is the object at []
@@ -1893,10 +1896,10 @@ class YAxis(PlotlyDict):
         'showline', 'showspikes', 'showticklabels', 'showtickprefix',
         'showticksuffix', 'side', 'spikecolor', 'spikedash', 'spikemode',
         'spikesides', 'spikethickness', 'tick0', 'tickangle', 'tickcolor',
-        'tickfont', 'tickformat', 'ticklen', 'tickmode', 'tickprefix', 'ticks',
-        'ticksuffix', 'ticktext', 'ticktextsrc', 'tickvals', 'tickvalssrc',
-        'tickwidth', 'title', 'titlefont', 'type', 'visible', 'zeroline',
-        'zerolinecolor', 'zerolinewidth']
+        'tickfont', 'tickformat', 'tickformatstops', 'ticklen', 'tickmode',
+        'tickprefix', 'ticks', 'ticksuffix', 'ticktext', 'ticktextsrc',
+        'tickvals', 'tickvalssrc', 'tickwidth', 'title', 'titlefont', 'type',
+        'visible', 'zeroline', 'zerolinecolor', 'zerolinewidth']
     
     Run `<yaxis-object>.help('attribute')` on any of the above.
     '<yaxis-object>' is the object at []
@@ -1930,10 +1933,10 @@ class ZAxis(PlotlyDict):
         'showexponent', 'showgrid', 'showline', 'showspikes', 'showticklabels',
         'showtickprefix', 'showticksuffix', 'spikecolor', 'spikesides',
         'spikethickness', 'tick0', 'tickangle', 'tickcolor', 'tickfont',
-        'tickformat', 'ticklen', 'tickmode', 'tickprefix', 'ticks',
-        'ticksuffix', 'ticktext', 'ticktextsrc', 'tickvals', 'tickvalssrc',
-        'tickwidth', 'title', 'titlefont', 'type', 'visible', 'zeroline',
-        'zerolinecolor', 'zerolinewidth']
+        'tickformat', 'tickformatstops', 'ticklen', 'tickmode', 'tickprefix',
+        'ticks', 'ticksuffix', 'ticktext', 'ticktextsrc', 'tickvals',
+        'tickvalssrc', 'tickwidth', 'title', 'titlefont', 'type', 'visible',
+        'zeroline', 'zerolinecolor', 'zerolinewidth']
     
     Run `<zaxis-object>.help('attribute')` on any of the above.
     '<zaxis-object>' is the object at []

--- a/plotly/graph_objs/graph_objs.py
+++ b/plotly/graph_objs/graph_objs.py
@@ -310,7 +310,7 @@ class PlotlyList(list, PlotlyBase):
     def to_string(self, level=0, indent=4, eol='\n',
                   pretty=True, max_chars=80):
         """Get formatted string by calling `to_string` on children items."""
-        if not self:
+        if not len(self):
             return "{name}()".format(name=self._get_class_name())
         string = "{name}([{eol}{indent}".format(
             name=self._get_class_name(),
@@ -691,7 +691,7 @@ class PlotlyDict(dict, PlotlyBase):
             print(obj.to_string())
 
         """
-        if not self:
+        if not len(self):
             return "{name}()".format(name=self._get_class_name())
         string = "{name}(".format(name=self._get_class_name())
         if self._name in graph_reference.TRACE_NAMES:
@@ -759,7 +759,7 @@ class PlotlyDict(dict, PlotlyBase):
             except AttributeError:
                 pass
             if isinstance(self[key], (dict, list)):
-                if not self[key]:
+                if len(self[key]) == 0:
                     del self[key]  # clears empty collections!
             elif self[key] is None:
                 del self[key]
@@ -805,10 +805,10 @@ class GraphObjectFactory(object):
 class AngularAxis(PlotlyDict):
     """
     Valid attributes for 'angularaxis' at path [] under parents ():
-
+    
         ['domain', 'endpadding', 'range', 'showline', 'showticklabels',
         'tickcolor', 'ticklen', 'tickorientation', 'ticksuffix', 'visible']
-
+    
     Run `<angularaxis-object>.help('attribute')` on any of the above.
     '<angularaxis-object>' is the object at []
 
@@ -819,7 +819,7 @@ class AngularAxis(PlotlyDict):
 class Annotation(PlotlyDict):
     """
     Valid attributes for 'annotation' at path [] under parents ():
-
+    
         ['align', 'arrowcolor', 'arrowhead', 'arrowsize', 'arrowwidth', 'ax',
         'axref', 'ay', 'ayref', 'bgcolor', 'bordercolor', 'borderpad',
         'borderwidth', 'captureevents', 'clicktoshow', 'font', 'height',
@@ -827,7 +827,7 @@ class Annotation(PlotlyDict):
         'text', 'textangle', 'valign', 'visible', 'width', 'x', 'xanchor',
         'xclick', 'xref', 'xshift', 'y', 'yanchor', 'yclick', 'yref', 'yshift',
         'z']
-
+    
     Run `<annotation-object>.help('attribute')` on any of the above.
     '<annotation-object>' is the object at []
 
@@ -847,12 +847,12 @@ class Annotations(PlotlyList):
 class Area(PlotlyDict):
     """
     Valid attributes for 'area' at path [] under parents ():
-
+    
         ['customdata', 'customdatasrc', 'hoverinfo', 'hoverinfosrc',
         'hoverlabel', 'ids', 'idssrc', 'legendgroup', 'marker', 'name',
         'opacity', 'r', 'rsrc', 'showlegend', 'stream', 't', 'tsrc', 'type',
         'uid', 'visible']
-
+    
     Run `<area-object>.help('attribute')` on any of the above.
     '<area-object>' is the object at []
 
@@ -863,7 +863,7 @@ class Area(PlotlyDict):
 class Bar(PlotlyDict):
     """
     Valid attributes for 'bar' at path [] under parents ():
-
+    
         ['bardir', 'base', 'basesrc', 'constraintext', 'customdata',
         'customdatasrc', 'dx', 'dy', 'error_x', 'error_y', 'hoverinfo',
         'hoverinfosrc', 'hoverlabel', 'hovertext', 'hovertextsrc', 'ids',
@@ -873,7 +873,7 @@ class Bar(PlotlyDict):
         'textpositionsrc', 'textsrc', 'tsrc', 'type', 'uid', 'visible',
         'width', 'widthsrc', 'x', 'x0', 'xaxis', 'xcalendar', 'xsrc', 'y',
         'y0', 'yaxis', 'ycalendar', 'ysrc']
-
+    
     Run `<bar-object>.help('attribute')` on any of the above.
     '<bar-object>' is the object at []
 
@@ -884,14 +884,14 @@ class Bar(PlotlyDict):
 class Box(PlotlyDict):
     """
     Valid attributes for 'box' at path [] under parents ():
-
+    
         ['boxmean', 'boxpoints', 'customdata', 'customdatasrc', 'fillcolor',
         'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc', 'jitter',
         'legendgroup', 'line', 'marker', 'name', 'opacity', 'orientation',
         'pointpos', 'showlegend', 'stream', 'type', 'uid', 'visible',
         'whiskerwidth', 'x', 'x0', 'xaxis', 'xcalendar', 'xsrc', 'y', 'y0',
         'yaxis', 'ycalendar', 'ysrc']
-
+    
     Run `<box-object>.help('attribute')` on any of the above.
     '<box-object>' is the object at []
 
@@ -902,14 +902,14 @@ class Box(PlotlyDict):
 class Candlestick(PlotlyDict):
     """
     Valid attributes for 'candlestick' at path [] under parents ():
-
+    
         ['close', 'closesrc', 'customdata', 'customdatasrc', 'decreasing',
         'high', 'highsrc', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids',
         'idssrc', 'increasing', 'legendgroup', 'line', 'low', 'lowsrc', 'name',
         'opacity', 'open', 'opensrc', 'showlegend', 'stream', 'text',
         'textsrc', 'type', 'uid', 'visible', 'whiskerwidth', 'x', 'xaxis',
         'xcalendar', 'xsrc', 'yaxis']
-
+    
     Run `<candlestick-object>.help('attribute')` on any of the above.
     '<candlestick-object>' is the object at []
 
@@ -920,13 +920,13 @@ class Candlestick(PlotlyDict):
 class Carpet(PlotlyDict):
     """
     Valid attributes for 'carpet' at path [] under parents ():
-
+    
         ['a', 'a0', 'aaxis', 'asrc', 'b', 'b0', 'baxis', 'bsrc', 'carpet',
         'cheaterslope', 'color', 'customdata', 'customdatasrc', 'da', 'db',
         'font', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc',
         'legendgroup', 'name', 'opacity', 'showlegend', 'stream', 'type',
         'uid', 'visible', 'x', 'xaxis', 'xsrc', 'y', 'yaxis', 'ysrc']
-
+    
     Run `<carpet-object>.help('attribute')` on any of the above.
     '<carpet-object>' is the object at []
 
@@ -937,14 +937,14 @@ class Carpet(PlotlyDict):
 class Choropleth(PlotlyDict):
     """
     Valid attributes for 'choropleth' at path [] under parents ():
-
+    
         ['autocolorscale', 'colorbar', 'colorscale', 'customdata',
         'customdatasrc', 'geo', 'hoverinfo', 'hoverinfosrc', 'hoverlabel',
         'ids', 'idssrc', 'legendgroup', 'locationmode', 'locations',
         'locationssrc', 'marker', 'name', 'opacity', 'reversescale',
         'showlegend', 'showscale', 'stream', 'text', 'textsrc', 'type', 'uid',
         'visible', 'z', 'zauto', 'zmax', 'zmin', 'zsrc']
-
+    
     Run `<choropleth-object>.help('attribute')` on any of the above.
     '<choropleth-object>' is the object at []
 
@@ -955,7 +955,7 @@ class Choropleth(PlotlyDict):
 class ColorBar(PlotlyDict):
     """
     Valid attributes for 'colorbar' at path [] under parents ():
-
+    
         ['bgcolor', 'bordercolor', 'borderwidth', 'dtick', 'exponentformat',
         'len', 'lenmode', 'nticks', 'outlinecolor', 'outlinewidth',
         'separatethousands', 'showexponent', 'showticklabels',
@@ -965,7 +965,7 @@ class ColorBar(PlotlyDict):
         'ticktextsrc', 'tickvals', 'tickvalssrc', 'tickwidth', 'title',
         'titlefont', 'titleside', 'x', 'xanchor', 'xpad', 'y', 'yanchor',
         'ypad']
-
+    
     Run `<colorbar-object>.help('attribute')` on any of the above.
     '<colorbar-object>' is the object at []
 
@@ -976,7 +976,7 @@ class ColorBar(PlotlyDict):
 class Contour(PlotlyDict):
     """
     Valid attributes for 'contour' at path [] under parents ():
-
+    
         ['autocolorscale', 'autocontour', 'colorbar', 'colorscale',
         'connectgaps', 'contours', 'customdata', 'customdatasrc', 'dx', 'dy',
         'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc',
@@ -985,7 +985,7 @@ class Contour(PlotlyDict):
         'type', 'uid', 'visible', 'x', 'x0', 'xaxis', 'xcalendar', 'xsrc',
         'xtype', 'y', 'y0', 'yaxis', 'ycalendar', 'ysrc', 'ytype', 'z',
         'zauto', 'zmax', 'zmin', 'zsrc']
-
+    
     Run `<contour-object>.help('attribute')` on any of the above.
     '<contour-object>' is the object at []
 
@@ -996,7 +996,7 @@ class Contour(PlotlyDict):
 class Contourcarpet(PlotlyDict):
     """
     Valid attributes for 'contourcarpet' at path [] under parents ():
-
+    
         ['a', 'a0', 'asrc', 'atype', 'autocolorscale', 'autocontour', 'b',
         'b0', 'bsrc', 'btype', 'carpet', 'colorbar', 'colorscale',
         'connectgaps', 'contours', 'customdata', 'customdatasrc', 'da', 'db',
@@ -1005,7 +1005,7 @@ class Contourcarpet(PlotlyDict):
         'opacity', 'reversescale', 'showlegend', 'showscale', 'stream', 'text',
         'textsrc', 'transpose', 'type', 'uid', 'visible', 'xaxis', 'yaxis',
         'z', 'zauto', 'zmax', 'zmin', 'zsrc']
-
+    
     Run `<contourcarpet-object>.help('attribute')` on any of the above.
     '<contourcarpet-object>' is the object at []
 
@@ -1016,11 +1016,11 @@ class Contourcarpet(PlotlyDict):
 class Contours(PlotlyDict):
     """
     Valid attributes for 'contours' at path [] under parents ():
-
+    
         ['coloring', 'end', 'labelfont', 'labelformat', 'operation',
         'showlabels', 'showlines', 'size', 'start', 'type', 'value', 'x', 'y',
         'z']
-
+    
     Run `<contours-object>.help('attribute')` on any of the above.
     '<contours-object>' is the object at []
 
@@ -1102,12 +1102,12 @@ class Data(PlotlyList):
 class ErrorX(PlotlyDict):
     """
     Valid attributes for 'error_x' at path [] under parents ():
-
+    
         ['array', 'arrayminus', 'arrayminussrc', 'arraysrc', 'color',
         'copy_ystyle', 'copy_zstyle', 'opacity', 'symmetric', 'thickness',
         'traceref', 'tracerefminus', 'type', 'value', 'valueminus', 'visible',
         'width']
-
+    
     Run `<error_x-object>.help('attribute')` on any of the above.
     '<error_x-object>' is the object at []
 
@@ -1118,12 +1118,12 @@ class ErrorX(PlotlyDict):
 class ErrorY(PlotlyDict):
     """
     Valid attributes for 'error_y' at path [] under parents ():
-
+    
         ['array', 'arrayminus', 'arrayminussrc', 'arraysrc', 'color',
         'copy_ystyle', 'copy_zstyle', 'opacity', 'symmetric', 'thickness',
         'traceref', 'tracerefminus', 'type', 'value', 'valueminus', 'visible',
         'width']
-
+    
     Run `<error_y-object>.help('attribute')` on any of the above.
     '<error_y-object>' is the object at []
 
@@ -1134,12 +1134,12 @@ class ErrorY(PlotlyDict):
 class ErrorZ(PlotlyDict):
     """
     Valid attributes for 'error_z' at path [] under parents ():
-
+    
         ['array', 'arrayminus', 'arrayminussrc', 'arraysrc', 'color',
         'copy_ystyle', 'copy_zstyle', 'opacity', 'symmetric', 'thickness',
         'traceref', 'tracerefminus', 'type', 'value', 'valueminus', 'visible',
         'width']
-
+    
     Run `<error_z-object>.help('attribute')` on any of the above.
     '<error_z-object>' is the object at []
 
@@ -1150,9 +1150,9 @@ class ErrorZ(PlotlyDict):
 class Figure(PlotlyDict):
     """
     Valid attributes for 'figure' at path [] under parents ():
-
+    
         ['data', 'frames', 'layout']
-
+    
     Run `<figure-object>.help('attribute')` on any of the above.
     '<figure-object>' is the object at []
 
@@ -1270,9 +1270,9 @@ class Figure(PlotlyDict):
 class Font(PlotlyDict):
     """
     Valid attributes for 'font' at path [] under parents ():
-
+    
         ['color', 'colorsrc', 'family', 'familysrc', 'size', 'sizesrc']
-
+    
     Run `<font-object>.help('attribute')` on any of the above.
     '<font-object>' is the object at []
 
@@ -1297,7 +1297,7 @@ class Frames(PlotlyList):
     def to_string(self, level=0, indent=4, eol='\n',
                   pretty=True, max_chars=80):
         """Get formatted string by calling `to_string` on children items."""
-        if not self:
+        if not len(self):
             return "{name}()".format(name=self._get_class_name())
         string = "{name}([{eol}{indent}".format(
             name=self._get_class_name(),
@@ -1324,7 +1324,7 @@ class Frames(PlotlyList):
 class Heatmap(PlotlyDict):
     """
     Valid attributes for 'heatmap' at path [] under parents ():
-
+    
         ['autocolorscale', 'colorbar', 'colorscale', 'connectgaps',
         'customdata', 'customdatasrc', 'dx', 'dy', 'hoverinfo', 'hoverinfosrc',
         'hoverlabel', 'ids', 'idssrc', 'legendgroup', 'name', 'opacity',
@@ -1332,7 +1332,7 @@ class Heatmap(PlotlyDict):
         'transpose', 'type', 'uid', 'visible', 'x', 'x0', 'xaxis', 'xcalendar',
         'xgap', 'xsrc', 'xtype', 'y', 'y0', 'yaxis', 'ycalendar', 'ygap',
         'ysrc', 'ytype', 'z', 'zauto', 'zmax', 'zmin', 'zsmooth', 'zsrc']
-
+    
     Run `<heatmap-object>.help('attribute')` on any of the above.
     '<heatmap-object>' is the object at []
 
@@ -1343,14 +1343,14 @@ class Heatmap(PlotlyDict):
 class Heatmapgl(PlotlyDict):
     """
     Valid attributes for 'heatmapgl' at path [] under parents ():
-
+    
         ['autocolorscale', 'colorbar', 'colorscale', 'customdata',
         'customdatasrc', 'dx', 'dy', 'hoverinfo', 'hoverinfosrc', 'hoverlabel',
         'ids', 'idssrc', 'legendgroup', 'name', 'opacity', 'reversescale',
         'showlegend', 'showscale', 'stream', 'text', 'textsrc', 'transpose',
         'type', 'uid', 'visible', 'x', 'x0', 'xaxis', 'xsrc', 'xtype', 'y',
         'y0', 'yaxis', 'ysrc', 'ytype', 'z', 'zauto', 'zmax', 'zmin', 'zsrc']
-
+    
     Run `<heatmapgl-object>.help('attribute')` on any of the above.
     '<heatmapgl-object>' is the object at []
 
@@ -1361,7 +1361,7 @@ class Heatmapgl(PlotlyDict):
 class Histogram(PlotlyDict):
     """
     Valid attributes for 'histogram' at path [] under parents ():
-
+    
         ['autobinx', 'autobiny', 'bardir', 'cumulative', 'customdata',
         'customdatasrc', 'error_x', 'error_y', 'histfunc', 'histnorm',
         'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc',
@@ -1369,7 +1369,7 @@ class Histogram(PlotlyDict):
         'orientation', 'showlegend', 'stream', 'text', 'textsrc', 'type',
         'uid', 'visible', 'x', 'xaxis', 'xbins', 'xcalendar', 'xsrc', 'y',
         'yaxis', 'ybins', 'ycalendar', 'ysrc']
-
+    
     Run `<histogram-object>.help('attribute')` on any of the above.
     '<histogram-object>' is the object at []
 
@@ -1380,7 +1380,7 @@ class Histogram(PlotlyDict):
 class Histogram2d(PlotlyDict):
     """
     Valid attributes for 'histogram2d' at path [] under parents ():
-
+    
         ['autobinx', 'autobiny', 'autocolorscale', 'colorbar', 'colorscale',
         'customdata', 'customdatasrc', 'histfunc', 'histnorm', 'hoverinfo',
         'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc', 'legendgroup', 'marker',
@@ -1388,7 +1388,7 @@ class Histogram2d(PlotlyDict):
         'showscale', 'stream', 'type', 'uid', 'visible', 'x', 'xaxis', 'xbins',
         'xcalendar', 'xgap', 'xsrc', 'y', 'yaxis', 'ybins', 'ycalendar',
         'ygap', 'ysrc', 'z', 'zauto', 'zmax', 'zmin', 'zsmooth', 'zsrc']
-
+    
     Run `<histogram2d-object>.help('attribute')` on any of the above.
     '<histogram2d-object>' is the object at []
 
@@ -1399,7 +1399,7 @@ class Histogram2d(PlotlyDict):
 class Histogram2dContour(PlotlyDict):
     """
     Valid attributes for 'histogram2dcontour' at path [] under parents ():
-
+    
         ['autobinx', 'autobiny', 'autocolorscale', 'autocontour', 'colorbar',
         'colorscale', 'contours', 'customdata', 'customdatasrc', 'histfunc',
         'histnorm', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc',
@@ -1408,7 +1408,7 @@ class Histogram2dContour(PlotlyDict):
         'stream', 'type', 'uid', 'visible', 'x', 'xaxis', 'xbins', 'xcalendar',
         'xsrc', 'y', 'yaxis', 'ybins', 'ycalendar', 'ysrc', 'z', 'zauto',
         'zmax', 'zmin', 'zsrc']
-
+    
     Run `<histogram2dcontour-object>.help('attribute')` on any of the above.
     '<histogram2dcontour-object>' is the object at []
 
@@ -1419,7 +1419,7 @@ class Histogram2dContour(PlotlyDict):
 class Histogram2dcontour(PlotlyDict):
     """
     Valid attributes for 'histogram2dcontour' at path [] under parents ():
-
+    
         ['autobinx', 'autobiny', 'autocolorscale', 'autocontour', 'colorbar',
         'colorscale', 'contours', 'customdata', 'customdatasrc', 'histfunc',
         'histnorm', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc',
@@ -1428,7 +1428,7 @@ class Histogram2dcontour(PlotlyDict):
         'stream', 'type', 'uid', 'visible', 'x', 'xaxis', 'xbins', 'xcalendar',
         'xsrc', 'y', 'yaxis', 'ybins', 'ycalendar', 'ysrc', 'z', 'zauto',
         'zmax', 'zmin', 'zsrc']
-
+    
     Run `<histogram2dcontour-object>.help('attribute')` on any of the above.
     '<histogram2dcontour-object>' is the object at []
 
@@ -1439,7 +1439,7 @@ class Histogram2dcontour(PlotlyDict):
 class Layout(PlotlyDict):
     """
     Valid attributes for 'layout' at path [] under parents ():
-
+    
         ['angularaxis', 'annotations', 'autosize', 'bargap', 'bargroupgap',
         'barmode', 'barnorm', 'boxgap', 'boxgroupgap', 'boxmode', 'calendar',
         'direction', 'dragmode', 'font', 'geo', 'height', 'hiddenlabels',
@@ -1448,7 +1448,7 @@ class Layout(PlotlyDict):
         'plot_bgcolor', 'radialaxis', 'scene', 'separators', 'shapes',
         'showlegend', 'sliders', 'smith', 'ternary', 'title', 'titlefont',
         'updatemenus', 'width', 'xaxis', 'yaxis']
-
+    
     Run `<layout-object>.help('attribute')` on any of the above.
     '<layout-object>' is the object at []
 
@@ -1459,10 +1459,10 @@ class Layout(PlotlyDict):
 class Legend(PlotlyDict):
     """
     Valid attributes for 'legend' at path [] under parents ():
-
+    
         ['bgcolor', 'bordercolor', 'borderwidth', 'font', 'orientation',
         'tracegroupgap', 'traceorder', 'x', 'xanchor', 'y', 'yanchor']
-
+    
     Run `<legend-object>.help('attribute')` on any of the above.
     '<legend-object>' is the object at []
 
@@ -1473,12 +1473,12 @@ class Legend(PlotlyDict):
 class Line(PlotlyDict):
     """
     Valid attributes for 'line' at path [] under parents ():
-
+    
         ['autocolorscale', 'cauto', 'cmax', 'cmin', 'color', 'colorbar',
         'colorscale', 'colorsrc', 'dash', 'outliercolor', 'outlierwidth',
         'reversescale', 'shape', 'showscale', 'simplify', 'smoothing', 'width',
         'widthsrc']
-
+    
     Run `<line-object>.help('attribute')` on any of the above.
     '<line-object>' is the object at []
 
@@ -1489,9 +1489,9 @@ class Line(PlotlyDict):
 class Margin(PlotlyDict):
     """
     Valid attributes for 'margin' at path [] under parents ():
-
+    
         ['autoexpand', 'b', 'l', 'pad', 'r', 't']
-
+    
     Run `<margin-object>.help('attribute')` on any of the above.
     '<margin-object>' is the object at []
 
@@ -1502,13 +1502,13 @@ class Margin(PlotlyDict):
 class Marker(PlotlyDict):
     """
     Valid attributes for 'marker' at path [] under parents ():
-
+    
         ['autocolorscale', 'blend', 'border', 'cauto', 'cmax', 'cmin', 'color',
         'colorbar', 'colors', 'colorscale', 'colorsrc', 'colorssrc',
         'gradient', 'line', 'maxdisplayed', 'opacity', 'opacitysrc',
         'outliercolor', 'reversescale', 'showscale', 'size', 'sizemax',
         'sizemin', 'sizemode', 'sizeref', 'sizesrc', 'symbol', 'symbolsrc']
-
+    
     Run `<marker-object>.help('attribute')` on any of the above.
     '<marker-object>' is the object at []
 
@@ -1519,7 +1519,7 @@ class Marker(PlotlyDict):
 class Mesh3d(PlotlyDict):
     """
     Valid attributes for 'mesh3d' at path [] under parents ():
-
+    
         ['alphahull', 'autocolorscale', 'cauto', 'cmax', 'cmin', 'color',
         'colorbar', 'colorscale', 'contour', 'customdata', 'customdatasrc',
         'delaunayaxis', 'facecolor', 'facecolorsrc', 'flatshading',
@@ -1529,7 +1529,7 @@ class Mesh3d(PlotlyDict):
         'reversescale', 'scene', 'showlegend', 'showscale', 'stream', 'type',
         'uid', 'vertexcolor', 'vertexcolorsrc', 'visible', 'x', 'xcalendar',
         'xsrc', 'y', 'ycalendar', 'ysrc', 'z', 'zcalendar', 'zsrc']
-
+    
     Run `<mesh3d-object>.help('attribute')` on any of the above.
     '<mesh3d-object>' is the object at []
 
@@ -1540,14 +1540,14 @@ class Mesh3d(PlotlyDict):
 class Ohlc(PlotlyDict):
     """
     Valid attributes for 'ohlc' at path [] under parents ():
-
+    
         ['close', 'closesrc', 'customdata', 'customdatasrc', 'decreasing',
         'high', 'highsrc', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids',
         'idssrc', 'increasing', 'legendgroup', 'line', 'low', 'lowsrc', 'name',
         'opacity', 'open', 'opensrc', 'showlegend', 'stream', 'text',
         'textsrc', 'tickwidth', 'type', 'uid', 'visible', 'x', 'xaxis',
         'xcalendar', 'xsrc', 'yaxis']
-
+    
     Run `<ohlc-object>.help('attribute')` on any of the above.
     '<ohlc-object>' is the object at []
 
@@ -1558,12 +1558,12 @@ class Ohlc(PlotlyDict):
 class Parcoords(PlotlyDict):
     """
     Valid attributes for 'parcoords' at path [] under parents ():
-
+    
         ['customdata', 'customdatasrc', 'dimensions', 'domain', 'hoverinfo',
         'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc', 'labelfont',
         'legendgroup', 'line', 'name', 'opacity', 'rangefont', 'showlegend',
         'stream', 'tickfont', 'type', 'uid', 'visible']
-
+    
     Run `<parcoords-object>.help('attribute')` on any of the above.
     '<parcoords-object>' is the object at []
 
@@ -1574,7 +1574,7 @@ class Parcoords(PlotlyDict):
 class Pie(PlotlyDict):
     """
     Valid attributes for 'pie' at path [] under parents ():
-
+    
         ['customdata', 'customdatasrc', 'direction', 'dlabel', 'domain',
         'hole', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'hovertext',
         'hovertextsrc', 'ids', 'idssrc', 'insidetextfont', 'label0', 'labels',
@@ -1583,7 +1583,7 @@ class Pie(PlotlyDict):
         'showlegend', 'sort', 'stream', 'text', 'textfont', 'textinfo',
         'textposition', 'textpositionsrc', 'textsrc', 'type', 'uid', 'values',
         'valuessrc', 'visible']
-
+    
     Run `<pie-object>.help('attribute')` on any of the above.
     '<pie-object>' is the object at []
 
@@ -1594,13 +1594,13 @@ class Pie(PlotlyDict):
 class Pointcloud(PlotlyDict):
     """
     Valid attributes for 'pointcloud' at path [] under parents ():
-
+    
         ['customdata', 'customdatasrc', 'hoverinfo', 'hoverinfosrc',
         'hoverlabel', 'ids', 'idssrc', 'indices', 'indicessrc', 'legendgroup',
         'marker', 'name', 'opacity', 'showlegend', 'stream', 'text', 'textsrc',
         'type', 'uid', 'visible', 'x', 'xaxis', 'xbounds', 'xboundssrc',
         'xsrc', 'xy', 'xysrc', 'y', 'yaxis', 'ybounds', 'yboundssrc', 'ysrc']
-
+    
     Run `<pointcloud-object>.help('attribute')` on any of the above.
     '<pointcloud-object>' is the object at []
 
@@ -1611,11 +1611,11 @@ class Pointcloud(PlotlyDict):
 class RadialAxis(PlotlyDict):
     """
     Valid attributes for 'radialaxis' at path [] under parents ():
-
+    
         ['domain', 'endpadding', 'orientation', 'range', 'showline',
         'showticklabels', 'tickcolor', 'ticklen', 'tickorientation',
         'ticksuffix', 'visible']
-
+    
     Run `<radialaxis-object>.help('attribute')` on any of the above.
     '<radialaxis-object>' is the object at []
 
@@ -1626,12 +1626,12 @@ class RadialAxis(PlotlyDict):
 class Sankey(PlotlyDict):
     """
     Valid attributes for 'sankey' at path [] under parents ():
-
+    
         ['arrangement', 'customdata', 'customdatasrc', 'domain', 'hoverinfo',
         'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc', 'legendgroup', 'link',
         'name', 'node', 'opacity', 'orientation', 'showlegend', 'stream',
         'textfont', 'type', 'uid', 'valueformat', 'valuesuffix', 'visible']
-
+    
     Run `<sankey-object>.help('attribute')` on any of the above.
     '<sankey-object>' is the object at []
 
@@ -1642,7 +1642,7 @@ class Sankey(PlotlyDict):
 class Scatter(PlotlyDict):
     """
     Valid attributes for 'scatter' at path [] under parents ():
-
+    
         ['cliponaxis', 'connectgaps', 'customdata', 'customdatasrc', 'dx',
         'dy', 'error_x', 'error_y', 'fill', 'fillcolor', 'hoverinfo',
         'hoverinfosrc', 'hoverlabel', 'hoveron', 'hovertext', 'hovertextsrc',
@@ -1651,7 +1651,7 @@ class Scatter(PlotlyDict):
         'textfont', 'textposition', 'textpositionsrc', 'textsrc', 'tsrc',
         'type', 'uid', 'visible', 'x', 'x0', 'xaxis', 'xcalendar', 'xsrc', 'y',
         'y0', 'yaxis', 'ycalendar', 'ysrc']
-
+    
     Run `<scatter-object>.help('attribute')` on any of the above.
     '<scatter-object>' is the object at []
 
@@ -1662,7 +1662,7 @@ class Scatter(PlotlyDict):
 class Scatter3d(PlotlyDict):
     """
     Valid attributes for 'scatter3d' at path [] under parents ():
-
+    
         ['connectgaps', 'customdata', 'customdatasrc', 'error_x', 'error_y',
         'error_z', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'hovertext',
         'hovertextsrc', 'ids', 'idssrc', 'legendgroup', 'line', 'marker',
@@ -1671,7 +1671,7 @@ class Scatter3d(PlotlyDict):
         'textposition', 'textpositionsrc', 'textsrc', 'type', 'uid', 'visible',
         'x', 'xcalendar', 'xsrc', 'y', 'ycalendar', 'ysrc', 'z', 'zcalendar',
         'zsrc']
-
+    
     Run `<scatter3d-object>.help('attribute')` on any of the above.
     '<scatter3d-object>' is the object at []
 
@@ -1682,14 +1682,14 @@ class Scatter3d(PlotlyDict):
 class Scattercarpet(PlotlyDict):
     """
     Valid attributes for 'scattercarpet' at path [] under parents ():
-
+    
         ['a', 'asrc', 'b', 'bsrc', 'carpet', 'connectgaps', 'customdata',
         'customdatasrc', 'fill', 'fillcolor', 'hoverinfo', 'hoverinfosrc',
         'hoverlabel', 'hoveron', 'ids', 'idssrc', 'legendgroup', 'line',
         'marker', 'mode', 'name', 'opacity', 'showlegend', 'stream', 'text',
         'textfont', 'textposition', 'textpositionsrc', 'textsrc', 'type',
         'uid', 'visible', 'xaxis', 'yaxis']
-
+    
     Run `<scattercarpet-object>.help('attribute')` on any of the above.
     '<scattercarpet-object>' is the object at []
 
@@ -1700,7 +1700,7 @@ class Scattercarpet(PlotlyDict):
 class Scattergeo(PlotlyDict):
     """
     Valid attributes for 'scattergeo' at path [] under parents ():
-
+    
         ['connectgaps', 'customdata', 'customdatasrc', 'fill', 'fillcolor',
         'geo', 'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'hovertext',
         'hovertextsrc', 'ids', 'idssrc', 'lat', 'latsrc', 'legendgroup',
@@ -1708,7 +1708,7 @@ class Scattergeo(PlotlyDict):
         'marker', 'mode', 'name', 'opacity', 'showlegend', 'stream', 'text',
         'textfont', 'textposition', 'textpositionsrc', 'textsrc', 'type',
         'uid', 'visible']
-
+    
     Run `<scattergeo-object>.help('attribute')` on any of the above.
     '<scattergeo-object>' is the object at []
 
@@ -1719,14 +1719,14 @@ class Scattergeo(PlotlyDict):
 class Scattergl(PlotlyDict):
     """
     Valid attributes for 'scattergl' at path [] under parents ():
-
+    
         ['connectgaps', 'customdata', 'customdatasrc', 'dx', 'dy', 'error_x',
         'error_y', 'fill', 'fillcolor', 'hoverinfo', 'hoverinfosrc',
         'hoverlabel', 'ids', 'idssrc', 'legendgroup', 'line', 'marker', 'mode',
         'name', 'opacity', 'showlegend', 'stream', 'text', 'textsrc', 'type',
         'uid', 'visible', 'x', 'x0', 'xaxis', 'xcalendar', 'xsrc', 'y', 'y0',
         'yaxis', 'ycalendar', 'ysrc']
-
+    
     Run `<scattergl-object>.help('attribute')` on any of the above.
     '<scattergl-object>' is the object at []
 
@@ -1737,14 +1737,14 @@ class Scattergl(PlotlyDict):
 class Scattermapbox(PlotlyDict):
     """
     Valid attributes for 'scattermapbox' at path [] under parents ():
-
+    
         ['connectgaps', 'customdata', 'customdatasrc', 'fill', 'fillcolor',
         'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'hovertext', 'hovertextsrc',
         'ids', 'idssrc', 'lat', 'latsrc', 'legendgroup', 'line', 'lon',
         'lonsrc', 'marker', 'mode', 'name', 'opacity', 'showlegend', 'stream',
         'subplot', 'text', 'textfont', 'textposition', 'textsrc', 'type',
         'uid', 'visible']
-
+    
     Run `<scattermapbox-object>.help('attribute')` on any of the above.
     '<scattermapbox-object>' is the object at []
 
@@ -1755,7 +1755,7 @@ class Scattermapbox(PlotlyDict):
 class Scatterternary(PlotlyDict):
     """
     Valid attributes for 'scatterternary' at path [] under parents ():
-
+    
         ['a', 'asrc', 'b', 'bsrc', 'c', 'cliponaxis', 'connectgaps', 'csrc',
         'customdata', 'customdatasrc', 'fill', 'fillcolor', 'hoverinfo',
         'hoverinfosrc', 'hoverlabel', 'hoveron', 'hovertext', 'hovertextsrc',
@@ -1763,7 +1763,7 @@ class Scatterternary(PlotlyDict):
         'opacity', 'showlegend', 'stream', 'subplot', 'sum', 'text',
         'textfont', 'textposition', 'textpositionsrc', 'textsrc', 'type',
         'uid', 'visible']
-
+    
     Run `<scatterternary-object>.help('attribute')` on any of the above.
     '<scatterternary-object>' is the object at []
 
@@ -1774,11 +1774,11 @@ class Scatterternary(PlotlyDict):
 class Scene(PlotlyDict):
     """
     Valid attributes for 'scene' at path [] under parents ():
-
+    
         ['annotations', 'aspectmode', 'aspectratio', 'bgcolor', 'camera',
         'cameraposition', 'domain', 'dragmode', 'hovermode', 'xaxis', 'yaxis',
         'zaxis']
-
+    
     Run `<scene-object>.help('attribute')` on any of the above.
     '<scene-object>' is the object at []
 
@@ -1789,9 +1789,9 @@ class Scene(PlotlyDict):
 class Stream(PlotlyDict):
     """
     Valid attributes for 'stream' at path [] under parents ():
-
+    
         ['maxpoints', 'token']
-
+    
     Run `<stream-object>.help('attribute')` on any of the above.
     '<stream-object>' is the object at []
 
@@ -1802,7 +1802,7 @@ class Stream(PlotlyDict):
 class Surface(PlotlyDict):
     """
     Valid attributes for 'surface' at path [] under parents ():
-
+    
         ['autocolorscale', 'cauto', 'cmax', 'cmin', 'colorbar', 'colorscale',
         'contours', 'customdata', 'customdatasrc', 'hidesurface', 'hoverinfo',
         'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc', 'legendgroup',
@@ -1811,7 +1811,7 @@ class Surface(PlotlyDict):
         'surfacecolorsrc', 'text', 'textsrc', 'type', 'uid', 'visible', 'x',
         'xcalendar', 'xsrc', 'y', 'ycalendar', 'ysrc', 'z', 'zauto',
         'zcalendar', 'zmax', 'zmin', 'zsrc']
-
+    
     Run `<surface-object>.help('attribute')` on any of the above.
     '<surface-object>' is the object at []
 
@@ -1822,13 +1822,13 @@ class Surface(PlotlyDict):
 class Table(PlotlyDict):
     """
     Valid attributes for 'table' at path [] under parents ():
-
+    
         ['cells', 'columnorder', 'columnordersrc', 'columnwidth',
         'columnwidthsrc', 'customdata', 'customdatasrc', 'domain', 'header',
         'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'ids', 'idssrc',
         'legendgroup', 'name', 'opacity', 'showlegend', 'stream', 'type',
         'uid', 'visible']
-
+    
     Run `<table-object>.help('attribute')` on any of the above.
     '<table-object>' is the object at []
 
@@ -1843,7 +1843,7 @@ class Trace(dict):
 class XAxis(PlotlyDict):
     """
     Valid attributes for 'xaxis' at path [] under parents ():
-
+    
         ['anchor', 'autorange', 'autotick', 'backgroundcolor', 'calendar',
         'categoryarray', 'categoryarraysrc', 'categoryorder', 'color',
         'constrain', 'constraintoward', 'domain', 'dtick', 'exponentformat',
@@ -1858,7 +1858,7 @@ class XAxis(PlotlyDict):
         'tickprefix', 'ticks', 'ticksuffix', 'ticktext', 'ticktextsrc',
         'tickvals', 'tickvalssrc', 'tickwidth', 'title', 'titlefont', 'type',
         'visible', 'zeroline', 'zerolinecolor', 'zerolinewidth']
-
+    
     Run `<xaxis-object>.help('attribute')` on any of the above.
     '<xaxis-object>' is the object at []
 
@@ -1869,9 +1869,9 @@ class XAxis(PlotlyDict):
 class XBins(PlotlyDict):
     """
     Valid attributes for 'xbins' at path [] under parents ():
-
+    
         ['end', 'size', 'start']
-
+    
     Run `<xbins-object>.help('attribute')` on any of the above.
     '<xbins-object>' is the object at []
 
@@ -1882,7 +1882,7 @@ class XBins(PlotlyDict):
 class YAxis(PlotlyDict):
     """
     Valid attributes for 'yaxis' at path [] under parents ():
-
+    
         ['anchor', 'autorange', 'autotick', 'backgroundcolor', 'calendar',
         'categoryarray', 'categoryarraysrc', 'categoryorder', 'color',
         'constrain', 'constraintoward', 'domain', 'dtick', 'exponentformat',
@@ -1897,7 +1897,7 @@ class YAxis(PlotlyDict):
         'ticksuffix', 'ticktext', 'ticktextsrc', 'tickvals', 'tickvalssrc',
         'tickwidth', 'title', 'titlefont', 'type', 'visible', 'zeroline',
         'zerolinecolor', 'zerolinewidth']
-
+    
     Run `<yaxis-object>.help('attribute')` on any of the above.
     '<yaxis-object>' is the object at []
 
@@ -1908,9 +1908,9 @@ class YAxis(PlotlyDict):
 class YBins(PlotlyDict):
     """
     Valid attributes for 'ybins' at path [] under parents ():
-
+    
         ['end', 'size', 'start']
-
+    
     Run `<ybins-object>.help('attribute')` on any of the above.
     '<ybins-object>' is the object at []
 
@@ -1921,7 +1921,7 @@ class YBins(PlotlyDict):
 class ZAxis(PlotlyDict):
     """
     Valid attributes for 'zaxis' at path [] under parents ():
-
+    
         ['autorange', 'backgroundcolor', 'calendar', 'categoryarray',
         'categoryarraysrc', 'categoryorder', 'color', 'dtick',
         'exponentformat', 'gridcolor', 'gridwidth', 'hoverformat', 'linecolor',
@@ -1934,7 +1934,7 @@ class ZAxis(PlotlyDict):
         'ticksuffix', 'ticktext', 'ticktextsrc', 'tickvals', 'tickvalssrc',
         'tickwidth', 'title', 'titlefont', 'type', 'visible', 'zeroline',
         'zerolinecolor', 'zerolinewidth']
-
+    
     Run `<zaxis-object>.help('attribute')` on any of the above.
     '<zaxis-object>' is the object at []
 

--- a/plotly/graph_reference.py
+++ b/plotly/graph_reference.py
@@ -72,55 +72,55 @@ def get_graph_reference():
 
     # TODO: Patch in frames info until it hits streambed. See #659
     graph_reference['frames'] = {
-        "items": {
-            "frames_entry": {
-                "baseframe": {
-                    "description": "The name of the frame into which this "
-                                   "frame's properties are merged before "
-                                   "applying. This is used to unify "
-                                   "properties and avoid needing to specify "
-                                   "the same values for the same properties "
-                                   "in multiple frames.",
-                    "role": "info",
-                    "valType": "string"
-                },
-                "data": {
-                    "description": "A list of traces this frame modifies. "
-                                   "The format is identical to the normal "
-                                   "trace definition.",
-                    "role": "object",
-                    "valType": "any"
-                },
-                "group": {
-                    "description": "An identifier that specifies the group "
-                                   "to which the frame belongs, used by "
-                                   "animate to select a subset of frames.",
-                    "role": "info",
-                    "valType": "string"
-                },
-                "layout": {
-                    "role": "object",
-                    "description": "Layout properties which this frame "
-                                   "modifies. The format is identical to "
-                                   "the normal layout definition.",
-                    "valType": "any"
-                },
-                "name": {
-                    "description": "A label by which to identify the frame",
-                    "role": "info",
-                    "valType": "string"
-                },
-                "role": "object",
-                "traces": {
-                    "description": "A list of trace indices that identify "
-                                   "the respective traces in the data "
-                                   "attribute",
-                    "role": "info",
-                    "valType": "info_array"
-                }
-            }
-        },
-        "role": "object"
+          "items": {
+              "frames_entry": {
+                  "baseframe": {
+                      "description": "The name of the frame into which this "
+                                     "frame's properties are merged before "
+                                     "applying. This is used to unify "
+                                     "properties and avoid needing to specify "
+                                     "the same values for the same properties "
+                                     "in multiple frames.",
+                      "role": "info",
+                      "valType": "string"
+                  },
+                  "data": {
+                      "description": "A list of traces this frame modifies. "
+                                     "The format is identical to the normal "
+                                     "trace definition.",
+                      "role": "object",
+                      "valType": "any"
+                  },
+                  "group": {
+                      "description": "An identifier that specifies the group "
+                                     "to which the frame belongs, used by "
+                                     "animate to select a subset of frames.",
+                      "role": "info",
+                      "valType": "string"
+                  },
+                  "layout": {
+                      "role": "object",
+                      "description": "Layout properties which this frame "
+                                     "modifies. The format is identical to "
+                                     "the normal layout definition.",
+                      "valType": "any"
+                  },
+                  "name": {
+                      "description": "A label by which to identify the frame",
+                      "role": "info",
+                      "valType": "string"
+                  },
+                  "role": "object",
+                  "traces": {
+                      "description": "A list of trace indices that identify "
+                                     "the respective traces in the data "
+                                     "attribute",
+                      "role": "info",
+                      "valType": "info_array"
+                  }
+              }
+          },
+          "role": "object"
     }
 
     return graph_reference
@@ -223,7 +223,7 @@ def get_attributes_dicts(object_name, parent_object_names=()):
     # We return a dict mapping paths to attributes. We also add in additional
     # attributes if defined.
     attributes_dicts = {path: utils.get_by_path(GRAPH_REFERENCE, path)
-                        for path in attribute_paths}
+                  for path in attribute_paths}
     attributes_dicts['additional_attributes'] = additional_attributes
 
     return attributes_dicts

--- a/plotly/grid_objs/grid_objs.py
+++ b/plotly/grid_objs/grid_objs.py
@@ -207,7 +207,7 @@ class Grid(MutableSequence):
                 ordered_columns.append(Column(
                     columns_or_json['cols'][column_name]['data'],
                     column_name)
-                                      )
+                )
             self._columns = ordered_columns
 
             # fill in column_ids

--- a/plotly/matplotlylib/mpltools.py
+++ b/plotly/matplotlylib/mpltools.py
@@ -292,7 +292,6 @@ def convert_path_array(path_array):
     else:
         return symbols
 
-
 def convert_linewidth_array(width_array):
     if len(width_array) == 1:
         return width_array[0]
@@ -309,7 +308,7 @@ def convert_size_array(size_array):
 
 
 def get_markerstyle_from_collection(props):
-    markerstyle = dict(
+    markerstyle=dict(
         alpha=None,
         facecolor=convert_rgba_array(props['styles']['facecolor']),
         marker=convert_path_array(props['paths']),
@@ -339,7 +338,6 @@ def get_rect_ymin(data):
 def get_rect_ymax(data):
     """Find maximum y value from four (x,y) vertices."""
     return max(data[0][1], data[1][1], data[2][1], data[3][1])
-
 
 def get_spine_visible(ax, spine_key):
     """Return some spine parameters for the spine, `spine_key`."""
@@ -395,7 +393,6 @@ def make_bar(**props):
         'zorder': props['style']['zorder']
     }
 
-
 def prep_ticks(ax, index, ax_type, props):
     """Prepare axis obj belonging to axes obj.
 
@@ -447,10 +444,10 @@ def prep_ticks(ax, index, ax_type, props):
         if base == 10:
             if ax_type == 'x':
                 axis_dict['range'] = [math.log10(props['xlim'][0]),
-                                      math.log10(props['xlim'][1])]
+                                 math.log10(props['xlim'][1])]
             elif ax_type == 'y':
                 axis_dict['range'] = [math.log10(props['ylim'][0]),
-                                      math.log10(props['ylim'][1])]
+                                 math.log10(props['ylim'][1])]
         else:
             axis_dict = dict(range=None, type='linear')
             warnings.warn("Converted non-base10 {0}-axis log scale to 'linear'"

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -6,12 +6,12 @@
 from __future__ import absolute_import
 
 import os
-import time
 import uuid
 import warnings
+from pkg_resources import resource_string
+import time
 import webbrowser
 
-from pkg_resources import resource_string
 from requests.compat import json as _json
 
 import plotly
@@ -40,7 +40,6 @@ def get_plotlyjs():
     path = os.path.join('package_data', 'plotly.min.js')
     plotlyjs = resource_string('plotly', path).decode('utf-8')
     return plotlyjs
-
 
 def get_image_download_script(caller):
     """
@@ -268,8 +267,8 @@ def _plot_html(figure_or_data, config, validate, default_width,
         optional_line2 +
         '</script>'
         '').format(
-            id=plotdivid, script=script,
-            height=height, width=width)
+        id=plotdivid, script=script,
+        height=height, width=width)
 
     return plotly_html_div, plotdivid, width, height
 
@@ -370,7 +369,7 @@ def iplot(figure_or_data, show_link=True, link_text='Export to plot.ly',
         if image not in __IMAGE_FORMATS:
             raise ValueError('The image parameter must be one of the following'
                              ': {}'.format(__IMAGE_FORMATS)
-                            )
+                             )
         # if image is given, and is a valid format, we will download the image
         script = get_image_download_script('iplot').format(format=image,
                                                            width=image_width,
@@ -494,7 +493,7 @@ def plot(figure_or_data, show_link=True, link_text='Export to plot.ly',
                 if image not in __IMAGE_FORMATS:
                     raise ValueError('The image parameter must be one of the '
                                      'following: {}'.format(__IMAGE_FORMATS)
-                                    )
+                                     )
                 # if the check passes then download script is injected.
                 # write the download script:
                 script = get_image_download_script('plot')

--- a/plotly/package_data/default-schema.json
+++ b/plotly/package_data/default-schema.json
@@ -2978,6 +2978,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "plot",
+                                    "items": [
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "plot",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "plot",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
                         "dflt": 5,
@@ -3489,6 +3521,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "plot",
+                                    "items": [
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "plot",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "plot",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
                         "dflt": 5,
@@ -3999,6 +4063,38 @@
                         "editType": "plot",
                         "role": "style",
                         "valType": "string"
+                    },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "plot",
+                                    "items": [
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "plot",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "plot",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
                     },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
@@ -4690,15 +4786,6 @@
                 },
                 "role": "object"
             },
-            "smith": {
-                "dflt": false,
-                "editType": "none",
-                "role": "info",
-                "valType": "enumerated",
-                "values": [
-                    false
-                ]
-            },
             "ternary": {
                 "_isSubplotObj": true,
                 "aaxis": {
@@ -4919,6 +5006,38 @@
                         "editType": "plot",
                         "role": "style",
                         "valType": "string"
+                    },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "plot",
+                                    "items": [
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "plot",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "plot",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
                     },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
@@ -5246,6 +5365,38 @@
                         "editType": "plot",
                         "role": "style",
                         "valType": "string"
+                    },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "plot",
+                                    "items": [
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "plot",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "plot",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
                     },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
@@ -5580,6 +5731,38 @@
                         "editType": "plot",
                         "role": "style",
                         "valType": "string"
+                    },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "plot",
+                                    "items": [
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "plot",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "plot",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "plot",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
                     },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
@@ -6746,6 +6929,38 @@
                     "role": "style",
                     "valType": "string"
                 },
+                "tickformatstops": {
+                    "items": {
+                        "tickformatstop": {
+                            "dtickrange": {
+                                "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                "editType": "ticks",
+                                "items": [
+                                    {
+                                        "editType": "ticks",
+                                        "valType": "any"
+                                    },
+                                    {
+                                        "editType": "ticks",
+                                        "valType": "any"
+                                    }
+                                ],
+                                "role": "info",
+                                "valType": "info_array"
+                            },
+                            "editType": "ticks",
+                            "role": "object",
+                            "value": {
+                                "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                "dflt": "",
+                                "editType": "ticks",
+                                "role": "style",
+                                "valType": "string"
+                            }
+                        }
+                    },
+                    "role": "object"
+                },
                 "ticklen": {
                     "description": "Sets the tick length (in px).",
                     "dflt": 5,
@@ -7391,6 +7606,38 @@
                     "editType": "ticks",
                     "role": "style",
                     "valType": "string"
+                },
+                "tickformatstops": {
+                    "items": {
+                        "tickformatstop": {
+                            "dtickrange": {
+                                "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                "editType": "ticks",
+                                "items": [
+                                    {
+                                        "editType": "ticks",
+                                        "valType": "any"
+                                    },
+                                    {
+                                        "editType": "ticks",
+                                        "valType": "any"
+                                    }
+                                ],
+                                "role": "info",
+                                "valType": "info_array"
+                            },
+                            "editType": "ticks",
+                            "role": "object",
+                            "value": {
+                                "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                "dflt": "",
+                                "editType": "ticks",
+                                "role": "style",
+                                "valType": "string"
+                            }
+                        }
+                    },
+                    "role": "object"
                 },
                 "ticklen": {
                     "description": "Sets the tick length (in px).",
@@ -8890,6 +9137,38 @@
                             "role": "style",
                             "valType": "string"
                         },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "colorbars",
+                                        "items": [
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "colorbars",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "colorbars",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
                             "dflt": 5,
@@ -9746,6 +10025,17 @@
                     },
                     "role": "object"
                 },
+                "hoveron": {
+                    "description": "Do the hover effects highlight individual boxes  or sample points or both?",
+                    "dflt": "boxes+points",
+                    "editType": "style",
+                    "flags": [
+                        "boxes",
+                        "points"
+                    ],
+                    "role": "info",
+                    "valType": "flaglist"
+                },
                 "ids": {
                     "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
                     "editType": "calc",
@@ -10217,6 +10507,20 @@
                         "strict": true,
                         "valType": "string"
                     }
+                },
+                "text": {
+                    "arrayOk": true,
+                    "description": "Sets the text elements associated with each sample value. If a single string, the same string appears over all the data points. If an array of string, the items are mapped in order to the this trace's (x,y) coordinates. To be seen, trace `hoverinfo` must contain a *text* flag.",
+                    "dflt": "",
+                    "editType": "calc",
+                    "role": "info",
+                    "valType": "string"
+                },
+                "textsrc": {
+                    "description": "Sets the source reference on plot.ly for  text .",
+                    "editType": "none",
+                    "role": "info",
+                    "valType": "string"
                 },
                 "type": "box",
                 "uid": {
@@ -11209,6 +11513,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "calc",
+                                    "items": [
+                                        {
+                                            "editType": "calc",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "calc",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "calc",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "calc",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "tickmode": {
                         "dflt": "array",
                         "editType": "calc",
@@ -11701,6 +12037,38 @@
                         "editType": "calc",
                         "role": "style",
                         "valType": "string"
+                    },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "calc",
+                                    "items": [
+                                        {
+                                            "editType": "calc",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "calc",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "calc",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "calc",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
                     },
                     "tickmode": {
                         "dflt": "array",
@@ -12345,6 +12713,38 @@
                         "editType": "colorbars",
                         "role": "style",
                         "valType": "string"
+                    },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "colorbars",
+                                    "items": [
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "colorbars",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "colorbars",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
                     },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
@@ -13118,6 +13518,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "colorbars",
+                                    "items": [
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "colorbars",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "colorbars",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
                         "dflt": 5,
@@ -13870,6 +14302,13 @@
                     "role": "info",
                     "valType": "boolean"
                 },
+                "zhoverformat": {
+                    "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. See: https://github.com/d3/d3-format/blob/master/README.md#locale_format",
+                    "dflt": "",
+                    "editType": "none",
+                    "role": "style",
+                    "valType": "string"
+                },
                 "zmax": {
                     "description": "Sets the upper bound of color domain.",
                     "dflt": null,
@@ -14211,6 +14650,38 @@
                         "editType": "colorbars",
                         "role": "style",
                         "valType": "string"
+                    },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "colorbars",
+                                    "items": [
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "colorbars",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "colorbars",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
                     },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
@@ -15159,6 +15630,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "colorbars",
+                                    "items": [
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "colorbars",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "colorbars",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
                         "dflt": 5,
@@ -15780,6 +16283,13 @@
                     "role": "info",
                     "valType": "boolean"
                 },
+                "zhoverformat": {
+                    "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. See: https://github.com/d3/d3-format/blob/master/README.md#locale_format",
+                    "dflt": "",
+                    "editType": "none",
+                    "role": "style",
+                    "valType": "string"
+                },
                 "zmax": {
                     "description": "Sets the upper bound of color domain.",
                     "dflt": null,
@@ -16049,6 +16559,38 @@
                         "editType": "calc",
                         "role": "style",
                         "valType": "string"
+                    },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "calc",
+                                    "items": [
+                                        {
+                                            "editType": "calc",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "calc",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "calc",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "calc",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
                     },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
@@ -17370,6 +17912,38 @@
                             "role": "style",
                             "valType": "string"
                         },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "colorbars",
+                                        "items": [
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "colorbars",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "colorbars",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
                             "dflt": 5,
@@ -18224,6 +18798,38 @@
                         "role": "style",
                         "valType": "string"
                     },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "colorbars",
+                                    "items": [
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "colorbars",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "colorbars",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
+                    },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
                         "dflt": 5,
@@ -18889,6 +19495,13 @@
                     "role": "info",
                     "valType": "boolean"
                 },
+                "zhoverformat": {
+                    "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. See: https://github.com/d3/d3-format/blob/master/README.md#locale_format",
+                    "dflt": "",
+                    "editType": "none",
+                    "role": "style",
+                    "valType": "string"
+                },
                 "zmax": {
                     "description": "Sets the upper bound of color domain.",
                     "dflt": null,
@@ -19183,6 +19796,38 @@
                         "editType": "colorbars",
                         "role": "style",
                         "valType": "string"
+                    },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "colorbars",
+                                    "items": [
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "colorbars",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "colorbars",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
                     },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
@@ -19980,6 +20625,13 @@
                     "role": "info",
                     "valType": "boolean"
                 },
+                "zhoverformat": {
+                    "description": "Sets the hover text formatting rule using d3 formatting mini-languages which are very similar to those in Python. See: https://github.com/d3/d3-format/blob/master/README.md#locale_format",
+                    "dflt": "",
+                    "editType": "none",
+                    "role": "style",
+                    "valType": "string"
+                },
                 "zmax": {
                     "description": "Sets the upper bound of color domain.",
                     "dflt": null,
@@ -20279,6 +20931,38 @@
                         "editType": "colorbars",
                         "role": "style",
                         "valType": "string"
+                    },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "colorbars",
+                                    "items": [
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "colorbars",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "colorbars",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "colorbars",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
                     },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",
@@ -22084,6 +22768,38 @@
                             "role": "style",
                             "valType": "string"
                         },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "colorbars",
+                                        "items": [
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "colorbars",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "colorbars",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
                             "dflt": 5,
@@ -22747,7 +23463,7 @@
                     "valType": "number"
                 },
                 "labels": {
-                    "description": "Sets the sector labels.",
+                    "description": "Sets the sector labels. If `labels` entries are duplicated, we sum associated `values` or simply count occurrences if `values` is not provided. For other array attributes (including color) we use the first non-empty entry among all occurrences of the label.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -22999,7 +23715,7 @@
                     "valType": "string"
                 },
                 "values": {
-                    "description": "Sets the values of the sectors of this pie chart.",
+                    "description": "Sets the values of the sectors of this pie chart. If omitted, we count occurrences of each label.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -24722,6 +25438,38 @@
                             "editType": "colorbars",
                             "role": "style",
                             "valType": "string"
+                        },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "colorbars",
+                                        "items": [
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "colorbars",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "colorbars",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
                         },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
@@ -26602,6 +27350,38 @@
                             "role": "style",
                             "valType": "string"
                         },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "calc",
+                                        "items": [
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "calc",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "calc",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
                             "dflt": 5,
@@ -27886,6 +28666,38 @@
                             "editType": "colorbars",
                             "role": "style",
                             "valType": "string"
+                        },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "colorbars",
+                                        "items": [
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "colorbars",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "colorbars",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
                         },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
@@ -29298,6 +30110,38 @@
                             "editType": "calc",
                             "role": "style",
                             "valType": "string"
+                        },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "calc",
+                                        "items": [
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "calc",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "calc",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
                         },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
@@ -30877,6 +31721,38 @@
                             "role": "style",
                             "valType": "string"
                         },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "calc",
+                                        "items": [
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "calc",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "calc",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
                             "dflt": 5,
@@ -31985,6 +32861,38 @@
                             "role": "style",
                             "valType": "string"
                         },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "calc",
+                                        "items": [
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "calc",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "calc",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "calc",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
+                        },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
                             "dflt": 5,
@@ -32968,6 +33876,38 @@
                             "editType": "colorbars",
                             "role": "style",
                             "valType": "string"
+                        },
+                        "tickformatstops": {
+                            "items": {
+                                "tickformatstop": {
+                                    "dtickrange": {
+                                        "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                        "editType": "colorbars",
+                                        "items": [
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            },
+                                            {
+                                                "editType": "colorbars",
+                                                "valType": "any"
+                                            }
+                                        ],
+                                        "role": "info",
+                                        "valType": "info_array"
+                                    },
+                                    "editType": "colorbars",
+                                    "role": "object",
+                                    "value": {
+                                        "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                        "dflt": "",
+                                        "editType": "colorbars",
+                                        "role": "style",
+                                        "valType": "string"
+                                    }
+                                }
+                            },
+                            "role": "object"
                         },
                         "ticklen": {
                             "description": "Sets the tick length (in px).",
@@ -34131,6 +35071,38 @@
                         "editType": "calc",
                         "role": "style",
                         "valType": "string"
+                    },
+                    "tickformatstops": {
+                        "items": {
+                            "tickformatstop": {
+                                "dtickrange": {
+                                    "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
+                                    "editType": "calc",
+                                    "items": [
+                                        {
+                                            "editType": "calc",
+                                            "valType": "any"
+                                        },
+                                        {
+                                            "editType": "calc",
+                                            "valType": "any"
+                                        }
+                                    ],
+                                    "role": "info",
+                                    "valType": "info_array"
+                                },
+                                "editType": "calc",
+                                "role": "object",
+                                "value": {
+                                    "description": "string - dtickformat for described zoom level, the same as *tickformat*",
+                                    "dflt": "",
+                                    "editType": "calc",
+                                    "role": "style",
+                                    "valType": "string"
+                                }
+                            }
+                        },
+                        "role": "object"
                     },
                     "ticklen": {
                         "description": "Sets the tick length (in px).",

--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -66,7 +66,6 @@ def sign_in(username, api_key, **kwargs):
     except exceptions.PlotlyRequestError:
         raise exceptions.PlotlyError('Sign in failed.')
 
-
 update_plot_options = session.update_session_plot_options
 
 

--- a/plotly/session.py
+++ b/plotly/session.py
@@ -132,7 +132,7 @@ def update_session_plot_options(**kwargs):
                                          .format(key, PLOT_OPTIONS[key]))
 
         # raise exception if sharing is invalid
-        if key == 'sharing' and not (kwargs[key] in SHARING_OPTIONS):
+        if (key == 'sharing' and not (kwargs[key] in SHARING_OPTIONS)):
             raise exceptions.PlotlyError("'{0}' must be of either '{1}', '{2}'"
                                          " or '{3}'"
                                          .format(key, *SHARING_OPTIONS))

--- a/plotly/tests/test_optional/test_matplotlylib/data/scatter.py
+++ b/plotly/tests/test_optional/test_matplotlylib/data/scatter.py
@@ -4,7 +4,7 @@ from plotly.graph_objs import (Data, Figure, Font, Layout, Line, Margin,
                                Marker, Scatter, XAxis, YAxis)
 
 D = dict(
-    x1=[1, 2, 2, 4, 5, 6, 1, 7, 8, 5, 3],
+    x1=[1, 2, 2, 4, 5, 6, 1, 7, 8, 5 ,3],
     y1=[5, 3, 7, 2, 9, 7, 8, 4, 5, 9, 2],
     x2=[-1, 1, -0.3, -0.6, 0.4, 0.8, -0.1, 0.7],
     y2=[-0.5, 0.4, 0.7, -0.6, 0.3, -1, 0, 0.3]

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -326,9 +326,9 @@ def get_embed(file_owner_or_url, file_id=None, width="100%", height=525):
              "~{file_owner}/{file_id}.embed\" "
              "height=\"{iframe_height}\" width=\"{iframe_width}\">"
              "</iframe>").format(
-                 plotly_rest_url=plotly_rest_url,
-                 file_owner=file_owner, file_id=file_id,
-                 iframe_height=height, iframe_width=width)
+            plotly_rest_url=plotly_rest_url,
+            file_owner=file_owner, file_id=file_id,
+            iframe_height=height, iframe_width=width)
     else:
         s = ("<iframe id=\"igraph\" scrolling=\"no\" style=\"border:none;\" "
              "seamless=\"seamless\" "
@@ -336,9 +336,9 @@ def get_embed(file_owner_or_url, file_id=None, width="100%", height=525):
              "~{file_owner}/{file_id}.embed?share_key={share_key}\" "
              "height=\"{iframe_height}\" width=\"{iframe_width}\">"
              "</iframe>").format(
-                 plotly_rest_url=plotly_rest_url,
-                 file_owner=file_owner, file_id=file_id, share_key=share_key,
-                 iframe_height=height, iframe_width=width)
+            plotly_rest_url=plotly_rest_url,
+            file_owner=file_owner, file_id=file_id, share_key=share_key,
+            iframe_height=height, iframe_width=width)
 
     return s
 
@@ -867,7 +867,7 @@ def make_subplots(rows=1, cols=1,
                     raise Exception(exception_msg)
     except KeyError:
         specs = [[{}
-                  for c in range(cols)]
+                 for c in range(cols)]
                  for r in range(rows)]     # default 'specs'
 
     # Throw exception if specs is over or under specified

--- a/plotly/utils.py
+++ b/plotly/utils.py
@@ -409,9 +409,9 @@ def get_by_path(obj, path):
 ### validation
 def validate_world_readable_and_sharing_settings(option_set):
     if ('world_readable' in option_set and
-            option_set['world_readable'] is True and
-            'sharing' in option_set and
-            option_set['sharing'] is not None and
+        option_set['world_readable'] is True and
+        'sharing' in option_set and
+        option_set['sharing'] is not None and
             option_set['sharing'] != 'public'):
         raise PlotlyError(
             "Looks like you are setting your plot privacy to both "

--- a/plotly/widgets/graph_widget.py
+++ b/plotly/widgets/graph_widget.py
@@ -121,7 +121,7 @@ class GraphWidget(widgets.DOMWidget):
         self._event_handlers[event_type].register_callback(callback,
                                                            remove=remove)
         event_callbacks = self._event_handlers[event_type].callbacks
-        if event_callbacks and event_type not in self._listener_set:
+        if (len(event_callbacks) and event_type not in self._listener_set):
             self._listener_set.add(event_type)
             message = {'task': 'listen', 'events': list(self._listener_set)}
             self._handle_outgoing_message(message)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from setuptools import setup
 
-main_ns = {}
-exec(open('plotly/version.py').read(), main_ns)
+exec (open('plotly/version.py').read())
 
 
 def readme():
@@ -10,7 +9,7 @@ def readme():
 
 
 setup(name='plotly',
-      version=main_ns['__version__'],
+      version=__version__,
       use_2to3=False,
       author='Chris P',
       author_email='chris@plot.ly',


### PR DESCRIPTION
Reverts plotly/plotly.py#909

some of these changes broke a few of the `figure_factory` functions and tests
for example: https://github.com/plotly/plotly.py/compare/master...revert-909-pylint-pep8-fixes?expand=1#diff-15c41c129536c7a3b0fd161641855ff3R206 and https://github.com/plotly/plotly.py/compare/master...revert-909-pylint-pep8-fixes?expand=1#diff-83b399f13d8b361d38016264ed1ce589R1055

it might be easier to revert this and reopen the pr running through our tests cc @chriddyp 