### PR TITLE
Emf support for save as

### DIFF
--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -712,7 +712,7 @@ class image:
                           describes a plotly figure.
                           Same argument used in `py.plot`, `py.iplot`,
                           see https://plot.ly/python for examples
-        - format: 'png', 'svg', 'jpeg', 'pdf'
+        - format: 'png', 'svg', 'jpeg', 'pdf', 'emf'
         - width: output width
         - height: output height
         - scale: Increase the resolution of the image by `scale`
@@ -730,7 +730,7 @@ class image:
         # TODO: format is a built-in name... we shouldn't really use it
         figure = tools.return_figure_from_figure_or_data(figure_or_data, True)
 
-        if format not in ['png', 'svg', 'jpeg', 'pdf']:
+        if format not in ['png', 'svg', 'jpeg', 'pdf', 'emf']:
             raise exceptions.PlotlyError(
                 "Invalid format. This version of your Plotly-Python "
                 "package currently only supports png, svg, jpeg, and pdf. "
@@ -760,7 +760,8 @@ class image:
         if ('content-type' in headers and
             headers['content-type'] in ['image/png', 'image/jpeg',
                                         'application/pdf',
-                                        'image/svg+xml']):
+                                        'image/svg+xml',
+                                        'image/emf']):
             return response.content
         elif ('content-type' in headers and
               'json' in headers['content-type']):
@@ -809,7 +810,7 @@ class image:
         """Save a image of the plot described by `figure_or_data` locally as
         `filename`.
 
-        Valid image formats are 'png', 'svg', 'jpeg', and 'pdf'.
+        Valid image formats are 'png', 'svg', 'jpeg', 'pdf' and 'emf'.
         The format is taken as the extension of the filename or as the
         supplied format.
 
@@ -819,7 +820,7 @@ class image:
                           Same argument used in `py.plot`, `py.iplot`,
                           see https://plot.ly/python for examples
         - filename: The filepath to save the image to
-        - format: 'png', 'svg', 'jpeg', 'pdf'
+        - format: 'png', 'svg', 'jpeg', 'pdf', 'emf'
         - width: output width
         - height: output height
         - scale: Increase the resolution of the image by `scale` amount

--- a/plotly/tests/test_plot_ly/test_image/test_image.py
+++ b/plotly/tests/test_plot_ly/test_image/test_image.py
@@ -59,7 +59,7 @@ def _generate_image_save_as_saves_valid_image(image_format,
     return _test
 
 kwargs = {
-    'format': ['png', 'jpeg', 'pdf', 'svg'],
+    'format': ['png', 'jpeg', 'pdf', 'svg', 'emf'],
     'width': [None, 300],
     'height': [None, 300],
     'scale': [None, 5]

--- a/plotly/tests/test_plot_ly/test_image/test_image.py
+++ b/plotly/tests/test_plot_ly/test_image/test_image.py
@@ -70,12 +70,6 @@ for args in itertools.product(kwargs['format'], kwargs['width'],
     for test_generator in [_generate_image_get_returns_valid_image_test,
                            _generate_image_save_as_saves_valid_image]:
 
-        if args[0] in ['jpeg', 'pdf', 'svg'] and args[3] is not None:
-            # Shouldn't need to skip these tests, the server should
-            # be responding with a 400 level error since scale isn't supported,
-            # but it doesn't yet, so just skip them
-            continue
-
         _test = test_generator(*args)
         arg_string = ', '.join([str(a) for a in args])
         test_name = test_generator.__name__.replace('_generate', 'test')


### PR DESCRIPTION
Update `plotly.plotly.image.save_as` to support the `emf` file type. The tests pass on the `add_emf_backend` branch of streambed in this [PR](https://github.com/plotly/streambed/pull/12020).

cc @bpostlethwaite 