### PR TITLE
Add support for 2D arrays in InfoArrayValidator

### DIFF
--- a/_plotly_utils/tests/validators/test_infoarray_validator.py
+++ b/_plotly_utils/tests/validators/test_infoarray_validator.py
@@ -46,7 +46,7 @@ def test_validator_rejection_any2_type(val, validator_any2):
     with pytest.raises(ValueError) as validation_failure:
         validator_any2.validate_coerce(val)
 
-    assert 'must be a list or tuple.' in str(validation_failure.value)
+    assert 'Invalid value' in str(validation_failure.value)
 
 
 # ### Rejection by length ###
@@ -80,7 +80,7 @@ def test_validator_rejection_number3_length(val, validator_number3):
     with pytest.raises(ValueError) as validation_failure:
         validator_number3.validate_coerce(val)
 
-    assert 'must be a list or tuple of length 3.' in str(validation_failure.value)
+    assert 'Invalid value' in str(validation_failure.value)
 
 
 # ### Rejection by element type ###
@@ -89,11 +89,11 @@ def test_validator_rejection_number3_length(val, validator_number3):
     ((0.1, set(), 0.99), 1),
     ([[], '2', {}], 0)
 ])
-def test_validator_rejection_number3_length(val, first_invalid_ind, validator_number3):
+def test_validator_rejection_number3_element_type(val, first_invalid_ind, validator_number3):
     with pytest.raises(ValueError) as validation_failure:
         validator_number3.validate_coerce(val)
 
-    assert 'The prop[%d] property of parent must be a number.' % first_invalid_ind in str(validation_failure.value)
+    assert 'Invalid value' in str(validation_failure.value)
 
 
 # ### Rejection by element value ###
@@ -103,12 +103,11 @@ def test_validator_rejection_number3_length(val, first_invalid_ind, validator_nu
     ((0.1, -0.4, 0.99), 1),
     ([-1, 1, 0], 0)
 ])
-def test_validator_rejection_number3_length(val, first_invalid_ind, validator_number3):
+def test_validator_rejection_number3_element_value(val, first_invalid_ind, validator_number3):
     with pytest.raises(ValueError) as validation_failure:
         validator_number3.validate_coerce(val)
 
-    assert ('The prop[%d] property of parent must be in the range [0, 1]' % first_invalid_ind
-            in str(validation_failure.value))
+    assert ('in the interval [0, 1]' in str(validation_failure.value))
 
 
 # Number3 Tests (free_length=True)
@@ -130,7 +129,7 @@ def test_validator_acceptance_number3_free(val, validator_number3_free):
 @pytest.mark.parametrize('val', [
     'Not a list', 123, set(), {}
 ])
-def test_validator_rejection_any2_type(val, validator_number3_free):
+def test_validator_rejection_number3_free_element_type(val, validator_number3_free):
     with pytest.raises(ValueError) as validation_failure:
         validator_number3_free.validate_coerce(val)
 
@@ -154,7 +153,7 @@ def test_validator_rejection_number3_free_length(val, validator_number3_free):
     ((0.1, set()), 1),
     ([[]], 0)
 ])
-def test_validator_rejection_number3_length(val, first_invalid_ind, validator_number3_free):
+def test_validator_rejection_number3_free_element_value(val, first_invalid_ind, validator_number3_free):
     with pytest.raises(ValueError) as validation_failure:
         validator_number3_free.validate_coerce(val)
 

--- a/_plotly_utils/tests/validators/test_infoarray_validator.py
+++ b/_plotly_utils/tests/validators/test_infoarray_validator.py
@@ -26,6 +26,42 @@ def validator_number3_free():
         {'valType': 'number', 'min': 0, 'max': 1}], free_length=True)
 
 
+@pytest.fixture()
+def validator_number2_2d():
+    return InfoArrayValidator('prop', 'parent', items=[
+        {'valType': 'number', 'min': 0, 'max': 1},
+        {'valType': 'number', 'min': 0, 'max': 1}],
+                              free_length=True,
+                              dimensions=2)
+
+
+@pytest.fixture()
+def validator_number2_12d():
+    return InfoArrayValidator('prop', 'parent', items=[
+        {'valType': 'number', 'min': 0, 'max': 1},
+        {'valType': 'number', 'min': 0, 'max': 1}],
+                              free_length=True,
+                              dimensions='1-2')
+
+
+@pytest.fixture()
+def validator_number_free_1d():
+    return InfoArrayValidator('prop', 'parent',
+                              items={'valType': 'number',
+                                     'min': 0, 'max': 1},
+                              free_length=True,
+                              dimensions=1)
+
+
+@pytest.fixture()
+def validator_number_free_2d():
+    return InfoArrayValidator('prop', 'parent',
+                              items={'valType': 'number',
+                                     'min': 0, 'max': 1},
+                              free_length=True,
+                              dimensions=2)
+
+
 # Any2 Tests
 # ----------
 # ### Acceptance ###
@@ -129,7 +165,7 @@ def test_validator_acceptance_number3_free(val, validator_number3_free):
 @pytest.mark.parametrize('val', [
     'Not a list', 123, set(), {}
 ])
-def test_validator_rejection_number3_free_element_type(val, validator_number3_free):
+def test_validator_rejection_number3_free_type(val, validator_number3_free):
     with pytest.raises(ValueError) as validation_failure:
         validator_number3_free.validate_coerce(val)
 
