### PR TITLE
subplot titles respecting row_width and column_width

### DIFF
--- a/plotly/tests/test_core/test_tools/test_make_subplots.py
+++ b/plotly/tests/test_core/test_tools/test_make_subplots.py
@@ -1946,7 +1946,7 @@ class TestMakeSubplots(TestCase):
             layout=Layout(
                 annotations=Annotations([
                     Annotation(
-                        x=0.22499999999999998,
+                        x=0.225,
                         y=1.0,
                         xref='paper',
                         yref='paper',
@@ -1957,7 +1957,7 @@ class TestMakeSubplots(TestCase):
                         yanchor='bottom'
                     ),
                     Annotation(
-                        x=0.7749999999999999,
+                        x=0.775,
                         y=1.0,
                         xref='paper',
                         yref='paper',
@@ -1968,7 +1968,7 @@ class TestMakeSubplots(TestCase):
                         yanchor='bottom'
                     ),
                     Annotation(
-                        x=0.22499999999999998,
+                        x=0.225,
                         y=0.375,
                         xref='paper',
                         yref='paper',
@@ -1979,7 +1979,7 @@ class TestMakeSubplots(TestCase):
                         yanchor='bottom'
                     ),
                     Annotation(
-                        x=0.7749999999999999,
+                        x=0.775,
                         y=0.375,
                         xref='paper',
                         yref='paper',
@@ -2010,6 +2010,7 @@ class TestMakeSubplots(TestCase):
                 )
             )
         )
+
         fig = tls.make_subplots(rows=2, cols=2,
                                 subplot_titles=('Title 1', 'Title 2',
                                                 'Title 3', 'Title 4'),
@@ -2155,3 +2156,57 @@ class TestMakeSubplots(TestCase):
         fig = tls.make_subplots(100, 1,
                                 vertical_spacing=v_space,
                                 specs=[[{'is_3d': True}] for _ in range(100)])
+
+    def test_row_width_and_column_width(self):
+
+        expected = Figure({
+            'data': [],
+            'layout': {'annotations': [{'font': {'size': 16},
+                                        'showarrow': False,
+                                        'text': 'Title 1',
+                                        'x': 0.405,
+                                        'xanchor': 'center',
+                                        'xref': 'paper',
+                                        'y': 1.0,
+                                        'yanchor': 'bottom',
+                                        'yref': 'paper'},
+                                       {'font': {'size': 16},
+                                        'showarrow': False,
+                                        'text': 'Title 2',
+                                        'x': 0.9550000000000001,
+                                        'xanchor': 'center',
+                                        'xref': 'paper',
+                                        'y': 1.0,
+                                        'yanchor': 'bottom',
+                                        'yref': 'paper'},
+                                       {'font': {'size': 16},
+                                        'showarrow': False,
+                                        'text': 'Title 3',
+                                        'x': 0.405,
+                                        'xanchor': 'center',
+                                        'xref': 'paper',
+                                        'y': 0.1875,
+                                        'yanchor': 'bottom',
+                                        'yref': 'paper'},
+                                       {'font': {'size': 16},
+                                        'showarrow': False,
+                                        'text': 'Title 4',
+                                        'x': 0.9550000000000001,
+                                        'xanchor': 'center',
+                                        'xref': 'paper',
+                                        'y': 0.1875,
+                                        'yanchor': 'bottom',
+                                        'yref': 'paper'}],
+                       'xaxis': {'anchor': 'y', 'domain': [0.0, 0.81]},
+                       'xaxis2': {'anchor': 'y2', 'domain': [0.91, 1.0]},
+                       'xaxis3': {'anchor': 'y3', 'domain': [0.0, 0.81]},
+                       'xaxis4': {'anchor': 'y4', 'domain': [0.91, 1.0]},
+                       'yaxis': {'anchor': 'x', 'domain': [0.4375, 1.0]},
+                       'yaxis2': {'anchor': 'x2', 'domain': [0.4375, 1.0]},
+                       'yaxis3': {'anchor': 'x3', 'domain': [0.0, 0.1875]},
+                       'yaxis4': {'anchor': 'x4', 'domain': [0.0, 0.1875]}}
+        })
+        fig = tls.make_subplots(rows=2, cols=2,
+                                subplot_titles=('Title 1', 'Title 2', 'Title 3', 'Title 4'),
+                                row_width=[1, 3], column_width=[9, 1])
+        self.assertEqual(fig.to_plotly_json(), expected.to_plotly_json())

--- a/plotly/tests/test_core/test_tools/test_make_subplots.py
+++ b/plotly/tests/test_core/test_tools/test_make_subplots.py
@@ -2017,7 +2017,6 @@ class TestMakeSubplots(TestCase):
                                 shared_xaxes=True, shared_yaxes=True)
         self.assertEqual(fig.to_plotly_json(), expected.to_plotly_json())
 
-
     def test_subplot_titles_irregular_layout(self):
         # make a title for each subplot when the layout is irregular:
         expected = Figure(
@@ -2210,3 +2209,58 @@ class TestMakeSubplots(TestCase):
                                 subplot_titles=('Title 1', 'Title 2', 'Title 3', 'Title 4'),
                                 row_width=[1, 3], column_width=[9, 1])
         self.assertEqual(fig.to_plotly_json(), expected.to_plotly_json())
+
+    def test_row_width_and_shared_yaxes(self):
+
+        expected = Figure({
+            'data': [],
+            'layout': {'annotations': [{'font': {'size': 16},
+                                        'showarrow': False,
+                                        'text': 'Title 1',
+                                        'x': 0.225,
+                                        'xanchor': 'center',
+                                        'xref': 'paper',
+                                        'y': 1.0,
+                                        'yanchor': 'bottom',
+                                        'yref': 'paper'},
+                                       {'font': {'size': 16},
+                                        'showarrow': False,
+                                        'text': 'Title 2',
+                                        'x': 0.775,
+                                        'xanchor': 'center',
+                                        'xref': 'paper',
+                                        'y': 1.0,
+                                        'yanchor': 'bottom',
+                                        'yref': 'paper'},
+                                       {'font': {'size': 16},
+                                        'showarrow': False,
+                                        'text': 'Title 3',
+                                        'x': 0.225,
+                                        'xanchor': 'center',
+                                        'xref': 'paper',
+                                        'y': 0.1875,
+                                        'yanchor': 'bottom',
+                                        'yref': 'paper'},
+                                       {'font': {'size': 16},
+                                        'showarrow': False,
+                                        'text': 'Title 4',
+                                        'x': 0.775,
+                                        'xanchor': 'center',
+                                        'xref': 'paper',
+                                        'y': 0.1875,
+                                        'yanchor': 'bottom',
+                                        'yref': 'paper'}],
+                       'xaxis': {'anchor': 'y', 'domain': [0.0, 0.45]},
+                       'xaxis2': {'anchor': 'free', 'domain': [0.55, 1.0], 'position': 0.4375},
+                       'xaxis3': {'anchor': 'y2', 'domain': [0.0, 0.45]},
+                       'xaxis4': {'anchor': 'free', 'domain': [0.55, 1.0], 'position': 0.0},
+                       'yaxis': {'anchor': 'x', 'domain': [0.4375, 1.0]},
+                       'yaxis2': {'anchor': 'x3', 'domain': [0.0, 0.1875]}}
+        })
+
+        fig = tls.make_subplots(rows=2, cols=2, row_width=[1, 3], shared_yaxes=True,
+                                subplot_titles=('Title 1', 'Title 2', 'Title 3', 'Title 4'))
+
+        self.assertEqual(fig.to_plotly_json(), expected.to_plotly_json())
+
+    # def test_row_width_and_shared_yaxes(self):

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -1352,7 +1352,6 @@ def make_subplots(rows=1, cols=1,
             subtitle_pos_x *= rows
 
         if shared_yaxes:
-            print 'the place to be'
             for index in range(rows):
                 subtitle_pos_y = []
                 for y_domain in y_dom:

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -1001,7 +1001,6 @@ def make_subplots(rows=1, cols=1,
             ) for c in col_seq
         ] for r in row_seq
     ]
