### PR TITLE
Fix JavaScript "Error: addFrames failure" in offline html export

### DIFF
--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -174,9 +174,9 @@ def _plot_html(figure_or_data, config, validate, default_width,
     jdata = _json.dumps(figure.get('data', []), cls=utils.PlotlyJSONEncoder)
     jlayout = _json.dumps(figure.get('layout', {}),
                           cls=utils.PlotlyJSONEncoder)
-    if 'frames' in figure_or_data:
-        jframes = _json.dumps(figure.get('frames', {}),
-                              cls=utils.PlotlyJSONEncoder)
+
+    jframes = _json.dumps(figure.get('frames', []),
+                          cls=utils.PlotlyJSONEncoder)
 
     configkeys = (
         'staticPlot',
@@ -229,7 +229,7 @@ def _plot_html(figure_or_data, config, validate, default_width,
         config['linkText'] = link_text
         jconfig = jconfig.replace('Export to plot.ly', link_text)
 
-    if 'frames' in figure_or_data:
+    if jframes:
         script = '''
         Plotly.plot(
             '{id}',

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -175,8 +175,11 @@ def _plot_html(figure_or_data, config, validate, default_width,
     jlayout = _json.dumps(figure.get('layout', {}),
                           cls=utils.PlotlyJSONEncoder)
 
-    jframes = _json.dumps(figure.get('frames', []),
-                          cls=utils.PlotlyJSONEncoder)
+    if figure.get('frames', None):
+        jframes = _json.dumps(figure.get('frames', []),
+                              cls=utils.PlotlyJSONEncoder)
+    else:
+        jframes = None
 
     configkeys = (
         'staticPlot',


### PR DESCRIPTION
Fix for "Problem 3" in #1147.

Since version 3.0, stand-alone html files/divs generated by `plotly.offline.plot` resulted in a harmless JavaScript error on load if no Frames were defined.

```
Uncaught (in promise) Error: addFrames failure: frameList must be an Array of frame definitions[object Object]
    at Object.r.addFrames (pca:73)
    at pca:79
```

The problem was that the no-frames case was being represented by an empty `dict` rather than an empty `list`. Also, the frames logic should not have been output at all for the empty frames case.

cc: @CiaranWelsh