### PR TITLE
fix to_scalar_or_list when v.ndim == 0

### DIFF
--- a/_plotly_utils/basevalidators.py
+++ b/_plotly_utils/basevalidators.py
@@ -55,6 +55,8 @@ def to_scalar_or_list(v):
     if isinstance(v, (list, tuple)):
         return [to_scalar_or_list(e) for e in v]
     elif np and isinstance(v, np.ndarray):
+        if v.ndim == 0:
+            return v.item()
         return [to_scalar_or_list(e) for e in v]
     elif pd and isinstance(v, (pd.Series, pd.Index)):
         return [to_scalar_or_list(e) for e in v]

--- a/_plotly_utils/tests/validators/test_dataarray_validator.py
+++ b/_plotly_utils/tests/validators/test_dataarray_validator.py
@@ -14,7 +14,7 @@ def validator():
 # -----
 # ### Acceptance ###
 @pytest.mark.parametrize('val', [
-    [], [1], [''], (), ('Hello, ',  'world!'), ['A', 1, 'B', 0, 'C']
+    [], [1], [''], (), ('Hello, ',  'world!'), ['A', 1, 'B', 0, 'C'], [np.array(1), np.array(2)]
 ])
 def test_validator_acceptance_simple(val, validator):
     coerce_val = validator.validate_coerce(val)


### PR DESCRIPTION

* test code

~~~ python3
import plotly.graph_objs as go
import numpy as np
go.Scatter(
    y=[np.array(1), np.array(2)],
    x=[1, 1]
)
~~~

* before fix

~~~ sh
sh-4.2# python test.py
Traceback (most recent call last):
  File "test.py", line 5, in <module>
    x=[1, 1]
  File "/root/review/plotly.py/plotly/graph_objs/_scatter.py", line 2567, in __init__
    self['y'] = y if y is not None else _v
  File "/root/review/plotly.py/plotly/basedatatypes.py", line 2841, in __setitem__
    self._set_prop(prop, value)
  File "/root/review/plotly.py/plotly/basedatatypes.py", line 3077, in _set_prop
    val = validator.validate_coerce(val)
  File "/root/review/plotly.py/_plotly_utils/basevalidators.py", line 382, in validate_coerce
    v = to_scalar_or_list(v)
  File "/root/review/plotly.py/_plotly_utils/basevalidators.py", line 56, in to_scalar_or_list
    return [to_scalar_or_list(e) for e in v]
  File "/root/review/plotly.py/_plotly_utils/basevalidators.py", line 56, in <listcomp>
    return [to_scalar_or_list(e) for e in v]
  File "/root/review/plotly.py/_plotly_utils/basevalidators.py", line 58, in to_scalar_or_list
    return [to_scalar_or_list(e) for e in v]
TypeError: iteration over a 0-d array
~~~ 

* after fix

~~~ sh
sh-4.2# python test.py
sh-4.2#
~~~
