### PR TITLE
fix wrong leaves determination bug

### DIFF
--- a/plotly/figure_factory/_dendrogram.py
+++ b/plotly/figure_factory/_dendrogram.py
@@ -140,7 +140,10 @@ class _Dendrogram(object):
         for i in range(len(yvals_flat)):
             if yvals_flat[i] == 0.0 and xvals_flat[i] not in self.zero_vals:
                 self.zero_vals.append(xvals_flat[i])
-
+        if len(self.zero_vals) > len(yvals) + 1:
+            l_border = int(min(self.zero_vals))
+            r_border = int(max(self.zero_vals))
+            self.zero_vals = [v for v in range(l_border,r_border + 1, int((r_border-l_border) / len(yvals)))]
         self.zero_vals.sort()
 
         self.layout = self.set_figure_layout(width, height)


### PR DESCRIPTION
@jonmmease Sorry for multiple pull request beacuse I am new to github cooperation.

Here is the formal request with code and example.

Before, run the code below
```
import plotly
import plotly.figure_factory as ff
import pandas as pd
demo_data = pd.DataFrame([[1,2,3,4],[1,2,3,4],[1,3,5,6],[1,4,2,3]])
figure = ff.create_dendrogram(demo_data)
plotly.offline.plot(figure)
```
demo_data looks like 
![image](https://user-images.githubusercontent.com/16633223/45663499-5649b080-bb39-11e8-9229-a59c63159dbc.png)
The data is some simple data and it mainly simulated the situation which has three and more rows are identical. When we using the euclidean distance, the distance between 0,1 and 3 will be identical.

we could get the dendrogram like that
![wrong dendrogram](https://user-images.githubusercontent.com/16633223/45663326-6d3bd300-bb38-11e8-8436-de217508eef3.png)

In the graph above, we can see wrong multiple x-axis ticks text raised. It will be severely when we pass the leaves name. 35 in the graph is the original x-coordinate of the leaves.

After, run the same code above.
![after bug fixed](https://user-images.githubusercontent.com/16633223/45663422-ea674800-bb38-11e8-8fb1-529b5f6d70f6.png)

Relative issue and request: 
#1180 
#1181 

