### PR TITLE
Add dash length list to dash property validator

### DIFF
--- a/_plotly_utils/tests/validators/test_dash_validator.py
+++ b/_plotly_utils/tests/validators/test_dash_validator.py
@@ -1,0 +1,53 @@
+import pytest
+from _plotly_utils.basevalidators import DashValidator
+
+
+# Constants
+# ---------
+dash_types = ['solid', 'dot', 'dash', 'longdash', 'dashdot', 'longdashdot']
+
+
+# Fixtures
+# --------
+@pytest.fixture()
+def validator():
+    return DashValidator('prop', 'parent', dash_types)
+
+
+# Acceptance
+# ----------
+@pytest.mark.parametrize('val',
+                         dash_types)
+def test_acceptance_dash_types(val, validator):
+    # Values should be accepted and returned unchanged
+    assert validator.validate_coerce(val) == val
+
+
+@pytest.mark.parametrize('val',
+                         ['2', '2.2', '2.002', '1 2 002',
+                          '1,2,3', '1, 2, 3',
+                          '1px 2px 3px', '1.5px, 2px, 3.9px',
+                          '23% 18% 13px', '200%   3px'])
+def test_acceptance_dash_lists(val, validator):
+    # Values should be accepted and returned unchanged
+    assert validator.validate_coerce(val) == val
+
+
+# Rejection
+# ---------
+# ### Value Rejection ###
+@pytest.mark.parametrize('val', ['bogus', 'not-a-dash'])
+def test_rejection_by_bad_dash_type(val, validator):
+    with pytest.raises(ValueError) as validation_failure:
+        validator.validate_coerce(val)
+
+    assert 'Invalid value' in str(validation_failure.value)
+
+
+@pytest.mark.parametrize('val',
+                         ['', '1,,3,4', '2 3 C', '2pxx 3 4'])
+def test_rejection_by_bad_dash_list(val, validator):
+    with pytest.raises(ValueError) as validation_failure:
+        validator.validate_coerce(val)
+
+    assert 'Invalid value' in str(validation_failure.value)

--- a/codegen/utils.py
+++ b/codegen/utils.py
@@ -141,6 +141,22 @@ CUSTOM_VALIDATOR_DATATYPES = {
     'frame.layout': 'plotly.validators.LayoutValidator'
 }
 
+# Add custom dash validators
+CUSTOM_VALIDATOR_DATATYPES.update(
+    {prop: '_plotly_utils.basevalidators.DashValidator'
+     for prop in [
+         'scatter.line.dash',
+         'histogram2dcontour.line.dash',
+         'scattergeo.line.dash',
+         'scatterpolar.line.dash',
+         'ohlc.line.dash',
+         'ohlc.decreasing.line.dash',
+         'ohlc.increasing.line.dash',
+         'contourcarpet.line.dash',
+         'contour.line.dash',
+         'scatterternary.line.dash',
+         'scattercarpet.line.dash']})
+
 # Mapping from property string (as found in plot-schema.json) to a custom
 # class name. If not included here, names are converted to TitleCase and
 # underscores are removed.

--- a/plotly/graph_objs/contour/_line.py
+++ b/plotly/graph_objs/contour/_line.py
@@ -74,11 +74,11 @@ class Line(BaseTraceHierarchyType):
         *longdashdot*) or a dash length list in px (eg
         *5px,10px,2px,2px*).
     
-        The 'dash' property is a string and must be specified as:
-          - One of the following strings:
-                ['solid', 'dot', 'dash', 'longdash', 'dashdot',
-                'longdashdot']
-          - A number that will be converted to a string
+        The 'dash' property is an enumeration that may be specified as:
+          - One of the following dash styles:
+                ['solid', 'dot', 'dash', 'longdash', 'dashdot', 'longdashdot']
+          - A string containing a dash length list in pixels or percentages
+                (e.g. '5px 10px 2px 2px', '5, 10, 2, 2', '10% 20% 40%', etc.)
 
         Returns
         -------

--- a/plotly/graph_objs/contourcarpet/_line.py
+++ b/plotly/graph_objs/contourcarpet/_line.py
@@ -74,11 +74,11 @@ class Line(BaseTraceHierarchyType):
         *longdashdot*) or a dash length list in px (eg
         *5px,10px,2px,2px*).
     
-        The 'dash' property is a string and must be specified as:
-          - One of the following strings:
-                ['solid', 'dot', 'dash', 'longdash', 'dashdot',
-                'longdashdot']
-          - A number that will be converted to a string
+        The 'dash' property is an enumeration that may be specified as:
+          - One of the following dash styles:
+                ['solid', 'dot', 'dash', 'longdash', 'dashdot', 'longdashdot']
+          - A string containing a dash length list in pixels or percentages
+                (e.g. '5px 10px 2px 2px', '5, 10, 2, 2', '10% 20% 40%', etc.)
 
         Returns
         -------

