### PR TITLE
validate plotly_(api)_domain - HTTPS, not HTTP

### DIFF
--- a/plotly/api/v2/utils.py
+++ b/plotly/api/v2/utils.py
@@ -8,37 +8,6 @@ from plotly import config, exceptions, version, utils
 from plotly.api.utils import basic_auth
 
 
-HTTP_ERROR_MESSAGE = (
-    """Your plotly_domain and plotly_api_domain must be HTTPS and not HTTP.\n
-    If you are not using On-Prem then run the following code to ensure your
-    plotly_domain and plotly_api_domain start with 'https':
-
-    ```
-    import plotly
-    plotly.tools.set_config_file(
-        plotly_domain='https://plot.ly',
-        plotly_api_domain='https://api.plot.ly'
-    )
-    ```
-
-    If you are using On-Prem then you will need to use your company's
-    domain and api_domain urls:
-
-    ```
-    import plotly
-    plotly.tools.set_config_file(
-        plotly_domain='https://plotly.your-company.com',
-        plotly_api_domain='https://plotly.your-company.com'
-    )
-    ```
-
-    Make sure to replace "your-company.com" with the URL of your Plotly On-Premise server.
-
-    See https://plot.ly/python/getting-started/#special-instructions-for-plotly-onpremise-users
-    for more tips for getting started with Plotly."""
-)
-
-
 def make_params(**kwargs):
     """
     Helper to create a params dict, skipping undefined entries.
@@ -106,11 +75,6 @@ def validate_response(response):
         message = '\n'.join([msg for msg in messages if msg])
     if not message:
         message = content if content else 'No Content'
-
-    if len(response.history) > 0:
-        if not response.history[0].url.startswith('https:'):
-            raise exceptions.PlotlyRequestError(HTTP_ERROR_MESSAGE,
-                                                status_code, content)
 
     raise exceptions.PlotlyRequestError(message, status_code, content)
 

--- a/plotly/api/v2/utils.py
+++ b/plotly/api/v2/utils.py
@@ -8,6 +8,37 @@ from plotly import config, exceptions, version, utils
 from plotly.api.utils import basic_auth
 
 
+HTTP_ERROR_MESSAGE = (
+    """Your plotly_domain and plotly_api_domain must be HTTPS and not HTTP.\n
+    If you are not using On-Prem then run the following code to ensure your
+    plotly_domain and plotly_api_domain start with 'https':
+
+    ```
+    import plotly
+    plotly.tools.set_config_file(
+        plotly_domain='https://plot.ly',
+        plotly_api_domain='https://api.plot.ly'
+    )
+    ```
+
+    If you are using On-Prem then you will need to use your company's
+    domain and api_domain urls:
+
+    ```
+    import plotly
+    plotly.tools.set_config_file(
+        plotly_domain='https://plotly.your-company.com',
+        plotly_api_domain='https://plotly.your-company.com'
+    )
+    ```
+
+    Make sure to replace "your-company.com" with the URL of your Plotly On-Premise server.
+
+    See https://plot.ly/python/getting-started/#special-instructions-for-plotly-onpremise-users
+    for more tips for getting started with Plotly."""
+)
+
+
 def make_params(**kwargs):
     """
     Helper to create a params dict, skipping undefined entries.
@@ -75,6 +106,10 @@ def validate_response(response):
         message = '\n'.join([msg for msg in messages if msg])
     if not message:
         message = content if content else 'No Content'
+
+    if not response.history[0].url.startswith('https:'):
+        raise exceptions.PlotlyRequestError(HTTP_ERROR_MESSAGE,
+                                            status_code, content)
 
     raise exceptions.PlotlyRequestError(message, status_code, content)
 

--- a/plotly/api/v2/utils.py
+++ b/plotly/api/v2/utils.py
@@ -107,9 +107,10 @@ def validate_response(response):
     if not message:
         message = content if content else 'No Content'
 
