### PR TITLE
Use latest plotly.js

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -31,7 +31,7 @@
     "ify-loader": "^1.1.0"
   },
   "dependencies": {
-    "plotly.js": "1.40.1",
+    "plotly.js": "^1.40.1",
     "@jupyter-widgets/base": "^1.0.0",
     "lodash": "^4.17.4"
   },


### PR DESCRIPTION
Is there a reason to lock the version of plotly.js used?

This results in a WARNING when building Jupyterlab:

```
WARNING in plotly.js
  Multiple versions of plotly.js found:
    1.40.1 ./~/plotly.js from ./~/plotly.js\src\components\colorscale\get_scale.js
    1.41.0 ./~/@jupyterlab\plotly-extension/~/plotly.js from ./~/@jupyterlab\plotly-extension\lib\index.js
```

Reference:
- Jupyterlab 0.34.8
- plotly.py 3.2.1
- plotlywidget@0.3.0 
- @jupyterlab/plotly-extension@0.17

Nota: I did not try it yet