--- a/plotly/graph_objs/histogram2dcontour/_line.py
+++ b/plotly/graph_objs/histogram2dcontour/_line.py
@@ -74,11 +74,11 @@ class Line(BaseTraceHierarchyType):
         *longdashdot*) or a dash length list in px (eg
         *5px,10px,2px,2px*).
     
-        The 'dash' property is a string and must be specified as:
-          - One of the following strings:
-                ['solid', 'dot', 'dash', 'longdash', 'dashdot',
-                'longdashdot']
-          - A number that will be converted to a string
+        The 'dash' property is an enumeration that may be specified as:
+          - One of the following dash styles:
+                ['solid', 'dot', 'dash', 'longdash', 'dashdot', 'longdashdot']
+          - A string containing a dash length list in pixels or percentages
+                (e.g. '5px 10px 2px 2px', '5, 10, 2, 2', '10% 20% 40%', etc.)
 
         Returns
         -------

--- a/plotly/graph_objs/ohlc/_line.py
+++ b/plotly/graph_objs/ohlc/_line.py
@@ -16,11 +16,11 @@ class Line(BaseTraceHierarchyType):
         set per direction via `increasing.line.dash` and
         `decreasing.line.dash`.
     
-        The 'dash' property is a string and must be specified as:
-          - One of the following strings:
-                ['solid', 'dot', 'dash', 'longdash', 'dashdot',
-                'longdashdot']
-          - A number that will be converted to a string
+        The 'dash' property is an enumeration that may be specified as:
+          - One of the following dash styles:
+                ['solid', 'dot', 'dash', 'longdash', 'dashdot', 'longdashdot']
+          - A string containing a dash length list in pixels or percentages
+                (e.g. '5px 10px 2px 2px', '5, 10, 2, 2', '10% 20% 40%', etc.)
 
         Returns
         -------

--- a/plotly/graph_objs/ohlc/decreasing/_line.py
+++ b/plotly/graph_objs/ohlc/decreasing/_line.py
@@ -73,11 +73,11 @@ class Line(BaseTraceHierarchyType):
         *longdashdot*) or a dash length list in px (eg
         *5px,10px,2px,2px*).
     
-        The 'dash' property is a string and must be specified as:
-          - One of the following strings:
-                ['solid', 'dot', 'dash', 'longdash', 'dashdot',
-                'longdashdot']
-          - A number that will be converted to a string
+        The 'dash' property is an enumeration that may be specified as:
+          - One of the following dash styles:
+                ['solid', 'dot', 'dash', 'longdash', 'dashdot', 'longdashdot']
+          - A string containing a dash length list in pixels or percentages
+                (e.g. '5px 10px 2px 2px', '5, 10, 2, 2', '10% 20% 40%', etc.)
 
         Returns
         -------

--- a/plotly/graph_objs/ohlc/increasing/_line.py
+++ b/plotly/graph_objs/ohlc/increasing/_line.py
@@ -73,11 +73,11 @@ class Line(BaseTraceHierarchyType):
         *longdashdot*) or a dash length list in px (eg
         *5px,10px,2px,2px*).
     
-        The 'dash' property is a string and must be specified as:
-          - One of the following strings:
-                ['solid', 'dot', 'dash', 'longdash', 'dashdot',
-                'longdashdot']
-          - A number that will be converted to a string
+        The 'dash' property is an enumeration that may be specified as:
+          - One of the following dash styles:
+                ['solid', 'dot', 'dash', 'longdash', 'dashdot', 'longdashdot']
+          - A string containing a dash length list in pixels or percentages
+                (e.g. '5px 10px 2px 2px', '5, 10, 2, 2', '10% 20% 40%', etc.)
 
         Returns
         -------

--- a/plotly/graph_objs/scatter/_line.py
+++ b/plotly/graph_objs/scatter/_line.py
@@ -73,11 +73,11 @@ class Line(BaseTraceHierarchyType):
         *longdashdot*) or a dash length list in px (eg
         *5px,10px,2px,2px*).
     
-        The 'dash' property is a string and must be specified as:
-          - One of the following strings:
-                ['solid', 'dot', 'dash', 'longdash', 'dashdot',
-                'longdashdot']
-          - A number that will be converted to a string
+        The 'dash' property is an enumeration that may be specified as:
+          - One of the following dash styles:
+                ['solid', 'dot', 'dash', 'longdash', 'dashdot', 'longdashdot']
+          - A string containing a dash length list in pixels or percentages
+                (e.g. '5px 10px 2px 2px', '5, 10, 2, 2', '10% 20% 40%', etc.)
 
         Returns
         -------

