### PR TITLE
Work around "[Error 35] Resource unavailable" on Python 2.7 during CI conda packaging

### DIFF
--- a/.circleci/create_conda_packages.sh
+++ b/.circleci/create_conda_packages.sh
@@ -5,7 +5,7 @@ conda install -y conda-build conda-verify zip
 mkdir artifacts
 
 # Perform build
-conda build --python $PYTHON_VERSION recipe/ > conda-build.out.txt 2>&1
+conda build --python $PYTHON_VERSION recipe/ > artifacts/conda-build.out.txt 2>&1
 
 # Convert to other architectures
 mkdir -p ./conda_packages_${PYTHON_VERSION}/linux-64/

--- a/.circleci/create_conda_packages.sh
+++ b/.circleci/create_conda_packages.sh
@@ -1,8 +1,11 @@
 # Install conda dependencies
 conda install -y conda-build conda-verify zip
 
+# Make artifacts directory (will be uploaded to CircleCI after build)
+mkdir artifacts
+
 # Perform build
-conda build --python $PYTHON_VERSION recipe/
+conda build --python $PYTHON_VERSION recipe/ > conda-build.out.txt 2>&1
 
 # Convert to other architectures
 mkdir -p ./conda_packages_${PYTHON_VERSION}/linux-64/
@@ -13,5 +16,4 @@ conda convert -p win-64 ./conda_packages_${PYTHON_VERSION}/linux-64/plotly-*.tar
 conda convert -p win-32 ./conda_packages_${PYTHON_VERSION}/linux-64/plotly-*.tar.bz2 -o ./conda_packages_${PYTHON_VERSION}/
 
 # zip up packages into artifacts directory
-mkdir artifacts
 zip -r artifacts/conda_packages_${PYTHON_VERSION}.zip ./conda_packages_${PYTHON_VERSION}/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -v"
 
 requirements:
   build:


### PR DESCRIPTION
Building conda packages for Python 2.7 has been erroring out with "[Error 35] Resource unavailable".
This *seems* to be somewhat related to the volume of output that the conda build command produces.  This PR reduces the verbosity of conda-build and redirects output to a file and uploads that as a circle CI artifact