-    if not response.history[0].url.startswith('https:'):
-        raise exceptions.PlotlyRequestError(HTTP_ERROR_MESSAGE,
-                                            status_code, content)
+    if len(response.history) > 0:
+        if not response.history[0].url.startswith('https:'):
+            raise exceptions.PlotlyRequestError(HTTP_ERROR_MESSAGE,
+                                                status_code, content)
 
     raise exceptions.PlotlyRequestError(message, status_code, content)
 

--- a/plotly/tests/test_core/test_stream/test_stream.py
+++ b/plotly/tests/test_core/test_stream/test_stream.py
@@ -18,7 +18,7 @@ ak = 'ubpiol2cve'
 tk = 'vaia8trjjb'
 config = {'plotly_domain': 'https://plot.ly',
           'plotly_streaming_domain': 'stream.plot.ly',
-          'plotly_api_domain': 'https://api.plot.ly', 
+          'plotly_api_domain': 'https://api.plot.ly',
           'plotly_ssl_verification': False}
 
 

--- a/plotly/tests/test_core/test_tools/test_file_tools.py
+++ b/plotly/tests/test_core/test_tools/test_file_tools.py
@@ -1,7 +1,6 @@
 from plotly import tools, session
 from plotly.tests.utils import PlotlyTestCase
 
-import ipdb
 import warnings
 
 
@@ -54,14 +53,16 @@ class FileToolsTest(PlotlyTestCase):
         self.assertRaises(TypeError, tools.set_config_file, **kwargs)
 
     def test_set_config_expected_error_msg(self):
-        kwargs = {'plotly_domain': 'http://www.foo-bar.com'}
-        #self.assertRaises(UserWarning, tools.set_config_file, **kwargs)
-        print 'abcd'
-        b = tools.set_config_file(**kwargs)
-        print type(b)
 
+        # Check that UserWarning is being called with http plotly_domain
 
-
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            kwargs = {'plotly_domain': 'http://www.foo-bar.com'}
+            tools.set_config_file(**kwargs)
+            assert len(w) == 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert "plotly_domain" in str(w[-1].message)
 
     def test_reset_config_file(self):
 

--- a/plotly/tests/test_core/test_tools/test_file_tools.py
+++ b/plotly/tests/test_core/test_tools/test_file_tools.py
@@ -1,6 +1,9 @@
 from plotly import tools, session
 from plotly.tests.utils import PlotlyTestCase
 
+import ipdb
+import warnings
+
 
 class FileToolsTest(PlotlyTestCase):
 
@@ -43,13 +46,22 @@ class FileToolsTest(PlotlyTestCase):
         self.assertEqual(config['plotly_streaming_domain'], streaming_domain)
         tools.reset_config_file()
 
-
     def test_set_config_file_world_readable(self):
 
         # Return TypeError when world_readable type is not a bool
 
         kwargs = {'world_readable': 'True'}
         self.assertRaises(TypeError, tools.set_config_file, **kwargs)
+
+    def test_set_config_expected_error_msg(self):
+        kwargs = {'plotly_domain': 'http://www.foo-bar.com'}
+        #self.assertRaises(UserWarning, tools.set_config_file, **kwargs)
+        print 'abcd'
+        b = tools.set_config_file(**kwargs)
+        print type(b)
+
+
+
 
     def test_reset_config_file(self):
 

--- a/plotly/tests/test_core/test_tools/test_file_tools.py
+++ b/plotly/tests/test_core/test_tools/test_file_tools.py
@@ -52,7 +52,7 @@ class FileToolsTest(PlotlyTestCase):
         kwargs = {'world_readable': 'True'}
         self.assertRaises(TypeError, tools.set_config_file, **kwargs)
 
-    def test_set_config_expected_error_msg(self):
+    def test_set_config_expected_warning_msg(self):
 
         # Check that UserWarning is being called with http plotly_domain
 
@@ -63,6 +63,18 @@ class FileToolsTest(PlotlyTestCase):
             assert len(w) == 1
             assert issubclass(w[-1].category, UserWarning)
             assert "plotly_domain" in str(w[-1].message)
