### PR TITLE
Pass config object to iplot when rendering plotly JSON

### DIFF
--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -114,6 +114,10 @@ def _build_mathjax_script(url):
 
 
 def _get_jconfig(config):
+    # TODO: The get_config 'source of truth' should
+    # really be somewhere other than plotly.plotly
+    config = config if config else plotly.plotly.get_config()
+
     configkeys = (
         'staticPlot',
         'plotlyServerURL',

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -167,6 +167,7 @@ def _get_jconfig(config):
             .replace('http://', '')
         link_text = clean_config['linkText'].replace('plot.ly', link_domain)
         clean_config['linkText'] = link_text
+        clean_config['plotlyServerURL'] = plotly_platform_url
 
     return clean_config
     

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -113,6 +113,60 @@ def _build_mathjax_script(url):
             .format(url=url))
 
 
+def _get_jconfig(config):
+    configkeys = (
+        'staticPlot',
+        'plotlyServerURL',
+        'editable',
+        'edits',
+        'autosizable',
+        'queueLength',
+        'fillFrame',
+        'frameMargins',
+        'scrollZoom',
+        'doubleClick',
+        'showTips',
+        'showAxisDragHandles',
+        'showAxisRangeEntryBoxes',
+        'showLink',
+        'sendData',
+        'linkText',
+        'showSources',
+        'displayModeBar',
+        'modeBarButtonsToRemove',
+        'modeBarButtonsToAdd',
+        'modeBarButtons',
+        'toImageButtonOptions',
+        'displaylogo',
+        'plotGlPixelRatio',
+        'setBackground',
+        'topojsonURL',
+        'mapboxAccessToken',
+        'logging',
+        'globalTransforms',
+        'locale',
+        'locales',
+    )
+
+    clean_config = dict((k, config[k]) for k in configkeys if k in config)
+
+    # TODO: The get_config 'source of truth' should
+    # really be somewhere other than plotly.plotly
+    plotly_platform_url = plotly.plotly.get_config().get('plotly_domain',
+                                                         'https://plot.ly')
+
+    if (plotly_platform_url != 'https://plot.ly' and
+        clean_config['linkText'] == 'Export to plot.ly'):
+
+        link_domain = plotly_platform_url\
+            .replace('https://', '')\
+            .replace('http://', '')
+        link_text = clean_config['linkText'].replace('plot.ly', link_domain)
+        clean_config['linkText'] = link_text
+
+    return clean_config
+    
+
 # Build script to set global PlotlyConfig object. This must execute before
 # plotly.js is loaded.
 _window_plotly_config = """\
@@ -271,56 +325,9 @@ def _plot_html(figure_or_data, config, validate, default_width,
     else:
         jframes = None
 
-    configkeys = (
-        'staticPlot',
-        'plotlyServerURL',
-        'editable',
-        'edits',
-        'autosizable',
-        'queueLength',
-        'fillFrame',
-        'frameMargins',
-        'scrollZoom',
-        'doubleClick',
-        'showTips',
-        'showAxisDragHandles',
-        'showAxisRangeEntryBoxes',
-        'showLink',
-        'sendData',
-        'linkText',
-        'showSources',
-        'displayModeBar',
-        'modeBarButtonsToRemove',
-        'modeBarButtonsToAdd',
-        'modeBarButtons',
-        'toImageButtonOptions',
-        'displaylogo',
-        'plotGlPixelRatio',
-        'setBackground',
-        'topojsonURL',
-        'mapboxAccessToken',
-        'logging',
-        'globalTransforms',
-        'locale',
-        'locales',
-    )
-
-    config_clean = dict((k, config[k]) for k in configkeys if k in config)
-    jconfig = _json.dumps(config_clean)
-
-    # TODO: The get_config 'source of truth' should
-    # really be somewhere other than plotly.plotly
+    jconfig = _json.dumps(_get_jconfig(config))
     plotly_platform_url = plotly.plotly.get_config().get('plotly_domain',
                                                          'https://plot.ly')
-    if (plotly_platform_url != 'https://plot.ly' and
-            config['linkText'] == 'Export to plot.ly'):
-
-        link_domain = plotly_platform_url\
-            .replace('https://', '')\
-            .replace('http://', '')
-        link_text = config['linkText'].replace('plot.ly', link_domain)
-        config['linkText'] = link_text
-        jconfig = jconfig.replace('Export to plot.ly', link_text)
 
     if jframes:
         script = '''
@@ -426,6 +433,8 @@ def iplot(figure_or_data, show_link=True, link_text='Export to plot.ly',
     config.setdefault('showLink', show_link)
     config.setdefault('linkText', link_text)
 
+    jconfig = _get_jconfig(config)
+
     figure = tools.return_figure_from_figure_or_data(figure_or_data, validate)
 
     # Though it can add quite a bit to the display-bundle size, we include
@@ -438,7 +447,7 @@ def iplot(figure_or_data, show_link=True, link_text='Export to plot.ly',
     frames = _json.loads(_json.dumps(figure.get('frames', None),
                                      cls=plotly.utils.PlotlyJSONEncoder))
 
-    fig = {'data': data, 'layout': layout}
+    fig = {'data': data, 'layout': layout, 'config': jconfig}
     if frames:
         fig['frames'] = frames
 


### PR DESCRIPTION
This fixes an issue where users render a Plotly chart to a Jupyter Notebook or JupyterLab (using Plotly JSON and [@jupyterlab/plotly-extension](https://github.com/jupyterlab/jupyter-renderers/tree/master/packages/plotly-extension) vs. `plotly.offline.init_notebook_mode`) but they're custom Plotly config is not passed to plotly.js (e.g. `plotly_domain` and `plotly_streaming_domain`). 

Demo notebook: 