### PR TITLE
Fix typo in contributing.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -100,7 +100,7 @@ There's a short list of core dependencies you'll need installed in your Python e
 
 ### Dependencies and Virtualenv
 
-If you decided to follow the suggestion about about the Virtualenv *and* you've run `source bin/activate` within your new virtualenv directory to activate it--you can run the following to install the core dependencies:
+If you decided to follow the suggestion about the Virtualenv *and* you've run `source bin/activate` within your new virtualenv directory to activate it--you can run the following to install the core dependencies:
 
 ```bash
 pip install -r requirements.txt


### PR DESCRIPTION
**Old:** "If you decided to follow the suggestion *about about* the Virtualenv *and* you've run `source bin/activate` ..."

**New:** "If you decided to follow the suggestion *about* the Virtualenv *and* you've run `source bin/activate` within your new virtualenv directory to activate..."