### PR TITLE
Bump npm to 6.0.0 for circle.ci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ machine:
 
   node:
     # use a pre-installed version of node so we don't need to download it.
-    version: 4.2.2
+    version: 6.0.0
 
 dependencies:
 


### PR DESCRIPTION
Lots of intermittent npm related failures I have noticed.

The Issue Message: https://discuss.circleci.com/t/econnreset-on-npm-install/4793/3