### PR TITLE
Allow init_notebook_mode to redefine/reinitialize plotly.js each time it's run

### DIFF
--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -291,14 +291,13 @@ def init_notebook_mode(connected=False):
             '{win_config}'
             '{mathjax_config}'
             '<script type=\'text/javascript\'>'
-            'if(!window._Plotly){{'
+            'require.undef("plotly");'
             'define(\'plotly\', function(require, exports, module) {{'
             '{script}'
             '}});'
             'require([\'plotly\'], function(Plotly) {{'
             'window._Plotly = Plotly;'
             '}});'
-            '}}'
             '</script>'
             '').format(script=get_plotlyjs(),
                        win_config=_window_plotly_config,

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -102,7 +102,9 @@ def _build_resize_script(plotdivid, plotly_root='Plotly'):
     resize_script = (
         '<script type="text/javascript">'
         'window.addEventListener("resize", function(){{'
-        '{plotly_root}.Plots.resize(document.getElementById("{id}"));}});'
+        'if (document.getElementById("{id}")) {{'
+        '{plotly_root}.Plots.resize(document.getElementById("{id}"));'
+        '}};}})'
         '</script>'
     ).format(plotly_root=plotly_root, id=plotdivid)
     return resize_script
@@ -356,12 +358,14 @@ def _plot_html(figure_or_data, config, validate, default_width,
             animate = ''
 
         script = '''
+    if (document.getElementById("{id}")) {{
         Plotly.plot(
             '{id}',
             {data},
             {layout},
             {config}
         ).then(function () {add_frames}){animate}
+    }}
         '''.format(
             id=plotdivid,
             data=jdata,
@@ -373,7 +377,11 @@ def _plot_html(figure_or_data, config, validate, default_width,
             animate=animate
         )
     else:
-        script = 'Plotly.newPlot("{id}", {data}, {layout}, {config})'.format(
+        script = """
+if (document.getElementById("{id}")) {{
+    Plotly.newPlot("{id}", {data}, {layout}, {config}); 
+}}
+""".format(
             id=plotdivid,
             data=jdata,
             layout=jlayout,


### PR DESCRIPTION
Work towards addressing #1448

I don't think this addresses the root of the problem, but hopefully it will make it possible for users to call `init_notebook_mode` to reinitialize plotly.js in the notebook after the issue appears.

I haven't been able to reproduce the error message naturally, but after some research an experimenting it looks like what's happening is that for some reason the requirejs infrastructure is forgetting that a library called `plotly` has been `define`d (which happens in `init_notebook_mode`).  I can force the same error by manually calling `require.undef('plotly')` in the JavaScript console and then running `iplot` again.

![screenshot_20190305_185521](https://user-images.githubusercontent.com/15064365/53876427-c0192200-3fd4-11e9-9e29-919cb603c8ca.png)

I don't have any leads at this point on what might be causing `requirejs` to "forget" about a registered module.

But this PR updates the `init_nodebook_mode` logic to take this possibility into account. Now, every time `init_notebook_mode` is called the 'plotly' module is explicitly undefined and redefined and the `window._Plotly` variable is reinitialized.

Now, when I invoke the error state by calling `require.undef('plotly')` I can at least recover from it by running `init_notebook_mode()` a second time.  Before this PR we would get stuck in a state where the requirejs 'plotly' module was undefined but the `window._Plotly` variable was still set and so `init_notebook_mode` would skip redefining the 'plotly' module.
