### PR TITLE
create_animations improvements, progress towards removing clientresp

### DIFF
--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -1658,16 +1658,20 @@ def _extract_grid_graph_obj(obj_dict, reference_obj, grid, path):
                     grid,
                     '{path}{prop}.'.format(path=path, prop=prop))
 
-            elif isinstance(prop_validator, CompoundArrayValidator):
-                # Recurse on elements of object arary
-                reference_element = prop_validator.validate_coerce([{}])[0]
-                for i, element_dict in enumerate(obj_dict[prop]):
-                    _extract_grid_graph_obj(
-                        element_dict,
-                        reference_element,
-                        grid,
-                        '{path}{prop}.i.'.format(path=path, prop=prop, i=i)
-                    )
+            # Chart studio doesn't handle links to columns inside object
+            # arrays, so we don't extract them for now.  Logic below works
+            # and should be reinstated if chart studio gets this capability
+            # 
+            # elif isinstance(prop_validator, CompoundArrayValidator):
+            #     # Recurse on elements of object arary
+            #     reference_element = prop_validator.validate_coerce([{}])[0]
+            #     for i, element_dict in enumerate(obj_dict[prop]):
+            #         _extract_grid_graph_obj(
+            #             element_dict,
+            #             reference_element,
+            #             grid,
+            #             '{path}{prop}.{i}.'.format(path=path, prop=prop, i=i)
+            #         )
 
 
 def _extract_grid_from_fig_like(fig, grid=None, path=''):
@@ -1959,6 +1963,7 @@ def create_animations(figure, filename=None, sharing='public', auto_open=True):
                         auto_open=False)
         _set_grid_column_references(figure, grid)
         body['figure'] = figure
+        print(figure)
 
     response = v2.plots.create(body)
     parsed_content = response.json()

--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -28,7 +28,7 @@ import six
 import six.moves
 from requests.compat import json as _json
 
-from _plotly_utils.basevalidators import CompoundValidator
+from _plotly_utils.basevalidators import CompoundValidator, is_array
 from plotly import exceptions, files, session, tools, utils
 from plotly.api import v1, v2
 from plotly.basedatatypes import BaseTraceType, BaseFigure, BaseLayoutType
@@ -1668,10 +1668,12 @@ def _extract_grid_graph_obj(obj_dict, reference_obj, grid, path):
     for prop in list(obj_dict.keys()):
         propsrc = '{}src'.format(prop)
         if propsrc in reference_obj:
-            column = Column(obj_dict[prop], path + prop)
-            grid.append(column)
-            obj_dict[propsrc] = 'TBD'
-            del obj_dict[prop]
+            val = obj_dict[prop]
+            if is_array(val):
+                column = Column(val, path + prop)
+                grid.append(column)
+                obj_dict[propsrc] = 'TBD'
+                del obj_dict[prop]
 
         elif prop in reference_obj:
             prop_validator = reference_obj._validators[prop]
@@ -1990,6 +1992,7 @@ def create_animations(figure, filename=None, sharing='public', auto_open=True):
 
     # Extract grid
     figure, grid = _extract_grid_from_fig_like(figure)
+    print(grid)
     if len(grid) > 0:
         if not filename:
             grid_filename = None

--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -16,6 +16,7 @@ and ploty's servers.
 """
 from __future__ import absolute_import
 
+import base64
 import copy
 import json
 import os
@@ -996,6 +997,11 @@ class grid_ops:
         ```
 
         """
+        # transmorgify grid object into plotly's format
+        grid_json = grid._to_plotly_grid_json()
+        if meta is not None:
+            grid_json['metadata'] = meta
+
         # Make a folder path
         if filename:
             if filename[-1] == '/':
@@ -1009,13 +1015,12 @@ class grid_ops:
                 file_ops.ensure_dirs(parent_path)
         else:
             # Create anonymous grid name
-            filename = 'grid_' + str(uuid.uuid4())[:13]
+            hash_val = hash(json.dumps(grid_json, sort_keys=True))
+            id = base64.urlsafe_b64encode(str(hash_val).encode('utf8'))
+            id_str = id.decode(encoding='utf8').replace('=', '')
+            filename = 'grid_' + id_str
+            # filename = 'grid_' + str(hash_val)
             parent_path = ''
