### PR TITLE
Redirect orca process stdout to devnull to prevent write_image deadlock

### DIFF
--- a/plotly/io/_orca.py
+++ b/plotly/io/_orca.py
@@ -1086,10 +1086,6 @@ def shutdown_server():
                     # Kill parent process
                     orca_state['proc'].terminate()
 
-                    # Retrieve standard out and standard error to avoid
-                    # warnings
-                    output, err = orca_state['proc'].communicate()
-
                     # Wait for the process to shutdown
                     child_status = orca_state['proc'].wait()
                 except:
@@ -1174,8 +1170,9 @@ Install using conda:
 
             # Create subprocess that launches the orca server on the
             # specified port.
+            DEVNULL = open(os.devnull, 'wb')
             orca_state['proc'] = subprocess.Popen(cmd_list,
-                                                  stdout=subprocess.PIPE)
+                                                  stdout=DEVNULL)
 
             # Update orca.status so the user has an accurate view
             # of the state of the orca server


### PR DESCRIPTION
Fix for #1255 

This only seemed to be causing a problem on Windows after
more than 20 images had been exported.

The reason `stdout` had previously been set to `subprocess.PIPE`
was to prevent orca's stdout from being displayed in the python
shell. Setting it to devnull accomplishes the same thing
but avoids the deadlock problem