--- a/plotly/graph_objs/scattercarpet/_line.py
+++ b/plotly/graph_objs/scattercarpet/_line.py
@@ -73,11 +73,11 @@ class Line(BaseTraceHierarchyType):
         *longdashdot*) or a dash length list in px (eg
         *5px,10px,2px,2px*).
     
-        The 'dash' property is a string and must be specified as:
-          - One of the following strings:
-                ['solid', 'dot', 'dash', 'longdash', 'dashdot',
-                'longdashdot']
-          - A number that will be converted to a string
+        The 'dash' property is an enumeration that may be specified as:
+          - One of the following dash styles:
+                ['solid', 'dot', 'dash', 'longdash', 'dashdot', 'longdashdot']
+          - A string containing a dash length list in pixels or percentages
+                (e.g. '5px 10px 2px 2px', '5, 10, 2, 2', '10% 20% 40%', etc.)
 
         Returns
         -------

--- a/plotly/graph_objs/scattergeo/_line.py
+++ b/plotly/graph_objs/scattergeo/_line.py
@@ -73,11 +73,11 @@ class Line(BaseTraceHierarchyType):
         *longdashdot*) or a dash length list in px (eg
         *5px,10px,2px,2px*).
     
-        The 'dash' property is a string and must be specified as:
-          - One of the following strings:
-                ['solid', 'dot', 'dash', 'longdash', 'dashdot',
-                'longdashdot']
-          - A number that will be converted to a string
+        The 'dash' property is an enumeration that may be specified as:
+          - One of the following dash styles:
+                ['solid', 'dot', 'dash', 'longdash', 'dashdot', 'longdashdot']
+          - A string containing a dash length list in pixels or percentages
+                (e.g. '5px 10px 2px 2px', '5, 10, 2, 2', '10% 20% 40%', etc.)
 
         Returns
         -------

--- a/plotly/graph_objs/scatterpolar/_line.py
+++ b/plotly/graph_objs/scatterpolar/_line.py
@@ -73,11 +73,11 @@ class Line(BaseTraceHierarchyType):
         *longdashdot*) or a dash length list in px (eg
         *5px,10px,2px,2px*).
     
-        The 'dash' property is a string and must be specified as:
-          - One of the following strings:
-                ['solid', 'dot', 'dash', 'longdash', 'dashdot',
-                'longdashdot']
-          - A number that will be converted to a string
+        The 'dash' property is an enumeration that may be specified as:
+          - One of the following dash styles:
+                ['solid', 'dot', 'dash', 'longdash', 'dashdot', 'longdashdot']
+          - A string containing a dash length list in pixels or percentages
+                (e.g. '5px 10px 2px 2px', '5, 10, 2, 2', '10% 20% 40%', etc.)
 
         Returns
         -------

--- a/plotly/graph_objs/scatterternary/_line.py
+++ b/plotly/graph_objs/scatterternary/_line.py
@@ -73,11 +73,11 @@ class Line(BaseTraceHierarchyType):
         *longdashdot*) or a dash length list in px (eg
         *5px,10px,2px,2px*).
     
-        The 'dash' property is a string and must be specified as:
-          - One of the following strings:
-                ['solid', 'dot', 'dash', 'longdash', 'dashdot',
-                'longdashdot']
-          - A number that will be converted to a string
+        The 'dash' property is an enumeration that may be specified as:
+          - One of the following dash styles:
+                ['solid', 'dot', 'dash', 'longdash', 'dashdot', 'longdashdot']
+          - A string containing a dash length list in pixels or percentages
+                (e.g. '5px 10px 2px 2px', '5, 10, 2, 2', '10% 20% 40%', etc.)
 
         Returns
         -------

--- a/plotly/validators/contour/line/_dash.py
+++ b/plotly/validators/contour/line/_dash.py
@@ -1,7 +1,7 @@
 import _plotly_utils.basevalidators
 
 