-
-        # transmorgify grid object into plotly's format
-        grid_json = grid._to_plotly_grid_json()
-        if meta is not None:
-            grid_json['metadata'] = meta
 
         payload = {
             'filename': filename,

--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -28,8 +28,7 @@ import six
 import six.moves
 from requests.compat import json as _json
 
-from _plotly_utils.basevalidators import CompoundValidator, \
-    CompoundArrayValidator
+from _plotly_utils.basevalidators import CompoundValidator
 from plotly import exceptions, files, session, tools, utils
 from plotly.api import v1, v2
 from plotly.basedatatypes import BaseTraceType, BaseFigure, BaseLayoutType

--- a/plotly/plotly/plotly.py
+++ b/plotly/plotly/plotly.py
@@ -1992,7 +1992,7 @@ def create_animations(figure, filename=None, sharing='public', auto_open=True):
 
     # Extract grid
     figure, grid = _extract_grid_from_fig_like(figure)
-    print(grid)
+
     if len(grid) > 0:
         if not filename:
             grid_filename = None

--- a/plotly/tests/test_plot_ly/test_plotly/test_plot.py
+++ b/plotly/tests/test_plot_ly/test_plotly/test_plot.py
@@ -11,6 +11,7 @@ import requests
 import six
 import sys
 from requests.compat import json as _json
+import warnings
 
 from nose.plugins.attrib import attr
 
@@ -157,6 +158,46 @@ class TestPlot(PlotlyTestCase):
         expected_plot_option_logic = {'filename': 'test',
                                       'auto_open': True,
                                       'fileopt': 'overwrite',
+                                      'validate': True,
+                                      'world_readable': False,
+                                      'sharing': 'private'}
+        self.assertEqual(plot_option_logic, expected_plot_option_logic)
+
+    def test_plot_option_fileopt_deprecations(self):
+        # If filename is not given and fileopt is not 'new',
+        # raise a deprecation warning
+        kwargs = {'auto_open': True,
+                  'fileopt': 'overwrite',
+                  'validate': True,
+                  'sharing': 'private'}
+
+        with warnings.catch_warnings(record=True) as w:
+            plot_option_logic = py._plot_option_logic(kwargs)
+            assert w[0].category == DeprecationWarning
+
+        expected_plot_option_logic = {'filename': 'plot from API',
+                                      'auto_open': True,
+                                      'fileopt': 'overwrite',
+                                      'validate': True,
+                                      'world_readable': False,
+                                      'sharing': 'private'}
+        self.assertEqual(plot_option_logic, expected_plot_option_logic)
+
+        # If filename is given and fileopt is not 'overwrite',
+        # raise a depreacation warning
+        kwargs = {'filename': 'test',
+                  'auto_open': True,
+                  'fileopt': 'append',
+                  'validate': True,
+                  'sharing': 'private'}
+
+        with warnings.catch_warnings(record=True) as w:
+            plot_option_logic = py._plot_option_logic(kwargs)
+            assert w[0].category == DeprecationWarning
+
+        expected_plot_option_logic = {'filename': 'test',
+                                      'auto_open': True,
+                                      'fileopt': 'append',
                                       'validate': True,
                                       'world_readable': False,
                                       'sharing': 'private'}

--- a/plotly/tests/test_plot_ly/test_plotly/test_plot.py
+++ b/plotly/tests/test_plot_ly/test_plotly/test_plot.py
@@ -164,6 +164,10 @@ class TestPlot(PlotlyTestCase):
         self.assertEqual(plot_option_logic, expected_plot_option_logic)
 
     def test_plot_option_fileopt_deprecations(self):
+
+        # Make sure DeprecationWarnings aren't filtered out by nose
+        warnings.filterwarnings('default', category=DeprecationWarning)
+
         # If filename is not given and fileopt is not 'new',
         # raise a deprecation warning
         kwargs = {'auto_open': True,


### PR DESCRIPTION
### Background (as I understand it)
The `plotly.plotly.create_animations` function was introduced to support plotly.js animations because the legacy clientrest API that is used by `plotly.plotly.plot` does not support frames. 

 `plotly.plotly.create_animations` uses the more recent v2 API that supports frames, but it was much more limited than `plotly.plotly.plot`.  In particular is did not support uploading figures that contain inline data arrays, requiring users to manually create grids and assign grid references to their figures (See https://plot.ly/python/gapminder-example/ for example).  It also did not support overwriting existing figures and it did not support creating figures in folders.

This investigation was inspired by this discussion on the forums: https://community.plot.ly/t/trouble-with-converting-offline-animation-to-online/19129/2

### Overview
This PR addresses these limitation mentioned above

 1. When a figure contains inline data arrays, these arrays are extracted into a Grid.  The grid is them uploaded and the column references are inserted into the figure's corresponding `*src` properties. Then the figure itself is uploaded.  If the figure is named, then the associated grid is named `'{filename}_grid'`. If the figure is not named, then the grid is named `'grid_{id}'` where `id` is the url safe base64 encoding of the hash of the JSON representation of the grid.  This way repeated unnamed figure creation with the same data will result in only one grid.
 2.  Use `v2.files.lookup` to check whether the figure already exists (and retrieve the `fid` if it does).  If it exists, update it, if not create it.
 3. Use `v2.folders.create` to create folders before uploading figures.

### What's left
This implementation is nearly ready to fully replace the clientresp backend of `plotly.plotly.plot`.  The only unsupported feature is the `fileopt` option. See https://plot.ly/python/file-options/.  Right now, the only behavior available is the default `fileopt='overwrite'` behavior., and it doesn't look like the other options are directly supportable with the v2 API as it currently stands.

### Testing
There isn't currently a test suite for `create_animations` and I didn't add any additional testing in the PR.  There will be a bunch of testing work to do when this implementation is used to replace the `plotly.plotly.plot` backend.

### Questions
I've never personally used the `fileopt` argument, does anyone have opinions on whether we can deprecate this?  I think my preference would be to start raising a deprecation warning for `fileopt != 'overwrite'` in 3.7.0, and then remove it from the API in 4.0.0.  The alternative would be to do a bit of work on the v2 API in streambed.

@jackparmer @scjody @nicolaskruchten @chriddyp 
