### PR TITLE
ignore divide error in streamline

### DIFF
--- a/plotly/figure_factory/_streamline.py
+++ b/plotly/figure_factory/_streamline.py
@@ -354,8 +354,11 @@ class _Streamline(object):
         dif_x = arrow_end_x - arrow_start_x
         dif_y = arrow_end_y - arrow_start_y
 
+        orig_err = np.geterr()
         np.seterr(divide='ignore', invalid='ignore')
         streamline_ang = np.arctan(dif_y / dif_x)
+        np.seterr(**orig_err)
+
 
         ang1 = streamline_ang + (self.angle)
         ang2 = streamline_ang - (self.angle)

--- a/plotly/figure_factory/_streamline.py
+++ b/plotly/figure_factory/_streamline.py
@@ -354,6 +354,7 @@ class _Streamline(object):
         dif_x = arrow_end_x - arrow_start_x
         dif_y = arrow_end_y - arrow_start_y
 
+        np.seterr(divide='ignore', invalid='ignore')
         streamline_ang = np.arctan(dif_y / dif_x)
 
         ang1 = streamline_ang + (self.angle)


### PR DESCRIPTION
Simple fix to warning that pops up when streamline code divides 0 by 0.

See  https://plot.ly/python/streamline-plots/#basic-streamline-plot for an example of the warning.