### PR TITLE
Fix race conditions

### DIFF
--- a/plotly/files.py
+++ b/plotly/files.py
@@ -27,12 +27,20 @@ FILE_CONTENT = {CREDENTIALS_FILE: {'username': '',
 def _permissions():
     try:
         if not os.path.exists(PLOTLY_DIR):
-            os.mkdir(PLOTLY_DIR)
+            try:
+                os.mkdir(PLOTLY_DIR)
+            except Exception:
+                # in case of race
+                if not os.path.isdir(PLOTLY_DIR):
+                    raise
         with open(TEST_FILE, 'w') as f:
             f.write('testing\n')
-        os.remove(TEST_FILE)
+        try:
+            os.remove(TEST_FILE)
+        except Exception:
+            pass
         return True
-    except:
+    except Exception: # Do not trap KeyboardInterrupt.
         return False
 
 


### PR DESCRIPTION
This is a "Heisenbug", a race condition. You might not be able to reproduce it, but I'll describe it anyway.

We're running this as an automated test, as a user we cannot control, so use `export PLOTLY_DIR=whatever`

re: #1076, addressed in #1195

This is still a problem with `plotly-3.7.1`. In `plotly/files.py`:
```py
 27 def _permissions():
 28     try:
 29         if not os.path.exists(PLOTLY_DIR):
 30             os.mkdir(PLOTLY_DIR)
 31         with open(TEST_FILE, 'w') as f:
 32             f.write('testing\n')
 33         os.remove(TEST_FILE)
 34         return True
 35     except:
 36         return False
```
Lines `30` and `33` can fail, wrongly, if two processes run this at the same time. (`f.write()` is fine here, IMO.)

Note that I want to make warnings into errors in my tests. (`pytest -W error`), so this is a big problem for me even if you simply trap and `warn()`.

I'm not sure if there is still a warning in 3.7.1, but like I said, it's a Heisenbug. I can only spend so much time on this. For me, it was happening via `pytest-xdist`, in a case where I lacked permissions to create `~/.plotly`. `PLOTLY_DIR` lets me reduce the likelihood of error, but the race conditions remain.