### PR TITLE
(matplotlylib) Make convert_dash more robust to changes in matplotlib.

### DIFF
--- a/plotly/matplotlylib/mpltools.py
+++ b/plotly/matplotlylib/mpltools.py
@@ -57,9 +57,21 @@ def convert_dash(mpl_dash):
     """Convert mpl line symbol to plotly line symbol and return symbol."""
     if mpl_dash in DASH_MAP:
         return DASH_MAP[mpl_dash]
-    else:
-        return 'solid'  # default
+    else:       
+        dash_array = mpl_dash.split(',')
 
+        if (len(dash_array) < 2):
+            return 'solid'
+
+        # Catch the exception where the off length is zero, in case
+        # matplotlib 'solid' changes from '10,0' to 'N,0'
+        if (math.isclose(float(dash_array[1]), 0.)):
+            return 'solid'
+
+        # If we can't find the dash pattern in the map, convert it
+        # into custom values in px, e.g. '7,5' -> '7px,5px'
+        dashpx=','.join([x + 'px' for x in dash_array])
+        return dashpx
 
 def convert_path(path):
     verts = path[0]  # may use this later


### PR DESCRIPTION
Now handles the case where the dashes are scaled, have floating-point values, or were customized with `dashes=(N,M)`.

Additional context: I was trying to use `mpl_to_plotly` in a jupyter notebook (python 3.6.3, matplotlib 2.1.2), and converting a plot with a non-solid line style (e.g linestyle='--') would still return a solid plot. It turns out that the `DASH_MAP` in `mpl_tools.py` has a set of hardcoded values, which I imagine changed with recent versions of `matplotlib`.

With linestyle='--', I was getting values like '7.4,3.2' which would not match the `6,6` of the match. Forcing `dash=(6,6)` would still not work because the `mpl_dash` string would become '6.0,6.0`, and still not match '6,6'.

I am new to plotly and matplotlib, so maybe I missed something, but this PR solves the issue for me, and all the line styles are now kept during the conversion, including custom `dashes`. It should also be somewhat robust to future changes.