### PR TITLE
Try to coerce all objects to Numpy arrays.

### DIFF
--- a/.circleci/create_conda_optional_env.sh
+++ b/.circleci/create_conda_optional_env.sh
@@ -16,7 +16,7 @@ if [ ! -d $HOME/miniconda/envs/circle_optional ]; then
     # Create environment
     # PYTHON_VERSION=3.6
     $HOME/miniconda/bin/conda create -n circle_optional --yes python=$PYTHON_VERSION \
-requests six pytz retrying psutil pandas decorator pytest mock nose poppler
+requests six pytz retrying psutil pandas decorator pytest mock nose poppler xarray
 
     # Install orca into environment
     $HOME/miniconda/bin/conda install --yes -n circle_optional -c plotly plotly-orca

--- a/_plotly_utils/basevalidators.py
+++ b/_plotly_utils/basevalidators.py
@@ -156,13 +156,15 @@ def is_numpy_convertable(v):
     Return whether a value is meaningfully convertable to a numpy array
     via 'numpy.array'
     """
+    if np.isscalar(v):  # Scalar types like numpy.float64 shouldn't count as arrays
+        return False
     return hasattr(v, '__array__') or hasattr(v, '__array_interface__')
 
 
 def is_homogeneous_array(v):
     """
     Return whether a value is considered to be a homogeneous array
-    """
+    """    
     return ((np and (isinstance(v, np.ndarray) or is_numpy_convertable(v))) or
             (pd and isinstance(v, (pd.Series, pd.Index))))
 

--- a/_plotly_utils/basevalidators.py
+++ b/_plotly_utils/basevalidators.py
@@ -350,7 +350,14 @@ class DataArrayValidator(BaseValidator):
         elif is_simple_array(v):
             v = to_scalar_or_list(v)
         else:
-            self.raise_invalid_val(v)
+            # Try to coerce 'v' into an array. Useful if 'v' is a list-like object, such as a 
+            # PyTorch tensor, an xarray Dataframe, etc that knows how to turn itself into a Numpy array.
+            v_array = np.array(v)
+            # If np.array returns a scalar object, then it failed to coerce it to a list-like object.
+            if v_array.shape == ():
+                self.raise_invalid_val(v)
+            else:
+                return self.validate_coerce(v_array)
         return v
 
 

--- a/_plotly_utils/basevalidators.py
+++ b/_plotly_utils/basevalidators.py
@@ -43,6 +43,16 @@ def fullmatch(regex, string, flags=0):
 # Utility functions
 # -----------------
 def to_scalar_or_list(v):
+    # Handle the case where 'v' is a non-native scalar-like type,
+    # such as numpy.float32. Without this case, the object might be
+    # considered numpy-convertable and therefore promoted to a
+    # 0-dimensional array, but we instead want it converted to a
+    # Python native scalar type ('float' in the example above).
+    # We explicitly check if is has the 'item' method, which conventionally
+    # converts these types to native scalars. This guards against 'v' already being
+    # a Python native scalar type since  `numpy.isscalar` would return
+    # True but `numpy.asscalar` will (oddly) raise an error is called with a
+    # a native Python scalar object.
     if np and np.isscalar(v) and hasattr(v, 'item'):
         return np.asscalar(v)
     if isinstance(v, (list, tuple)):

--- a/_plotly_utils/basevalidators.py
+++ b/_plotly_utils/basevalidators.py
@@ -43,7 +43,7 @@ def fullmatch(regex, string, flags=0):
 # Utility functions
 # -----------------
 def to_scalar_or_list(v):
-    if np.isscalar(v) and hasattr(v, 'item'):
+    if np and np.isscalar(v) and hasattr(v, 'item'):
         return np.asscalar(v)
     if isinstance(v, (list, tuple)):
         return [to_scalar_or_list(e) for e in v]

--- a/_plotly_utils/basevalidators.py
+++ b/_plotly_utils/basevalidators.py
@@ -947,6 +947,7 @@ class StringValidator(BaseValidator):
             # Pass None through
             pass
         elif self.array_ok and is_array(v):
+
             # If strict, make sure all elements are strings.
             if self.strict:
                 invalid_els = [e for e in v if not isinstance(e, string_types)]
@@ -1123,9 +1124,9 @@ class ColorValidator(BaseValidator):
             v = copy_to_readonly_numpy_array(v)
             if (self.numbers_allowed() and
                     v.dtype.kind in ['u', 'i', 'f']):
-                    pass
                 # Numbers are allowed and we have an array of numbers.
                 # All good
