### PR TITLE
Add workaround for orca segmentation fault

### DIFF
--- a/plotly/io/_orca.py
+++ b/plotly/io/_orca.py
@@ -911,6 +911,13 @@ Searched for executable '{executable}' on the following path:
             formatted_path=formatted_path,
             instructions=install_location_instructions))
 
+    # Clear NODE_OPTIONS environment variable
+    # ---------------------------------------
+    # When this variable is set, orca <v1.2 will have a segmentation fault
+    # due to an electron bug.
+    # See: https://github.com/electron/electron/issues/12695
+    os.environ.pop('NODE_OPTIONS', None)
+
     # Run executable with --help and see if it's our orca
     # ---------------------------------------------------
     invalid_executable_msg = """

--- a/plotly/plotly/chunked_requests/chunked_request.py
+++ b/plotly/plotly/chunked_requests/chunked_request.py
@@ -25,7 +25,7 @@ class Stream:
         self._ssl_verification_enabled = ssl_verification_enabled
         self._connect()
 
-    def write(self, data, reconnect_on=('', 200, )):
+    def write(self, data, reconnect_on=('', 200, 502)):
         ''' Send `data` to the server in chunk-encoded form.
         Check the connection before writing and reconnect
         if disconnected and if the response status code is in `reconnect_on`.

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,7 @@ deps=
     pytest==3.5.1
     optional: numpy==1.11.3
     optional: ipython[all]==5.1.0
+    optional: ipykernel==4.8.2
     optional: jupyter==1.0.0
     optional: pandas==0.19.2
     optional: scipy==0.18.1


### PR DESCRIPTION
See discussion in https://github.com/plotly/orca/issues/124

This PR adds a line to unset the `NODE_OPTIONS` environment variable before calling orca, thereby avoiding the segmentation fault.
