### PR TITLE
Fix for windows os error (#1402) Changed to use py3.6 behavior also with python 3.7 and above.

### DIFF
--- a/plotly/utils.py
+++ b/plotly/utils.py
@@ -36,7 +36,7 @@ sage_all = get_module('sage.all')
 lock = threading.Lock()
 
 PY36 = (
-    sys.version_info.major == 3 and sys.version_info.minor == 6
+    sys.version_info.major == 3 and sys.version_info.minor >= 6
 )
 
 


### PR DESCRIPTION
Fix for https://github.com/plotly/plotly.py/issues/1402.
Dash/Plotly work fine with python 3.5 and 3.6., but using python 3.7 creates uncaught OS Error exceptions from plotly utils.py.

Reason:
The variable PY36 in utils.py is used to branch code for different behaviour for datetime objects depending on the python version. This was set to 3.6 by using '==', this 1-character change ('>=') fixes the problems on windows when using plotly/dash with python 3.7. Without it 3.7 gets same behaviour as 3.5, which does not work. ;-)
