### PR TITLE
Only retry on request errors with 5XX status code and use exponential backoff

### DIFF
--- a/plotly/api/v1/utils.py
+++ b/plotly/api/v1/utils.py
@@ -2,9 +2,11 @@ from __future__ import absolute_import
 
 import requests
 from requests.exceptions import RequestException
+from retrying import retry
 
 from plotly import config, exceptions
 from plotly.api.utils import basic_auth
+from plotly.api.v2.utils import should_retry
 
 
 def validate_response(response):
@@ -59,6 +61,8 @@ def get_headers():
     return headers
 
 
+@retry(wait_exponential_multiplier=1000, wait_exponential_max=16000,
+       stop_max_delay=180000, retry_on_exception=should_retry)
 def request(method, url, **kwargs):
     """
     Central place to make any v1 api request.

--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -578,7 +578,7 @@ class Stream:
 
         return streaming_specs
 
-    def heartbeat(self, reconnect_on=(200, '', 408)):
+    def heartbeat(self, reconnect_on=(200, '', 408, 502)):
         """
         Keep stream alive. Streams will close after ~1 min of inactivity.
 
@@ -616,7 +616,7 @@ class Stream:
         self._stream = chunked_requests.Stream(**streaming_specs)
 
     def write(self, trace, layout=None,
-              reconnect_on=(200, '', 408)):
+              reconnect_on=(200, '', 408, 502)):
         """
         Write to an open stream.
 


### PR DESCRIPTION
Implements #1114 and changes from random retry every second or so to exponential backoff.

This should be more reliable for when the back-end servers are temporarily overwhelmed.

Tries in seconds:
     0, 1, 2, 4, 8, 16, 16, 16... for up to 3 minutes total.

cc @priyatharsan 