### PR TITLE
Add configkeys to offline matching plotly js 1.39.2

### DIFF
--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -179,13 +179,19 @@ def _plot_html(figure_or_data, config, validate, default_width,
                               cls=utils.PlotlyJSONEncoder)
 
     configkeys = (
+        'staticPlot'
+        'plotlyServerURL',
         'editable',
+        'edits',
         'autosizable',
+        'queueLength'
         'fillFrame',
         'frameMargins',
         'scrollZoom',
         'doubleClick',
         'showTips',
+        'showAxisDragHandles',
+        'showAxisRangeEntryBoxes',
         'showLink',
         'sendData',
         'linkText',
@@ -194,10 +200,16 @@ def _plot_html(figure_or_data, config, validate, default_width,
         'modeBarButtonsToRemove',
         'modeBarButtonsToAdd',
         'modeBarButtons',
+        'toImageButtonOptions',
         'displaylogo',
         'plotGlPixelRatio',
         'setBackground',
         'topojsonURL'
+        'mapboxAccessToken',
+        'logging',
+        'globalTransforms'
+        'locale',
+        'locales',
     )
 
     config_clean = dict((k, config[k]) for k in configkeys if k in config)


### PR DESCRIPTION
Looking at plotly js, there are a number of configkeys that are valid that aren't in this offline whitelist. This adds [all configkeys from current plotly js](https://github.com/plotly/plotly.js/blob/master/src/plot_api/plot_config.js#L19).

Note, this PR encompasses: #1042
