### PR TITLE
Include the license in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 description-file = README.rst
+license_file = LICENSE.txt
 
 [bdist_wheel]
 universal=1


### PR DESCRIPTION
The MIT license requires all copies of the software to include the license text.