-class DashValidator(_plotly_utils.basevalidators.StringValidator):
+class DashValidator(_plotly_utils.basevalidators.DashValidator):
 
     def __init__(
         self, plotly_name='dash', parent_name='contour.line', **kwargs

--- a/plotly/validators/contourcarpet/line/_dash.py
+++ b/plotly/validators/contourcarpet/line/_dash.py
@@ -1,7 +1,7 @@
 import _plotly_utils.basevalidators
 
 
-class DashValidator(_plotly_utils.basevalidators.StringValidator):
+class DashValidator(_plotly_utils.basevalidators.DashValidator):
 
     def __init__(
         self, plotly_name='dash', parent_name='contourcarpet.line', **kwargs

--- a/plotly/validators/histogram2dcontour/line/_dash.py
+++ b/plotly/validators/histogram2dcontour/line/_dash.py
@@ -1,7 +1,7 @@
 import _plotly_utils.basevalidators
 
 
-class DashValidator(_plotly_utils.basevalidators.StringValidator):
+class DashValidator(_plotly_utils.basevalidators.DashValidator):
 
     def __init__(
         self,

--- a/plotly/validators/ohlc/decreasing/line/_dash.py
+++ b/plotly/validators/ohlc/decreasing/line/_dash.py
@@ -1,7 +1,7 @@
 import _plotly_utils.basevalidators
 
 
-class DashValidator(_plotly_utils.basevalidators.StringValidator):
+class DashValidator(_plotly_utils.basevalidators.DashValidator):
 
     def __init__(
         self, plotly_name='dash', parent_name='ohlc.decreasing.line', **kwargs

--- a/plotly/validators/ohlc/increasing/line/_dash.py
+++ b/plotly/validators/ohlc/increasing/line/_dash.py
@@ -1,7 +1,7 @@
 import _plotly_utils.basevalidators
 
 
-class DashValidator(_plotly_utils.basevalidators.StringValidator):
+class DashValidator(_plotly_utils.basevalidators.DashValidator):
 
     def __init__(
         self, plotly_name='dash', parent_name='ohlc.increasing.line', **kwargs

--- a/plotly/validators/ohlc/line/_dash.py
+++ b/plotly/validators/ohlc/line/_dash.py
@@ -1,7 +1,7 @@
 import _plotly_utils.basevalidators
 
 
-class DashValidator(_plotly_utils.basevalidators.StringValidator):
+class DashValidator(_plotly_utils.basevalidators.DashValidator):
 
     def __init__(self, plotly_name='dash', parent_name='ohlc.line', **kwargs):
         super(DashValidator, self).__init__(

--- a/plotly/validators/scatter/line/_dash.py
+++ b/plotly/validators/scatter/line/_dash.py
@@ -1,7 +1,7 @@
 import _plotly_utils.basevalidators
 
 
-class DashValidator(_plotly_utils.basevalidators.StringValidator):
+class DashValidator(_plotly_utils.basevalidators.DashValidator):
 
     def __init__(
         self, plotly_name='dash', parent_name='scatter.line', **kwargs

--- a/plotly/validators/scattercarpet/line/_dash.py
+++ b/plotly/validators/scattercarpet/line/_dash.py
@@ -1,7 +1,7 @@
 import _plotly_utils.basevalidators
 
 
-class DashValidator(_plotly_utils.basevalidators.StringValidator):
+class DashValidator(_plotly_utils.basevalidators.DashValidator):
 
     def __init__(
         self, plotly_name='dash', parent_name='scattercarpet.line', **kwargs

--- a/plotly/validators/scattergeo/line/_dash.py
+++ b/plotly/validators/scattergeo/line/_dash.py
@@ -1,7 +1,7 @@
 import _plotly_utils.basevalidators
 
 
-class DashValidator(_plotly_utils.basevalidators.StringValidator):
+class DashValidator(_plotly_utils.basevalidators.DashValidator):
 
     def __init__(
         self, plotly_name='dash', parent_name='scattergeo.line', **kwargs

--- a/plotly/validators/scatterpolar/line/_dash.py
+++ b/plotly/validators/scatterpolar/line/_dash.py
@@ -1,7 +1,7 @@
 import _plotly_utils.basevalidators
 
 
-class DashValidator(_plotly_utils.basevalidators.StringValidator):
+class DashValidator(_plotly_utils.basevalidators.DashValidator):
 
     def __init__(
         self, plotly_name='dash', parent_name='scatterpolar.line', **kwargs

--- a/plotly/validators/scatterternary/line/_dash.py
+++ b/plotly/validators/scatterternary/line/_dash.py
@@ -1,7 +1,7 @@
 import _plotly_utils.basevalidators
 
 
-class DashValidator(_plotly_utils.basevalidators.StringValidator):
+class DashValidator(_plotly_utils.basevalidators.DashValidator):
 
     def __init__(
         self, plotly_name='dash', parent_name='scatterternary.line', **kwargs


### PR DESCRIPTION
Fix for #1107

This PR introduces a new custom `DashValidator`. This is a `EnumerationValidator` subclass that adds a regular expression to the acceptable values list that covers the dash list case.

It also customizes the validator description so that we don't simple tell users that their specification must match the regular expression `^\d+(\.\d+)?(px|%)?((,|\s)\s*\d+(\.\d+)?(px|%)?)*$` 🙂 

The new `DashValidator` is used for all `dash` properties that support dash lists. At the moment this includes the `dash` properties in all non-WebGL trace types.  The validators for the dash properties in WebGL trace types have not been modified.

cc @APlowman