### PR TITLE
Annotated heatmap figure factory fixes and improvements

### DIFF
--- a/plotly/tests/test_optional/test_tools/test_figure_factory.py
+++ b/plotly/tests/test_optional/test_tools/test_figure_factory.py
@@ -822,16 +822,14 @@ class TestAnnotatedHeatmap(TestCase, NumpyTestUtilsMixin):
 
         z = [[1, 0], [.25, .75], [.45, .5]]
         text = [['first', 'second'], ['third', 'fourth'], ['fifth', 'sixth']]
-        a = ff.create_annotated_heatmap(z, x=['A', 'B'],
-                                                       y=['One', 'Two',
-                                                          'Three'],
-                                                       annotation_text=text,
-                                                       colorscale=[[0,
-                                                                    '#ffffff'],
-                                                                   [1,
-                                                                    '#e6005a']]
-                                                       )
-        expected_a = {'data': [{'colorscale': [[0, '#ffffff'], [1, '#e6005a']],
+        a = ff.create_annotated_heatmap(z,
+                                        x=['A', 'B'],
+                                        y=['One', 'Two', 'Three'],
+                                        annotation_text=text,
+                                        colorscale=[[0, 'rgb(255,255,255)'],
+                                                    [1, '#e6005a']])
+        expected_a = {'data': [{'colorscale':
+                                    [[0, 'rgb(255,255,255)'], [1, '#e6005a']],
                                 'showscale': False,
                                 'type': 'heatmap',
                                 'x': ['A', 'B'],


### PR DESCRIPTION
 - Fix `map object not subscriptable` error #1122 (This happened on Python 3 when specifying a custom colormap using `rgb` colors)
 - Use colorscale validator to validate specified colorscale (and produce helpful error message) before trying to do text color inference.
 - Handle case where some colors are specified as rgb and some as hex.
 - Add 'Cividis" to list of know lighter-to-darker colorscales.

Thanks for bring this up @andy-lz!