### PR TITLE
Fix deprecation warning for go.Annotations.

### DIFF
--- a/codegen/compatibility.py
+++ b/codegen/compatibility.py
@@ -11,7 +11,7 @@ DEPRECATED_DATATYPES = {
          'new': ['Scatter', 'Bar', 'Area', 'Histogram', 'etc.']},
     'Annotations':
         {'base_type': list,
-         'new': ['layout', 'layout.scene']},
+         'new': ['layout.Annotation', 'layout.scene.Annotation']},
     'Frames':
         {'base_type': list,
          'new': ['Frame']},

--- a/plotly/graph_objs/_deprecations.py
+++ b/plotly/graph_objs/_deprecations.py
@@ -45,8 +45,8 @@ class Annotations(list):
     """
     plotly.graph_objs.Annotations is deprecated.
 Please replace it with a list or tuple of instances of the following types
-  - plotly.graph_objs.layout.Annotations
-  - plotly.graph_objs.layout.scene.Annotations
+  - plotly.graph_objs.layout.Annotation
+  - plotly.graph_objs.layout.scene.Annotation
 
     """
 
@@ -54,15 +54,15 @@ Please replace it with a list or tuple of instances of the following types
         """
         plotly.graph_objs.Annotations is deprecated.
 Please replace it with a list or tuple of instances of the following types
-  - plotly.graph_objs.layout.Annotations
-  - plotly.graph_objs.layout.scene.Annotations
+  - plotly.graph_objs.layout.Annotation
+  - plotly.graph_objs.layout.scene.Annotation
 
         """
         warnings.warn(
             """plotly.graph_objs.Annotations is deprecated.
 Please replace it with a list or tuple of instances of the following types
-  - plotly.graph_objs.layout.Annotations
-  - plotly.graph_objs.layout.scene.Annotations
+  - plotly.graph_objs.layout.Annotation
+  - plotly.graph_objs.layout.scene.Annotation
 """, DeprecationWarning
         )
         super(Annotations, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Fix for #1125.
There is no `go.layout.Annotations` (it should not have been plural)

Thanks @timkpaine