+                pass
             else:
                 validated_v = [
                     self.validate_coerce(e, should_raise=False)
@@ -1579,6 +1580,7 @@ class FlaglistValidator(BaseValidator):
             # Pass None through
             pass
         elif self.array_ok and is_array(v):
+
             # Coerce individual strings
             validated_v = [self.vc_scalar(e) for e in v]
 

--- a/_plotly_utils/tests/validators/test_xarray_input.py
+++ b/_plotly_utils/tests/validators/test_xarray_input.py
@@ -1,0 +1,126 @@
+import pytest
+import numpy as np
+import xarray
+import datetime
+from _plotly_utils.basevalidators import (NumberValidator,
+                                          IntegerValidator,
+                                          DataArrayValidator,
+                                          ColorValidator)
+
+
+@pytest.fixture
+def data_array_validator(request):
+    return DataArrayValidator('prop', 'parent')
+
+
+@pytest.fixture
+def integer_validator(request):
+    return IntegerValidator('prop', 'parent', array_ok=True)
+
+
+@pytest.fixture
+def number_validator(request):
+    return NumberValidator('prop', 'parent', array_ok=True)
+
+
+@pytest.fixture
+def color_validator(request):
+    return ColorValidator('prop', 'parent', array_ok=True, colorscale_path='')
+
+
+@pytest.fixture(
+    params=['int8', 'int16', 'int32', 'int64',
+            'uint8', 'uint16', 'uint32', 'uint64',
+            'float16', 'float32', 'float64'])
+def numeric_dtype(request):
+    return request.param
+
+
+@pytest.fixture(
+    params=[xarray.DataArray])
+def xarray_type(request):
+    return request.param
+
+
+@pytest.fixture
+def numeric_xarray(request, xarray_type, numeric_dtype):
+    return xarray_type(np.arange(10, dtype=numeric_dtype))
+
+
+@pytest.fixture
+def color_object_xarray(request, xarray_type):
+    return xarray_type(['blue', 'green', 'red']*3)
+
+
+def test_numeric_validator_numeric_xarray(number_validator, numeric_xarray):
+    res = number_validator.validate_coerce(numeric_xarray)
+
+    # Check type
+    assert isinstance(res, np.ndarray)
+
+    # Check dtype
+    assert res.dtype == numeric_xarray.dtype
+
+    # Check values
+    np.testing.assert_array_equal(res, numeric_xarray)
+
+
+def test_integer_validator_numeric_xarray(integer_validator, numeric_xarray):
+    res = integer_validator.validate_coerce(numeric_xarray)
+
+    # Check type
+    assert isinstance(res, np.ndarray)
+
+    # Check dtype
+    if numeric_xarray.dtype.kind in ('u', 'i'):
+        # Integer and unsigned integer dtype unchanged
+        assert res.dtype == numeric_xarray.dtype
+    else:
+        # Float datatypes converted to default integer type of int32
+        assert res.dtype == 'int32'
+
+    # Check values
+    np.testing.assert_array_equal(res, numeric_xarray)
+
+
+def test_data_array_validator(data_array_validator,
+                              numeric_xarray):
+    res = data_array_validator.validate_coerce(numeric_xarray)
+
+    # Check type
+    assert isinstance(res, np.ndarray)
+
+    # Check dtype
+    assert res.dtype == numeric_xarray.dtype
+
+    # Check values
+    np.testing.assert_array_equal(res, numeric_xarray)
+
+
+def test_color_validator_numeric(color_validator,
+                                 numeric_xarray):
+    res = color_validator.validate_coerce(numeric_xarray)
+
+    # Check type
+    assert isinstance(res, np.ndarray)
+
+    # Check dtype
+    assert res.dtype == numeric_xarray.dtype
+
+    # Check values
+    np.testing.assert_array_equal(res, numeric_xarray)
+
+
+def test_color_validator_object(color_validator,
+                                color_object_xarray):
+
+    res = color_validator.validate_coerce(color_object_xarray)
+
+    # Check type
+    assert isinstance(res, np.ndarray)
+
+    # Check dtype
+    assert res.dtype == 'object'
+
+    # Check values
+    np.testing.assert_array_equal(res, color_object_xarray)

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -17,7 +17,7 @@ mock==2.0.0
 nose==1.3.3
 pytest==3.5.1
 backports.tempfile==1.0
-
+xarray
 ## orca ##
 psutil
 

--- a/tox.ini
+++ b/tox.ini
@@ -72,6 +72,7 @@ deps=
     optional: pyshp==1.2.10
     optional: pillow==5.2.0
     optional: matplotlib==2.2.3
+    optional: xarray==0.11.2
 
 ; CORE ENVIRONMENTS
 [testenv:py27-core]

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ deps=
     optional: pyshp==1.2.10
     optional: pillow==5.2.0
     optional: matplotlib==2.2.3
-    optional: xarray==0.11.2
+    optional: xarray==0.10.9
 
 ; CORE ENVIRONMENTS
 [testenv:py27-core]


### PR DESCRIPTION
This lets you pass a broad array of list-like objects as data to be plotted instead of the current hard-coded list of numpy arrays, lists, tuples, and Pandas objects. Objects such as PyTorch tensors (widely used in the machine-learning world), xarrays, and others know how to convert themselves into Numpy arrays and so might as well be allowed to be passed directly as plotting arguments so users don't have to explicitly convert them.