### PR TITLE
Improve error messages when trying to validate orca

### DIFF
--- a/plotly/io/_orca.py
+++ b/plotly/io/_orca.py
@@ -938,7 +938,7 @@ Here is the error that was returned by the command
 [Return code: {returncode}]
 {err_msg}
         """.format(executable=executable,
-                   err_msg=help_error,
+                   err_msg=help_error.decode('utf-8'),
                    returncode=p.returncode))
 
     if not help_result:
@@ -977,7 +977,7 @@ This command returned the following error:
 [Return code: {returncode}]
 {err_msg}
         """.format(executable=executable,
-                   err_msg=version_error,
+                   err_msg=version_error.decode('utf-8'),
                    returncode=p.returncode))
 
     if not version_result:

--- a/plotly/io/_orca.py
+++ b/plotly/io/_orca.py
@@ -932,15 +932,25 @@ this message for details on what went wrong.
     help_result, help_error = p.communicate()
 
     if p.returncode != 0:
-        raise ValueError(invalid_executable_msg + """
+        err_msg = invalid_executable_msg + """
 Here is the error that was returned by the command
     $ {executable} --help
 
 [Return code: {returncode}]
 {err_msg}
-        """.format(executable=executable,
-                   err_msg=help_error.decode('utf-8'),
-                   returncode=p.returncode))
+""".format(executable=executable,
+           err_msg=help_error.decode('utf-8'),
+           returncode=p.returncode)
+
+        # Check for Linux without X installed.
+        if (sys.platform.startswith('linux') and
+            not os.environ.get('DISPLAY')):
+
+            err_msg += """
+Note: when used on Linux orca requires an X11 display server, but none was
+detected. Please install x11, or configure your system with Xvfb.
+"""
+        raise ValueError(err_msg)
 
     if not help_result:
         raise ValueError(invalid_executable_msg + """

--- a/plotly/io/_orca.py
+++ b/plotly/io/_orca.py
@@ -946,7 +946,7 @@ Here is the error that was returned by the command
         if (sys.platform.startswith('linux') and
             not os.environ.get('DISPLAY')):
 
-            err_msg += """
+            err_msg += """\
 Note: when used on Linux orca requires an X11 display server, but none was
 detected. Please install x11, or configure your system with Xvfb.
 """

--- a/plotly/io/_orca.py
+++ b/plotly/io/_orca.py
@@ -915,8 +915,9 @@ Searched for executable '{executable}' on the following path:
     # ---------------------------------------------------
     invalid_executable_msg = """
 The orca executable is required in order to export figures as static images,
-but the executable that was found at '{executable}' does not seem to be a
-valid plotly orca executable.
+but the executable that was found at '{executable}'
+does not seem to be a valid plotly orca executable. Please refer to the end of
+this message for details on what went wrong.
 
 {instructions}""".format(
         executable=executable,

--- a/plotly/io/_orca.py
+++ b/plotly/io/_orca.py
@@ -887,7 +887,8 @@ will be applied automatically in future sessions. You can do this as follows:
     >>> plotly.io.orca.config.save() 
 
 If you're still having trouble, feel free to ask for help on the forums at
-https://community.plot.ly/c/api/python"""
+https://community.plot.ly/c/api/python
+"""
 
     # Try to find an executable
     # -------------------------
@@ -923,32 +924,49 @@ valid plotly orca executable.
 
     try:
         help_result = subprocess.check_output([executable, '--help'])
-    except subprocess.CalledProcessError:
-        raise ValueError(invalid_executable_msg)
+    except subprocess.CalledProcessError as err:
+
+        raise ValueError(invalid_executable_msg + """
+Here is the error that was returned by the command
+    $ {executable} --help
+
+{err_msg}
+""".format(executable=executable, err_msg=str(err)))
 
     if not help_result:
-        raise ValueError(invalid_executable_msg)
+        raise ValueError(invalid_executable_msg + """
+The error encountered is that no output was returned by the command
+    $ {executable} --help  
+""".format(executable=executable))
 
     if ("Plotly's image-exporting utilities" not in
             help_result.decode('utf-8')):
-        raise ValueError(invalid_executable_msg)
+        raise ValueError(invalid_executable_msg + """
+The error encountered is that unexpected output was returned by the command
+    $ {executable} --help
+
+{help_result}
+""".format(executable=executable, help_result=help_result))
 
     # Get orca version
     # ----------------
     try:
         orca_version = subprocess.check_output([executable, '--version'])
-    except subprocess.CalledProcessError:
-        raise ValueError("""
+    except subprocess.CalledProcessError as err:
+        raise ValueError(invalid_executable_msg + """
 An error occurred while trying to get the version of the orca executable.
 Here is the command that plotly.py ran to request the version:
 
     $ {executable} --version
-""".format(executable=executable))
+    
+This command returned the following error:
+
+{err_msg}
+""".format(executable=executable, err_msg=str(err)))
 
     if not orca_version:
-        raise ValueError("""
-No version was reported by the orca executable.      
-
+        raise ValueError(invalid_executable_msg + """
+The error encountered is that no version was reported by the orca executable.
 Here is the command that plotly.py ran to request the version:
 
     $ {executable} --version  

--- a/plotly/io/_orca.py
+++ b/plotly/io/_orca.py
@@ -947,8 +947,10 @@ Here is the error that was returned by the command
             not os.environ.get('DISPLAY')):
 
             err_msg += """\
-Note: when used on Linux orca requires an X11 display server, but none was
-detected. Please install x11, or configure your system with Xvfb.
+Note: When used on Linux, orca requires an X11 display server, but none was
+detected. Please install X11, or configure your system with Xvfb. See
+the orca README (https://github.com/plotly/orca) for instructions on using
+orca with Xvfb.
 """
         raise ValueError(err_msg)
 

--- a/plotly/io/_orca.py
+++ b/plotly/io/_orca.py
@@ -1030,18 +1030,28 @@ def shutdown_server():
                 # process. This prevents any zombie processes from being
                 # left over, and it saves us from needing to write
                 # OS-specific process management code here.
+
                 parent = psutil.Process(orca_state['proc'].pid)
                 for child in parent.children(recursive=True):
-                    child.terminate()
+                    try:
+                        child.terminate()
+                    except:
+                        # We tried, move on
+                        pass
 
-                # Kill parent process
-                orca_state['proc'].terminate()
+                try:
+                    # Kill parent process
+                    orca_state['proc'].terminate()
 
-                # Retrieve standard out and standard error to avoid warnings
-                output, err = orca_state['proc'].communicate()
+                    # Retrieve standard out and standard error to avoid
+                    # warnings
+                    output, err = orca_state['proc'].communicate()
 
-                # Wait for the process to shutdown
-                child_status = orca_state['proc'].wait()
+                    # Wait for the process to shutdown
+                    child_status = orca_state['proc'].wait()
+                except:
+                    # We tried, move on
+                    pass
 
                 # Update our internal process management state
                 orca_state['proc'] = None


### PR DESCRIPTION
This PR works to improve the error messages displayed during the validator orca process.  In particular, it appends the full text of the error at the end of the message.

Also adds a special case error for Linux without a display server configured.