### PR TITLE
Don't convert None to 'None' string in a non-strict string array

### DIFF
--- a/_plotly_utils/basevalidators.py
+++ b/_plotly_utils/basevalidators.py
@@ -938,7 +938,10 @@ class StringValidator(BaseValidator):
 
             elif is_simple_array(v):
                 if not self.strict:
-                    v = [str(e) for e in v]
+                    # Convert all elements other than None to strings
+                    # Leave None as is, Plotly.js will decide how to handle
+                    # these null values.
+                    v = [str(e) if e is not None else None for e in v]
 
                 # Check no_blank
                 if self.no_blank:

--- a/_plotly_utils/tests/validators/test_string_validator.py
+++ b/_plotly_utils/tests/validators/test_string_validator.py
@@ -27,8 +27,12 @@ def validator_strict():
 
 @pytest.fixture
 def validator_aok():
-    return StringValidator('prop', 'parent', array_ok=True, strict=True)
+    return StringValidator('prop', 'parent', array_ok=True, strict=False)
 
+
+@pytest.fixture
+def validator_aok_strict():
+    return StringValidator('prop', 'parent', array_ok=True, strict=True)
 
 @pytest.fixture
 def validator_aok_values():
@@ -127,7 +131,8 @@ def test_acceptance_aok_scalars(val, validator_aok):
                          ['foo',
                           ['foo'],
                           np.array(['BAR', ''], dtype='object'),
-                          ['baz', 'baz', 'baz']])
+                          ['baz', 'baz', 'baz'],
+                          ['foo', None, 'bar']])
 def test_acceptance_aok_list(val, validator_aok):
     coerce_val = validator_aok.validate_coerce(val)
     if isinstance(val, np.ndarray):
@@ -143,16 +148,19 @@ def test_acceptance_aok_list(val, validator_aok):
 # ### Rejection by type ###
 @pytest.mark.parametrize('val',
                          [['foo', ()], ['foo', 3, 4], [3, 2, 1]])
-def test_rejection_aok(val, validator_aok):
+def test_rejection_aok(val, validator_aok_strict):
     with pytest.raises(ValueError) as validation_failure:
-        validator_aok.validate_coerce(val)
+        validator_aok_strict.validate_coerce(val)
 
     assert 'Invalid element(s)' in str(validation_failure.value)
 
 
 # ### Rejection by value ###
 @pytest.mark.parametrize('val',
-                         [['foo', 'bar'], ['3', '4'], ['BAR', 'BAR', 'hello!']])
+                         [['foo', 'bar'],
+                          ['3', '4'],
+                          ['BAR', 'BAR', 'hello!'],
+                          ['foo', None]])
 def test_rejection_aok_values(val, validator_aok_values):
     with pytest.raises(ValueError) as validation_failure:
         validator_aok_values.validate_coerce(val)


### PR DESCRIPTION
Fix for https://github.com/plotly/plotly.py/issues/1244.  Don't convert `None` to the string `'None'` in a string array during validation.  Leave value as `None` so that plotly.js sees it as `null`.