### PR TITLE
Fix dict ordering assumption for Python < 3.6.0

### DIFF
--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import collections
+from collections import OrderedDict
 import re
 import six
 from six import string_types
@@ -233,14 +234,14 @@ class BaseFigure(object):
         # are suitable as `data` elements of Plotly.animate, but not
         # the Plotly.update (See `_build_update_params_from_batch`)
         #
-        # type: typ.Dict[int, typ.Dict[str, typ.Any]]
-        self._batch_trace_edits = {}
+        # type: OrderedDict[int, OrderedDict[str, typ.Any]]
+        self._batch_trace_edits = OrderedDict()
 
         # ### Batch layout edits ###
         # Dict from layout properties to new layout values. This dict is
         # directly suitable for use in Plotly.animate and Plotly.update
-        # type: typ.Dict[str, typ.Any]
-        self._batch_layout_edits = {}
+        # type: collections.OrderedDict[str, typ.Any]
+        self._batch_layout_edits = OrderedDict()
 
         # Animation property validators
         # -----------------------------
@@ -772,7 +773,7 @@ Invalid property path '{key_path_str}' for trace class {trace_class}
         # Add key_path_str/val to saved batch edits
         else:
             if trace_index not in self._batch_trace_edits:
-                self._batch_trace_edits[trace_index] = {}
+                self._batch_trace_edits[trace_index] = OrderedDict()
             self._batch_trace_edits[trace_index][key_path_str] = val
 
     def _normalize_trace_indexes(self, trace_indexes):

--- a/plotly/tests/test_core/test_graph_objs/test_layout_subplots.py
+++ b/plotly/tests/test_core/test_graph_objs/test_layout_subplots.py
@@ -208,3 +208,20 @@ class TestLayoutSubplots(TestCase):
         self.assertEqual(self.layout.scene6.dragmode, 'zoom')
         self.assertEqual(self.layout.mapbox7.zoom, 2)
         self.assertEqual(self.layout.polar8.sector, (0, 90))
+
+    def test_bug_1462(self):
+        # https: // github.com / plotly / plotly.py / issues / 1462
+        fig = go.Figure(data=[
+            go.Scatter(x=[1, 2], y=[1, 2], xaxis='x'),
+            go.Scatter(x=[2, 3], y=[2, 3], xaxis='x2')])
+
+        layout_dict = {
+            'grid': {'xaxes': ['x', 'x2'], 'yaxes': ['y']},
+            # 'xaxis': {'title': 'total_bill'},
+            'xaxis2': {'matches': 'x', 'title': {'text': 'total_bill'}}
+        }
+
+        fig.update(layout=layout_dict)
+        updated_layout_dict = fig.layout.to_plotly_json()
+
+        self.assertEqual(updated_layout_dict, layout_dict)


### PR DESCRIPTION
Fix for #1462, issue is that we were relying on the preservation of dict insertion order during batch updates.  This was fine for Python 3.6+, but not for 2.7 and, I suspect, not for 3.5.  Now use `OrdererdDict` objects.

Some background at https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6