-
     # [grid_ref] Initialize the grid and insets' axis-reference lists
     grid_ref = [[None for c in range(cols)] for r in range(rows)]
     insets_ref = [None for inset in range(len(insets))] if insets else None
@@ -1080,6 +1079,7 @@ def make_subplots(rows=1, cols=1,
         return x_anchor, y_anchor
 
     list_of_domains = []  # added for subplot titles
+    list_of_domains_complete = []  # hold onto every domain used, even if shared axes
 
     # Function pasting x/y domains in layout object (2d case)
     def _add_domain(layout, x_or_y, label, domain, anchor, position):
@@ -1323,20 +1323,33 @@ def make_subplots(rows=1, cols=1,
             subtitle_pos_x.append(sum(x_domains) / 2)
         for y_domains in y_dom:
             subtitle_pos_y.append(y_domains[1])
+
     # If shared_axes is True the domin of each subplot is not returned so the
     # title position must be calculated for each subplot
     else:
-        subtitle_pos_x = [None] * cols
-        subtitle_pos_y = [None] * rows
-        delt_x = (x_e - x_s)
+        x_dom = [layout[k]['domain'] for k in layout if 'xaxis' in k]
+        y_dom = [layout[k]['domain'] for k in layout if 'yaxis' in k]
         for index in range(cols):
-            subtitle_pos_x[index] = ((delt_x / 2) +
-                                     ((delt_x + horizontal_spacing) * index))
-        subtitle_pos_x *= rows
-        for index in range(rows):
-            subtitle_pos_y[index] = (1 - ((y_e + vertical_spacing) * index))
-        subtitle_pos_y *= cols
-        subtitle_pos_y = sorted(subtitle_pos_y, reverse=True)
+            subtitle_pos_x = []
+            for x_domains in x_dom:
+                subtitle_pos_x.append(sum(x_domains) / 2)
+            subtitle_pos_x *= rows
+
+        if shared_yaxes:
+            for index in range(rows):
+                subtitle_pos_y = []
+                for y_domain in y_dom:
+                    subtitle_pos_y.append(y_domain[1])
+                subtitle_pos_y *= cols
+            subtitle_pos_y = sorted(subtitle_pos_y, reverse=True)
+
+        else:
+            for index in range(rows):
+                subtitle_pos_y = []
+                for y_domain in y_dom:
+                    subtitle_pos_y.append(y_domain[1])
+            subtitle_pos_y = sorted(subtitle_pos_y, reverse=True)
+            subtitle_pos_y *= cols
 
     plot_titles = []
     for index in range(len(subplot_titles)):

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -1327,8 +1327,8 @@ def make_subplots(rows=1, cols=1,
     # If shared_axes is True the domin of each subplot is not returned so the
     # title position must be calculated for each subplot
     else:
-        x_dom = [layout[k]['domain'] for k in layout if 'xaxis' in k]
-        y_dom = [layout[k]['domain'] for k in layout if 'yaxis' in k]
+        x_dom = [layout[k]['domain'] for k in sorted(layout.to_plotly_json().keys()) if 'xaxis' in k]
+        y_dom = [layout[k]['domain'] for k in sorted(layout.to_plotly_json().keys()) if 'yaxis' in k]
         for index in range(cols):
             subtitle_pos_x = []
             for x_domains in x_dom:


### PR DESCRIPTION
issue: https://github.com/plotly/plotly.py/issues/1229

Going to write some tests that ensure that subtitles are in the right place w/ row_/column_width, if none exist already.

Still fixing broken tests

![newplot](https://user-images.githubusercontent.com/10369095/47577847-e38cdb80-d915-11e8-914c-017b73e4cbd0.png)

![newplot 1](https://user-images.githubusercontent.com/10369095/47577851-e5ef3580-d915-11e8-927f-6dc9e73574bb.png)

