### PR TITLE
deactivating all streaming tests

### DIFF
--- a/plotly/graph_objs/graph_objs.py
+++ b/plotly/graph_objs/graph_objs.py
@@ -873,15 +873,16 @@ class Bar(PlotlyDict):
     """
     Valid attributes for 'bar' at path [] under parents ():
     
-        ['bardir', 'base', 'basesrc', 'constraintext', 'customdata',
-        'customdatasrc', 'dx', 'dy', 'error_x', 'error_y', 'hoverinfo',
-        'hoverinfosrc', 'hoverlabel', 'hovertext', 'hovertextsrc', 'ids',
-        'idssrc', 'insidetextfont', 'legendgroup', 'marker', 'name', 'offset',
-        'offsetsrc', 'opacity', 'orientation', 'outsidetextfont', 'r', 'rsrc',
-        'selected', 'selectedpoints', 'showlegend', 'stream', 't', 'text',
-        'textfont', 'textposition', 'textpositionsrc', 'textsrc', 'tsrc',
-        'type', 'uid', 'unselected', 'visible', 'width', 'widthsrc', 'x', 'x0',
-        'xaxis', 'xcalendar', 'xsrc', 'y', 'y0', 'yaxis', 'ycalendar', 'ysrc']
+        ['bardir', 'base', 'basesrc', 'cliponaxis', 'constraintext',
+        'customdata', 'customdatasrc', 'dx', 'dy', 'error_x', 'error_y',
+        'hoverinfo', 'hoverinfosrc', 'hoverlabel', 'hovertext', 'hovertextsrc',
+        'ids', 'idssrc', 'insidetextfont', 'legendgroup', 'marker', 'name',
+        'offset', 'offsetsrc', 'opacity', 'orientation', 'outsidetextfont',
+        'r', 'rsrc', 'selected', 'selectedpoints', 'showlegend', 'stream', 't',
+        'text', 'textfont', 'textposition', 'textpositionsrc', 'textsrc',
+        'tsrc', 'type', 'uid', 'unselected', 'visible', 'width', 'widthsrc',
+        'x', 'x0', 'xaxis', 'xcalendar', 'xsrc', 'y', 'y0', 'yaxis',
+        'ycalendar', 'ysrc']
     
     Run `<bar-object>.help('attribute')` on any of the above.
     '<bar-object>' is the object at []
@@ -1132,9 +1133,8 @@ class ErrorY(PlotlyDict):
     Valid attributes for 'error_y' at path [] under parents ():
     
         ['array', 'arrayminus', 'arrayminussrc', 'arraysrc', 'color',
-        'copy_ystyle', 'copy_zstyle', 'opacity', 'symmetric', 'thickness',
-        'traceref', 'tracerefminus', 'type', 'value', 'valueminus', 'visible',
-        'width']
+        'copy_zstyle', 'opacity', 'symmetric', 'thickness', 'traceref',
+        'tracerefminus', 'type', 'value', 'valueminus', 'visible', 'width']
     
     Run `<error_y-object>.help('attribute')` on any of the above.
     '<error_y-object>' is the object at []
@@ -1148,9 +1148,8 @@ class ErrorZ(PlotlyDict):
     Valid attributes for 'error_z' at path [] under parents ():
     
         ['array', 'arrayminus', 'arrayminussrc', 'arraysrc', 'color',
-        'copy_ystyle', 'copy_zstyle', 'opacity', 'symmetric', 'thickness',
-        'traceref', 'tracerefminus', 'type', 'value', 'valueminus', 'visible',
-        'width']
+        'opacity', 'symmetric', 'thickness', 'traceref', 'tracerefminus',
+        'type', 'value', 'valueminus', 'visible', 'width']
     
     Run `<error_z-object>.help('attribute')` on any of the above.
     '<error_z-object>' is the object at []
@@ -1459,7 +1458,7 @@ class Layout(PlotlyDict):
         ['angularaxis', 'annotations', 'autosize', 'bargap', 'bargroupgap',
         'barmode', 'barnorm', 'boxgap', 'boxgroupgap', 'boxmode', 'calendar',
         'colorway', 'datarevision', 'direction', 'dragmode', 'font', 'geo',
-        'height', 'hiddenlabels', 'hiddenlabelssrc', 'hidesources',
+        'grid', 'height', 'hiddenlabels', 'hiddenlabelssrc', 'hidesources',
         'hoverdistance', 'hoverlabel', 'hovermode', 'images', 'legend',
         'mapbox', 'margin', 'orientation', 'paper_bgcolor', 'plot_bgcolor',
         'polar', 'radialaxis', 'scene', 'separators', 'shapes', 'showlegend',
@@ -1934,18 +1933,19 @@ class XAxis(PlotlyDict):
     """
     Valid attributes for 'xaxis' at path [] under parents ():
     