@@ -151,12 +187,312 @@ def test_validator_rejection_number3_free_length(val, validator_number3_free):
 @pytest.mark.parametrize('val,first_invalid_ind', [
     ([1, 0, '0.5'], 2),
     ((0.1, set()), 1),
-    ([[]], 0)
+    ([{}], 0)
+])
+def test_validator_rejection_number3_free_element_type(val, first_invalid_ind, validator_number3_free):
+    with pytest.raises(ValueError) as validation_failure:
+        validator_number3_free.validate_coerce(val)
+
+    assert ("Invalid value of type {typ} received for the 'prop[{first_invalid_ind}]' property of parent"
+            .format(typ=type_str(val[first_invalid_ind]),
+                    first_invalid_ind=first_invalid_ind)) in str(validation_failure.value)
+
+
+# ### Rejection by element value ###
+@pytest.mark.parametrize('val,first_invalid_ind', [
+    ([1, 0, -0.5], 2),
+    ((0.1, 2), 1),
+    ([99], 0)
 ])
 def test_validator_rejection_number3_free_element_value(val, first_invalid_ind, validator_number3_free):
     with pytest.raises(ValueError) as validation_failure:
         validator_number3_free.validate_coerce(val)
 
     assert ("Invalid value of type {typ} received for the 'prop[{first_invalid_ind}]' property of parent"
-            .format(typ= type_str(val[first_invalid_ind]),
+            .format(typ=type_str(val[first_invalid_ind]),
                     first_invalid_ind=first_invalid_ind)) in str(validation_failure.value)
+
+
+# Number2 2D
+# ----------
+# ### Acceptance ###
+@pytest.mark.parametrize('val', [
+    [],
+    [[1, 0]],
+    [(0.1, 0.99)],
+    np.array([[0.1, 0.99]]),
+    [np.array([0.1, 0.4]), [0.2, 0], (0.9, 0.5)]
+])
+def test_validator_acceptance_number2_2d(val, validator_number2_2d):
+    coerce_val = validator_number2_2d.validate_coerce(val)
+    assert coerce_val == list((list(row) for row in val))
+    expected = tuple([tuple(e) for e in val])
+    assert validator_number2_2d.present(coerce_val) == expected
+
+
+# ### Rejection by type ###
+@pytest.mark.parametrize('val', [
+    'Not a list', 123, set(), {},
+])
+def test_validator_rejection_number2_2d_type(val, validator_number2_2d):
+    with pytest.raises(ValueError) as validation_failure:
+        validator_number2_2d.validate_coerce(val)
+
+    assert 'Invalid value' in str(validation_failure.value)
+
+
+# ### Rejection by element type ###
+@pytest.mark.parametrize('val,first_invalid_ind', [
+    ([[1, 0], [0.2, 0.4], 'string'], 2),
+    ([[0.1, 0.7], set()], 1),
+    (['bogus'], 0)
+])
+def test_validator_rejection_number2_2d_element_type(val, first_invalid_ind, validator_number2_2d):
+    with pytest.raises(ValueError) as validation_failure:
+        validator_number2_2d.validate_coerce(val)
+
+    assert ("Invalid value of type {typ} received for the 'prop[{first_invalid_ind}]' property of parent"
+            .format(typ=type_str(val[first_invalid_ind]),
+                    first_invalid_ind=first_invalid_ind)) in str(validation_failure.value)
+
+
+# ### Rejection by element length ###
+@pytest.mark.parametrize('val,first_invalid_ind', [
+    ([[1, 0], [0.2, 0.4], [0.2]], 2),
+    ([[0.1, 0.7], [0, .1, .4]], 1),
+    ([[]], 0)
+])
+def test_validator_rejection_number2_2d_element_length(val, first_invalid_ind, validator_number2_2d):
+    with pytest.raises(ValueError) as validation_failure:
+        validator_number2_2d.validate_coerce(val)
+
+    assert ("Invalid value of type {typ} received for the 'prop[{first_invalid_ind}]' property of parent"
+            .format(typ=type_str(val[first_invalid_ind]),
+                    first_invalid_ind=first_invalid_ind)) in str(validation_failure.value)
+
+
+# ### Rejection by element value ###
+@pytest.mark.parametrize('val,invalid_inds', [
+    ([[1, 0], [0.2, 0.4], [0.2, 1.2]], [2, 1]),
+    ([[0.1, 0.7], [-2, .1]], [1, 0]),
+    ([[99, 0.3]], [0, 0])
+])
+def test_validator_rejection_number2_2d_element_value(val, invalid_inds, validator_number2_2d):
+    with pytest.raises(ValueError) as validation_failure:
+        validator_number2_2d.validate_coerce(val)
+
+    invalid_val = val[invalid_inds[0]][invalid_inds[1]]
+    invalid_name = 'prop[{}][{}]'.format(*invalid_inds)
+    assert ("Invalid value of type {typ} received for the '{invalid_name}' property of parent"
+            .format(typ=type_str(invalid_val),
+                    invalid_name=invalid_name)) in str(validation_failure.value)
+
+
+# Number2 '1-2'
+# -------------
+# ### Acceptance ###
+@pytest.mark.parametrize('val', [
+    [],
+    [1, 0],
+    (0.1, 0.99),
+    np.array([0.1, 0.99])
+])
+def test_validator_acceptance_number2_12d_1d(val, validator_number2_12d):
+    coerce_val = validator_number2_12d.validate_coerce(val)
+    assert coerce_val == list(val)
+    expected = tuple(val)
+    assert validator_number2_12d.present(coerce_val) == expected
+
+
+@pytest.mark.parametrize('val', [
+    [],
+    [[1, 0]],
+    [(0.1, 0.99)],
+    np.array([[0.1, 0.99]]),
+    [np.array([0.1, 0.4]), [0.2, 0], (0.9, 0.5)]
+])
+def test_validator_acceptance_number2_12d_2d(val, validator_number2_12d):
+    coerce_val = validator_number2_12d.validate_coerce(val)
+    assert coerce_val == list((list(row) for row in val))
+    expected = tuple([tuple(e) for e in val])
+    assert validator_number2_12d.present(coerce_val) == expected
+
+
+# ### Rejection by type / length###
+@pytest.mark.parametrize('val', [
+    'Not a list', 123, set(), {}, [0.1, 0.3, 0.2]
+])
+def test_validator_rejection_number2_12d_type(val, validator_number2_12d):
+    with pytest.raises(ValueError) as validation_failure:
+        validator_number2_12d.validate_coerce(val)
+
+    assert 'Invalid value' in str(validation_failure.value)
+
+
+# ### Rejection by element type 2D ###
+@pytest.mark.parametrize('val,first_invalid_ind', [
+    ([[1, 0], [0.2, 0.4], 'string'], 2),
+    ([[0.1, 0.7], set()], 1),
+    (['bogus'], 0)
+])
+def test_validator_rejection_number2_12d_element_type(val, first_invalid_ind, validator_number2_12d):
+    with pytest.raises(ValueError) as validation_failure:
+        validator_number2_12d.validate_coerce(val)
+
+    assert ("Invalid value of type {typ} received for the 'prop[{first_invalid_ind}]' property of parent"
+            .format(typ=type_str(val[first_invalid_ind]),
+                    first_invalid_ind=first_invalid_ind)) in str(validation_failure.value)
+
+
+# ### Rejection by element length ###
+@pytest.mark.parametrize('val,first_invalid_ind', [
+    ([[1, 0], [0.2, 0.4], [0.2]], 2),
+    ([[0.1, 0.7], [0, .1, .4]], 1),
+    ([[]], 0)
+])
+def test_validator_rejection_number2_12d_element_length(val, first_invalid_ind, validator_number2_12d):
+    with pytest.raises(ValueError) as validation_failure:
+        validator_number2_12d.validate_coerce(val)
+
+    assert ("Invalid value of type {typ} received for the 'prop[{first_invalid_ind}]' property of parent"
+            .format(typ=type_str(val[first_invalid_ind]),
+                    first_invalid_ind=first_invalid_ind)) in str(validation_failure.value)
+
+
+# ### Rejection by element value ###
+@pytest.mark.parametrize('val,invalid_inds', [
+    ([[1, 0], [0.2, 0.4], [0.2, 1.2]], [2, 1]),
+    ([[0.1, 0.7], [-2, .1]], [1, 0]),
+    ([[99, 0.3]], [0, 0]),
+    ([0.1, 1.2], [1]),
+    ([-0.1, 0.99], [0]),
+])
+def test_validator_rejection_number2_12d_element_value(val, invalid_inds, validator_number2_12d):
+    with pytest.raises(ValueError) as validation_failure:
+        validator_number2_12d.validate_coerce(val)
+
+    if len(invalid_inds) > 1:
+        invalid_val = val[invalid_inds[0]][invalid_inds[1]]
+        invalid_name = 'prop[{}][{}]'.format(*invalid_inds)
+    else:
+        invalid_val = val[invalid_inds[0]]
+        invalid_name = 'prop[{}]'.format(*invalid_inds)
+
+    assert ("Invalid value of type {typ} received for the '{invalid_name}' property of parent"
+            .format(typ=type_str(invalid_val),
+                    invalid_name=invalid_name)) in str(validation_failure.value)
+
+
+# Number free 1D
+# --------------
+@pytest.mark.parametrize('val', [
+    [],
+    [1, 0],
+    (0.1, 0.99, 0.4),
+    np.array([0.1, 0.4, 0.5, 0.1, 0.6, 0.99])
+])
+def test_validator_acceptance_number_free_1d(val, validator_number_free_1d):
+    coerce_val = validator_number_free_1d.validate_coerce(val)
+    assert coerce_val == list(val)
+    expected = tuple(val)
+    assert validator_number_free_1d.present(coerce_val) == expected
+
+
+# ### Rejection by type ###
+@pytest.mark.parametrize('val', [
+    'Not a list', 123, set(), {},
+])
+def test_validator_rejection_number_free_1d_type(val, validator_number_free_1d):
+    with pytest.raises(ValueError) as validation_failure:
+        validator_number_free_1d.validate_coerce(val)
+
+    assert 'Invalid value' in str(validation_failure.value)
+
+
+# ### Rejection by element type ###
+@pytest.mark.parametrize('val,first_invalid_ind', [
+    ([1, 0, 0.3, 0.5, '0.5', 0.2], 4),
+    ((0.1, set()), 1),
+    ([{}], 0)
+])
+def test_validator_rejection_number_free_1d_element_type(val, first_invalid_ind, validator_number_free_1d):
+    with pytest.raises(ValueError) as validation_failure:
+        validator_number_free_1d.validate_coerce(val)
+
+    assert ("Invalid value of type {typ} received for the 'prop[{first_invalid_ind}]' property of parent"
+            .format(typ=type_str(val[first_invalid_ind]),
+                    first_invalid_ind=first_invalid_ind)) in str(validation_failure.value)
+
+
+# ### Rejection by element value ###
+@pytest.mark.parametrize('val,first_invalid_ind', [
+    ([1, 0, 0.3, 0.999, -0.5], 4),
+    ((0.1, 2, 0.8), 1),
+    ([99, 0.3], 0)
+])
+def test_validator_rejection_number_free_1d_element_value(val, first_invalid_ind, validator_number_free_1d):
+    with pytest.raises(ValueError) as validation_failure:
+        validator_number_free_1d.validate_coerce(val)
+
+    assert ("Invalid value of type {typ} received for the 'prop[{first_invalid_ind}]' property of parent"
+            .format(typ=type_str(val[first_invalid_ind]),
+                    first_invalid_ind=first_invalid_ind)) in str(validation_failure.value)
+
+
+# Number free 2D
+# --------------
+@pytest.mark.parametrize('val', [
+    [],
+    [[1, 0]],
+    [(0.1, 0.99)],
+    np.array([[0.1, 0.99]]),
+    [np.array([0.1, 0.4]), [0.2, 0], (0.9, 0.5)]
+])
+def test_validator_acceptance_number_free_2d(val, validator_number_free_2d):
+    coerce_val = validator_number_free_2d.validate_coerce(val)
+    assert coerce_val == list((list(row) for row in val))
+    expected = tuple([tuple(e) for e in val])
+    assert validator_number_free_2d.present(coerce_val) == expected
+
+
+# ### Rejection by type ###
+@pytest.mark.parametrize('val', [
+    'Not a list', 123, set(), {},
+])
+def test_validator_rejection_number_free_2d_type(val, validator_number_free_2d):
+    with pytest.raises(ValueError) as validation_failure:
+        validator_number_free_2d.validate_coerce(val)
+
+    assert 'Invalid value' in str(validation_failure.value)
+
+
+# ### Rejection by element type ###
+@pytest.mark.parametrize('val,first_invalid_ind', [
+    ([[1, 0], [0.2, 0.4], 'string'], 2),
+    ([[0.1, 0.7], set()], 1),
+    (['bogus'], 0)
+])
+def test_validator_rejection_number_free_2d_element_type(val, first_invalid_ind, validator_number_free_2d):
+    with pytest.raises(ValueError) as validation_failure:
+        validator_number_free_2d.validate_coerce(val)
+
+    assert ("Invalid value of type {typ} received for the 'prop[{first_invalid_ind}]' property of parent"
+            .format(typ=type_str(val[first_invalid_ind]),
+                    first_invalid_ind=first_invalid_ind)) in str(validation_failure.value)
+
+
+# ### Rejection by element value ###
+@pytest.mark.parametrize('val,invalid_inds', [
+    ([[1, 0], [0.2, 0.4], [0.2, 1.2]], [2, 1]),
+    ([[0.1, 0.7], [-2, .1]], [1, 0]),
+    ([[99, 0.3]], [0, 0])
+])
+def test_validator_rejection_number_free_2d_element_value(val, invalid_inds, validator_number_free_2d):
+    with pytest.raises(ValueError) as validation_failure:
+        validator_number_free_2d.validate_coerce(val)
+
+    invalid_val = val[invalid_inds[0]][invalid_inds[1]]
+    invalid_name = 'prop[{}][{}]'.format(*invalid_inds)
+    assert ("Invalid value of type {typ} received for the '{invalid_name}' property of parent"
+            .format(typ=type_str(invalid_val),
+                    invalid_name=invalid_name)) in str(validation_failure.value)

--- a/_plotly_utils/tests/validators/test_infoarray_validator.py
+++ b/_plotly_utils/tests/validators/test_infoarray_validator.py
@@ -74,6 +74,12 @@ def test_validator_acceptance_any2(val, validator_any2):
     assert validator_any2.present(coerce_val) == tuple(val)
 
 
+def test_validator_acceptance_any2_none(validator_any2):
+    coerce_val = validator_any2.validate_coerce(None)
+    assert coerce_val is None
+    assert validator_any2.present(coerce_val) is None
+
+
 # ### Rejection by type ###
 @pytest.mark.parametrize('val', [
     'Not a list', 123, set(), {}

--- a/codegen/utils.py
+++ b/codegen/utils.py
@@ -146,9 +146,10 @@ def format_description(desc):
     desc = re.sub('(^|[\s(,.:])\*(\S+)\*([\s),.:]|$)', r'\1"\2"\3', desc)
 
     # Special case strings that don't satisfy regex above
-    other_strings = ['Courier New', 'Droid Sans', 'Droid Serif',
+    other_strings = ['', 'Courier New', 'Droid Sans', 'Droid Serif',
                      'Droid Sans Mono', 'Gravitas One', 'Old Standard TT',
-                     'Open Sans', 'PT Sans Narrow', 'Times New Roman']
+                     'Open Sans', 'PT Sans Narrow', 'Times New Roman',
+                     'bottom plot', 'top plot']
 
     for s in other_strings:
         desc = desc.replace("*%s*" % s, '"%s"' % s)

--- a/plotly/graph_objs/_choropleth.py
+++ b/plotly/graph_objs/_choropleth.py
@@ -192,7 +192,7 @@ class Choropleth(BaseTraceType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/_cone.py
+++ b/plotly/graph_objs/_cone.py
@@ -281,7 +281,7 @@ class Cone(BaseTraceType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/_contour.py
+++ b/plotly/graph_objs/_contour.py
@@ -214,7 +214,7 @@ class Contour(BaseTraceType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/_contourcarpet.py
+++ b/plotly/graph_objs/_contourcarpet.py
@@ -408,7 +408,7 @@ class Contourcarpet(BaseTraceType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/_figure.py
+++ b/plotly/graph_objs/_figure.py
@@ -3558,7 +3558,7 @@ class Figure(BaseFigure):
             respectively.
         histnorm
             Specifies the type of normalization used for this
-            histogram trace. If **, the span of each bar
+            histogram trace. If "", the span of each bar
             corresponds to the number of occurrences (i.e. the
             number of data points lying inside the bins). If
             "percent" / "probability", the span of each bar
@@ -3850,7 +3850,7 @@ class Figure(BaseFigure):
             respectively.
         histnorm
             Specifies the type of normalization used for this
-            histogram trace. If **, the span of each bar
+            histogram trace. If "", the span of each bar
             corresponds to the number of occurrences (i.e. the
             number of data points lying inside the bins). If
             "percent" / "probability", the span of each bar
@@ -4172,7 +4172,7 @@ class Figure(BaseFigure):
             respectively.
         histnorm
             Specifies the type of normalization used for this
-            histogram trace. If **, the span of each bar
+            histogram trace. If "", the span of each bar
             corresponds to the number of occurrences (i.e. the
             number of data points lying inside the bins). If
             "percent" / "probability", the span of each bar

--- a/plotly/graph_objs/_figurewidget.py
+++ b/plotly/graph_objs/_figurewidget.py
@@ -3558,7 +3558,7 @@ class FigureWidget(BaseFigureWidget):
             respectively.
         histnorm
             Specifies the type of normalization used for this
-            histogram trace. If **, the span of each bar
+            histogram trace. If "", the span of each bar
             corresponds to the number of occurrences (i.e. the
             number of data points lying inside the bins). If
             "percent" / "probability", the span of each bar
@@ -3850,7 +3850,7 @@ class FigureWidget(BaseFigureWidget):
             respectively.
         histnorm
             Specifies the type of normalization used for this
-            histogram trace. If **, the span of each bar
+            histogram trace. If "", the span of each bar
             corresponds to the number of occurrences (i.e. the
             number of data points lying inside the bins). If
             "percent" / "probability", the span of each bar
@@ -4172,7 +4172,7 @@ class FigureWidget(BaseFigureWidget):
             respectively.
         histnorm
             Specifies the type of normalization used for this
-            histogram trace. If **, the span of each bar
+            histogram trace. If "", the span of each bar
             corresponds to the number of occurrences (i.e. the
             number of data points lying inside the bins). If
             "percent" / "probability", the span of each bar

--- a/plotly/graph_objs/_heatmap.py
+++ b/plotly/graph_objs/_heatmap.py
@@ -191,7 +191,7 @@ class Heatmap(BaseTraceType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/_heatmapgl.py
+++ b/plotly/graph_objs/_heatmapgl.py
@@ -192,7 +192,7 @@ class Heatmapgl(BaseTraceType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/_histogram.py
+++ b/plotly/graph_objs/_histogram.py
@@ -84,7 +84,7 @@ class Histogram(BaseTraceType):
                     and `centralbin` attributes to tune the
                     accumulation method. Note: in this mode, the
                     "density" `histnorm` settings behave the same
-                    as their equivalents without "density": ** and
+                    as their equivalents without "density": "" and
                     "density" both rise to the number of data
                     points, and "probability" and *probability
                     density* both rise to the number of sample
@@ -335,7 +335,7 @@ class Histogram(BaseTraceType):
     def histnorm(self):
         """
         Specifies the type of normalization used for this histogram
-        trace. If **, the span of each bar corresponds to the number of
+        trace. If "", the span of each bar corresponds to the number of
         occurrences (i.e. the number of data points lying inside the
         bins). If "percent" / "probability", the span of each bar
         corresponds to the percentage / fraction of occurrences with
@@ -1255,7 +1255,7 @@ class Histogram(BaseTraceType):
             respectively.
         histnorm
             Specifies the type of normalization used for this
-            histogram trace. If **, the span of each bar
+            histogram trace. If "", the span of each bar
             corresponds to the number of occurrences (i.e. the
             number of data points lying inside the bins). If
             "percent" / "probability", the span of each bar
@@ -1473,7 +1473,7 @@ class Histogram(BaseTraceType):
             respectively.
         histnorm
             Specifies the type of normalization used for this
-            histogram trace. If **, the span of each bar
+            histogram trace. If "", the span of each bar
             corresponds to the number of occurrences (i.e. the
             number of data points lying inside the bins). If
             "percent" / "probability", the span of each bar

--- a/plotly/graph_objs/_histogram2d.py
+++ b/plotly/graph_objs/_histogram2d.py
@@ -239,7 +239,7 @@ class Histogram2d(BaseTraceType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix
@@ -412,7 +412,7 @@ class Histogram2d(BaseTraceType):
     def histnorm(self):
         """
         Specifies the type of normalization used for this histogram
-        trace. If **, the span of each bar corresponds to the number of
+        trace. If "", the span of each bar corresponds to the number of
         occurrences (i.e. the number of data points lying inside the
         bins). If "percent" / "probability", the span of each bar
         corresponds to the percentage / fraction of occurrences with
@@ -1376,7 +1376,7 @@ class Histogram2d(BaseTraceType):
             respectively.
         histnorm
             Specifies the type of normalization used for this
-            histogram trace. If **, the span of each bar
+            histogram trace. If "", the span of each bar
             corresponds to the number of occurrences (i.e. the
             number of data points lying inside the bins). If
             "percent" / "probability", the span of each bar
@@ -1629,7 +1629,7 @@ class Histogram2d(BaseTraceType):
             respectively.
         histnorm
             Specifies the type of normalization used for this
-            histogram trace. If **, the span of each bar
+            histogram trace. If "", the span of each bar
             corresponds to the number of occurrences (i.e. the
             number of data points lying inside the bins). If
             "percent" / "probability", the span of each bar

--- a/plotly/graph_objs/_histogram2dcontour.py
+++ b/plotly/graph_objs/_histogram2dcontour.py
@@ -262,7 +262,7 @@ class Histogram2dContour(BaseTraceType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix
@@ -521,7 +521,7 @@ class Histogram2dContour(BaseTraceType):
     def histnorm(self):
         """
         Specifies the type of normalization used for this histogram
-        trace. If **, the span of each bar corresponds to the number of
+        trace. If "", the span of each bar corresponds to the number of
         occurrences (i.e. the number of data points lying inside the
         bins). If "percent" / "probability", the span of each bar
         corresponds to the percentage / fraction of occurrences with
@@ -1494,7 +1494,7 @@ class Histogram2dContour(BaseTraceType):
             respectively.
         histnorm
             Specifies the type of normalization used for this
-            histogram trace. If **, the span of each bar
+            histogram trace. If "", the span of each bar
             corresponds to the number of occurrences (i.e. the
             number of data points lying inside the bins). If
             "percent" / "probability", the span of each bar
@@ -1759,7 +1759,7 @@ class Histogram2dContour(BaseTraceType):
             respectively.
         histnorm
             Specifies the type of normalization used for this
-            histogram trace. If **, the span of each bar
+            histogram trace. If "", the span of each bar
             corresponds to the number of occurrences (i.e. the
             number of data points lying inside the bins). If
             "percent" / "probability", the span of each bar

--- a/plotly/graph_objs/_layout.py
+++ b/plotly/graph_objs/_layout.py
@@ -934,7 +934,7 @@ class Layout(BaseLayoutType):
                     Used for freeform grids, where some axes may be
                     shared across subplots but others are not. Each
                     entry should be a cartesian subplot id, like
-                    "xy" or "x3y2", or ** to leave that cell empty.
+                    "xy" or "x3y2", or "" to leave that cell empty.
                     You may reuse x axes within the same column,
                     and y axes within the same row. Non-cartesian
                     subplots and traces that support `domain` can
@@ -944,8 +944,8 @@ class Layout(BaseLayoutType):
                     Used with `yaxes` when the x and y axes are
                     shared across columns and rows. Each entry
                     should be an x axis id like "x", "x2", etc., or
-                    ** to not put an x axis in that column. Entries
-                    other than ** must be unique. Ignored if
+                    "" to not put an x axis in that column. Entries
+                    other than "" must be unique. Ignored if
                     `subplots` is present. If missing but `yaxes`
                     is present, will generate consecutive IDs.
                 xgap
@@ -956,15 +956,15 @@ class Layout(BaseLayoutType):
                 xside
                     Sets where the x axis labels and titles go.
                     "bottom" means the very bottom of the grid.
-                    *bottom plot* is the lowest plot that each x
-                    axis is used in. "top" and *top plot* are
+                    "bottom plot" is the lowest plot that each x
+                    axis is used in. "top" and "top plot" are
                     similar.
                 yaxes
                     Used with `yaxes` when the x and y axes are
                     shared across columns and rows. Each entry
                     should be an y axis id like "y", "y2", etc., or
-                    ** to not put a y axis in that row. Entries
-                    other than ** must be unique. Ignored if
+                    "" to not put a y axis in that row. Entries
+                    other than "" must be unique. Ignored if
                     `subplots` is present. If missing but `xaxes`
                     is present, will generate consecutive IDs.
                 ygap
@@ -2979,7 +2979,7 @@ class Layout(BaseLayoutType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix
@@ -3366,7 +3366,7 @@ class Layout(BaseLayoutType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/_mesh3d.py
+++ b/plotly/graph_objs/_mesh3d.py
@@ -354,7 +354,7 @@ class Mesh3d(BaseTraceType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/_splom.py
+++ b/plotly/graph_objs/_splom.py
@@ -764,10 +764,9 @@ class Splom(BaseTraceType):
         default, a splom will match the first N xaxes where N is the
         number of input dimensions.
     
-        The 'xaxes' property is an info array that may be specified as a
-        list or tuple of up to 1 elements where:
-    
-    (0) The 'xaxes[0]' property is an identifier of a particular
+        The 'xaxes' property is an info array that may be specified as:
+        * a list of elements where:
+          The 'xaxes[i]' property is an identifier of a particular
         subplot, of type 'x', that may be specified as the string 'x'
         optionally followed by an integer >= 1
         (e.g. 'x', 'x1', 'x2', 'x3', etc.)
@@ -791,10 +790,9 @@ class Splom(BaseTraceType):
         default, a splom will match the first N yaxes where N is the
         number of input dimensions.
     
-        The 'yaxes' property is an info array that may be specified as a
-        list or tuple of up to 1 elements where:
-    
-    (0) The 'yaxes[0]' property is an identifier of a particular
+        The 'yaxes' property is an info array that may be specified as:
+        * a list of elements where:
+          The 'yaxes[i]' property is an identifier of a particular
         subplot, of type 'y', that may be specified as the string 'y'
         optionally followed by an integer >= 1
         (e.g. 'y', 'y1', 'y2', 'y3', etc.)

--- a/plotly/graph_objs/_streamtube.py
+++ b/plotly/graph_objs/_streamtube.py
@@ -259,7 +259,7 @@ class Streamtube(BaseTraceType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/_surface.py
+++ b/plotly/graph_objs/_surface.py
@@ -258,7 +258,7 @@ class Surface(BaseTraceType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/_violin.py
+++ b/plotly/graph_objs/_violin.py
@@ -753,9 +753,9 @@ class Violin(BaseTraceType):
         be computed. Has an effect only when `spanmode` is set to
         "manual".
     
-        The 'span' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'span' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'span[0]' property accepts values of any type
     (1) The 'span[1]' property accepts values of any type
 

--- a/plotly/graph_objs/bar/_marker.py
+++ b/plotly/graph_objs/bar/_marker.py
@@ -329,7 +329,7 @@ class Marker(BaseTraceHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/bar/marker/_colorbar.py
+++ b/plotly/graph_objs/bar/marker/_colorbar.py
@@ -847,7 +847,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1346,7 +1346,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1582,7 +1582,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/bar/marker/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/bar/marker/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/barpolar/_marker.py
+++ b/plotly/graph_objs/barpolar/_marker.py
@@ -330,7 +330,7 @@ class Marker(BaseTraceHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/barpolar/marker/_colorbar.py
+++ b/plotly/graph_objs/barpolar/marker/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1584,7 +1584,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/barpolar/marker/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/barpolar/marker/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/carpet/_aaxis.py
+++ b/plotly/graph_objs/carpet/_aaxis.py
@@ -749,9 +749,9 @@ class Aaxis(BaseTraceHierarchyType):
         should be numbers, using the scale where each category is
         assigned a serial number from zero in the order it appears.
     
-        The 'range' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'range' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'range[0]' property accepts values of any type
     (1) The 'range[1]' property accepts values of any type
 

--- a/plotly/graph_objs/carpet/_baxis.py
+++ b/plotly/graph_objs/carpet/_baxis.py
@@ -749,9 +749,9 @@ class Baxis(BaseTraceHierarchyType):
         should be numbers, using the scale where each category is
         assigned a serial number from zero in the order it appears.
     
-        The 'range' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'range' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'range[0]' property accepts values of any type
     (1) The 'range[1]' property accepts values of any type
 

--- a/plotly/graph_objs/carpet/aaxis/_tickformatstop.py
+++ b/plotly/graph_objs/carpet/aaxis/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/carpet/baxis/_tickformatstop.py
+++ b/plotly/graph_objs/carpet/baxis/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/choropleth/_colorbar.py
+++ b/plotly/graph_objs/choropleth/_colorbar.py
@@ -847,7 +847,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1346,7 +1346,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1582,7 +1582,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/choropleth/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/choropleth/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/cone/_colorbar.py
+++ b/plotly/graph_objs/cone/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1583,7 +1583,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/cone/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/cone/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/contour/_colorbar.py
+++ b/plotly/graph_objs/contour/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1583,7 +1583,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/contour/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/contour/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/contourcarpet/_colorbar.py
+++ b/plotly/graph_objs/contourcarpet/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1583,7 +1583,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/contourcarpet/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/contourcarpet/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/heatmap/_colorbar.py
+++ b/plotly/graph_objs/heatmap/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1583,7 +1583,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/heatmap/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/heatmap/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/heatmapgl/_colorbar.py
+++ b/plotly/graph_objs/heatmapgl/_colorbar.py
@@ -847,7 +847,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1346,7 +1346,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1582,7 +1582,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/heatmapgl/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/heatmapgl/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/histogram/_cumulative.py
+++ b/plotly/graph_objs/histogram/_cumulative.py
@@ -63,7 +63,7 @@ class Cumulative(BaseTraceHierarchyType):
         binned values. Use the `direction` and `centralbin` attributes
         to tune the accumulation method. Note: in this mode, the
         "density" `histnorm` settings behave the same as their
-        equivalents without "density": ** and "density" both rise to
+        equivalents without "density": "" and "density" both rise to
         the number of data points, and "probability" and *probability
         density* both rise to the number of sample points.
     
@@ -109,7 +109,7 @@ class Cumulative(BaseTraceHierarchyType):
             the binned values. Use the `direction` and `centralbin`
             attributes to tune the accumulation method. Note: in
             this mode, the "density" `histnorm` settings behave the
-            same as their equivalents without "density": ** and
+            same as their equivalents without "density": "" and
             "density" both rise to the number of data points, and
             "probability" and *probability density* both rise to
             the number of sample points.
@@ -149,7 +149,7 @@ class Cumulative(BaseTraceHierarchyType):
             the binned values. Use the `direction` and `centralbin`
             attributes to tune the accumulation method. Note: in
             this mode, the "density" `histnorm` settings behave the
-            same as their equivalents without "density": ** and
+            same as their equivalents without "density": "" and
             "density" both rise to the number of data points, and
             "probability" and *probability density* both rise to
             the number of sample points.

--- a/plotly/graph_objs/histogram/_marker.py
+++ b/plotly/graph_objs/histogram/_marker.py
@@ -330,7 +330,7 @@ class Marker(BaseTraceHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/histogram/marker/_colorbar.py
+++ b/plotly/graph_objs/histogram/marker/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1584,7 +1584,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/histogram/marker/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/histogram/marker/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/histogram2d/_colorbar.py
+++ b/plotly/graph_objs/histogram2d/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1583,7 +1583,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/histogram2d/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/histogram2d/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/histogram2dcontour/_colorbar.py
+++ b/plotly/graph_objs/histogram2dcontour/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1584,7 +1584,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/histogram2dcontour/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/histogram2dcontour/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/layout/_angularaxis.py
+++ b/plotly/graph_objs/layout/_angularaxis.py
@@ -12,9 +12,9 @@ class AngularAxis(BaseLayoutHierarchyType):
         Polar chart subplots are not supported yet. This key has
         currently no effect.
     
-        The 'domain' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'domain' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'domain[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'domain[1]' property is a number and may be specified as:
@@ -59,9 +59,9 @@ class AngularAxis(BaseLayoutHierarchyType):
         Legacy polar charts are deprecated! Please switch to "polar"
         subplots. Defines the start and end point of this angular axis.
     
-        The 'range' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'range' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'range[0]' property is a number and may be specified as:
           - An int or float
     (1) The 'range[1]' property is a number and may be specified as:

--- a/plotly/graph_objs/layout/_grid.py
+++ b/plotly/graph_objs/layout/_grid.py
@@ -143,16 +143,15 @@ class Grid(BaseLayoutHierarchyType):
         """
         Used for freeform grids, where some axes may be shared across
         subplots but others are not. Each entry should be a cartesian
-        subplot id, like "xy" or "x3y2", or ** to leave that cell
+        subplot id, like "xy" or "x3y2", or "" to leave that cell
         empty. You may reuse x axes within the same column, and y axes
         within the same row. Non-cartesian subplots and traces that
         support `domain` can place themselves in this grid separately
         using the `gridcell` attribute.
     
-        The 'subplots' property is an info array that may be specified as a
-        list or tuple of up to 1 elements where:
-    
-    (0) The 'subplots[0]' property is an enumeration that may be specified as:
+        The 'subplots' property is an info array that may be specified as:
+        * a 2D list where:
+          The 'subplots[i][j]' property is an enumeration that may be specified as:
           - One of the following enumeration values:
                 ['']
           - A string that matches one of the following regular expressions:
@@ -175,15 +174,14 @@ class Grid(BaseLayoutHierarchyType):
         """
         Used with `yaxes` when the x and y axes are shared across
         columns and rows. Each entry should be an x axis id like "x",
-        "x2", etc., or ** to not put an x axis in that column. Entries
-        other than ** must be unique. Ignored if `subplots` is present.
+        "x2", etc., or "" to not put an x axis in that column. Entries
+        other than "" must be unique. Ignored if `subplots` is present.
         If missing but `yaxes` is present, will generate consecutive
         IDs.
     
-        The 'xaxes' property is an info array that may be specified as a
-        list or tuple of up to 1 elements where:
-    
-    (0) The 'xaxes[0]' property is an enumeration that may be specified as:
+        The 'xaxes' property is an info array that may be specified as:
+        * a list of elements where:
+          The 'xaxes[i]' property is an enumeration that may be specified as:
           - One of the following enumeration values:
                 ['']
           - A string that matches one of the following regular expressions:
@@ -227,8 +225,8 @@ class Grid(BaseLayoutHierarchyType):
     def xside(self):
         """
         Sets where the x axis labels and titles go. "bottom" means the
-        very bottom of the grid. *bottom plot* is the lowest plot that
-        each x axis is used in. "top" and *top plot* are similar.
+        very bottom of the grid. "bottom plot" is the lowest plot that
+        each x axis is used in. "top" and "top plot" are similar.
     
         The 'xside' property is an enumeration that may be specified as:
           - One of the following enumeration values:
@@ -251,15 +249,14 @@ class Grid(BaseLayoutHierarchyType):
         """
         Used with `yaxes` when the x and y axes are shared across
         columns and rows. Each entry should be an y axis id like "y",
-        "y2", etc., or ** to not put a y axis in that row. Entries
-        other than ** must be unique. Ignored if `subplots` is present.
+        "y2", etc., or "" to not put a y axis in that row. Entries
+        other than "" must be unique. Ignored if `subplots` is present.
         If missing but `xaxes` is present, will generate consecutive
         IDs.
     
-        The 'yaxes' property is an info array that may be specified as a
-        list or tuple of up to 1 elements where:
-    
-    (0) The 'yaxes[0]' property is an enumeration that may be specified as:
+        The 'yaxes' property is an info array that may be specified as:
+        * a list of elements where:
+          The 'yaxes[i]' property is an enumeration that may be specified as:
           - One of the following enumeration values:
                 ['']
           - A string that matches one of the following regular expressions:
@@ -362,7 +359,7 @@ class Grid(BaseLayoutHierarchyType):
         subplots
             Used for freeform grids, where some axes may be shared
             across subplots but others are not. Each entry should
-            be a cartesian subplot id, like "xy" or "x3y2", or **
+            be a cartesian subplot id, like "xy" or "x3y2", or ""
             to leave that cell empty. You may reuse x axes within
             the same column, and y axes within the same row. Non-
             cartesian subplots and traces that support `domain` can
@@ -371,8 +368,8 @@ class Grid(BaseLayoutHierarchyType):
         xaxes
             Used with `yaxes` when the x and y axes are shared
             across columns and rows. Each entry should be an x axis
-            id like "x", "x2", etc., or ** to not put an x axis in
-            that column. Entries other than ** must be unique.
+            id like "x", "x2", etc., or "" to not put an x axis in
+            that column. Entries other than "" must be unique.
             Ignored if `subplots` is present. If missing but
             `yaxes` is present, will generate consecutive IDs.
         xgap
@@ -382,14 +379,14 @@ class Grid(BaseLayoutHierarchyType):
             independent grids.
         xside
             Sets where the x axis labels and titles go. "bottom"
-            means the very bottom of the grid. *bottom plot* is the
-            lowest plot that each x axis is used in. "top" and *top
-            plot* are similar.
+            means the very bottom of the grid. "bottom plot" is the
+            lowest plot that each x axis is used in. "top" and "top
+            plot" are similar.
         yaxes
             Used with `yaxes` when the x and y axes are shared
             across columns and rows. Each entry should be an y axis
-            id like "y", "y2", etc., or ** to not put a y axis in
-            that row. Entries other than ** must be unique. Ignored
+            id like "y", "y2", etc., or "" to not put a y axis in
+            that row. Entries other than "" must be unique. Ignored
             if `subplots` is present. If missing but `xaxes` is
             present, will generate consecutive IDs.
         ygap
@@ -459,7 +456,7 @@ class Grid(BaseLayoutHierarchyType):
         subplots
             Used for freeform grids, where some axes may be shared
             across subplots but others are not. Each entry should
-            be a cartesian subplot id, like "xy" or "x3y2", or **
+            be a cartesian subplot id, like "xy" or "x3y2", or ""
             to leave that cell empty. You may reuse x axes within
             the same column, and y axes within the same row. Non-
             cartesian subplots and traces that support `domain` can
@@ -468,8 +465,8 @@ class Grid(BaseLayoutHierarchyType):
         xaxes
             Used with `yaxes` when the x and y axes are shared
             across columns and rows. Each entry should be an x axis
-            id like "x", "x2", etc., or ** to not put an x axis in
-            that column. Entries other than ** must be unique.
+            id like "x", "x2", etc., or "" to not put an x axis in
+            that column. Entries other than "" must be unique.
             Ignored if `subplots` is present. If missing but
             `yaxes` is present, will generate consecutive IDs.
         xgap
@@ -479,14 +476,14 @@ class Grid(BaseLayoutHierarchyType):
             independent grids.
         xside
             Sets where the x axis labels and titles go. "bottom"
-            means the very bottom of the grid. *bottom plot* is the
-            lowest plot that each x axis is used in. "top" and *top
-            plot* are similar.
+            means the very bottom of the grid. "bottom plot" is the
+            lowest plot that each x axis is used in. "top" and "top
+            plot" are similar.
         yaxes
             Used with `yaxes` when the x and y axes are shared
             across columns and rows. Each entry should be an y axis
-            id like "y", "y2", etc., or ** to not put a y axis in
-            that row. Entries other than ** must be unique. Ignored
+            id like "y", "y2", etc., or "" to not put a y axis in
+            that row. Entries other than "" must be unique. Ignored
             if `subplots` is present. If missing but `xaxes` is
             present, will generate consecutive IDs.
         ygap

--- a/plotly/graph_objs/layout/_polar.py
+++ b/plotly/graph_objs/layout/_polar.py
@@ -221,7 +221,7 @@ class Polar(BaseLayoutHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix
@@ -693,7 +693,7 @@ class Polar(BaseLayoutHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix
@@ -750,9 +750,9 @@ class Polar(BaseLayoutHierarchyType):
         counterclockwise direction with 0 corresponding to rightmost
         limit of the polar subplot.
     
-        The 'sector' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'sector' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'sector[0]' property is a number and may be specified as:
           - An int or float
     (1) The 'sector[1]' property is a number and may be specified as:

--- a/plotly/graph_objs/layout/_radialaxis.py
+++ b/plotly/graph_objs/layout/_radialaxis.py
@@ -12,9 +12,9 @@ class RadialAxis(BaseLayoutHierarchyType):
         Polar chart subplots are not supported yet. This key has
         currently no effect.
     
-        The 'domain' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'domain' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'domain[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'domain[1]' property is a number and may be specified as:
@@ -81,9 +81,9 @@ class RadialAxis(BaseLayoutHierarchyType):
         Legacy polar charts are deprecated! Please switch to "polar"
         subplots. Defines the start and end point of this radial axis.
     
-        The 'range' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'range' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'range[0]' property is a number and may be specified as:
           - An int or float
     (1) The 'range[1]' property is a number and may be specified as:

--- a/plotly/graph_objs/layout/_scene.py
+++ b/plotly/graph_objs/layout/_scene.py
@@ -713,7 +713,7 @@ class Scene(BaseLayoutHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix
@@ -1013,7 +1013,7 @@ class Scene(BaseLayoutHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix
@@ -1313,7 +1313,7 @@ class Scene(BaseLayoutHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/layout/_ternary.py
+++ b/plotly/graph_objs/layout/_ternary.py
@@ -184,7 +184,7 @@ class Ternary(BaseLayoutHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix
@@ -401,7 +401,7 @@ class Ternary(BaseLayoutHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix
@@ -677,7 +677,7 @@ class Ternary(BaseLayoutHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/layout/_xaxis.py
+++ b/plotly/graph_objs/layout/_xaxis.py
@@ -293,9 +293,9 @@ class XAxis(BaseLayoutHierarchyType):
         """
         Sets the domain of this axis (in plot fraction).
     
-        The 'domain' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'domain' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'domain[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'domain[1]' property is a number and may be specified as:
@@ -719,9 +719,9 @@ class XAxis(BaseLayoutHierarchyType):
         should be numbers, using the scale where each category is
         assigned a serial number from zero in the order it appears.
     
-        The 'range' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'range' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'range[0]' property accepts values of any type
     (1) The 'range[1]' property accepts values of any type
 
@@ -1634,7 +1634,7 @@ class XAxis(BaseLayoutHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -2289,7 +2289,7 @@ class XAxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -2701,7 +2701,7 @@ class XAxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/layout/_yaxis.py
+++ b/plotly/graph_objs/layout/_yaxis.py
@@ -293,9 +293,9 @@ class YAxis(BaseLayoutHierarchyType):
         """
         Sets the domain of this axis (in plot fraction).
     
-        The 'domain' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'domain' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'domain[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'domain[1]' property is a number and may be specified as:
@@ -719,9 +719,9 @@ class YAxis(BaseLayoutHierarchyType):
         should be numbers, using the scale where each category is
         assigned a serial number from zero in the order it appears.
     
-        The 'range' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'range' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'range[0]' property accepts values of any type
     (1) The 'range[1]' property accepts values of any type
 
@@ -1508,7 +1508,7 @@ class YAxis(BaseLayoutHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -2157,7 +2157,7 @@ class YAxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -2561,7 +2561,7 @@ class YAxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/layout/geo/_domain.py
+++ b/plotly/graph_objs/layout/geo/_domain.py
@@ -64,9 +64,9 @@ class Domain(BaseLayoutHierarchyType):
         general, when `projection.scale` is set to 1. a map will fit
         either its x or y domain, but not both.
     
-        The 'x' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'x' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'x[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'x[1]' property is a number and may be specified as:
@@ -92,9 +92,9 @@ class Domain(BaseLayoutHierarchyType):
         general, when `projection.scale` is set to 1. a map will fit
         either its x or y domain, but not both.
     
-        The 'y' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'y' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'y[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'y[1]' property is a number and may be specified as:

--- a/plotly/graph_objs/layout/geo/_lataxis.py
+++ b/plotly/graph_objs/layout/geo/_lataxis.py
@@ -111,9 +111,9 @@ class Lataxis(BaseLayoutHierarchyType):
         Sets the range of this axis (in degrees), sets the map's
         clipped coordinates.
     
-        The 'range' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'range' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'range[0]' property is a number and may be specified as:
           - An int or float
     (1) The 'range[1]' property is a number and may be specified as:

--- a/plotly/graph_objs/layout/geo/_lonaxis.py
+++ b/plotly/graph_objs/layout/geo/_lonaxis.py
@@ -111,9 +111,9 @@ class Lonaxis(BaseLayoutHierarchyType):
         Sets the range of this axis (in degrees), sets the map's
         clipped coordinates.
     
-        The 'range' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'range' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'range[0]' property is a number and may be specified as:
           - An int or float
     (1) The 'range[1]' property is a number and may be specified as:

--- a/plotly/graph_objs/layout/geo/_projection.py
+++ b/plotly/graph_objs/layout/geo/_projection.py
@@ -12,9 +12,9 @@ class Projection(BaseLayoutHierarchyType):
         For conic projection types only. Sets the parallels (tangent,
         secant) where the cone intersects the sphere.
     
-        The 'parallels' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'parallels' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'parallels[0]' property is a number and may be specified as:
           - An int or float
     (1) The 'parallels[1]' property is a number and may be specified as:

--- a/plotly/graph_objs/layout/grid/_domain.py
+++ b/plotly/graph_objs/layout/grid/_domain.py
@@ -13,9 +13,9 @@ class Domain(BaseLayoutHierarchyType):
         fraction). The first and last cells end exactly at the domain
         edges, with no grout around the edges.
     
-        The 'x' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'x' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'x[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'x[1]' property is a number and may be specified as:
@@ -40,9 +40,9 @@ class Domain(BaseLayoutHierarchyType):
         fraction). The first and last cells end exactly at the domain
         edges, with no grout around the edges.
     
-        The 'y' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'y' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'y[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'y[1]' property is a number and may be specified as:

--- a/plotly/graph_objs/layout/mapbox/_domain.py
+++ b/plotly/graph_objs/layout/mapbox/_domain.py
@@ -56,9 +56,9 @@ class Domain(BaseLayoutHierarchyType):
         Sets the horizontal domain of this mapbox subplot (in plot
         fraction).
     
-        The 'x' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'x' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'x[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'x[1]' property is a number and may be specified as:
@@ -82,9 +82,9 @@ class Domain(BaseLayoutHierarchyType):
         Sets the vertical domain of this mapbox subplot (in plot
         fraction).
     
-        The 'y' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'y' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'y[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'y[1]' property is a number and may be specified as:

--- a/plotly/graph_objs/layout/polar/_angularaxis.py
+++ b/plotly/graph_objs/layout/polar/_angularaxis.py
@@ -1022,7 +1022,7 @@ class AngularAxis(BaseLayoutHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1399,7 +1399,7 @@ class AngularAxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1664,7 +1664,7 @@ class AngularAxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/layout/polar/_domain.py
+++ b/plotly/graph_objs/layout/polar/_domain.py
@@ -56,9 +56,9 @@ class Domain(BaseLayoutHierarchyType):
         Sets the horizontal domain of this polar subplot (in plot
         fraction).
     
-        The 'x' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'x' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'x[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'x[1]' property is a number and may be specified as:
@@ -82,9 +82,9 @@ class Domain(BaseLayoutHierarchyType):
         Sets the vertical domain of this polar subplot (in plot
         fraction).
     
-        The 'y' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'y' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'y[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'y[1]' property is a number and may be specified as:

--- a/plotly/graph_objs/layout/polar/_radialaxis.py
+++ b/plotly/graph_objs/layout/polar/_radialaxis.py
@@ -530,9 +530,9 @@ class RadialAxis(BaseLayoutHierarchyType):
         should be numbers, using the scale where each category is
         assigned a serial number from zero in the order it appears.
     
-        The 'range' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'range' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'range[0]' property accepts values of any type
     (1) The 'range[1]' property accepts values of any type
 
@@ -1084,7 +1084,7 @@ class RadialAxis(BaseLayoutHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1546,7 +1546,7 @@ class RadialAxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1838,7 +1838,7 @@ class RadialAxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/layout/polar/angularaxis/_tickformatstop.py
+++ b/plotly/graph_objs/layout/polar/angularaxis/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseLayoutHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/layout/polar/radialaxis/_tickformatstop.py
+++ b/plotly/graph_objs/layout/polar/radialaxis/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseLayoutHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/layout/scene/_domain.py
+++ b/plotly/graph_objs/layout/scene/_domain.py
@@ -56,9 +56,9 @@ class Domain(BaseLayoutHierarchyType):
         Sets the horizontal domain of this scene subplot (in plot
         fraction).
     
-        The 'x' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'x' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'x[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'x[1]' property is a number and may be specified as:
@@ -82,9 +82,9 @@ class Domain(BaseLayoutHierarchyType):
         Sets the vertical domain of this scene subplot (in plot
         fraction).
     
-        The 'y' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'y' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'y[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'y[1]' property is a number and may be specified as:

--- a/plotly/graph_objs/layout/scene/_xaxis.py
+++ b/plotly/graph_objs/layout/scene/_xaxis.py
@@ -563,9 +563,9 @@ class XAxis(BaseLayoutHierarchyType):
         should be numbers, using the scale where each category is
         assigned a serial number from zero in the order it appears.
     
-        The 'range' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'range' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'range[0]' property accepts values of any type
     (1) The 'range[1]' property accepts values of any type
 
@@ -1257,7 +1257,7 @@ class XAxis(BaseLayoutHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1829,7 +1829,7 @@ class XAxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -2145,7 +2145,7 @@ class XAxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/layout/scene/_yaxis.py
+++ b/plotly/graph_objs/layout/scene/_yaxis.py
@@ -563,9 +563,9 @@ class YAxis(BaseLayoutHierarchyType):
         should be numbers, using the scale where each category is
         assigned a serial number from zero in the order it appears.
     
-        The 'range' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'range' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'range[0]' property accepts values of any type
     (1) The 'range[1]' property accepts values of any type
 
@@ -1257,7 +1257,7 @@ class YAxis(BaseLayoutHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1829,7 +1829,7 @@ class YAxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -2145,7 +2145,7 @@ class YAxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/layout/scene/_zaxis.py
+++ b/plotly/graph_objs/layout/scene/_zaxis.py
@@ -563,9 +563,9 @@ class ZAxis(BaseLayoutHierarchyType):
         should be numbers, using the scale where each category is
         assigned a serial number from zero in the order it appears.
     
-        The 'range' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'range' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'range[0]' property accepts values of any type
     (1) The 'range[1]' property accepts values of any type
 
@@ -1257,7 +1257,7 @@ class ZAxis(BaseLayoutHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1829,7 +1829,7 @@ class ZAxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -2145,7 +2145,7 @@ class ZAxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/layout/scene/xaxis/_tickformatstop.py
+++ b/plotly/graph_objs/layout/scene/xaxis/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseLayoutHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/layout/scene/yaxis/_tickformatstop.py
+++ b/plotly/graph_objs/layout/scene/yaxis/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseLayoutHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/layout/scene/zaxis/_tickformatstop.py
+++ b/plotly/graph_objs/layout/scene/zaxis/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseLayoutHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/layout/slider/_step.py
+++ b/plotly/graph_objs/layout/slider/_step.py
@@ -12,9 +12,9 @@ class Step(BaseLayoutHierarchyType):
         Sets the arguments values to be passed to the Plotly method set
         in `method` on slide.
     
-        The 'args' property is an info array that may be specified as a
-        list or tuple of up to 3 elements where:
+        The 'args' property is an info array that may be specified as:
     
+        * a list or tuple of up to 3 elements where:
     (0) The 'args[0]' property accepts values of any type
     (1) The 'args[1]' property accepts values of any type
     (2) The 'args[2]' property accepts values of any type

--- a/plotly/graph_objs/layout/ternary/_aaxis.py
+++ b/plotly/graph_objs/layout/ternary/_aaxis.py
@@ -880,7 +880,7 @@ class Aaxis(BaseLayoutHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1246,7 +1246,7 @@ class Aaxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1468,7 +1468,7 @@ class Aaxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/layout/ternary/_baxis.py
+++ b/plotly/graph_objs/layout/ternary/_baxis.py
@@ -880,7 +880,7 @@ class Baxis(BaseLayoutHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1246,7 +1246,7 @@ class Baxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1468,7 +1468,7 @@ class Baxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/layout/ternary/_caxis.py
+++ b/plotly/graph_objs/layout/ternary/_caxis.py
@@ -880,7 +880,7 @@ class Caxis(BaseLayoutHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1246,7 +1246,7 @@ class Caxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1468,7 +1468,7 @@ class Caxis(BaseLayoutHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/layout/ternary/_domain.py
+++ b/plotly/graph_objs/layout/ternary/_domain.py
@@ -56,9 +56,9 @@ class Domain(BaseLayoutHierarchyType):
         Sets the horizontal domain of this ternary subplot (in plot
         fraction).
     
-        The 'x' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'x' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'x[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'x[1]' property is a number and may be specified as:
@@ -82,9 +82,9 @@ class Domain(BaseLayoutHierarchyType):
         Sets the vertical domain of this ternary subplot (in plot
         fraction).
     
-        The 'y' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'y' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'y[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'y[1]' property is a number and may be specified as:

--- a/plotly/graph_objs/layout/ternary/aaxis/_tickformatstop.py
+++ b/plotly/graph_objs/layout/ternary/aaxis/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseLayoutHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/layout/ternary/baxis/_tickformatstop.py
+++ b/plotly/graph_objs/layout/ternary/baxis/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseLayoutHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/layout/ternary/caxis/_tickformatstop.py
+++ b/plotly/graph_objs/layout/ternary/caxis/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseLayoutHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/layout/updatemenu/_button.py
+++ b/plotly/graph_objs/layout/updatemenu/_button.py
@@ -12,9 +12,9 @@ class Button(BaseLayoutHierarchyType):
         Sets the arguments values to be passed to the Plotly method set
         in `method` on click.
     
-        The 'args' property is an info array that may be specified as a
-        list or tuple of up to 3 elements where:
+        The 'args' property is an info array that may be specified as:
     
+        * a list or tuple of up to 3 elements where:
     (0) The 'args[0]' property accepts values of any type
     (1) The 'args[1]' property accepts values of any type
     (2) The 'args[2]' property accepts values of any type

--- a/plotly/graph_objs/layout/xaxis/_rangeslider.py
+++ b/plotly/graph_objs/layout/xaxis/_rangeslider.py
@@ -179,9 +179,9 @@ class Rangeslider(BaseLayoutHierarchyType):
         numbers, using the scale where each category is assigned a
         serial number from zero in the order it appears.
     
-        The 'range' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'range' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'range[0]' property accepts values of any type
     (1) The 'range[1]' property accepts values of any type
 

--- a/plotly/graph_objs/layout/xaxis/_tickformatstop.py
+++ b/plotly/graph_objs/layout/xaxis/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseLayoutHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/layout/xaxis/rangeslider/_yaxis.py
+++ b/plotly/graph_objs/layout/xaxis/rangeslider/_yaxis.py
@@ -11,9 +11,9 @@ class YAxis(BaseLayoutHierarchyType):
         """
         Sets the range of this axis for the rangeslider.
     
-        The 'range' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'range' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'range[0]' property accepts values of any type
     (1) The 'range[1]' property accepts values of any type
 

--- a/plotly/graph_objs/layout/yaxis/_tickformatstop.py
+++ b/plotly/graph_objs/layout/yaxis/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseLayoutHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/mesh3d/_colorbar.py
+++ b/plotly/graph_objs/mesh3d/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1583,7 +1583,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/mesh3d/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/mesh3d/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/parcoords/_dimension.py
+++ b/plotly/graph_objs/parcoords/_dimension.py
@@ -15,12 +15,18 @@ class Dimension(BaseTraceHierarchyType):
         you may give an array of arrays, where each inner array is
         `[fromValue, toValue]`.
     
-        The 'constraintrange' property is an info array that may be specified as a
-        list or tuple of up to 2 elements where:
+        The 'constraintrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'constraintrange[0]' property is a number and may be specified as:
           - An int or float
     (1) The 'constraintrange[1]' property is a number and may be specified as:
+          - An int or float
+    
+        * a 2D list where:
+    (0) The 'constraintrange[i][0]' property is a number and may be specified as:
+          - An int or float
+    (1) The 'constraintrange[i][1]' property is a number and may be specified as:
           - An int or float
 
         Returns
@@ -110,9 +116,9 @@ class Dimension(BaseTraceHierarchyType):
         Defaults to the `values` extent. Must be an array of
         `[fromValue, toValue]` with finite numbers as elements.
     
-        The 'range' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'range' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'range[0]' property is a number and may be specified as:
           - An int or float
     (1) The 'range[1]' property is a number and may be specified as:

--- a/plotly/graph_objs/parcoords/_domain.py
+++ b/plotly/graph_objs/parcoords/_domain.py
@@ -56,9 +56,9 @@ class Domain(BaseTraceHierarchyType):
         Sets the horizontal domain of this parcoords trace (in plot
         fraction).
     
-        The 'x' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'x' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'x[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'x[1]' property is a number and may be specified as:
@@ -82,9 +82,9 @@ class Domain(BaseTraceHierarchyType):
         Sets the vertical domain of this parcoords trace (in plot
         fraction).
     
-        The 'y' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'y' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'y[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'y[1]' property is a number and may be specified as:

--- a/plotly/graph_objs/parcoords/_line.py
+++ b/plotly/graph_objs/parcoords/_line.py
@@ -329,7 +329,7 @@ class Line(BaseTraceHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/parcoords/line/_colorbar.py
+++ b/plotly/graph_objs/parcoords/line/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1584,7 +1584,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/parcoords/line/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/parcoords/line/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/pie/_domain.py
+++ b/plotly/graph_objs/pie/_domain.py
@@ -56,9 +56,9 @@ class Domain(BaseTraceHierarchyType):
         Sets the horizontal domain of this pie trace (in plot
         fraction).
     
-        The 'x' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'x' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'x[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'x[1]' property is a number and may be specified as:
@@ -81,9 +81,9 @@ class Domain(BaseTraceHierarchyType):
         """
         Sets the vertical domain of this pie trace (in plot fraction).
     
-        The 'y' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'y' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'y[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'y[1]' property is a number and may be specified as:

--- a/plotly/graph_objs/sankey/_domain.py
+++ b/plotly/graph_objs/sankey/_domain.py
@@ -56,9 +56,9 @@ class Domain(BaseTraceHierarchyType):
         Sets the horizontal domain of this sankey trace (in plot
         fraction).
     
-        The 'x' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'x' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'x[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'x[1]' property is a number and may be specified as:
@@ -82,9 +82,9 @@ class Domain(BaseTraceHierarchyType):
         Sets the vertical domain of this sankey trace (in plot
         fraction).
     
-        The 'y' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'y' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'y[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'y[1]' property is a number and may be specified as:

--- a/plotly/graph_objs/scatter/_marker.py
+++ b/plotly/graph_objs/scatter/_marker.py
@@ -330,7 +330,7 @@ class Marker(BaseTraceHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/scatter/marker/_colorbar.py
+++ b/plotly/graph_objs/scatter/marker/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1584,7 +1584,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/scatter/marker/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/scatter/marker/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/scatter3d/_marker.py
+++ b/plotly/graph_objs/scatter3d/_marker.py
@@ -330,7 +330,7 @@ class Marker(BaseTraceHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/scatter3d/marker/_colorbar.py
+++ b/plotly/graph_objs/scatter3d/marker/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1584,7 +1584,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/scatter3d/marker/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/scatter3d/marker/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/scattercarpet/_marker.py
+++ b/plotly/graph_objs/scattercarpet/_marker.py
@@ -330,7 +330,7 @@ class Marker(BaseTraceHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/scattercarpet/marker/_colorbar.py
+++ b/plotly/graph_objs/scattercarpet/marker/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1584,7 +1584,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/scattercarpet/marker/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/scattercarpet/marker/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/scattergeo/_marker.py
+++ b/plotly/graph_objs/scattergeo/_marker.py
@@ -330,7 +330,7 @@ class Marker(BaseTraceHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/scattergeo/marker/_colorbar.py
+++ b/plotly/graph_objs/scattergeo/marker/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1584,7 +1584,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/scattergeo/marker/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/scattergeo/marker/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/scattergl/_marker.py
+++ b/plotly/graph_objs/scattergl/_marker.py
@@ -330,7 +330,7 @@ class Marker(BaseTraceHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/scattergl/marker/_colorbar.py
+++ b/plotly/graph_objs/scattergl/marker/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1584,7 +1584,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/scattergl/marker/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/scattergl/marker/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/scattermapbox/_marker.py
+++ b/plotly/graph_objs/scattermapbox/_marker.py
@@ -330,7 +330,7 @@ class Marker(BaseTraceHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/scattermapbox/marker/_colorbar.py
+++ b/plotly/graph_objs/scattermapbox/marker/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1584,7 +1584,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/scattermapbox/marker/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/scattermapbox/marker/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/scatterpolar/_marker.py
+++ b/plotly/graph_objs/scatterpolar/_marker.py
@@ -330,7 +330,7 @@ class Marker(BaseTraceHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/scatterpolar/marker/_colorbar.py
+++ b/plotly/graph_objs/scatterpolar/marker/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1584,7 +1584,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/scatterpolar/marker/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/scatterpolar/marker/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/scatterpolargl/_marker.py
+++ b/plotly/graph_objs/scatterpolargl/_marker.py
@@ -330,7 +330,7 @@ class Marker(BaseTraceHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/scatterpolargl/marker/_colorbar.py
+++ b/plotly/graph_objs/scatterpolargl/marker/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1584,7 +1584,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/scatterpolargl/marker/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/scatterpolargl/marker/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/scatterternary/_marker.py
+++ b/plotly/graph_objs/scatterternary/_marker.py
@@ -330,7 +330,7 @@ class Marker(BaseTraceHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/scatterternary/marker/_colorbar.py
+++ b/plotly/graph_objs/scatterternary/marker/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1584,7 +1584,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/scatterternary/marker/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/scatterternary/marker/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/splom/_marker.py
+++ b/plotly/graph_objs/splom/_marker.py
@@ -330,7 +330,7 @@ class Marker(BaseTraceHierarchyType):
                     Sets a tick label prefix.
                 ticks
                     Determines whether ticks are drawn or not. If
-                    **, this axis' ticks are not drawn. If
+                    "", this axis' ticks are not drawn. If
                     "outside" ("inside"), this axis' are drawn
                     outside (inside) the axis lines.
                 ticksuffix

--- a/plotly/graph_objs/splom/marker/_colorbar.py
+++ b/plotly/graph_objs/splom/marker/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1583,7 +1583,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/splom/marker/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/splom/marker/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/streamtube/_colorbar.py
+++ b/plotly/graph_objs/streamtube/_colorbar.py
@@ -847,7 +847,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1346,7 +1346,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1582,7 +1582,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/streamtube/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/streamtube/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/surface/_colorbar.py
+++ b/plotly/graph_objs/surface/_colorbar.py
@@ -848,7 +848,7 @@ class ColorBar(BaseTraceHierarchyType):
     @property
     def ticks(self):
         """
-        Determines whether ticks are drawn or not. If **, this axis'
+        Determines whether ticks are drawn or not. If "", this axis'
         ticks are not drawn. If "outside" ("inside"), this axis' are
         drawn outside (inside) the axis lines.
     
@@ -1347,7 +1347,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix
@@ -1583,7 +1583,7 @@ class ColorBar(BaseTraceHierarchyType):
         tickprefix
             Sets a tick label prefix.
         ticks
-            Determines whether ticks are drawn or not. If **, this
+            Determines whether ticks are drawn or not. If "", this
             axis' ticks are not drawn. If "outside" ("inside"),
             this axis' are drawn outside (inside) the axis lines.
         ticksuffix

--- a/plotly/graph_objs/surface/colorbar/_tickformatstop.py
+++ b/plotly/graph_objs/surface/colorbar/_tickformatstop.py
@@ -13,9 +13,9 @@ class Tickformatstop(BaseTraceHierarchyType):
         describe some zoom level, it is possible to omit "min" or "max"
         value by passing "null"
     
-        The 'dtickrange' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'dtickrange' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'dtickrange[0]' property accepts values of any type
     (1) The 'dtickrange[1]' property accepts values of any type
 

--- a/plotly/graph_objs/table/_domain.py
+++ b/plotly/graph_objs/table/_domain.py
@@ -56,9 +56,9 @@ class Domain(BaseTraceHierarchyType):
         Sets the horizontal domain of this table trace (in plot
         fraction).
     
-        The 'x' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'x' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'x[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'x[1]' property is a number and may be specified as:
@@ -82,9 +82,9 @@ class Domain(BaseTraceHierarchyType):
         Sets the vertical domain of this table trace (in plot
         fraction).
     
-        The 'y' property is an info array that may be specified as a
-        list or tuple of 2 elements where:
+        The 'y' property is an info array that may be specified as:
     
+        * a list or tuple of 2 elements where:
     (0) The 'y[0]' property is a number and may be specified as:
           - An int or float in the interval [0, 1]
     (1) The 'y[1]' property is a number and may be specified as:

--- a/plotly/tests/test_core/test_graph_objs/test_instantiate_hierarchy.py
+++ b/plotly/tests/test_core/test_graph_objs/test_instantiate_hierarchy.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import
+from unittest import TestCase
+import os
+import importlib
+import inspect
+
+from plotly.basedatatypes import BasePlotlyType, BaseFigure
+datatypes_root = 'plotly/graph_objs'
+datatype_modules = [dirpath.replace('/', '.')
+                    for dirpath, _, _ in os.walk(datatypes_root)
+                    if not dirpath.endswith('__pycache__')]
+
+
+class HierarchyTest(TestCase):
+
+    def test_construct_datatypes(self):
+        for datatypes_module in datatype_modules:
+            module = importlib.import_module(datatypes_module)
+            for name, obj in inspect.getmembers(module, inspect.isclass):
+                v = obj()
+                if obj.__module__ == 'plotly.graph_objs._deprecations':
+                    self.assertTrue(
+                        isinstance(v, list) or isinstance(v, dict)
+                    )
+                    obj()
+                elif name in ('Figure', 'FigureWidget'):
+                    self.assertIsInstance(v, BaseFigure)
+                else:
+                    self.assertIsInstance(v, BasePlotlyType)

--- a/plotly/validators/_histogram.py
+++ b/plotly/validators/_histogram.py
@@ -51,7 +51,7 @@ class HistogramValidator(_plotly_utils.basevalidators.CompoundValidator):
                 respectively.
             histnorm
                 Specifies the type of normalization used for
-                this histogram trace. If **, the span of each
+                this histogram trace. If "", the span of each
                 bar corresponds to the number of occurrences
                 (i.e. the number of data points lying inside
                 the bins). If "percent" / "probability", the

--- a/plotly/validators/_histogram2d.py
+++ b/plotly/validators/_histogram2d.py
@@ -67,7 +67,7 @@ class Histogram2dValidator(_plotly_utils.basevalidators.CompoundValidator):
                 respectively.
             histnorm
                 Specifies the type of normalization used for
-                this histogram trace. If **, the span of each
+                this histogram trace. If "", the span of each
                 bar corresponds to the number of occurrences
                 (i.e. the number of data points lying inside
                 the bins). If "percent" / "probability", the

--- a/plotly/validators/_histogram2dcontour.py
+++ b/plotly/validators/_histogram2dcontour.py
@@ -80,7 +80,7 @@ class Histogram2dContourValidator(
                 respectively.
             histnorm
                 Specifies the type of normalization used for
-                this histogram trace. If **, the span of each
+                this histogram trace. If "", the span of each
                 bar corresponds to the number of occurrences
                 (i.e. the number of data points lying inside
                 the bins). If "percent" / "probability", the

--- a/plotly/validators/bar/marker/_colorbar.py
+++ b/plotly/validators/bar/marker/_colorbar.py
@@ -162,7 +162,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/barpolar/marker/_colorbar.py
+++ b/plotly/validators/barpolar/marker/_colorbar.py
@@ -163,7 +163,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/choropleth/_colorbar.py
+++ b/plotly/validators/choropleth/_colorbar.py
@@ -162,7 +162,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/cone/_colorbar.py
+++ b/plotly/validators/cone/_colorbar.py
@@ -159,7 +159,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/contour/_colorbar.py
+++ b/plotly/validators/contour/_colorbar.py
@@ -161,7 +161,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/contourcarpet/_colorbar.py
+++ b/plotly/validators/contourcarpet/_colorbar.py
@@ -163,7 +163,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/heatmap/_colorbar.py
+++ b/plotly/validators/heatmap/_colorbar.py
@@ -161,7 +161,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/heatmapgl/_colorbar.py
+++ b/plotly/validators/heatmapgl/_colorbar.py
@@ -162,7 +162,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/histogram/_cumulative.py
+++ b/plotly/validators/histogram/_cumulative.py
@@ -33,7 +33,7 @@ class CumulativeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 and `centralbin` attributes to tune the
                 accumulation method. Note: in this mode, the
                 "density" `histnorm` settings behave the same
-                as their equivalents without "density": ** and
+                as their equivalents without "density": "" and
                 "density" both rise to the number of data
                 points, and "probability" and *probability
                 density* both rise to the number of sample

--- a/plotly/validators/histogram/marker/_colorbar.py
+++ b/plotly/validators/histogram/marker/_colorbar.py
@@ -163,7 +163,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/histogram2d/_colorbar.py
+++ b/plotly/validators/histogram2d/_colorbar.py
@@ -163,7 +163,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/histogram2dcontour/_colorbar.py
+++ b/plotly/validators/histogram2dcontour/_colorbar.py
@@ -166,7 +166,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/layout/_grid.py
+++ b/plotly/validators/layout/_grid.py
@@ -45,7 +45,7 @@ class GridValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Used for freeform grids, where some axes may be
                 shared across subplots but others are not. Each
                 entry should be a cartesian subplot id, like
-                "xy" or "x3y2", or ** to leave that cell empty.
+                "xy" or "x3y2", or "" to leave that cell empty.
                 You may reuse x axes within the same column,
                 and y axes within the same row. Non-cartesian
                 subplots and traces that support `domain` can
@@ -55,8 +55,8 @@ class GridValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Used with `yaxes` when the x and y axes are
                 shared across columns and rows. Each entry
                 should be an x axis id like "x", "x2", etc., or
-                ** to not put an x axis in that column. Entries
-                other than ** must be unique. Ignored if
+                "" to not put an x axis in that column. Entries
+                other than "" must be unique. Ignored if
                 `subplots` is present. If missing but `yaxes`
                 is present, will generate consecutive IDs.
             xgap
@@ -67,15 +67,15 @@ class GridValidator(_plotly_utils.basevalidators.CompoundValidator):
             xside
                 Sets where the x axis labels and titles go.
                 "bottom" means the very bottom of the grid.
-                *bottom plot* is the lowest plot that each x
-                axis is used in. "top" and *top plot* are
+                "bottom plot" is the lowest plot that each x
+                axis is used in. "top" and "top plot" are
                 similar.
             yaxes
                 Used with `yaxes` when the x and y axes are
                 shared across columns and rows. Each entry
                 should be an y axis id like "y", "y2", etc., or
-                ** to not put a y axis in that row. Entries
-                other than ** must be unique. Ignored if
+                "" to not put a y axis in that row. Entries
+                other than "" must be unique. Ignored if
                 `subplots` is present. If missing but `xaxes`
                 is present, will generate consecutive IDs.
             ygap

--- a/plotly/validators/layout/_xaxis.py
+++ b/plotly/validators/layout/_xaxis.py
@@ -335,7 +335,7 @@ class XAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/layout/_yaxis.py
+++ b/plotly/validators/layout/_yaxis.py
@@ -329,7 +329,7 @@ class YAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/layout/polar/_angularaxis.py
+++ b/plotly/validators/layout/polar/_angularaxis.py
@@ -216,7 +216,7 @@ class AngularAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/layout/polar/_radialaxis.py
+++ b/plotly/validators/layout/polar/_radialaxis.py
@@ -237,7 +237,7 @@ class RadialAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/layout/scene/_xaxis.py
+++ b/plotly/validators/layout/scene/_xaxis.py
@@ -244,7 +244,7 @@ class XAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/layout/scene/_yaxis.py
+++ b/plotly/validators/layout/scene/_yaxis.py
@@ -244,7 +244,7 @@ class YAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/layout/scene/_zaxis.py
+++ b/plotly/validators/layout/scene/_zaxis.py
@@ -244,7 +244,7 @@ class ZAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/layout/ternary/_aaxis.py
+++ b/plotly/validators/layout/ternary/_aaxis.py
@@ -179,7 +179,7 @@ class AaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/layout/ternary/_baxis.py
+++ b/plotly/validators/layout/ternary/_baxis.py
@@ -179,7 +179,7 @@ class BaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/layout/ternary/_caxis.py
+++ b/plotly/validators/layout/ternary/_caxis.py
@@ -179,7 +179,7 @@ class CaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/mesh3d/_colorbar.py
+++ b/plotly/validators/mesh3d/_colorbar.py
@@ -159,7 +159,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/parcoords/line/_colorbar.py
+++ b/plotly/validators/parcoords/line/_colorbar.py
@@ -163,7 +163,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/scatter/marker/_colorbar.py
+++ b/plotly/validators/scatter/marker/_colorbar.py
@@ -163,7 +163,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/scatter3d/marker/_colorbar.py
+++ b/plotly/validators/scatter3d/marker/_colorbar.py
@@ -163,7 +163,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/scattercarpet/marker/_colorbar.py
+++ b/plotly/validators/scattercarpet/marker/_colorbar.py
@@ -166,7 +166,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/scattergeo/marker/_colorbar.py
+++ b/plotly/validators/scattergeo/marker/_colorbar.py
@@ -166,7 +166,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/scattergl/marker/_colorbar.py
+++ b/plotly/validators/scattergl/marker/_colorbar.py
@@ -163,7 +163,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/scattermapbox/marker/_colorbar.py
+++ b/plotly/validators/scattermapbox/marker/_colorbar.py
@@ -166,7 +166,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/scatterpolar/marker/_colorbar.py
+++ b/plotly/validators/scatterpolar/marker/_colorbar.py
@@ -166,7 +166,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/scatterpolargl/marker/_colorbar.py
+++ b/plotly/validators/scatterpolargl/marker/_colorbar.py
@@ -166,7 +166,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/scatterternary/marker/_colorbar.py
+++ b/plotly/validators/scatterternary/marker/_colorbar.py
@@ -166,7 +166,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/splom/marker/_colorbar.py
+++ b/plotly/validators/splom/marker/_colorbar.py
@@ -163,7 +163,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/streamtube/_colorbar.py
+++ b/plotly/validators/streamtube/_colorbar.py
@@ -162,7 +162,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix

--- a/plotly/validators/surface/_colorbar.py
+++ b/plotly/validators/surface/_colorbar.py
@@ -161,7 +161,7 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets a tick label prefix.
             ticks
                 Determines whether ticks are drawn or not. If
-                **, this axis' ticks are not drawn. If
+                "", this axis' ticks are not drawn. If
                 "outside" ("inside"), this axis' are drawn
                 outside (inside) the axis lines.
             ticksuffix


### PR DESCRIPTION
Supersedes #1233, which didn't recover from the GitHub outage:

----

Rework `InfoArrayValidator` to fix #1220 