+
+
+    def test_set_config_no_warning_msg_if_plotly_domain_is_https(self):
+
+        # Check that no UserWarning is being called with https plotly_domain
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            kwargs = {'plotly_domain': 'https://www.foo-bar.com'}
+            tools.set_config_file(**kwargs)
+            assert len(w) == 0
+
 
     def test_reset_config_file(self):
 

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -186,7 +186,6 @@ def set_config_file(plotly_domain=None,
     :param (bool) world_readable: True = public, False = private
 
     """
-    # import ipdb; ipdb.set_trace()
     if not check_file_permissions():
         raise exceptions.PlotlyError("You don't have proper file permissions "
                                      "to run this function.")

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -276,9 +276,20 @@ def get_config_file(*args):
     """
     if check_file_permissions():
         ensure_local_plotly_files()  # make sure what's there is OK
-        return utils.load_json_dict(CONFIG_FILE, *args)
+        returned_obj = utils.load_json_dict(CONFIG_FILE, *args)
     else:
-        return FILE_CONTENT[CONFIG_FILE]
+        returned_obj = FILE_CONTENT[CONFIG_FILE]
+
+    list_of_domains = []
+    for domain in ['plotly_domain', 'plotly_api_domain']:
+        if domain in returned_obj:
+            list_of_domains.append(returned_obj[domain])
+
+    validate_domains(*list_of_domains)
+
+    return returned_obj
+
+
 
 
 def reset_config_file():

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -222,9 +222,9 @@ def set_config_file(plotly_domain=None,
     ensure_local_plotly_files()  # make sure what's there is OK
     utils.validate_world_readable_and_sharing_settings({
         'sharing': sharing, 'world_readable': world_readable})
-    settings = get_config_file()
+
+    settings = get_config_file(validate=False)
     if isinstance(plotly_domain, six.string_types):
-        #validate_domains(plotly_domain)
         settings['plotly_domain'] = plotly_domain
     elif plotly_domain is not None:
         raise TypeError('plotly_domain should be a string')
@@ -233,7 +233,6 @@ def set_config_file(plotly_domain=None,
     elif plotly_streaming_domain is not None:
         raise TypeError('plotly_streaming_domain should be a string')
     if isinstance(plotly_api_domain, six.string_types):
-        #validate_domains(plotly_api_domain)
         settings['plotly_api_domain'] = plotly_api_domain
     elif plotly_api_domain is not None:
         raise TypeError('plotly_api_domain should be a string')
@@ -250,6 +249,14 @@ def set_config_file(plotly_domain=None,
     elif auto_open is not None:
         raise TypeError('auto_open should be a boolean')
 
+    # validate plotly_domain and plotly_api_domain
+    list_of_domains = []
+    if plotly_domain is not None:
+        list_of_domains.append(plotly_domain)
+    if plotly_api_domain is not None:
+        list_of_domains.append(plotly_api_domain)
+    validate_domains(*list_of_domains)
+
     if isinstance(world_readable, bool):
         settings['world_readable'] = world_readable
         settings.pop('sharing')
@@ -265,7 +272,7 @@ def set_config_file(plotly_domain=None,
     ensure_local_plotly_files()  # make sure what we just put there is OK
 
 
-def get_config_file(*args):
+def get_config_file(*args, validate=True):
     """Return specified args from `~/.plotly/.config`. as tuple.
 
     Returns all if no arguments are specified.
@@ -285,7 +292,8 @@ def get_config_file(*args):
         if domain in returned_obj:
             list_of_domains.append(returned_obj[domain])
 
-    validate_domains(*list_of_domains)
+    if validate:
+        validate_domains(*list_of_domains)
 
     return returned_obj
 
@@ -325,7 +333,7 @@ def get_embed(file_owner_or_url, file_id=None, width="100%", height=525):
 
     """
     plotly_rest_url = (session.get_session_config().get('plotly_domain') or
-                       get_config_file()['plotly_domain'])
+                       get_config_file(validate=False)['plotly_domain'])
     if file_id is None:  # assume we're using a url
         url = file_owner_or_url
         if url[:len(plotly_rest_url)] != plotly_rest_url:
@@ -422,7 +430,7 @@ def embed(file_owner_or_url, file_id=None, width="100%", height=525):
         if file_id:
             plotly_domain = (
                 session.get_session_config().get('plotly_domain') or
-                get_config_file()['plotly_domain']
+                get_config_file(validate=False)['plotly_domain']
             )
             url = "{plotly_domain}/~{un}/{fid}".format(
                 plotly_domain=plotly_domain,
@@ -448,7 +456,7 @@ def embed(file_owner_or_url, file_id=None, width="100%", height=525):
 
 
 ### mpl-related tools ###
-@utils.template_doc(**get_config_file())
+@utils.template_doc(**get_config_file(validate=False))
 def mpl_to_plotly(fig, resize=False, strip_style=False, verbose=False):
     """Convert a matplotlib figure to plotly dictionary and send.
 

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -73,7 +73,7 @@ http_msg = (
 )
 
 
-def validate_config_file(*domains):
+def validate_domains(*domains):
     for d in domains:
         if not d.lower().startswith('https'):
             warnings.warn(http_msg)
@@ -224,7 +224,7 @@ def set_config_file(plotly_domain=None,
         'sharing': sharing, 'world_readable': world_readable})
     settings = get_config_file()
     if isinstance(plotly_domain, six.string_types):
-        validate_config_file(plotly_domain)
+        #validate_domains(plotly_domain)
         settings['plotly_domain'] = plotly_domain
     elif plotly_domain is not None:
         raise TypeError('plotly_domain should be a string')
@@ -233,7 +233,7 @@ def set_config_file(plotly_domain=None,
     elif plotly_streaming_domain is not None:
         raise TypeError('plotly_streaming_domain should be a string')
     if isinstance(plotly_api_domain, six.string_types):
-        validate_config_file(plotly_api_domain)
+        #validate_domains(plotly_api_domain)
         settings['plotly_api_domain'] = plotly_api_domain
     elif plotly_api_domain is not None:
         raise TypeError('plotly_api_domain should be a string')
@@ -276,10 +276,9 @@ def get_config_file(*args):
     """
     if check_file_permissions():
         ensure_local_plotly_files()  # make sure what's there is OK
-        returned_obj = utils.load_json_dict(CONFIG_FILE, *args)
+        return utils.load_json_dict(CONFIG_FILE, *args)
     else:
-        returned_obj = FILE_CONTENT[CONFIG_FILE]
-    return returned_obj
+        return FILE_CONTENT[CONFIG_FILE]
 
 
 def reset_config_file():

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -49,6 +49,36 @@ DEFAULT_HISTNORM = 'probability density'
 ALTERNATIVE_HISTNORM = 'probability'
 
 
+http_msg = (
+    "The plotly_domain and plotly_api_domain of your config file must start "
+    "with 'https', 'http'.\n If you are not using On-Prem then run the "
+    "following code to ensure your plotly_domain and plotly_api_domain start "
+    "with 'https':\n\n\n"
+    "import plotly\n"
+    "plotly.tools.set_config_file(\n"
+    "    plotly_domain='https://plot.ly',\n"
+    "    plotly_api_domain='https://api.plot.ly'\n"
+    ")\n\n\n"
+    "If you are using On-Prem then you will need to use your company's "
+    "domain and api_domain urls:\n\n\n"
+    "import plotly\n"
+    "plotly.tools.set_config_file(\n"
+    "    plotly_domain='https://plotly.your-company.com',\n"
+    "    plotly_api_domain='https://plotly.your-company.com'\n"
+    ")\n\n\n"
+    "Make sure to replace `your-company.com` with the URL of your Plotly "
+    "On-Premise server.\nSee "
+    "https://plot.ly/python/getting-started/#special-instructions-for-plotly-onpremise-users "
+    "for more help with getting started with On-Prem."
+)
+
+
+def validate_config_file(*domains):
+    for d in domains:
+        if not d.lower().startswith('https'):
+            warnings.warn(http_msg)
+
+
 # Warning format
 def warning_on_one_line(message, category, filename, lineno,
                         file=None, line=None):
@@ -194,6 +224,7 @@ def set_config_file(plotly_domain=None,
         'sharing': sharing, 'world_readable': world_readable})
     settings = get_config_file()
     if isinstance(plotly_domain, six.string_types):
+        validate_config_file(plotly_domain)
         settings['plotly_domain'] = plotly_domain
     elif plotly_domain is not None:
         raise TypeError('plotly_domain should be a string')
@@ -202,6 +233,7 @@ def set_config_file(plotly_domain=None,
     elif plotly_streaming_domain is not None:
         raise TypeError('plotly_streaming_domain should be a string')
     if isinstance(plotly_api_domain, six.string_types):
+        validate_config_file(plotly_api_domain)
         settings['plotly_api_domain'] = plotly_api_domain
     elif plotly_api_domain is not None:
         raise TypeError('plotly_api_domain should be a string')
@@ -244,9 +276,10 @@ def get_config_file(*args):
     """
     if check_file_permissions():
         ensure_local_plotly_files()  # make sure what's there is OK
-        return utils.load_json_dict(CONFIG_FILE, *args)
+        returned_obj = utils.load_json_dict(CONFIG_FILE, *args)
     else:
-        return FILE_CONTENT[CONFIG_FILE]
+        returned_obj = FILE_CONTENT[CONFIG_FILE]
+    return returned_obj
 
 
 def reset_config_file():

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -73,10 +73,10 @@ http_msg = (
 )
 
 
-def validate_domains(*domains):
+def _validate_domains(*domains):
     for d in domains:
         if not d.lower().startswith('https'):
-            warnings.warn(http_msg)
+            warnings.warn(http_msg, category=UserWarning)
 
 
 # Warning format
@@ -255,7 +255,7 @@ def set_config_file(plotly_domain=None,
         list_of_domains.append(plotly_domain)
     if plotly_api_domain is not None:
         list_of_domains.append(plotly_api_domain)
-    validate_domains(*list_of_domains)
+    _validate_domains(*list_of_domains)
 
     if isinstance(world_readable, bool):
         settings['world_readable'] = world_readable
@@ -272,7 +272,7 @@ def set_config_file(plotly_domain=None,
     ensure_local_plotly_files()  # make sure what we just put there is OK
 
 
-def get_config_file(*args, validate=True):
+def get_config_file(validate=True, *args):
     """Return specified args from `~/.plotly/.config`. as tuple.
 
     Returns all if no arguments are specified.
@@ -293,11 +293,9 @@ def get_config_file(*args, validate=True):
             list_of_domains.append(returned_obj[domain])
 
     if validate:
-        validate_domains(*list_of_domains)
+        _validate_domains(*list_of_domains)
 
     return returned_obj
-
-
 
 
 def reset_config_file():

--- a/plotly/utils.py
+++ b/plotly/utils.py
@@ -35,7 +35,7 @@ lock = threading.Lock()
 
 http_msg = (
     "The plotly_domain and plotly_api_domain of your config file must start "
-    "with 'https', not 'http'.\n If you are not using On-Premise then run the "
+    "with 'https', not 'http'. If you are not using On-Premise then run the "
     "following code to ensure your plotly_domain and plotly_api_domain start "
     "with 'https':\n\n\n"
     "import plotly\n"

--- a/plotly/utils.py
+++ b/plotly/utils.py
@@ -35,7 +35,7 @@ lock = threading.Lock()
 
 http_msg = (
     "The plotly_domain and plotly_api_domain of your config file must start "
-    "with 'https', 'http'.\n If you are not using On-Prem then run the "
+    "with 'https', not 'http'.\n If you are not using On-Premise then run the "
     "following code to ensure your plotly_domain and plotly_api_domain start "
     "with 'https':\n\n\n"
     "import plotly\n"
@@ -43,7 +43,7 @@ http_msg = (
     "    plotly_domain='https://plot.ly',\n"
     "    plotly_api_domain='https://api.plot.ly'\n"
     ")\n\n\n"
-    "If you are using On-Prem then you will need to use your company's "
+    "If you are using On-Premise then you will need to use your company's "
     "domain and api_domain urls:\n\n\n"
     "import plotly\n"
     "plotly.tools.set_config_file(\n"
@@ -53,7 +53,7 @@ http_msg = (
     "Make sure to replace `your-company.com` with the URL of your Plotly "
     "On-Premise server.\nSee "
     "https://plot.ly/python/getting-started/#special-instructions-for-plotly-onpremise-users "
-    "for more help with getting started with On-Prem."
+    "for more help with getting started with On-Premise."
 )
 
 

--- a/plotly/utils.py
+++ b/plotly/utils.py
@@ -7,11 +7,12 @@ Low-level functionality NOT intended for users to EVER use.
 """
 from __future__ import absolute_import
 
+import decimal
 import os.path
 import re
 import sys
 import threading
-import decimal
+import warnings
 from collections import deque
 
 import pytz
@@ -30,6 +31,30 @@ sage_all = get_module('sage.all')
 
 ### incase people are using threading, we lock file reads
 lock = threading.Lock()
+
+
+http_msg = (
+    "The plotly_domain and plotly_api_domain of your config file must start "
+    "with 'https', 'http'.\n If you are not using On-Prem then run the "
+    "following code to ensure your plotly_domain and plotly_api_domain start "
+    "with 'https':\n\n\n"
+    "import plotly\n"
+    "plotly.tools.set_config_file(\n"
+    "    plotly_domain='https://plot.ly',\n"
+    "    plotly_api_domain='https://api.plot.ly'\n"
+    ")\n\n\n"
+    "If you are using On-Prem then you will need to use your company's "
+    "domain and api_domain urls:\n\n\n"
+    "import plotly\n"
+    "plotly.tools.set_config_file(\n"
+    "    plotly_domain='https://plotly.your-company.com',\n"
+    "    plotly_api_domain='https://plotly.your-company.com'\n"
+    ")\n\n\n"
+    "Make sure to replace `your-company.com` with the URL of your Plotly "
+    "On-Premise server.\nSee "
+    "https://plot.ly/python/getting-started/#special-instructions-for-plotly-onpremise-users "
+    "for more help with getting started with On-Prem."
+)
 
 
 ### general file setup tools ###
@@ -297,6 +322,7 @@ class PlotlyJSONEncoder(_json.JSONEncoder):
         else:
             raise NotEncodable
 
+
 ### unicode stuff ###
 def decode_unicode(coll):
     if isinstance(coll, list):
@@ -434,6 +460,16 @@ def validate_world_readable_and_sharing_settings(option_set):
             "'secret' -- for private plots that can be shared with a "
             "secret url"
         )
+
+
+def validate_plotly_domains(option_set):
+    domains_not_none = []
+    for d in ['plotly_domain', 'plotly_api_domain']:
+        if d in option_set and option_set[d]:
+            domains_not_none.append(option_set[d])
+
+    if not all(d.lower().startswith('https') for d in domains_not_none):
+        warnings.warn(http_msg, category=UserWarning)
 
 
 def set_sharing_and_world_readable(option_set):


### PR DESCRIPTION
Addresses https://github.com/plotly/plotly.py/issues/996

Notes:
1. This error message does not get triggered if the original url in the request starts with `zhttp://...`. A separate error message is thrown for that.
2. The original url sent by a user is getting coerced into all lowercase, so a lowercase to lowercase comparison is not necessary.