-        ['anchor', 'autorange', 'autotick', 'backgroundcolor', 'calendar',
-        'categoryarray', 'categoryarraysrc', 'categoryorder', 'color',
-        'constrain', 'constraintoward', 'domain', 'dtick', 'exponentformat',
-        'fixedrange', 'gridcolor', 'gridwidth', 'hoverformat', 'layer',
-        'linecolor', 'linewidth', 'mirror', 'nticks', 'overlaying', 'position',
-        'range', 'rangemode', 'rangeselector', 'rangeslider', 'scaleanchor',
-        'scaleratio', 'separatethousands', 'showaxeslabels', 'showbackground',
-        'showexponent', 'showgrid', 'showline', 'showspikes', 'showticklabels',
-        'showtickprefix', 'showticksuffix', 'side', 'spikecolor', 'spikedash',
-        'spikemode', 'spikesides', 'spikesnap', 'spikethickness', 'tick0',
-        'tickangle', 'tickcolor', 'tickfont', 'tickformat', 'tickformatstops',
-        'ticklen', 'tickmode', 'tickprefix', 'ticks', 'ticksuffix', 'ticktext',
+        ['anchor', 'automargin', 'autorange', 'autotick', 'backgroundcolor',
+        'calendar', 'categoryarray', 'categoryarraysrc', 'categoryorder',
+        'color', 'constrain', 'constraintoward', 'domain', 'dtick',
+        'exponentformat', 'fixedrange', 'gridcolor', 'gridwidth',
+        'hoverformat', 'layer', 'linecolor', 'linewidth', 'mirror', 'nticks',
+        'overlaying', 'position', 'range', 'rangemode', 'rangeselector',
+        'rangeslider', 'scaleanchor', 'scaleratio', 'separatethousands',
+        'showaxeslabels', 'showbackground', 'showexponent', 'showgrid',
+        'showline', 'showspikes', 'showticklabels', 'showtickprefix',
+        'showticksuffix', 'side', 'spikecolor', 'spikedash', 'spikemode',
+        'spikesides', 'spikesnap', 'spikethickness', 'tick0', 'tickangle',
+        'tickcolor', 'tickfont', 'tickformat', 'tickformatstops', 'ticklen',
+        'tickmode', 'tickprefix', 'ticks', 'ticksuffix', 'ticktext',
         'ticktextsrc', 'tickvals', 'tickvalssrc', 'tickwidth', 'title',
         'titlefont', 'type', 'visible', 'zeroline', 'zerolinecolor',
         'zerolinewidth']
@@ -1974,18 +1974,18 @@ class YAxis(PlotlyDict):
     """
     Valid attributes for 'yaxis' at path [] under parents ():
     
-        ['anchor', 'autorange', 'autotick', 'backgroundcolor', 'calendar',
-        'categoryarray', 'categoryarraysrc', 'categoryorder', 'color',
-        'constrain', 'constraintoward', 'domain', 'dtick', 'exponentformat',
-        'fixedrange', 'gridcolor', 'gridwidth', 'hoverformat', 'layer',
-        'linecolor', 'linewidth', 'mirror', 'nticks', 'overlaying', 'position',
-        'range', 'rangemode', 'scaleanchor', 'scaleratio', 'separatethousands',
-        'showaxeslabels', 'showbackground', 'showexponent', 'showgrid',
-        'showline', 'showspikes', 'showticklabels', 'showtickprefix',
-        'showticksuffix', 'side', 'spikecolor', 'spikedash', 'spikemode',
-        'spikesides', 'spikesnap', 'spikethickness', 'tick0', 'tickangle',
-        'tickcolor', 'tickfont', 'tickformat', 'tickformatstops', 'ticklen',
-        'tickmode', 'tickprefix', 'ticks', 'ticksuffix', 'ticktext',
+        ['anchor', 'automargin', 'autorange', 'autotick', 'backgroundcolor',
+        'calendar', 'categoryarray', 'categoryarraysrc', 'categoryorder',
+        'color', 'constrain', 'constraintoward', 'domain', 'dtick',
+        'exponentformat', 'fixedrange', 'gridcolor', 'gridwidth',
+        'hoverformat', 'layer', 'linecolor', 'linewidth', 'mirror', 'nticks',
+        'overlaying', 'position', 'range', 'rangemode', 'scaleanchor',
+        'scaleratio', 'separatethousands', 'showaxeslabels', 'showbackground',
+        'showexponent', 'showgrid', 'showline', 'showspikes', 'showticklabels',
+        'showtickprefix', 'showticksuffix', 'side', 'spikecolor', 'spikedash',
+        'spikemode', 'spikesides', 'spikesnap', 'spikethickness', 'tick0',
+        'tickangle', 'tickcolor', 'tickfont', 'tickformat', 'tickformatstops',
+        'ticklen', 'tickmode', 'tickprefix', 'ticks', 'ticksuffix', 'ticktext',
         'ticktextsrc', 'tickvals', 'tickvalssrc', 'tickwidth', 'title',
         'titlefont', 'type', 'visible', 'zeroline', 'zerolinecolor',
         'zerolinewidth']

--- a/plotly/package_data/default-schema.json
+++ b/plotly/package_data/default-schema.json
@@ -101,7 +101,7 @@
     "defs": {
         "editType": {
             "layout": {
-                "description": "layout attributes should include an `editType` string matching this flaglist. *calc* is the most extensive: a full `Plotly.plot` starting by clearing `gd.calcdata` to force it to be regenerated *calcIfAutorange* does a full `Plotly.plot`, but only clears and redoes `gd.calcdata` if there is at least one autoranged axis. *plot* calls `Plotly.plot` but without first clearing `gd.calcdata`. *legend* only redraws the legend. *ticks* only redraws axis ticks, labels, and gridlines. *layoutstyle* reapplies global and SVG cartesian axis styles. *modebar* just updates the modebar. *camera* just updates the camera settings for gl3d scenes. *arraydraw* allows component arrays to invoke the redraw routines just for the component(s) that changed.",
+                "description": "layout attributes should include an `editType` string matching this flaglist. *calc* is the most extensive: a full `Plotly.plot` starting by clearing `gd.calcdata` to force it to be regenerated *calcIfAutorange* does a full `Plotly.plot`, but only clears and redoes `gd.calcdata` if there is at least one autoranged axis. *plot* calls `Plotly.plot` but without first clearing `gd.calcdata`. *legend* only redraws the legend. *ticks* only redraws axis ticks, labels, and gridlines. *margins* recomputes ticklabel automargins. *layoutstyle* reapplies global and SVG cartesian axis styles. *modebar* just updates the modebar. *camera* just updates the camera settings for gl3d scenes. *arraydraw* allows component arrays to invoke the redraw routines just for the component(s) that changed.",
                 "extras": [
                     "none"
                 ],
@@ -111,6 +111,7 @@
                     "plot",
                     "legend",
                     "ticks",
+                    "margins",
                     "layoutstyle",
                     "modebar",
                     "camera",
@@ -194,7 +195,7 @@
                 "requiredOpts": []
             },
             "data_array": {
-                "description": "An {array} of data. The value MUST be an {array}, or we ignore it.",
+                "description": "An {array} of data. The value MUST be an {array}, or we ignore it. Note that typed arrays (e.g. Float32Array) are supported.",
                 "otherOpts": [
                     "dflt"
                 ],
@@ -226,7 +227,8 @@
                 "description": "An {array} of plot information.",
                 "otherOpts": [
                     "dflt",
-                    "freeLength"
+                    "freeLength",
+                    "dimensions"
                 ],
                 "requiredOpts": [
                     "items"
@@ -981,8 +983,24 @@
                     "valType": "number"
                 },
                 "domain": {
+                    "column": {
+                        "description": "If there is a layout grid, use the domain for this column in the grid for this geo subplot . Note that geo subplots are constrained by domain. In general, when `projection.scale` is set to 1. a map will fit either its x or y domain, but not both.",
+                        "dflt": 0,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "editType": "plot",
                     "role": "object",
+                    "row": {
+                        "description": "If there is a layout grid, use the domain for this row in the grid for this geo subplot . Note that geo subplots are constrained by domain. In general, when `projection.scale` is set to 1. a map will fit either its x or y domain, but not both.",
+                        "dflt": 0,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "x": {
                         "description": "Sets the horizontal domain of this geo subplot (in plot fraction). Note that geo subplots are constrained by domain. In general, when `projection.scale` is set to 1. a map will fit either its x or y domain, but not both.",
                         "dflt": [
@@ -1369,10 +1387,190 @@
                     "valType": "number"
                 }
             },
+            "grid": {
+                "columns": {
+                    "description": "The number of columns in the grid. If you provide a 2D `subplots` array, the length of its longest row is used as the default. If you give an `xaxes` array, its length is used as the default. But it's also possible to have a different length, if you want to leave a row at the end for non-cartesian subplots.",
+                    "editType": "plot",
+                    "min": 1,
+                    "role": "info",
+                    "valType": "integer"
+                },
+                "domain": {
+                    "editType": "plot",
+                    "role": "object",
+                    "x": {
+                        "description": "Sets the horizontal domain of this grid subplot (in plot fraction). The first and last cells end exactly at the domain edges, with no grout around the edges.",
+                        "dflt": [
+                            0,
+                            1
+                        ],
+                        "editType": "plot",
+                        "items": [
+                            {
+                                "editType": "plot",
+                                "max": 1,
+                                "min": 0,
+                                "valType": "number"
+                            },
+                            {
+                                "editType": "plot",
+                                "max": 1,
+                                "min": 0,
+                                "valType": "number"
+                            }
+                        ],
+                        "role": "info",
+                        "valType": "info_array"
+                    },
+                    "y": {
+                        "description": "Sets the vertical domain of this grid subplot (in plot fraction). The first and last cells end exactly at the domain edges, with no grout around the edges.",
+                        "dflt": [
+                            0,
+                            1
+                        ],
+                        "editType": "plot",
+                        "items": [
+                            {
+                                "editType": "plot",
+                                "max": 1,
+                                "min": 0,
+                                "valType": "number"
+                            },
+                            {
+                                "editType": "plot",
+                                "max": 1,
+                                "min": 0,
+                                "valType": "number"
+                            }
+                        ],
+                        "role": "info",
+                        "valType": "info_array"
+                    }
+                },
+                "editType": "plot",
+                "pattern": {
+                    "description": "If no `subplots`, `xaxes`, or `yaxes` are given but we do have `rows` and `columns`, we can generate defaults using consecutive axis IDs, in two ways: *coupled* gives one x axis per column and one y axis per row. *independent* uses a new xy pair for each cell, left-to-right across each row then iterating rows according to `roworder`.",
+                    "dflt": "coupled",
+                    "editType": "plot",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        "independent",
+                        "coupled"
+                    ]
+                },
+                "role": "object",
+                "roworder": {
+                    "description": "Is the first row the top or the bottom? Note that columns are always enumerated from left to right.",
+                    "dflt": "top to bottom",
+                    "editType": "plot",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        "top to bottom",
+                        "bottom to top"
+                    ]
+                },
+                "rows": {
+                    "description": "The number of rows in the grid. If you provide a 2D `subplots` array or a `yaxes` array, its length is used as the default. But it's also possible to have a different length, if you want to leave a row at the end for non-cartesian subplots.",
+                    "editType": "plot",
+                    "min": 1,
+                    "role": "info",
+                    "valType": "integer"
+                },
+                "subplots": {
+                    "description": "Used for freeform grids, where some axes may be shared across subplots but others are not. Each entry should be a cartesian subplot id, like *xy* or *x3y2*, or ** to leave that cell empty. You may reuse x axes within the same column, and y axes within the same row. Non-cartesian subplots and traces that support `domain` can place themselves in this grid separately using the `gridcell` attribute.",
+                    "dimensions": 2,
+                    "editType": "plot",
+                    "freeLength": true,
+                    "items": {
+                        "editType": "plot",
+                        "valType": "enumerated",
+                        "values": [
+                            "/^x([2-9]|[1-9][0-9]+)?y([2-9]|[1-9][0-9]+)?$/",
+                            ""
+                        ]
+                    },
+                    "role": "info",
+                    "valType": "info_array"
+                },
+                "xaxes": {
+                    "description": "Used with `yaxes` when the x and y axes are shared across columns and rows. Each entry should be an x axis id like *x*, *x2*, etc., or ** to not put an x axis in that column. Entries other than ** must be unique. Ignored if `subplots` is present. If missing but `yaxes` is present, will generate consecutive IDs.",
+                    "editType": "plot",
+                    "freeLength": true,
+                    "items": {
+                        "editType": "plot",
+                        "valType": "enumerated",
+                        "values": [
+                            "/^x([2-9]|[1-9][0-9]+)?$/",
+                            ""
+                        ]
+                    },
+                    "role": "info",
+                    "valType": "info_array"
+                },
+                "xgap": {
+                    "description": "Horizontal space between grid cells, expressed as a fraction of the total width available to one cell. Defaults to 0.1 for coupled-axes grids and 0.2 for independent grids.",
+                    "editType": "plot",
+                    "max": 1,
+                    "min": 0,
+                    "role": "info",
+                    "valType": "number"
+                },
+                "xside": {
+                    "description": "Sets where the x axis labels and titles go. *bottom* means the very bottom of the grid. *bottom plot* is the lowest plot that each x axis is used in. *top* and *top plot* are similar.",
+                    "dflt": "bottom plot",
+                    "editType": "ticks",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        "bottom",
+                        "bottom plot",
+                        "top plot",
+                        "top"
+                    ]
+                },
+                "yaxes": {
+                    "description": "Used with `yaxes` when the x and y axes are shared across columns and rows. Each entry should be an y axis id like *y*, *y2*, etc., or ** to not put a y axis in that row. Entries other than ** must be unique. Ignored if `subplots` is present. If missing but `xaxes` is present, will generate consecutive IDs.",
+                    "editType": "plot",
+                    "freeLength": true,
+                    "items": {
+                        "editType": "plot",
+                        "valType": "enumerated",
+                        "values": [
+                            "/^y([2-9]|[1-9][0-9]+)?$/",
+                            ""
+                        ]
+                    },
+                    "role": "info",
+                    "valType": "info_array"
+                },
+                "ygap": {
+                    "description": "Vertical space between grid cells, expressed as a fraction of the total height available to one cell. Defaults to 0.1 for coupled-axes grids and 0.3 for independent grids.",
+                    "editType": "plot",
+                    "max": 1,
+                    "min": 0,
+                    "role": "info",
+                    "valType": "number"
+                },
+                "yside": {
+                    "description": "Sets where the y axis labels and titles go. *left* means the very left edge of the grid. *left plot* is the leftmost plot that each y axis is used in. *right* and *right plot* are similar.",
+                    "dflt": "left plot",
+                    "editType": "ticks",
+                    "role": "info",
+                    "valType": "enumerated",
+                    "values": [
+                        "left",
+                        "left plot",
+                        "right plot",
+                        "right"
+                    ]
+                }
+            },
             "height": {
                 "description": "Sets the plot's height (in px).",
                 "dflt": 450,
-                "editType": "none",
+                "editType": "plot",
                 "min": 10,
                 "role": "info",
                 "valType": "number"
@@ -1385,7 +1583,7 @@
                 "valType": "boolean"
             },
             "hoverdistance": {
-                "description": "Sets the default distance (in pixels) to look for data to add hover labels (-1 means no cutoff, 0 means no looking for data)",
+                "description": "Sets the default distance (in pixels) to look for data to add hover labels (-1 means no cutoff, 0 means no looking for data). This is only a real distance for hovering on point-like objects, like scatter points. For area-like objects (bars, scatter fills, etc) hovering is on inside the area and off outside, but these objects will not supersede hover on point-like objects in case of conflict.",
                 "dflt": 20,
                 "editType": "none",
                 "min": -1,
@@ -1746,8 +1944,24 @@
                     "role": "object"
                 },
                 "domain": {
+                    "column": {
+                        "description": "If there is a layout grid, use the domain for this column in the grid for this mapbox subplot .",
+                        "dflt": 0,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "editType": "plot",
                     "role": "object",
+                    "row": {
+                        "description": "If there is a layout grid, use the domain for this row in the grid for this mapbox subplot .",
+                        "dflt": 0,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "x": {
                         "description": "Sets the horizontal domain of this mapbox subplot (in plot fraction).",
                         "dflt": [
@@ -2004,23 +2218,23 @@
             "margin": {
                 "autoexpand": {
                     "dflt": true,
-                    "editType": "calc",
+                    "editType": "plot",
                     "role": "info",
                     "valType": "boolean"
                 },
                 "b": {
                     "description": "Sets the bottom margin (in px).",
                     "dflt": 80,
-                    "editType": "calc",
+                    "editType": "plot",
                     "min": 0,
                     "role": "info",
                     "valType": "number"
                 },
-                "editType": "calc",
+                "editType": "plot",
                 "l": {
                     "description": "Sets the left margin (in px).",
                     "dflt": 80,
-                    "editType": "calc",
+                    "editType": "plot",
                     "min": 0,
                     "role": "info",
                     "valType": "number"
@@ -2028,7 +2242,7 @@
                 "pad": {
                     "description": "Sets the amount of padding (in px) between the plotting area and the axis lines",
                     "dflt": 0,
-                    "editType": "calc",
+                    "editType": "plot",
                     "min": 0,
                     "role": "info",
                     "valType": "number"
@@ -2036,7 +2250,7 @@
                 "r": {
                     "description": "Sets the right margin (in px).",
                     "dflt": 80,
-                    "editType": "calc",
+                    "editType": "plot",
                     "min": 0,
                     "role": "info",
                     "valType": "number"
@@ -2045,7 +2259,7 @@
                 "t": {
                     "description": "Sets the top margin (in px).",
                     "dflt": 100,
-                    "editType": "calc",
+                    "editType": "plot",
                     "min": 0,
                     "role": "info",
                     "valType": "number"
@@ -2481,8 +2695,24 @@
                     "valType": "color"
                 },
                 "domain": {
+                    "column": {
+                        "description": "If there is a layout grid, use the domain for this column in the grid for this polar subplot .",
+                        "dflt": 0,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "editType": "plot",
                     "role": "object",
+                    "row": {
+                        "description": "If there is a layout grid, use the domain for this row in the grid for this polar subplot .",
+                        "dflt": 0,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "x": {
                         "description": "Sets the horizontal domain of this polar subplot (in plot fraction).",
                         "dflt": [
@@ -2492,11 +2722,13 @@
                         "editType": "plot",
                         "items": [
                             {
+                                "editType": "plot",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
                             },
                             {
+                                "editType": "plot",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
@@ -2514,11 +2746,13 @@
                         "editType": "plot",
                         "items": [
                             {
+                                "editType": "plot",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
                             },
                             {
+                                "editType": "plot",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
@@ -2689,20 +2923,20 @@
                     },
                     "range": {
                         "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
-                        "editType": "plot",
+                        "editType": "plot+margins",
                         "impliedEdits": {
                             "autorange": false
                         },
                         "items": [
                             {
-                                "editType": "plot",
+                                "editType": "plot+margins",
                                 "impliedEdits": {
                                     "^autorange": false
                                 },
                                 "valType": "any"
                             },
                             {
-                                "editType": "plot",
+                                "editType": "plot+margins",
                                 "impliedEdits": {
                                     "^autorange": false
                                 },
@@ -3624,8 +3858,24 @@
                     }
                 },
                 "domain": {
+                    "column": {
+                        "description": "If there is a layout grid, use the domain for this column in the grid for this scene subplot .",
+                        "dflt": 0,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "editType": "plot",
                     "role": "object",
+                    "row": {
+                        "description": "If there is a layout grid, use the domain for this row in the grid for this scene subplot .",
+                        "dflt": 0,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "x": {
                         "description": "Sets the horizontal domain of this scene subplot (in plot fraction).",
                         "dflt": [
@@ -3635,11 +3885,13 @@
                         "editType": "plot",
                         "items": [
                             {
+                                "editType": "plot",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
                             },
                             {
+                                "editType": "plot",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
@@ -3657,11 +3909,13 @@
                         "editType": "plot",
                         "items": [
                             {
+                                "editType": "plot",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
                             },
                             {
+                                "editType": "plot",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
@@ -5869,7 +6123,7 @@
                 "role": "object"
             },
             "spikedistance": {
-                "description": "Sets the default distance (in pixels) to look for data to draw spikelines to (-1 means no cutoff, 0 means no looking for data).",
+                "description": "Sets the default distance (in pixels) to look for data to draw spikelines to (-1 means no cutoff, 0 means no looking for data). As with hoverdistance, distance does not apply to area-like objects. In addition, some objects can be hovered on but will not generate spikelines, such as scatter fills.",
                 "dflt": 20,
                 "editType": "none",
                 "min": -1,
@@ -6963,8 +7217,24 @@
                     }
                 },
                 "domain": {
+                    "column": {
+                        "description": "If there is a layout grid, use the domain for this column in the grid for this ternary subplot .",
+                        "dflt": 0,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "editType": "plot",
                     "role": "object",
+                    "row": {
+                        "description": "If there is a layout grid, use the domain for this row in the grid for this ternary subplot .",
+                        "dflt": 0,
+                        "editType": "plot",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "x": {
                         "description": "Sets the horizontal domain of this ternary subplot (in plot fraction).",
                         "dflt": [
@@ -7295,7 +7565,7 @@
             "width": {
                 "description": "Sets the plot's width (in px).",
                 "dflt": 700,
-                "editType": "none",
+                "editType": "plot",
                 "min": 10,
                 "role": "info",
                 "valType": "number"
@@ -7304,7 +7574,7 @@
                 "_deprecated": {
                     "autotick": {
                         "description": "Obsolete. Set `tickmode` to *auto* for old `autotick` *true* behavior. Set `tickmode` to *linear* for `autotick` *false*.",
-                        "editType": "ticks",
+                        "editType": "ticks+margins",
                         "role": "info",
                         "valType": "boolean"
                     }
@@ -7312,7 +7582,7 @@
                 "_isSubplotObj": true,
                 "anchor": {
                     "description": "If set to an opposite-letter axis id (e.g. `x2`, `y`), this axis is bound to the corresponding opposite-letter axis. If set to *free*, this axis' position is determined by `position`.",
-                    "editType": "plot",
+                    "editType": "plot+margins",
                     "role": "info",
                     "valType": "enumerated",
                     "values": [
@@ -7320,6 +7590,13 @@
                         "/^x([2-9]|[1-9][0-9]+)?$/",
                         "/^y([2-9]|[1-9][0-9]+)?$/"
                     ]
+                },
+                "automargin": {
+                    "description": "Determines whether long tick labels automatically grow the figure margins.",
+                    "dflt": false,
+                    "editType": "ticks+margins",
+                    "role": "style",
+                    "valType": "boolean"
                 },
                 "autorange": {
                     "description": "Determines whether or not the range of this axis is computed in relation to the input data. See `rangemode` for more info. If `range` is provided, then `autorange` is set to *false*.",
@@ -7394,7 +7671,7 @@
                 "constrain": {
                     "description": "If this axis needs to be compressed (either due to its own `scaleanchor` and `scaleratio` or those of the other axis), determines how that happens: by increasing the *range* (default), or by decreasing the *domain*.",
                     "dflt": "range",
-                    "editType": "calc",
+                    "editType": "plot",
                     "role": "info",
                     "valType": "enumerated",
                     "values": [
@@ -7404,7 +7681,7 @@
                 },
                 "constraintoward": {
                     "description": "If this axis needs to be compressed (either due to its own `scaleanchor` and `scaleratio` or those of the other axis), determines which direction we push the originally specified plot area. Options are *left*, *center* (default), and *right* for x axes, and *top*, *middle* (default), and *bottom* for y axes.",
-                    "editType": "calc",
+                    "editType": "plot",
                     "role": "info",
                     "valType": "enumerated",
                     "values": [
@@ -7422,16 +7699,16 @@
                         0,
                         1
                     ],
-                    "editType": "calc",
+                    "editType": "plot+margins",
                     "items": [
                         {
-                            "editType": "calc",
+                            "editType": "plot+margins",
                             "max": 1,
                             "min": 0,
                             "valType": "number"
                         },
                         {
-                            "editType": "calc",
+                            "editType": "plot+margins",
                             "max": 1,
                             "min": 0,
                             "valType": "number"
@@ -7442,7 +7719,7 @@
                 },
                 "dtick": {
                     "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "impliedEdits": {
                         "tickmode": "linear"
                     },
@@ -7453,7 +7730,7 @@
                 "exponentformat": {
                     "description": "Determines a formatting rule for the tick exponents. For example, consider the number 1,000,000,000. If *none*, it appears as 1,000,000,000. If *e*, 1e+9. If *E*, 1E+9. If *power*, 1x10^9 (with 9 in a super script). If *SI*, 1G. If *B*, 1B.",
                     "dflt": "B",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "enumerated",
                     "values": [
@@ -7537,14 +7814,14 @@
                 "nticks": {
                     "description": "Specifies the maximum number of ticks for the particular axis. The actual number of ticks will be chosen automatically to be less than or equal to `nticks`. Has an effect only if `tickmode` is set to *auto*.",
                     "dflt": 0,
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "min": 0,
                     "role": "style",
                     "valType": "integer"
                 },
                 "overlaying": {
                     "description": "If set a same-letter axis id, this axis is overlaid on top of the corresponding same-letter axis. If *false*, this axis does not overlay any same-letter axes.",
-                    "editType": "calc",
+                    "editType": "plot",
                     "role": "info",
                     "valType": "enumerated",
                     "values": [
@@ -7556,7 +7833,7 @@
                 "position": {
                     "description": "Sets the position of this axis in the plotting space (in normalized coordinates). Only has an effect if `anchor` is set to *free*.",
                     "dflt": 0,
-                    "editType": "plot",
+                    "editType": "plot+margins",
                     "max": 1,
                     "min": 0,
                     "role": "style",
@@ -7564,20 +7841,20 @@
                 },
                 "range": {
                     "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
-                    "editType": "plot",
+                    "editType": "plot+margins",
                     "impliedEdits": {
                         "autorange": false
                     },
                     "items": [
                         {
-                            "editType": "plot",
+                            "editType": "plot+margins",
                             "impliedEdits": {
                                 "^autorange": false
                             },
                             "valType": "any"
                         },
                         {
-                            "editType": "plot",
+                            "editType": "plot+margins",
                             "impliedEdits": {
                                 "^autorange": false
                             },
@@ -7590,7 +7867,7 @@
                 "rangemode": {
                     "description": "If *normal*, the range is computed in relation to the extrema of the input data. If *tozero*`, the range extends to 0, regardless of the input data If *nonnegative*, the range is non-negative, regardless of the input data.",
                     "dflt": "normal",
-                    "editType": "calc",
+                    "editType": "plot",
                     "role": "style",
                     "valType": "enumerated",
                     "values": [
@@ -7766,21 +8043,21 @@
                     "bgcolor": {
                         "description": "Sets the background color of the range slider.",
                         "dflt": "#fff",
-                        "editType": "calc",
+                        "editType": "plot",
                         "role": "style",
                         "valType": "color"
                     },
                     "bordercolor": {
                         "description": "Sets the border color of the range slider.",
                         "dflt": "#444",
-                        "editType": "calc",
+                        "editType": "plot",
                         "role": "style",
                         "valType": "color"
                     },
                     "borderwidth": {
                         "description": "Sets the border color of the range slider.",
                         "dflt": 0,
-                        "editType": "calc",
+                        "editType": "plot",
                         "min": 0,
                         "role": "style",
                         "valType": "integer"
@@ -7815,7 +8092,7 @@
                     "thickness": {
                         "description": "The height of the range slider as a fraction of the total plot area height.",
                         "dflt": 0.15,
-                        "editType": "calc",
+                        "editType": "plot",
                         "max": 1,
                         "min": 0,
                         "role": "style",
@@ -7827,12 +8104,45 @@
                         "editType": "calc",
                         "role": "info",
                         "valType": "boolean"
+                    },
+                    "yaxis": {
+                        "_isSubplotObj": true,
+                        "editType": "calc",
+                        "range": {
+                            "description": "Sets the range of this axis for the rangeslider.",
+                            "editType": "plot",
+                            "items": [
+                                {
+                                    "editType": "plot",
+                                    "valType": "any"
+                                },
+                                {
+                                    "editType": "plot",
+                                    "valType": "any"
+                                }
+                            ],
+                            "role": "style",
+                            "valType": "info_array"
+                        },
+                        "rangemode": {
+                            "description": "Determines whether or not the range of this axis in the rangeslider use the same value than in the main plot when zooming in/out. If *auto*, the autorange will be used. If *fixed*, the `range` is used. If *match*, the current range of the corresponding y-axis on the main subplot is used.",
+                            "dflt": "match",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "enumerated",
+                            "values": [
+                                "auto",
+                                "fixed",
+                                "match"
+                            ]
+                        },
+                        "role": "object"
                     }
                 },
                 "role": "object",
                 "scaleanchor": {
                     "description": "If set to another axis id (e.g. `x2`, `y`), the range of this axis changes together with the range of the corresponding axis such that the scale of pixels per unit is in a constant ratio. Both axes are still zoomable, but when you zoom one, the other will zoom the same amount, keeping a fixed midpoint. `constrain` and `constraintoward` determine how we enforce the constraint. You can chain these, ie `yaxis: {scaleanchor: *x*}, xaxis2: {scaleanchor: *y*}` but you can only link axes of the same `type`. The linked axis can have the opposite letter (to constrain the aspect ratio) or the same letter (to match scales across subplots). Loops (`yaxis: {scaleanchor: *x*}, xaxis: {scaleanchor: *y*}` or longer) are redundant and the last constraint encountered will be ignored to avoid possible inconsistent constraints via `scaleratio`.",
-                    "editType": "calc",
+                    "editType": "plot",
                     "role": "info",
                     "valType": "enumerated",
                     "values": [
@@ -7843,7 +8153,7 @@
                 "scaleratio": {
                     "description": "If this axis is linked to another by `scaleanchor`, this determines the pixel to unit scale ratio. For example, if this value is 10, then every unit on this axis spans 10 times the number of pixels as a unit on the linked axis. Use this for example to create an elevation profile where the vertical scale is exaggerated a fixed amount with respect to the horizontal.",
                     "dflt": 1,
-                    "editType": "calc",
+                    "editType": "plot",
                     "min": 0,
                     "role": "info",
                     "valType": "number"
@@ -7851,14 +8161,14 @@
                 "separatethousands": {
                     "description": "If \"true\", even 4-digit integers are separated",
                     "dflt": false,
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "boolean"
                 },
                 "showexponent": {
                     "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                     "dflt": "all",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "enumerated",
                     "values": [
@@ -7891,14 +8201,14 @@
                 "showticklabels": {
                     "description": "Determines whether or not the tick labels are drawn.",
                     "dflt": true,
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "boolean"
                 },
                 "showtickprefix": {
                     "description": "If *all*, all tick labels are displayed with a prefix. If *first*, only the first tick is displayed with a prefix. If *last*, only the last tick is displayed with a suffix. If *none*, tick prefixes are hidden.",
                     "dflt": "all",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "enumerated",
                     "values": [
@@ -7911,7 +8221,7 @@
                 "showticksuffix": {
                     "description": "Same as `showtickprefix` but for tick suffixes.",
                     "dflt": "all",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "enumerated",
                     "values": [
@@ -7923,7 +8233,7 @@
                 },
                 "side": {
                     "description": "Determines whether a x (y) axis is positioned at the *bottom* (*left*) or *top* (*right*) of the plotting area.",
-                    "editType": "plot",
+                    "editType": "plot+margins",
                     "role": "info",
                     "valType": "enumerated",
                     "values": [
@@ -7987,7 +8297,7 @@
                 },
                 "tick0": {
                     "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "impliedEdits": {
                         "tickmode": "linear"
                     },
@@ -7997,7 +8307,7 @@
                 "tickangle": {
                     "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
                     "dflt": "auto",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "angle"
                 },
@@ -8010,15 +8320,15 @@
                 },
                 "tickfont": {
                     "color": {
-                        "editType": "ticks",
+                        "editType": "ticks+margins",
                         "role": "style",
                         "valType": "color"
                     },
                     "description": "Sets the tick font.",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "family": {
                         "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
-                        "editType": "ticks",
+                        "editType": "ticks+margins",
                         "noBlank": true,
                         "role": "style",
                         "strict": true,
@@ -8026,7 +8336,7 @@
                     },
                     "role": "object",
                     "size": {
-                        "editType": "ticks",
+                        "editType": "ticks+margins",
                         "min": 1,
                         "role": "style",
                         "valType": "number"
@@ -8035,7 +8345,7 @@
                 "tickformat": {
                     "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                     "dflt": "",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "string"
                 },
@@ -8044,26 +8354,26 @@
                         "tickformatstop": {
                             "dtickrange": {
                                 "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
-                                "editType": "ticks",
+                                "editType": "ticks+margins",
                                 "items": [
                                     {
-                                        "editType": "ticks",
+                                        "editType": "ticks+margins",
                                         "valType": "any"
                                     },
                                     {
-                                        "editType": "ticks",
+                                        "editType": "ticks+margins",
                                         "valType": "any"
                                     }
                                 ],
                                 "role": "info",
                                 "valType": "info_array"
                             },
-                            "editType": "ticks",
+                            "editType": "ticks+margins",
                             "role": "object",
                             "value": {
                                 "description": "string - dtickformat for described zoom level, the same as *tickformat*",
                                 "dflt": "",
-                                "editType": "ticks",
+                                "editType": "ticks+margins",
                                 "role": "style",
                                 "valType": "string"
                             }
@@ -8081,7 +8391,7 @@
                 },
                 "tickmode": {
                     "description": "Sets the tick mode for this axis. If *auto*, the number of ticks is set via `nticks`. If *linear*, the placement of the ticks is determined by a starting position `tick0` and a tick step `dtick` (*linear* is the default value if `tick0` and `dtick` are provided). If *array*, the placement of the ticks is set via `tickvals` and the tick text is `ticktext`. (*array* is the default value if `tickvals` is provided).",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "impliedEdits": {},
                     "role": "info",
                     "valType": "enumerated",
@@ -8094,13 +8404,13 @@
                 "tickprefix": {
                     "description": "Sets a tick label prefix.",
                     "dflt": "",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "string"
                 },
                 "ticks": {
                     "description": "Determines whether ticks are drawn or not. If **, this axis' ticks are not drawn. If *outside* (*inside*), this axis' are drawn outside (inside) the axis lines.",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "enumerated",
                     "values": [
@@ -8112,13 +8422,13 @@
                 "ticksuffix": {
                     "description": "Sets a tick label suffix.",
                     "dflt": "",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "string"
                 },
                 "ticktext": {
                     "description": "Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "data",
                     "valType": "data_array"
                 },
@@ -8130,7 +8440,7 @@
                 },
                 "tickvals": {
                     "description": "Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "data",
                     "valType": "data_array"
                 },
@@ -8150,21 +8460,21 @@
                 },
                 "title": {
                     "description": "Sets the title of this axis.",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "info",
                     "valType": "string"
                 },
                 "titlefont": {
                     "color": {
-                        "editType": "ticks",
+                        "editType": "ticks+margins",
                         "role": "style",
                         "valType": "color"
                     },
                     "description": "Sets this axis' title font.",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "family": {
                         "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
-                        "editType": "ticks",
+                        "editType": "ticks+margins",
                         "noBlank": true,
                         "role": "style",
                         "strict": true,
@@ -8172,7 +8482,7 @@
                     },
                     "role": "object",
                     "size": {
-                        "editType": "ticks",
+                        "editType": "ticks+margins",
                         "min": 1,
                         "role": "style",
                         "valType": "number"
@@ -8223,7 +8533,7 @@
                 "_deprecated": {
                     "autotick": {
                         "description": "Obsolete. Set `tickmode` to *auto* for old `autotick` *true* behavior. Set `tickmode` to *linear* for `autotick` *false*.",
-                        "editType": "ticks",
+                        "editType": "ticks+margins",
                         "role": "info",
                         "valType": "boolean"
                     }
@@ -8231,7 +8541,7 @@
                 "_isSubplotObj": true,
                 "anchor": {
                     "description": "If set to an opposite-letter axis id (e.g. `x2`, `y`), this axis is bound to the corresponding opposite-letter axis. If set to *free*, this axis' position is determined by `position`.",
-                    "editType": "plot",
+                    "editType": "plot+margins",
                     "role": "info",
                     "valType": "enumerated",
                     "values": [
@@ -8239,6 +8549,13 @@
                         "/^x([2-9]|[1-9][0-9]+)?$/",
                         "/^y([2-9]|[1-9][0-9]+)?$/"
                     ]
+                },
+                "automargin": {
+                    "description": "Determines whether long tick labels automatically grow the figure margins.",
+                    "dflt": false,
+                    "editType": "ticks+margins",
+                    "role": "style",
+                    "valType": "boolean"
                 },
                 "autorange": {
                     "description": "Determines whether or not the range of this axis is computed in relation to the input data. See `rangemode` for more info. If `range` is provided, then `autorange` is set to *false*.",
@@ -8313,7 +8630,7 @@
                 "constrain": {
                     "description": "If this axis needs to be compressed (either due to its own `scaleanchor` and `scaleratio` or those of the other axis), determines how that happens: by increasing the *range* (default), or by decreasing the *domain*.",
                     "dflt": "range",
-                    "editType": "calc",
+                    "editType": "plot",
                     "role": "info",
                     "valType": "enumerated",
                     "values": [
@@ -8323,7 +8640,7 @@
                 },
                 "constraintoward": {
                     "description": "If this axis needs to be compressed (either due to its own `scaleanchor` and `scaleratio` or those of the other axis), determines which direction we push the originally specified plot area. Options are *left*, *center* (default), and *right* for x axes, and *top*, *middle* (default), and *bottom* for y axes.",
-                    "editType": "calc",
+                    "editType": "plot",
                     "role": "info",
                     "valType": "enumerated",
                     "values": [
@@ -8341,16 +8658,16 @@
                         0,
                         1
                     ],
-                    "editType": "calc",
+                    "editType": "plot+margins",
                     "items": [
                         {
-                            "editType": "calc",
+                            "editType": "plot+margins",
                             "max": 1,
                             "min": 0,
                             "valType": "number"
                         },
                         {
-                            "editType": "calc",
+                            "editType": "plot+margins",
                             "max": 1,
                             "min": 0,
                             "valType": "number"
@@ -8361,7 +8678,7 @@
                 },
                 "dtick": {
                     "description": "Sets the step in-between ticks on this axis. Use with `tick0`. Must be a positive number, or special strings available to *log* and *date* axes. If the axis `type` is *log*, then ticks are set every 10^(n*dtick) where n is the tick number. For example, to set a tick mark at 1, 10, 100, 1000, ... set dtick to 1. To set tick marks at 1, 100, 10000, ... set dtick to 2. To set tick marks at 1, 5, 25, 125, 625, 3125, ... set dtick to log_10(5), or 0.69897000433. *log* has several special values; *L<f>*, where `f` is a positive number, gives ticks linearly spaced in value (but not position). For example `tick0` = 0.1, `dtick` = *L0.5* will put ticks at 0.1, 0.6, 1.1, 1.6 etc. To show powers of 10 plus small digits between, use *D1* (all digits) or *D2* (only 2 and 5). `tick0` is ignored for *D1* and *D2*. If the axis `type` is *date*, then you must convert the time to milliseconds. For example, to set the interval between ticks to one day, set `dtick` to 86400000.0. *date* also has special values *M<n>* gives ticks spaced by a number of months. `n` must be a positive integer. To set ticks on the 15th of every third month, set `tick0` to *2000-01-15* and `dtick` to *M3*. To set ticks every 4 years, set `dtick` to *M48*",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "impliedEdits": {
                         "tickmode": "linear"
                     },
@@ -8372,7 +8689,7 @@
                 "exponentformat": {
                     "description": "Determines a formatting rule for the tick exponents. For example, consider the number 1,000,000,000. If *none*, it appears as 1,000,000,000. If *e*, 1e+9. If *E*, 1E+9. If *power*, 1x10^9 (with 9 in a super script). If *SI*, 1G. If *B*, 1B.",
                     "dflt": "B",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "enumerated",
                     "values": [
@@ -8456,14 +8773,14 @@
                 "nticks": {
                     "description": "Specifies the maximum number of ticks for the particular axis. The actual number of ticks will be chosen automatically to be less than or equal to `nticks`. Has an effect only if `tickmode` is set to *auto*.",
                     "dflt": 0,
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "min": 0,
                     "role": "style",
                     "valType": "integer"
                 },
                 "overlaying": {
                     "description": "If set a same-letter axis id, this axis is overlaid on top of the corresponding same-letter axis. If *false*, this axis does not overlay any same-letter axes.",
-                    "editType": "calc",
+                    "editType": "plot",
                     "role": "info",
                     "valType": "enumerated",
                     "values": [
@@ -8475,7 +8792,7 @@
                 "position": {
                     "description": "Sets the position of this axis in the plotting space (in normalized coordinates). Only has an effect if `anchor` is set to *free*.",
                     "dflt": 0,
-                    "editType": "plot",
+                    "editType": "plot+margins",
                     "max": 1,
                     "min": 0,
                     "role": "style",
@@ -8483,20 +8800,20 @@
                 },
                 "range": {
                     "description": "Sets the range of this axis. If the axis `type` is *log*, then you must take the log of your desired range (e.g. to set the range from 1 to 100, set the range from 0 to 2). If the axis `type` is *date*, it should be date strings, like date data, though Date objects and unix milliseconds will be accepted and converted to strings. If the axis `type` is *category*, it should be numbers, using the scale where each category is assigned a serial number from zero in the order it appears.",
-                    "editType": "plot",
+                    "editType": "plot+margins",
                     "impliedEdits": {
                         "autorange": false
                     },
                     "items": [
                         {
-                            "editType": "plot",
+                            "editType": "plot+margins",
                             "impliedEdits": {
                                 "^autorange": false
                             },
                             "valType": "any"
                         },
                         {
-                            "editType": "plot",
+                            "editType": "plot+margins",
                             "impliedEdits": {
                                 "^autorange": false
                             },
@@ -8509,7 +8826,7 @@
                 "rangemode": {
                     "description": "If *normal*, the range is computed in relation to the extrema of the input data. If *tozero*`, the range extends to 0, regardless of the input data If *nonnegative*, the range is non-negative, regardless of the input data.",
                     "dflt": "normal",
-                    "editType": "calc",
+                    "editType": "plot",
                     "role": "style",
                     "valType": "enumerated",
                     "values": [
@@ -8521,7 +8838,7 @@
                 "role": "object",
                 "scaleanchor": {
                     "description": "If set to another axis id (e.g. `x2`, `y`), the range of this axis changes together with the range of the corresponding axis such that the scale of pixels per unit is in a constant ratio. Both axes are still zoomable, but when you zoom one, the other will zoom the same amount, keeping a fixed midpoint. `constrain` and `constraintoward` determine how we enforce the constraint. You can chain these, ie `yaxis: {scaleanchor: *x*}, xaxis2: {scaleanchor: *y*}` but you can only link axes of the same `type`. The linked axis can have the opposite letter (to constrain the aspect ratio) or the same letter (to match scales across subplots). Loops (`yaxis: {scaleanchor: *x*}, xaxis: {scaleanchor: *y*}` or longer) are redundant and the last constraint encountered will be ignored to avoid possible inconsistent constraints via `scaleratio`.",
-                    "editType": "calc",
+                    "editType": "plot",
                     "role": "info",
                     "valType": "enumerated",
                     "values": [
@@ -8532,7 +8849,7 @@
                 "scaleratio": {
                     "description": "If this axis is linked to another by `scaleanchor`, this determines the pixel to unit scale ratio. For example, if this value is 10, then every unit on this axis spans 10 times the number of pixels as a unit on the linked axis. Use this for example to create an elevation profile where the vertical scale is exaggerated a fixed amount with respect to the horizontal.",
                     "dflt": 1,
-                    "editType": "calc",
+                    "editType": "plot",
                     "min": 0,
                     "role": "info",
                     "valType": "number"
@@ -8540,14 +8857,14 @@
                 "separatethousands": {
                     "description": "If \"true\", even 4-digit integers are separated",
                     "dflt": false,
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "boolean"
                 },
                 "showexponent": {
                     "description": "If *all*, all exponents are shown besides their significands. If *first*, only the exponent of the first tick is shown. If *last*, only the exponent of the last tick is shown. If *none*, no exponents appear.",
                     "dflt": "all",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "enumerated",
                     "values": [
@@ -8580,14 +8897,14 @@
                 "showticklabels": {
                     "description": "Determines whether or not the tick labels are drawn.",
                     "dflt": true,
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "boolean"
                 },
                 "showtickprefix": {
                     "description": "If *all*, all tick labels are displayed with a prefix. If *first*, only the first tick is displayed with a prefix. If *last*, only the last tick is displayed with a suffix. If *none*, tick prefixes are hidden.",
                     "dflt": "all",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "enumerated",
                     "values": [
@@ -8600,7 +8917,7 @@
                 "showticksuffix": {
                     "description": "Same as `showtickprefix` but for tick suffixes.",
                     "dflt": "all",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "enumerated",
                     "values": [
@@ -8612,7 +8929,7 @@
                 },
                 "side": {
                     "description": "Determines whether a x (y) axis is positioned at the *bottom* (*left*) or *top* (*right*) of the plotting area.",
-                    "editType": "plot",
+                    "editType": "plot+margins",
                     "role": "info",
                     "valType": "enumerated",
                     "values": [
@@ -8676,7 +8993,7 @@
                 },
                 "tick0": {
                     "description": "Sets the placement of the first tick on this axis. Use with `dtick`. If the axis `type` is *log*, then you must take the log of your starting tick (e.g. to set the starting tick to 100, set the `tick0` to 2) except when `dtick`=*L<f>* (see `dtick` for more info). If the axis `type` is *date*, it should be a date string, like date data. If the axis `type` is *category*, it should be a number, using the scale where each category is assigned a serial number from zero in the order it appears.",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "impliedEdits": {
                         "tickmode": "linear"
                     },
@@ -8686,7 +9003,7 @@
                 "tickangle": {
                     "description": "Sets the angle of the tick labels with respect to the horizontal. For example, a `tickangle` of -90 draws the tick labels vertically.",
                     "dflt": "auto",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "angle"
                 },
@@ -8699,15 +9016,15 @@
                 },
                 "tickfont": {
                     "color": {
-                        "editType": "ticks",
+                        "editType": "ticks+margins",
                         "role": "style",
                         "valType": "color"
                     },
                     "description": "Sets the tick font.",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "family": {
                         "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
-                        "editType": "ticks",
+                        "editType": "ticks+margins",
                         "noBlank": true,
                         "role": "style",
                         "strict": true,
@@ -8715,7 +9032,7 @@
                     },
                     "role": "object",
                     "size": {
-                        "editType": "ticks",
+                        "editType": "ticks+margins",
                         "min": 1,
                         "role": "style",
                         "valType": "number"
@@ -8724,7 +9041,7 @@
                 "tickformat": {
                     "description": "Sets the tick label formatting rule using d3 formatting mini-languages which are very similar to those in Python. For numbers, see: https://github.com/d3/d3-format/blob/master/README.md#locale_format And for dates see: https://github.com/d3/d3-time-format/blob/master/README.md#locale_format We add one item to d3's date formatter: *%{n}f* for fractional seconds with n digits. For example, *2016-10-13 09:15:23.456* with tickformat *%H~%M~%S.%2f* would display *09~15~23.46*",
                     "dflt": "",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "string"
                 },
@@ -8733,26 +9050,26 @@
                         "tickformatstop": {
                             "dtickrange": {
                                 "description": "range [*min*, *max*], where *min*, *max* - dtick values which describe some zoom level, it is possible to omit *min* or *max* value by passing *null*",
-                                "editType": "ticks",
+                                "editType": "ticks+margins",
                                 "items": [
                                     {
-                                        "editType": "ticks",
+                                        "editType": "ticks+margins",
                                         "valType": "any"
                                     },
                                     {
-                                        "editType": "ticks",
+                                        "editType": "ticks+margins",
                                         "valType": "any"
                                     }
                                 ],
                                 "role": "info",
                                 "valType": "info_array"
                             },
-                            "editType": "ticks",
+                            "editType": "ticks+margins",
                             "role": "object",
                             "value": {
                                 "description": "string - dtickformat for described zoom level, the same as *tickformat*",
                                 "dflt": "",
-                                "editType": "ticks",
+                                "editType": "ticks+margins",
                                 "role": "style",
                                 "valType": "string"
                             }
@@ -8770,7 +9087,7 @@
                 },
                 "tickmode": {
                     "description": "Sets the tick mode for this axis. If *auto*, the number of ticks is set via `nticks`. If *linear*, the placement of the ticks is determined by a starting position `tick0` and a tick step `dtick` (*linear* is the default value if `tick0` and `dtick` are provided). If *array*, the placement of the ticks is set via `tickvals` and the tick text is `ticktext`. (*array* is the default value if `tickvals` is provided).",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "impliedEdits": {},
                     "role": "info",
                     "valType": "enumerated",
@@ -8783,13 +9100,13 @@
                 "tickprefix": {
                     "description": "Sets a tick label prefix.",
                     "dflt": "",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "string"
                 },
                 "ticks": {
                     "description": "Determines whether ticks are drawn or not. If **, this axis' ticks are not drawn. If *outside* (*inside*), this axis' are drawn outside (inside) the axis lines.",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "enumerated",
                     "values": [
@@ -8801,13 +9118,13 @@
                 "ticksuffix": {
                     "description": "Sets a tick label suffix.",
                     "dflt": "",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "style",
                     "valType": "string"
                 },
                 "ticktext": {
                     "description": "Sets the text displayed at the ticks position via `tickvals`. Only has an effect if `tickmode` is set to *array*. Used with `tickvals`.",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "data",
                     "valType": "data_array"
                 },
@@ -8819,7 +9136,7 @@
                 },
                 "tickvals": {
                     "description": "Sets the values at which ticks on this axis appear. Only has an effect if `tickmode` is set to *array*. Used with `ticktext`.",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "data",
                     "valType": "data_array"
                 },
@@ -8839,21 +9156,21 @@
                 },
                 "title": {
                     "description": "Sets the title of this axis.",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "role": "info",
                     "valType": "string"
                 },
                 "titlefont": {
                     "color": {
-                        "editType": "ticks",
+                        "editType": "ticks+margins",
                         "role": "style",
                         "valType": "color"
                     },
                     "description": "Sets this axis' title font.",
-                    "editType": "ticks",
+                    "editType": "ticks+margins",
                     "family": {
                         "description": "HTML font family - the typeface that will be applied by the web browser. The web browser will only be able to apply a font if it is available on the system which it operates. Provide multiple font families, separated by commas, to indicate the preference in which to apply fonts if they aren't available on the system. The plotly service (at https://plot.ly or on-premise) generates images on a server, where only a select number of fonts are installed and supported. These include *Arial*, *Balto*, *Courier New*, *Droid Sans*,, *Droid Serif*, *Droid Sans Mono*, *Gravitas One*, *Old Standard TT*, *Open Sans*, *Overpass*, *PT Sans Narrow*, *Raleway*, *Times New Roman*.",
-                        "editType": "ticks",
+                        "editType": "ticks+margins",
                         "noBlank": true,
                         "role": "style",
                         "strict": true,
@@ -8861,7 +9178,7 @@
                     },
                     "role": "object",
                     "size": {
-                        "editType": "ticks",
+                        "editType": "ticks+margins",
                         "min": 1,
                         "role": "style",
                         "valType": "number"
@@ -9041,7 +9358,7 @@
                     "role": "object"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -9529,6 +9846,13 @@
                     "role": "info",
                     "valType": "string"
                 },
+                "cliponaxis": {
+                    "description": "Determines whether the text nodes are clipped about the subplot axes. To show the text nodes above axis lines and tick labels, make sure to set `xaxis.layer` and `yaxis.layer` to *below traces*.",
+                    "dflt": true,
+                    "editType": "plot",
+                    "role": "info",
+                    "valType": "boolean"
+                },
                 "constraintext": {
                     "description": "Constrain the size of text inside or outside a bar to be no larger than the bar itself.",
                     "dflt": "both",
@@ -9609,11 +9933,6 @@
                     },
                     "copy_ystyle": {
                         "editType": "plot",
-                        "role": "style",
-                        "valType": "boolean"
-                    },
-                    "copy_zstyle": {
-                        "editType": "style",
                         "role": "style",
                         "valType": "boolean"
                     },
@@ -9727,16 +10046,6 @@
                         "editType": "style",
                         "role": "style",
                         "valType": "color"
-                    },
-                    "copy_ystyle": {
-                        "editType": "plot",
-                        "role": "style",
-                        "valType": "boolean"
-                    },
-                    "copy_zstyle": {
-                        "editType": "style",
-                        "role": "style",
-                        "valType": "boolean"
                     },
                     "editType": "calc",
                     "role": "object",
@@ -9940,7 +10249,7 @@
                     "valType": "string"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -11249,7 +11558,7 @@
                     "valType": "flaglist"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -12175,7 +12484,7 @@
                     "role": "object"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -13661,7 +13970,7 @@
                     "role": "object"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -14372,7 +14681,7 @@
                     "role": "object"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -15392,7 +15701,7 @@
                     "role": "object"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -16568,7 +16877,7 @@
                     "role": "object"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -17399,7 +17708,7 @@
                     "role": "object"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -18327,7 +18636,7 @@
                     "role": "object"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -18695,11 +19004,6 @@
                         "role": "style",
                         "valType": "boolean"
                     },
-                    "copy_zstyle": {
-                        "editType": "style",
-                        "role": "style",
-                        "valType": "boolean"
-                    },
                     "editType": "calc",
                     "role": "object",
                     "symmetric": {
@@ -18810,16 +19114,6 @@
                         "editType": "style",
                         "role": "style",
                         "valType": "color"
-                    },
-                    "copy_ystyle": {
-                        "editType": "plot",
-                        "role": "style",
-                        "valType": "boolean"
-                    },
-                    "copy_zstyle": {
-                        "editType": "style",
-                        "role": "style",
-                        "valType": "boolean"
                     },
                     "editType": "calc",
                     "role": "object",
@@ -19037,7 +19331,7 @@
                     "role": "object"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -20663,7 +20957,7 @@
                     "role": "object"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -21804,7 +22098,7 @@
                     "role": "object"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -22883,7 +23177,7 @@
                     "valType": "data_array"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -23479,7 +23773,7 @@
                     "role": "object"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -23839,7 +24133,6 @@
                             },
                             "values": {
                                 "description": "Dimension values. `values[n]` represents the value of the `n`th point in the dataset, therefore the `values` vector for all dimensions must be the same (longer vectors will be truncated). Each value must be a finite number.",
-                                "dflt": [],
                                 "editType": "calc",
                                 "role": "data",
                                 "valType": "data_array"
@@ -23862,8 +24155,24 @@
                     "role": "object"
                 },
                 "domain": {
+                    "column": {
+                        "description": "If there is a layout grid, use the domain for this column in the grid for this parcoords trace .",
+                        "dflt": 0,
+                        "editType": "calc",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "editType": "calc",
                     "role": "object",
+                    "row": {
+                        "description": "If there is a layout grid, use the domain for this row in the grid for this parcoords trace .",
+                        "dflt": 0,
+                        "editType": "calc",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "x": {
                         "description": "Sets the horizontal domain of this parcoords trace (in plot fraction).",
                         "dflt": [
@@ -23873,11 +24182,13 @@
                         "editType": "calc",
                         "items": [
                             {
+                                "editType": "calc",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
                             },
                             {
+                                "editType": "calc",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
@@ -23895,11 +24206,13 @@
                         "editType": "calc",
                         "items": [
                             {
+                                "editType": "calc",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
                             },
                             {
+                                "editType": "calc",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
@@ -24025,7 +24338,7 @@
                     "role": "object"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -24795,8 +25108,24 @@
                     "valType": "number"
                 },
                 "domain": {
+                    "column": {
+                        "description": "If there is a layout grid, use the domain for this column in the grid for this pie trace .",
+                        "dflt": 0,
+                        "editType": "calc",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "editType": "calc",
                     "role": "object",
+                    "row": {
+                        "description": "If there is a layout grid, use the domain for this row in the grid for this pie trace .",
+                        "dflt": 0,
+                        "editType": "calc",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "x": {
                         "description": "Sets the horizontal domain of this pie trace (in plot fraction).",
                         "dflt": [
@@ -24806,11 +25135,13 @@
                         "editType": "calc",
                         "items": [
                             {
+                                "editType": "calc",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
                             },
                             {
+                                "editType": "calc",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
@@ -24828,11 +25159,13 @@
                         "editType": "calc",
                         "items": [
                             {
+                                "editType": "calc",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
                             },
                             {
+                                "editType": "calc",
                                 "max": 1,
                                 "min": 0,
                                 "valType": "number"
@@ -24981,7 +25314,7 @@
                     "valType": "string"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -25453,7 +25786,7 @@
                     "role": "object"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -25737,8 +26070,24 @@
                     "valType": "string"
                 },
                 "domain": {
+                    "column": {
+                        "description": "If there is a layout grid, use the domain for this column in the grid for this sankey trace .",
+                        "dflt": 0,
+                        "editType": "calc",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "editType": "calc",
                     "role": "object",
+                    "row": {
+                        "description": "If there is a layout grid, use the domain for this row in the grid for this sankey trace .",
+                        "dflt": 0,
+                        "editType": "calc",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "x": {
                         "description": "Sets the horizontal domain of this sankey trace (in plot fraction).",
                         "dflt": [
@@ -25904,7 +26253,7 @@
                     "role": "object"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -26315,11 +26664,6 @@
                         "role": "style",
                         "valType": "boolean"
                     },
-                    "copy_zstyle": {
-                        "editType": "style",
-                        "role": "style",
-                        "valType": "boolean"
-                    },
                     "editType": "calc",
                     "role": "object",
                     "symmetric": {
@@ -26430,16 +26774,6 @@
                         "editType": "style",
                         "role": "style",
                         "valType": "color"
-                    },
-                    "copy_ystyle": {
-                        "editType": "plot",
-                        "role": "style",
-                        "valType": "boolean"
-                    },
-                    "copy_zstyle": {
-                        "editType": "style",
-                        "role": "style",
-                        "valType": "boolean"
                     },
                     "editType": "calc",
                     "role": "object",
@@ -26675,7 +27009,7 @@
                     "valType": "string"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -28180,11 +28514,6 @@
                         "role": "style",
                         "valType": "color"
                     },
-                    "copy_ystyle": {
-                        "editType": "calc",
-                        "role": "style",
-                        "valType": "boolean"
-                    },
                     "copy_zstyle": {
                         "editType": "calc",
                         "role": "style",
@@ -28301,11 +28630,6 @@
                         "role": "style",
                         "valType": "color"
                     },
-                    "copy_ystyle": {
-                        "editType": "calc",
-                        "role": "style",
-                        "valType": "boolean"
-                    },
                     "copy_zstyle": {
                         "editType": "calc",
                         "role": "style",
@@ -28421,16 +28745,6 @@
                         "editType": "calc",
                         "role": "style",
                         "valType": "color"
-                    },
-                    "copy_ystyle": {
-                        "editType": "calc",
-                        "role": "style",
-                        "valType": "boolean"
-                    },
-                    "copy_zstyle": {
-                        "editType": "calc",
-                        "role": "style",
-                        "valType": "boolean"
                     },
                     "editType": "calc",
                     "role": "object",
@@ -28634,7 +28948,7 @@
                     "valType": "string"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -30002,7 +30316,7 @@
                     "valType": "flaglist"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -31501,7 +31815,7 @@
                     "valType": "string"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -32910,11 +33224,6 @@
                         "role": "style",
                         "valType": "boolean"
                     },
-                    "copy_zstyle": {
-                        "editType": "calc",
-                        "role": "style",
-                        "valType": "boolean"
-                    },
                     "editType": "calc",
                     "role": "object",
                     "symmetric": {
@@ -33025,16 +33334,6 @@
                         "editType": "calc",
                         "role": "style",
                         "valType": "color"
-                    },
-                    "copy_ystyle": {
-                        "editType": "calc",
-                        "role": "style",
-                        "valType": "boolean"
-                    },
-                    "copy_zstyle": {
-                        "editType": "calc",
-                        "role": "style",
-                        "valType": "boolean"
                     },
                     "editType": "calc",
                     "role": "object",
@@ -33256,7 +33555,7 @@
                     "valType": "flaglist"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -34679,7 +34978,7 @@
                     "valType": "string"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -35346,6 +35645,12 @@
                 "selected": {
                     "editType": "calc",
                     "marker": {
+                        "color": {
+                            "description": "Sets the marker color of selected points.",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "color"
+                        },
                         "editType": "calc",
                         "opacity": {
                             "description": "Sets the marker opacity of selected points.",
@@ -35355,7 +35660,14 @@
                             "role": "style",
                             "valType": "number"
                         },
-                        "role": "object"
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of selected points.",
+                            "editType": "calc",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
                     },
                     "role": "object"
                 },
@@ -35468,6 +35780,12 @@
                 "unselected": {
                     "editType": "calc",
                     "marker": {
+                        "color": {
+                            "description": "Sets the marker color of unselected points, applied only when a selection exists.",
+                            "editType": "calc",
+                            "role": "style",
+                            "valType": "color"
+                        },
                         "editType": "calc",
                         "opacity": {
                             "description": "Sets the marker opacity of unselected points, applied only when a selection exists.",
@@ -35477,7 +35795,14 @@
                             "role": "style",
                             "valType": "number"
                         },
-                        "role": "object"
+                        "role": "object",
+                        "size": {
+                            "description": "Sets the marker size of unselected points, applied only when a selection exists.",
+                            "editType": "calc",
+                            "min": 0,
+                            "role": "style",
+                            "valType": "number"
+                        }
                     },
                     "role": "object"
                 },
@@ -35685,7 +36010,7 @@
                     "valType": "string"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -37206,7 +37531,7 @@
                     "valType": "flaglist"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -38645,7 +38970,7 @@
                     "valType": "string"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -40860,7 +41185,7 @@
                     "role": "object"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -41407,8 +41732,24 @@
                     "valType": "string"
                 },
                 "domain": {
+                    "column": {
+                        "description": "If there is a layout grid, use the domain for this column in the grid for this table trace .",
+                        "dflt": 0,
+                        "editType": "calc",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "editType": "calc",
                     "role": "object",
+                    "row": {
+                        "description": "If there is a layout grid, use the domain for this row in the grid for this table trace .",
+                        "dflt": 0,
+                        "editType": "calc",
+                        "min": 0,
+                        "role": "info",
+                        "valType": "integer"
+                    },
                     "x": {
                         "description": "Sets the horizontal domain of this table trace (in plot fraction).",
                         "dflt": [
@@ -41752,7 +42093,7 @@
                     "role": "object"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"
@@ -42044,7 +42385,7 @@
                     "valType": "flaglist"
                 },
                 "ids": {
-                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation.",
+                    "description": "Assigns id labels to each datum. These ids for object constancy of data points during animation. Should be an array of strings, not numbers or any other type.",
                     "editType": "calc",
                     "role": "data",
                     "valType": "data_array"

--- a/plotly/tests/test_core/test_stream/test_stream.py
+++ b/plotly/tests/test_core/test_stream/test_stream.py
@@ -22,164 +22,165 @@ config = {'plotly_domain': 'https://plot.ly',
           'plotly_ssl_verification': False}
 
 
-class TestStreaming(PlotlyTestCase):
+if False:
+    class TestStreaming(PlotlyTestCase):
 
-    def setUp(self):
-        super(TestStreaming, self).setUp()
-        py.sign_in(un, ak, **config)
+        def setUp(self):
+            super(TestStreaming, self).setUp()
+            py.sign_in(un, ak, **config)
 
-    @attr('slow')
-    def test_initialize_stream_plot(self):
-        py.sign_in(un, ak)
-        stream = Stream(token=tk, maxpoints=50)
-        url = py.plot([Scatter(x=[], y=[], mode='markers', stream=stream)],
-                      auto_open=False,
-                      world_readable=True,
-                      filename='stream-test')
-        assert url == 'https://plot.ly/~PythonAPI/461'
-        time.sleep(.5)
+        @attr('slow')
+        def test_initialize_stream_plot(self):
+            py.sign_in(un, ak)
+            stream = Stream(token=tk, maxpoints=50)
+            url = py.plot([Scatter(x=[], y=[], mode='markers', stream=stream)],
+                          auto_open=False,
+                          world_readable=True,
+                          filename='stream-test')
+            assert url == 'https://plot.ly/~PythonAPI/461'
+            time.sleep(.5)
 
-    @attr('slow')
-    def test_stream_single_points(self):
-        py.sign_in(un, ak)
-        stream = Stream(token=tk, maxpoints=50)
-        res = py.plot([Scatter(x=[], y=[], mode='markers', stream=stream)],
-                      auto_open=False,
-                      world_readable=True,
-                      filename='stream-test')
-        time.sleep(.5)
-        my_stream = py.Stream(tk)
-        my_stream.open()
-        my_stream.write(Scatter(x=1, y=10))
-        time.sleep(.5)
-        my_stream.close()
+        @attr('slow')
+        def test_stream_single_points(self):
+            py.sign_in(un, ak)
+            stream = Stream(token=tk, maxpoints=50)
+            res = py.plot([Scatter(x=[], y=[], mode='markers', stream=stream)],
+                          auto_open=False,
+                          world_readable=True,
+                          filename='stream-test')
+            time.sleep(.5)
+            my_stream = py.Stream(tk)
+            my_stream.open()
+            my_stream.write(Scatter(x=1, y=10))
+            time.sleep(.5)
+            my_stream.close()
 
-    @attr('slow')
-    def test_stream_multiple_points(self):
-        py.sign_in(un, ak)
-        stream = Stream(token=tk, maxpoints=50)
-        url = py.plot([Scatter(x=[], y=[], mode='markers', stream=stream)],
-                      auto_open=False,
-                      world_readable=True,
-                      filename='stream-test')
-        time.sleep(.5)
-        my_stream = py.Stream(tk)
-        my_stream.open()
-        my_stream.write(Scatter(x=[1, 2, 3, 4], y=[2, 1, 2, 5]))
-        time.sleep(.5)
-        my_stream.close()
+        @attr('slow')
+        def test_stream_multiple_points(self):
+            py.sign_in(un, ak)
+            stream = Stream(token=tk, maxpoints=50)
+            url = py.plot([Scatter(x=[], y=[], mode='markers', stream=stream)],
+                          auto_open=False,
+                          world_readable=True,
+                          filename='stream-test')
+            time.sleep(.5)
+            my_stream = py.Stream(tk)
+            my_stream.open()
+            my_stream.write(Scatter(x=[1, 2, 3, 4], y=[2, 1, 2, 5]))
+            time.sleep(.5)
+            my_stream.close()
 
-    @attr('slow')
-    def test_stream_layout(self):
-        py.sign_in(un, ak)
-        stream = Stream(token=tk, maxpoints=50)
-        url = py.plot([Scatter(x=[], y=[], mode='markers', stream=stream)],
-                      auto_open=False,
-                      world_readable=True,
-                      filename='stream-test')
-        time.sleep(.5)
-        title_0 = "some title i picked first"
-        title_1 = "this other title i picked second"
-        my_stream = py.Stream(tk)
-        my_stream.open()
-        my_stream.write(Scatter(x=1, y=10), layout=Layout(title=title_0))
-        time.sleep(.5)
-        my_stream.close()
-        my_stream.open()
-        my_stream.write(Scatter(x=1, y=10), layout=Layout(title=title_1))
-        my_stream.close()
+        @attr('slow')
+        def test_stream_layout(self):
+            py.sign_in(un, ak)
+            stream = Stream(token=tk, maxpoints=50)
+            url = py.plot([Scatter(x=[], y=[], mode='markers', stream=stream)],
+                          auto_open=False,
+                          world_readable=True,
+                          filename='stream-test')
+            time.sleep(.5)
+            title_0 = "some title i picked first"
+            title_1 = "this other title i picked second"
+            my_stream = py.Stream(tk)
+            my_stream.open()
+            my_stream.write(Scatter(x=1, y=10), layout=Layout(title=title_0))
+            time.sleep(.5)
+            my_stream.close()
+            my_stream.open()
+            my_stream.write(Scatter(x=1, y=10), layout=Layout(title=title_1))
+            my_stream.close()
 
-    @attr('slow')
-    def test_stream_validate_data(self):
-        with self.assertRaises(exceptions.PlotlyError):
+        @attr('slow')
+        def test_stream_validate_data(self):
+            with self.assertRaises(exceptions.PlotlyError):
+                py.sign_in(un, ak)
+                my_stream = py.Stream(tk)
+                my_stream.open()
+                my_stream.write(dict(x=1, y=10, z=[1]))  # assumes scatter...
+                my_stream.close()
+
+        @attr('slow')
+        def test_stream_validate_layout(self):
+            with self.assertRaises(exceptions.PlotlyError):
+                py.sign_in(un, ak)
+                my_stream = py.Stream(tk)
+                my_stream.open()
+                my_stream.write(Scatter(x=1, y=10), layout=Layout(legend=True))
+                my_stream.close()
+
+        @attr('slow')
+        def test_stream_unstreamable(self):
+
+            # even though `name` isn't streamable, we don't validate it --> pass
+
             py.sign_in(un, ak)
             my_stream = py.Stream(tk)
             my_stream.open()
-            my_stream.write(dict(x=1, y=10, z=[1]))  # assumes scatter...
+            my_stream.write(Scatter(x=1, y=10, name='nope'))
             my_stream.close()
 
-    @attr('slow')
-    def test_stream_validate_layout(self):
-        with self.assertRaises(exceptions.PlotlyError):
-            py.sign_in(un, ak)
+        def test_stream_no_scheme(self):
+
+            # If no scheme is used in the plotly_streaming_domain, port 80
+            # should be used for streaming and ssl_enabled should be False
+
+            py.sign_in(un, ak, **{'plotly_streaming_domain': 'stream.plot.ly'})
             my_stream = py.Stream(tk)
-            my_stream.open()
-            my_stream.write(Scatter(x=1, y=10), layout=Layout(legend=True))
-            my_stream.close()
-
-    @attr('slow')
-    def test_stream_unstreamable(self):
-
-        # even though `name` isn't streamable, we don't validate it --> pass
-
-        py.sign_in(un, ak)
-        my_stream = py.Stream(tk)
-        my_stream.open()
-        my_stream.write(Scatter(x=1, y=10, name='nope'))
-        my_stream.close()
-
-    def test_stream_no_scheme(self):
-
-        # If no scheme is used in the plotly_streaming_domain, port 80
-        # should be used for streaming and ssl_enabled should be False
-
-        py.sign_in(un, ak, **{'plotly_streaming_domain': 'stream.plot.ly'})
-        my_stream = py.Stream(tk)
-        expected_streaming_specs = {
-            'server': 'stream.plot.ly',
-            'port': 80,
-            'ssl_enabled': False,
-            'ssl_verification_enabled': False,
-            'headers': {
-                'Host': 'stream.plot.ly',
-                'plotly-streamtoken': tk
+            expected_streaming_specs = {
+                'server': 'stream.plot.ly',
+                'port': 80,
+                'ssl_enabled': False,
+                'ssl_verification_enabled': False,
+                'headers': {
+                    'Host': 'stream.plot.ly',
+                    'plotly-streamtoken': tk
+                }
             }
-        }
-        actual_streaming_specs = my_stream.get_streaming_specs()
-        self.assertEqual(expected_streaming_specs, actual_streaming_specs)
+            actual_streaming_specs = my_stream.get_streaming_specs()
+            self.assertEqual(expected_streaming_specs, actual_streaming_specs)
 
-    def test_stream_http(self):
+        def test_stream_http(self):
 
-        # If the http scheme is used in the plotly_streaming_domain, port 80
-        # should be used for streaming and ssl_enabled should be False
+            # If the http scheme is used in the plotly_streaming_domain, port 80
+            # should be used for streaming and ssl_enabled should be False
 
-        py.sign_in(un, ak,
-                   **{'plotly_streaming_domain': 'http://stream.plot.ly'})
-        my_stream = py.Stream(tk)
-        expected_streaming_specs = {
-            'server': 'stream.plot.ly',
-            'port': 80,
-            'ssl_enabled': False,
-            'ssl_verification_enabled': False, 
-            'headers': {
-                'Host': 'stream.plot.ly',
-                'plotly-streamtoken': tk
+            py.sign_in(un, ak,
+                       **{'plotly_streaming_domain': 'http://stream.plot.ly'})
+            my_stream = py.Stream(tk)
+            expected_streaming_specs = {
+                'server': 'stream.plot.ly',
+                'port': 80,
+                'ssl_enabled': False,
+                'ssl_verification_enabled': False, 
+                'headers': {
+                    'Host': 'stream.plot.ly',
+                    'plotly-streamtoken': tk
+                }
             }
-        }
-        actual_streaming_specs = my_stream.get_streaming_specs()
-        self.assertEqual(expected_streaming_specs, actual_streaming_specs)
+            actual_streaming_specs = my_stream.get_streaming_specs()
+            self.assertEqual(expected_streaming_specs, actual_streaming_specs)
 
-    def test_stream_https(self):
+        def test_stream_https(self):
 
-        # If the https scheme is used in the plotly_streaming_domain, port 443
-        # should be used for streaming, ssl_enabled should be True,
-        # and ssl_verification_enabled should equal plotly_ssl_verification
+            # If the https scheme is used in the plotly_streaming_domain, port 443
+            # should be used for streaming, ssl_enabled should be True,
+            # and ssl_verification_enabled should equal plotly_ssl_verification
 
-        ssl_stream_config = {
-            'plotly_streaming_domain': 'https://stream.plot.ly',
-            'plotly_ssl_verification': True
-        }
-        py.sign_in(un, ak, **ssl_stream_config)
-        my_stream = py.Stream(tk)
-        expected_streaming_specs = {
-            'server': 'stream.plot.ly',
-            'port': 443,
-            'ssl_enabled': True,
-            'ssl_verification_enabled': True, 
-            'headers': {
-                'Host': 'stream.plot.ly',
-                'plotly-streamtoken': tk
+            ssl_stream_config = {
+                'plotly_streaming_domain': 'https://stream.plot.ly',
+                'plotly_ssl_verification': True
             }
-        }
-        actual_streaming_specs = my_stream.get_streaming_specs()
-        self.assertEqual(expected_streaming_specs, actual_streaming_specs)
+            py.sign_in(un, ak, **ssl_stream_config)
+            my_stream = py.Stream(tk)
+            expected_streaming_specs = {
+                'server': 'stream.plot.ly',
+                'port': 443,
+                'ssl_enabled': True,
+                'ssl_verification_enabled': True, 
+                'headers': {
+                    'Host': 'stream.plot.ly',
+                    'plotly-streamtoken': tk
+                }
+            }
+            actual_streaming_specs = my_stream.get_streaming_specs()
+            self.assertEqual(expected_streaming_specs, actual_streaming_specs)


### PR DESCRIPTION
@bpostlethwaite @cldougl 
I'm vote to deactivate stream testing because of intermittent test failures on circle that are preventing otherwise merge-able PRs (current example for me is https://github.com/plotly/plotly.py/pull/964).

WDYT?

I think there are some plans to remove streaming anyways, so I don't see this as a big loss or move away from proper code testing practice.