### PR TITLE
traces selection/update methods and "magic underscore" support

### DIFF
--- a/codegen/figure.py
+++ b/codegen/figure.py
@@ -68,7 +68,7 @@ class {fig_classname}({base_classname}):\n""")
 
     buffer.write(f"""
     def __init__(self, data=None, layout=None,
-                 frames=None, skip_invalid=False):
+                 frames=None, skip_invalid=False, **kwargs):
         \"\"\"
         Create a new {fig_classname} instance
         
@@ -95,7 +95,8 @@ class {fig_classname}({base_classname}):\n""")
             is invalid AND skip_invalid is False
         \"\"\"
         super({fig_classname} ,self).__init__(data, layout,
-                                              frames, skip_invalid)
+                                              frames, skip_invalid,
+                                              **kwargs)
     """)
 
     # ### add_trace methods for each trace type ###

--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -2532,8 +2532,16 @@ class BasePlotlyType(object):
         """
         Process any extra kwargs that are not predefined as constructor params
         """
-        if not self._skip_invalid:
-            self._raise_on_invalid_property_error(*kwargs.keys())
+        invalid_kwargs = {}
+        for k, v in kwargs.items():
+            if k in self:
+                # e.g. underscore kwargs like marker_line_color
+                self[k] = v
+            else:
+                invalid_kwargs[k] = v
+
+        if invalid_kwargs and not self._skip_invalid:
+            self._raise_on_invalid_property_error(*invalid_kwargs.keys())
 
     @property
     def plotly_name(self):

--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -54,7 +54,8 @@ class BaseFigure(object):
                  data=None,
                  layout_plotly=None,
                  frames=None,
-                 skip_invalid=False):
+                 skip_invalid=False,
+                 **kwargs):
         """
         Construct a BaseFigure object
 
@@ -262,6 +263,14 @@ class BaseFigure(object):
         # ### Check for default template ###
         self._initialize_layout_template()
 
+        # Process kwargs
+        # --------------
+        for k, v in kwargs.items():
+            if k in self:
+                self[k] = v
+            elif not skip_invalid:
+                raise TypeError('invalid Figure property: {}'.format(k))
+
     # Magic Methods
     # -------------
     def __reduce__(self):
@@ -371,7 +380,13 @@ class BaseFigure(object):
         return iter(('data', 'layout', 'frames'))
 
     def __contains__(self, prop):
-        return prop in ('data', 'layout', 'frames')
+        prop = BaseFigure._str_to_dict_path(prop)
+        if prop[0] not in ('data', 'layout', 'frames'):
+            return False
+        elif len(prop) == 1:
+            return True
+        else:
+            return prop[1:] in self[prop[0]]
 
     def __eq__(self, other):
         if not isinstance(other, BaseFigure):

--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -451,7 +451,8 @@ class BaseFigure(object):
             for d in [dict1, kwargs]:
                 if d:
                     for k, v in d.items():
-                        if self[k] == ():
+                        update_target = self[k]
+                        if update_target == ():
                             # existing data or frames property is empty
                             # In this case we accept the v as is.
                             if k == 'data':
@@ -459,9 +460,12 @@ class BaseFigure(object):
                             else:
                                 # Accept v
                                 self[k] = v
-                        else:
+                        elif (isinstance(update_target, BasePlotlyType) or
+                              (isinstance(update_target, tuple) and
+                               isinstance(update_target[0], BasePlotlyType))):
                             BaseFigure._perform_update(self[k], v)
-
+                        else:
+                            self[k] = v
         return self
 
     # Data
@@ -2737,7 +2741,9 @@ class BasePlotlyType(object):
             plotly_obj = self[prop_path[:-1]]
             prop = prop_path[-1]
         else:
-            plotly_obj = self
+            prop_path = BaseFigure._str_to_dict_path(prop)
+            plotly_obj = self[prop_path[:-1]]
+            prop = prop_path[-1]
 
         # Return validator
         # ----------------

--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -1330,6 +1330,8 @@ Please use the add_trace method with the row and col parameters.
     def _validate_get_grid_ref(self):
         try:
             grid_ref = self._grid_ref
+            if grid_ref is None:
+                raise AttributeError('_grid_ref')
         except AttributeError:
             raise Exception("In order to reference traces by row and column, "
                             "you must first use "

--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -673,7 +673,7 @@ class BaseFigure(object):
             except Exception:
                 pass
 
-            return obj1 == obj2
+            return BasePlotlyType._vals_equal(obj1, obj2)
 
         if not selector:
             selector = {}

--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -639,7 +639,30 @@ class BaseFigure(object):
             trace._trace_ind = trace_ind
 
     def select_traces(self, selector=None, row=None, col=None):
+        """
+        Select traces from a particular subplot cell and/or traces
+        that satisfy custom selection criteria.
 
+        Parameters
+        ----------
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            Traces will be selected if they contain properties corresponding
+            to all of the dictionary's keys, with values that exactly match
+            the supplied values. If None (the default), all traces are
+            selected.
+        row, col: int or None (default None)
+            Subplot row and column index of traces to select.
+            To select traces by row and column, the Figure must have been
+            created using plotly.subplots.make_subplots.  If None
+            (the default), all traces are selected.
+
+        Returns
+        -------
+        generator
+            Generator that iterates through all of the traces that satisfy
+            all of the specified selection criteria
+        """
         def select_eq(obj1, obj2):
             try:
                 obj1 = obj1.to_plotly_json()
@@ -679,12 +702,65 @@ class BaseFigure(object):
             yield trace
 
     def for_each_trace(self, fn, selector=None, row=None, col=None):
+        """
+        Apply a function to all traces that satisfy the specified selection
+        criteria
+
+        Parameters
+        ----------
+        fn:
+            Function that inputs a single trace object.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            Traces will be selected if they contain properties corresponding
+            to all of the dictionary's keys, with values that exactly match
+            the supplied values. If None (the default), all traces are
+            selected.
+        row, col: int or None (default None)
+            Subplot row and column index of traces to select.
+            To select traces by row and column, the Figure must have been
+            created using plotly.subplots.make_subplots.  If None
+            (the default), all traces are selected.
+
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
         for trace in self.select_traces(selector=selector, row=row, col=col):
             fn(trace)
 
         return self
 
     def update_traces(self, patch, selector=None, row=None, col=None):
+        """
+        Perform a property update operation on all traces that satisfy the
+        specified selection criteria
+
+        Parameters
+        ----------
+        patch: dict
+            Dictionary of property updates to be applied to all traces that
+            satisfy the selection criteria.
+        fn:
+            Function that inputs a single trace object.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            Traces will be selected if they contain properties corresponding
+            to all of the dictionary's keys, with values that exactly match
+            the supplied values. If None (the default), all traces are
+            selected.
+        row, col: int or None (default None)
+            Subplot row and column index of traces to select.
+            To select traces by row and column, the Figure must have been
+            created using plotly.subplots.make_subplots.  If None
+            (the default), all traces are selected.
+
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
         for trace in self.select_traces(selector=selector, row=row, col=col):
             trace.update(patch)
         return self

--- a/plotly/basewidget.py
+++ b/plotly/basewidget.py
@@ -119,7 +119,8 @@ class BaseFigureWidget(BaseFigure, widgets.DOMWidget):
                  data=None,
                  layout=None,
                  frames=None,
-                 skip_invalid=False):
+                 skip_invalid=False,
+                 **kwargs):
 
         # Call superclass constructors
         # ----------------------------
@@ -129,7 +130,8 @@ class BaseFigureWidget(BaseFigure, widgets.DOMWidget):
         super(BaseFigureWidget, self).__init__(data=data,
                                                layout_plotly=layout,
                                                frames=frames,
-                                               skip_invalid=skip_invalid)
+                                               skip_invalid=skip_invalid,
+                                               **kwargs)
 
         # Validate Frames
         # ---------------

--- a/plotly/graph_objs/_figure.py
+++ b/plotly/graph_objs/_figure.py
@@ -12,7 +12,12 @@ from plotly.graph_objs import (
 class Figure(BaseFigure):
 
     def __init__(
-        self, data=None, layout=None, frames=None, skip_invalid=False
+        self,
+        data=None,
+        layout=None,
+        frames=None,
+        skip_invalid=False,
+        **kwargs
     ):
         """
         Create a new Figure instance
@@ -500,7 +505,8 @@ class Figure(BaseFigure):
             if a property in the specification of data, layout, or frames
             is invalid AND skip_invalid is False
         """
-        super(Figure, self).__init__(data, layout, frames, skip_invalid)
+        super(Figure,
+              self).__init__(data, layout, frames, skip_invalid, **kwargs)
 
     def add_area(
         self,

--- a/plotly/graph_objs/_figurewidget.py
+++ b/plotly/graph_objs/_figurewidget.py
@@ -12,7 +12,12 @@ from plotly.graph_objs import (
 class FigureWidget(BaseFigureWidget):
 
     def __init__(
-        self, data=None, layout=None, frames=None, skip_invalid=False
+        self,
+        data=None,
+        layout=None,
+        frames=None,
+        skip_invalid=False,
+        **kwargs
     ):
         """
         Create a new FigureWidget instance
@@ -500,7 +505,8 @@ class FigureWidget(BaseFigureWidget):
             if a property in the specification of data, layout, or frames
             is invalid AND skip_invalid is False
         """
-        super(FigureWidget, self).__init__(data, layout, frames, skip_invalid)
+        super(FigureWidget,
+              self).__init__(data, layout, frames, skip_invalid, **kwargs)
 
     def add_area(
         self,

--- a/plotly/subplots.py
+++ b/plotly/subplots.py
@@ -627,8 +627,8 @@ The row_titles argument to make_subplots must be a list or tuple
             # grid_ref_element['spec'] = spec
             grid_ref[r][c] = grid_ref_element
 
-    _configure_shared_axes(layout, grid_ref, 'x', shared_xaxes, row_dir)
-    _configure_shared_axes(layout, grid_ref, 'y', shared_yaxes, row_dir)
+    _configure_shared_axes(layout, grid_ref, specs, 'x', shared_xaxes, row_dir)
+    _configure_shared_axes(layout, grid_ref, specs, 'y', shared_yaxes, row_dir)
 
     # Build inset reference
     # ---------------------
@@ -769,7 +769,7 @@ The row_titles argument to make_subplots must be a list or tuple
     return fig
 
 
-def _configure_shared_axes(layout, grid_ref, x_or_y, shared, row_dir):
+def _configure_shared_axes(layout, grid_ref, specs, x_or_y, shared, row_dir):
     rows = len(grid_ref)
     cols = len(grid_ref[0])
 
@@ -780,14 +780,14 @@ def _configure_shared_axes(layout, grid_ref, x_or_y, shared, row_dir):
     else:
         rows_iter = range(rows)
 
-    def update_axis_matches(first_axis_id, ref, remove_label):
+    def update_axis_matches(first_axis_id, ref, spec, remove_label):
         if ref is None:
             return first_axis_id
 
         if x_or_y == 'x':
-            span = ref['spec']['colspan']
+            span = spec['colspan']
         else:
-            span = ref['spec']['rowspan']
+            span = spec['rowspan']
 
         if ref['subplot_type'] == 'xy' and span == 1:
             if first_axis_id is None:
@@ -808,8 +808,9 @@ def _configure_shared_axes(layout, grid_ref, x_or_y, shared, row_dir):
             ok_to_remove_label = x_or_y == 'x'
             for r in rows_iter:
                 ref = grid_ref[r][c]
+                spec = specs[r][c]
                 first_axis_id = update_axis_matches(
-                    first_axis_id, ref, ok_to_remove_label)
+                    first_axis_id, ref, spec, ok_to_remove_label)
 
     elif shared == 'rows' or (x_or_y == 'y' and shared is True):
         for r in rows_iter:
@@ -817,14 +818,16 @@ def _configure_shared_axes(layout, grid_ref, x_or_y, shared, row_dir):
             ok_to_remove_label = x_or_y == 'y'
             for c in range(cols):
                 ref = grid_ref[r][c]
+                spec = specs[r][c]
                 first_axis_id = update_axis_matches(
-                    first_axis_id, ref, ok_to_remove_label)
+                    first_axis_id, ref, spec, ok_to_remove_label)
 
     elif shared == 'all':
         first_axis_id = None
         for c in range(cols):
             for ri, r in enumerate(rows_iter):
                 ref = grid_ref[r][c]
+                spec = specs[r][c]
 
                 if x_or_y == 'y':
                     ok_to_remove_label = c > 0
@@ -832,7 +835,7 @@ def _configure_shared_axes(layout, grid_ref, x_or_y, shared, row_dir):
                     ok_to_remove_label = ri > 0 if row_dir > 0 else r < rows - 1
 
                 first_axis_id = update_axis_matches(
-                    first_axis_id, ref, ok_to_remove_label)
+                    first_axis_id, ref, spec, ok_to_remove_label)
 
 
 def _init_subplot_xy(

--- a/plotly/subplots.py
+++ b/plotly/subplots.py
@@ -306,17 +306,7 @@ def make_subplots(
     ...     cols=[1, 2, 1, 2])
     """
 
-    # Make sure we're in future subplots mode
-    from _plotly_future_ import _future_flags
-    if 'v4_subplots' not in _future_flags:
-        raise ValueError("""
-plotly.subplots.make_subplots may only be used in the
-v4_subplots _plotly_future_ mode.  To try it out, run
-
->>> from _plotly_future_ import v4_subplots
-
-before importing plotly.
-""")
+    _validate_v4_subplots('plotly.subplots.make_subplots')
 
     import plotly.graph_objs as go
 
@@ -624,7 +614,6 @@ The row_titles argument to make_subplots must be a list or tuple
             subplot_type = spec['type']
             grid_ref_element = _init_subplot(
                 layout, subplot_type, x_domain, y_domain, max_subplot_ids)
-            # grid_ref_element['spec'] = spec
             grid_ref[r][c] = grid_ref_element
 
     _configure_shared_axes(layout, grid_ref, specs, 'x', shared_xaxes, row_dir)
@@ -767,6 +756,20 @@ The row_titles argument to make_subplots must be a list or tuple
     fig.__dict__['_grid_str'] = grid_str
 
     return fig
+
+
+def _validate_v4_subplots(method_name):
+    # Make sure we're in future subplots mode
+    from _plotly_future_ import _future_flags
+    if 'v4_subplots' not in _future_flags:
+        raise ValueError("""
+{method_name} may only be used in the
+v4_subplots _plotly_future_ mode.  To try it out, run
+
+>>> from _plotly_future_ import v4_subplots
+
+before importing plotly.
+""".format(method_name=method_name))
 
 
 def _configure_shared_axes(layout, grid_ref, specs, x_or_y, shared, row_dir):
@@ -1346,7 +1349,8 @@ def _get_subplot_ref_for_trace(trace):
     elif 'subplot' in trace:
         for t in _subplot_prop_named_subplot:
             try:
-                trace.subplot = t
+                validator = trace._get_prop_validator('subplot')
+                validator.validate_coerce(t)
                 return {
                     'subplot_type': t,
                     'layout_keys': (trace.subplot,),

--- a/plotly/tests/test_core/test_graph_objs/test_constructor.py
+++ b/plotly/tests/test_core/test_graph_objs/test_constructor.py
@@ -15,6 +15,11 @@ class TestGraphObjConstructor(TestCase):
         self.assertEqual(m.to_plotly_json(),
                          {'color': 'green'})
 
+    def test_valid_underscore_kwarg(self):
+        m = go.scatter.Marker(line_color='green')
+        self.assertEqual(m.to_plotly_json(),
+                         {'line': {'color': 'green'}})
+
     def test_valid_arg_obj(self):
         m = go.scatter.Marker(
             go.scatter.Marker(color='green'))

--- a/plotly/tests/test_core/test_graph_objs/test_figure.py
+++ b/plotly/tests/test_core/test_graph_objs/test_figure.py
@@ -55,6 +55,7 @@ class FigureTest(TestCase):
                 'data': [{'type': 'bar', 'bogus': 123}],
                 'layout': {'bogus': 23, 'title': 'Figure title'},
             }],
+            bogus=123,
             skip_invalid=True)
 
         fig_dict = fig.to_dict()
@@ -93,7 +94,8 @@ class FigureTest(TestCase):
                 'data': [{'type': 'bar', 'showlegend': 'bad_value'}],
                 'layout': {'bgcolor': 'bad_color', 'title': 'Figure title'},
             }],
-            skip_invalid=True)
+            skip_invalid=True,
+        )
 
         fig_dict = fig.to_dict()
 
@@ -111,3 +113,23 @@ class FigureTest(TestCase):
                              'layout':
                                  {'title': {'text': 'Figure title'}}
                          }])
+
+    def test_raises_invalid_toplevel_kwarg(self):
+        with self.assertRaises(TypeError):
+            go.Figure(
+                data=[{'type': 'bar'}],
+                layout={'title': 'Figure title'},
+                frames=[{
+                    'data': [{'type': 'bar'}],
+                    'layout': {'title': 'Figure title'},
+                }],
+                bogus=123
+            )
+
+    def test_toplevel_underscore_kwarg(self):
+        fig = go.Figure(
+            data=[{'type': 'bar'}],
+            layout_title_text='Hello, Figure title!'
+        )
+
+        self.assertEqual(fig.layout.title.text, 'Hello, Figure title!')

--- a/plotly/tests/test_core/test_graph_objs/test_figure.py
+++ b/plotly/tests/test_core/test_graph_objs/test_figure.py
@@ -133,3 +133,10 @@ class FigureTest(TestCase):
         )
 
         self.assertEqual(fig.layout.title.text, 'Hello, Figure title!')
+
+    def test_add_trace_underscore_kwarg(self):
+        fig = go.Figure()
+
+        fig.add_scatter(y=[2, 1, 3], marker_line_color='green')
+
+        self.assertEqual(fig.data[0].marker.line.color, 'green')

--- a/plotly/tests/test_core/test_graph_objs/test_figure_properties.py
+++ b/plotly/tests/test_core/test_graph_objs/test_figure_properties.py
@@ -138,6 +138,26 @@ class TestFigureProperties(TestCase):
         self.figure.update({'data[0].marker.color': 'yellow'})
         self.assertEqual(self.figure.data[0].marker.color, 'yellow')
 
+    def test_update_data_underscores(self):
+        # Check initial marker color
+        self.assertEqual(self.figure.data[0].marker.color, 'green')
+
+        # Update with dict kwarg
+        self.figure.update(data={0: {'marker_color': 'blue'}})
+        self.assertEqual(self.figure.data[0].marker.color, 'blue')
+
+        # Update with list kwarg
+        self.figure.update(data=[{'marker_color': 'red'}])
+        self.assertEqual(self.figure.data[0].marker.color, 'red')
+
+        # Update with dict
+        self.figure.update({'data_0_marker_color': 'yellow'})
+        self.assertEqual(self.figure.data[0].marker.color, 'yellow')
+
+        # Update with kwarg
+        self.figure.update(data_0_marker_color='yellow')
+        self.assertEqual(self.figure.data[0].marker.color, 'yellow')
+
     def test_update_data_empty(self):
         # Create figure with empty data (no traces)
         figure = go.Figure(layout={'width': 1000})

--- a/plotly/tests/test_core/test_graph_objs/test_figure_properties.py
+++ b/plotly/tests/test_core/test_graph_objs/test_figure_properties.py
@@ -122,6 +122,22 @@ class TestFigureProperties(TestCase):
         self.figure.update({'data': {0: {'marker': {'color': 'yellow'}}}})
         self.assertEqual(self.figure.data[0].marker.color, 'yellow')
 
+    def test_update_data_dots(self):
+        # Check initial marker color
+        self.assertEqual(self.figure.data[0].marker.color, 'green')
+
+        # Update with dict kwarg
+        self.figure.update(data={0: {'marker.color': 'blue'}})
+        self.assertEqual(self.figure.data[0].marker.color, 'blue')
+
+        # Update with list kwarg
+        self.figure.update(data=[{'marker.color': 'red'}])
+        self.assertEqual(self.figure.data[0].marker.color, 'red')
+
+        # Update with dict
+        self.figure.update({'data[0].marker.color': 'yellow'})
+        self.assertEqual(self.figure.data[0].marker.color, 'yellow')
+
     def test_update_data_empty(self):
         # Create figure with empty data (no traces)
         figure = go.Figure(layout={'width': 1000})

--- a/plotly/tests/test_core/test_graph_objs/test_property_assignment.py
+++ b/plotly/tests/test_core/test_graph_objs/test_property_assignment.py
@@ -30,6 +30,11 @@ class TestAssignmentPrimitive(TestCase):
             'marker': {'colorbar': {
                 'title': {'font': {'family': 'courier'}}}}}
 
+        self.expected_nested_error_x = {
+            'type': 'scatter',
+            'name': 'scatter A',
+            'error_x': {'type': 'percent'}}
+
     def test_toplevel_attr(self):
         assert self.scatter.fillcolor is None
         self.scatter.fillcolor = 'green'
@@ -86,12 +91,20 @@ class TestAssignmentPrimitive(TestCase):
         d1, d2 = strip_dict_params(self.scatter, self.expected_nested)
         assert d1 == d2
 
-    def test_nested_update__dots(self):
+    def test_nested_update_dots(self):
         assert self.scatter['marker.colorbar.title.font.family'] is None
         self.scatter.update({'marker.colorbar.title.font.family': 'courier'})
 
         assert self.scatter['marker.colorbar.title.font.family'] == 'courier'
         d1, d2 = strip_dict_params(self.scatter, self.expected_nested)
+        assert d1 == d2
+
+    def test_nested_update_underscores(self):
+        assert self.scatter['error_x.type'] is None
+        self.scatter.update({'error_x_type': 'percent'})
+
+        assert self.scatter['error_x_type'] == 'percent'
+        d1, d2 = strip_dict_params(self.scatter, self.expected_nested_error_x)
         assert d1 == d2
 
 
@@ -472,6 +485,25 @@ class TestAssignCompoundArray(TestCase):
 
         # Update
         self.layout.update({'updatemenus[1].buttons[2].method': 'restyle'})
+
+        # Check
+        self.assertEqual(
+            self.layout['updatemenus[1].buttons[2].method'],
+            'restyle')
+        d1, d2 = strip_dict_params(self.layout, self.expected_layout2)
+        assert d1 == d2
+
+    def test_update_double_nested_underscore(self):
+        self.assertEqual(self.layout.updatemenus, ())
+
+        # Initialize empty updatemenus
+        self.layout['updatemenus'] = [{}, {}]
+
+        # Initialize empty buttons in updatemenu[1]
+        self.layout['updatemenus_1_buttons'] = [{}, {}, {}]
+
+        # Update
+        self.layout.update({'updatemenus_1_buttons_2_method': 'restyle'})
 
         # Check
         self.assertEqual(

--- a/plotly/tests/test_core/test_graph_objs/test_property_assignment.py
+++ b/plotly/tests/test_core/test_graph_objs/test_property_assignment.py
@@ -86,6 +86,14 @@ class TestAssignmentPrimitive(TestCase):
         d1, d2 = strip_dict_params(self.scatter, self.expected_nested)
         assert d1 == d2
 
+    def test_nested_update__dots(self):
+        assert self.scatter['marker.colorbar.title.font.family'] is None
+        self.scatter.update({'marker.colorbar.title.font.family': 'courier'})
+
+        assert self.scatter['marker.colorbar.title.font.family'] == 'courier'
+        d1, d2 = strip_dict_params(self.scatter, self.expected_nested)
+        assert d1 == d2
+
 
 class TestAssignmentCompound(TestCase):
 
@@ -453,4 +461,21 @@ class TestAssignCompoundArray(TestCase):
         d1, d2 = strip_dict_params(self.layout, self.expected_layout2)
         assert d1 == d2
 
+    def test_update_double_nested_dot(self):
+        self.assertEqual(self.layout.updatemenus, ())
 
+        # Initialize empty updatemenus
+        self.layout['updatemenus'] = [{}, {}]
+
+        # Initialize empty buttons in updatemenu[1]
+        self.layout['updatemenus.1.buttons'] = [{}, {}, {}]
+
+        # Update
+        self.layout.update({'updatemenus[1].buttons[2].method': 'restyle'})
+
+        # Check
+        self.assertEqual(
+            self.layout['updatemenus[1].buttons[2].method'],
+            'restyle')
+        d1, d2 = strip_dict_params(self.layout, self.expected_layout2)
+        assert d1 == d2

--- a/plotly/tests/test_core/test_update_traces/test_update_traces.py
+++ b/plotly/tests/test_core/test_update_traces/test_update_traces.py
@@ -1,0 +1,187 @@
+from __future__ import absolute_import
+from unittest import TestCase
+import inspect
+
+import plotly.graph_objs as go
+from plotly.subplots import make_subplots
+from _plotly_future_ import _future_flags
+
+
+class TestSelectTraces(TestCase):
+
+    def setUp(self):
+        _future_flags.add('v4_subplots')
+        fig = make_subplots(
+            rows=3,
+            cols=2,
+            specs=[[{}, {'type': 'scene'}],
+                   [{}, {'type': 'polar'}],
+                   [{'type': 'domain', 'colspan': 2}, None]]
+        ).update(layout={'height': 800})
+
+        # data[0], (1, 1)
+        fig.add_scatter(
+            mode='markers',
+            y=[2, 3, 1],
+            name='A',
+            marker={'color': 'green', 'size': 10},
+            row=1, col=1)
+
+        # data[1], (1, 1)
+        fig.add_bar(y=[2, 3, 1], row=1, col=1, name='B')
+
+        # data[2], (2, 1)
+        fig.add_scatter(
+            mode='lines',
+            y=[1, 2, 0],
+            line={'color': 'purple'},
+            name='C',
+            row=2,
+            col=1,
+        )
+
+        # data[3], (2, 1)
+        fig.add_heatmap(
+            z=[[2, 3, 1], [2, 1, 3], [3, 2, 1]],
+            row=2,
+            col=1,
+            name='D',
+        )
+
+        # data[4], (1, 2)
+        fig.add_scatter3d(
+            x=[0, 0, 0],
+            y=[0, 0, 0],
+            z=[0, 1, 2],
+            mode='markers',
+            marker={'color': 'green', 'size': 10},
+            name='E',
+            row=1,
+            col=2
+        )
+
+        # data[5], (1, 2)
+        fig.add_scatter3d(
+            x=[0, 0, -1],
+            y=[-1, 0, 0],
+            z=[0, 1, 2],
+            mode='lines',
+            line={'color': 'purple', 'width': 4},
+            name='F',
+            row=1,
+            col=2
+        )
+
+        # data[6], (2, 2)
+        fig.add_scatterpolar(
+            mode='markers',
+            r=[0, 3, 2],
+            theta=[0, 20, 87],
+            marker={'color': 'green', 'size': 8},
+            name='G',
+            row=2,
+            col=2
+        )
+
+        # data[7], (2, 2)
+        fig.add_scatterpolar(
+            mode='lines',
+            r=[0, 3, 2],
+            theta=[20, 87, 111],
+            name='H',
+            row=2,
+            col=2
+        )
+
+        # data[8], (3, 1)
+        fig.add_parcoords(
+            dimensions=[{'values': [1, 2, 3, 2, 1]},
+                        {'values': [3, 2, 1, 3, 2, 1]}],
+            line={'color': 'purple'},
+            name='I',
+            row=3,
+            col=1
+        )
+
+        self.fig = fig
+        self.fig_no_grid = go.Figure(self.fig)
+        del self.fig_no_grid.__dict__['_grid_ref']
+        del self.fig_no_grid.__dict__['_grid_str']
+
+    def tearDown(self):
+        _future_flags.remove('v4_subplots')
+
+    def assert_select_traces(self, expected_inds, selector=None, row=None, col=None, test_no_grid=False):
+        trace_generator = self.fig.select_traces(
+            selector=selector, row=row, col=col)
+        self.assertTrue(inspect.isgenerator(trace_generator))
+
+        trace_list = list(trace_generator)
+        self.assertEqual(trace_list, [self.fig.data[i] for i in expected_inds])
+
+        if test_no_grid:
+            trace_generator = self.fig_no_grid.select_traces(
+                selector=selector, row=row, col=col)
+            trace_list = list(trace_generator)
+            self.assertEqual(trace_list, [self.fig_no_grid.data[i] for i in expected_inds])
+
+    def test_select_by_type(self):
+        self.assert_select_traces(
+            [0, 2], selector={'type': 'scatter'}, test_no_grid=True)
+        self.assert_select_traces(
+            [1], selector={'type': 'bar'}, test_no_grid=True)
+        self.assert_select_traces(
+            [3], selector={'type': 'heatmap'}, test_no_grid=True)
+        self.assert_select_traces(
+            [4, 5], selector={'type': 'scatter3d'}, test_no_grid=True)
+        self.assert_select_traces(
+            [6, 7], selector={'type': 'scatterpolar'}, test_no_grid=True)
+        self.assert_select_traces(
+            [8], selector={'type': 'parcoords'}, test_no_grid=True)
+        self.assert_select_traces(
+            [], selector={'type': 'pie'}, test_no_grid=True)
+
+    def test_select_by_grid(self):
+        self.assert_select_traces([0, 1], row=1, col=1)
+        self.assert_select_traces([2, 3], row=2, col=1)
+        self.assert_select_traces([4, 5], row=1, col=2)
+        self.assert_select_traces([6, 7], row=2, col=2)
+        self.assert_select_traces([8], row=3, col=1)
+
+    def test_select_by_property_across_trace_types(self):
+        self.assert_select_traces(
+            [0, 4, 6], selector={'mode': 'markers'}, test_no_grid=True)
+        self.assert_select_traces(
+            [2, 5, 7], selector={'mode': 'lines'}, test_no_grid=True)
+        self.assert_select_traces(
+            [0, 4],
+            selector={'marker': {'color': 'green', 'size': 10}},
+            test_no_grid=True)
+
+        # Several traces have 'marker.color' == 'green', but they all have
+        # additional marker properties so there should be no exact match.
+        self.assert_select_traces(
+            [], selector={'marker': {'color': 'green'}}, test_no_grid=True)
+        self.assert_select_traces(
+            [0, 4, 6], selector={'marker.color': 'green'}, test_no_grid=True)
+        self.assert_select_traces(
+            [2, 5, 8], selector={'line.color': 'purple'}, test_no_grid=True)
+
+    def test_select_property_and_grid(self):
+        # (1, 1)
+        self.assert_select_traces(
+            [0], selector={'mode': 'markers'}, row=1, col=1)
+        self.assert_select_traces(
+            [1], selector={'type': 'bar'}, row=1, col=1)
+
+        # (2, 1)
+        self.assert_select_traces(
+            [2], selector={'mode': 'lines'}, row=2, col=1)
+
+        # (1, 2)
+        self.assert_select_traces(
+            [4], selector={'marker.color': 'green'}, row=1, col=2)
+
+        # Valid row/col and valid selector but the intersection is empty
+        self.assert_select_traces(
+            [], selector={'type': 'markers'}, row=3, col=1)

--- a/plotly/tests/test_core/test_update_traces/test_update_traces.py
+++ b/plotly/tests/test_core/test_update_traces/test_update_traces.py
@@ -269,8 +269,16 @@ class TestSelectForEachUpdateTraces(TestCase):
             selector={'type': 'heatmap'}
         )
 
+        # Nest dictionaries
         self.assert_update_traces(
             {'marker': {'line': {'color': 'yellow'}}},
+            [4, 5],
+            selector={'type': 'scatter3d'}
+        )
+
+        # dot syntax
+        self.assert_update_traces(
+            {'marker.line.color': 'cyan'},
             [4, 5],
             selector={'type': 'scatter3d'}
         )
@@ -281,12 +289,21 @@ class TestSelectForEachUpdateTraces(TestCase):
             selector={'type': 'scatterpolar'}
         )
 
+        # Nested dictionaries
         self.assert_update_traces(
             {'dimensions': {1: {'label': 'Dimension 1'}}},
             [8],
             selector={'type': 'parcoords'}
         )
 
+        # Dot syntax
+        self.assert_update_traces(
+            {'dimensions[1].label': 'Dimension A'},
+            [8],
+            selector={'type': 'parcoords'}
+        )
+
         self.assert_update_traces(
             {'hoverinfo': 'label+percent'},
-            [], selector={'type': 'pie'})
+            [], selector={'type': 'pie'}
+        )

--- a/plotly/tests/test_core/test_update_traces/test_update_traces.py
+++ b/plotly/tests/test_core/test_update_traces/test_update_traces.py
@@ -283,6 +283,13 @@ class TestSelectForEachUpdateTraces(TestCase):
             selector={'type': 'scatter3d'}
         )
 
+        # underscore syntax
+        self.assert_update_traces(
+            dict(marker_line_color='pink'),
+            [4, 5],
+            selector={'type': 'scatter3d'}
+        )
+
         self.assert_update_traces(
             {'line': {'dash': 'dot'}},
             [6, 7],
@@ -299,6 +306,14 @@ class TestSelectForEachUpdateTraces(TestCase):
         # Dot syntax
         self.assert_update_traces(
             {'dimensions[1].label': 'Dimension A'},
+            [8],
+            selector={'type': 'parcoords'}
+        )
+
+        # underscore syntax
+        # Dot syntax
+        self.assert_update_traces(
+            dict(dimensions_1_label='Dimension X'),
             [8],
             selector={'type': 'parcoords'}
         )


### PR DESCRIPTION
Closes https://github.com/plotly/plotly.py/issues/1481 and the trace portion of https://github.com/plotly/plotly.py/issues/1484.

## Overview
This PR introduces 3 new figure methods to make it easier to make updates to traces that have already been added to a Figure (e.g. a Figure from `plotly_express` or a figure factory). It also introduces a convenient shorthand for updating nested properties that we've been calling "magic underscore" support.

### New Figure methods
All 3 methods allow the user to select certain traces from the figure using a "selector". This is an `update` style dict that can be used to specify the desired values of arbitrary properties in the trace. For example, a selector of `{'type': 'scatter'}` will select all scatter traces in the figure.  A selector of `{'type': 'scatter', 'mode': 'markers'}` will select only those scatter traces that are in `'markers'` mode. 

In addition to the selector, for figures created using `plotly.subplots.make_subplots`, the trace row and column index may also be used as selection criteria.

The lowest level method is `select_traces`. This returns a generator that iterates over all of the traces in the figure that satisfy the selection criteria.

The `for_each_trace` method applies a custom function to each trace produced by `select_traces`

The `update_traces` method accepts a "patch" to update all of the traces that satisfy the selection criteria. This "patch" is a dict that is passed to `trace.update` for all selected traces.

### "Magic underscore" support
For background on "magic underscore" support, see https://github.com/plotly/plotly.py/pull/919 and https://github.com/plotly/plotly.py/issues/1481.

The goal of magic underscore support is to make it more convenient to reference nested figure properties without the need to created deeply nested `dict` instances.

Here are the updates that have been implemented:

#### Figure and graph_objs constructors
Here's a current approach to creating a figure with a particular title:
```python
import plotly.graph_objs as go
fig = go.Figure(layout={'title': {'text': 'Hello, Figure'}})
```
With magic-underscore support:
```python
fig = go.Figure(layout_title_text='Hello, Figure')
```

#### .update operations
Here's a current approach to updating the title text for an existing figure
```python
fig = go.Figure()
fig.update(layout={'title': {'text': 'Hello, Figure'}})
```
with magic-underscore support:

```python
fig = go.Figure()
fig.update(layout_title_text='Hello, Figure')
```
In addition to using underscores to separate nested keys, when the update argument is supplied as a dict (rather than as kwargs), the path parts can be separated by periods.

```python
fig = go.Figure()
fig.update({'layout_title_text': 'Hello, Figure',
            'layout.title.font.color': 'green'})
```

#### add trace methods
Here's a current approach creating a scatter trace with green markers
```
fig = go.Figure()
fig.add_scatter(y=[2, 3, 1], mode='markers', marker={'color': 'green'})
fig
```
With magic underscore support
```
fig = go.Figure()
fig.add_scatter(y=[2, 3, 1], mode='markers', marker_color='green')
fig
```

#### compatibility
One tricky thing to keep track of is that there are a few properties in plotly.js that contain underscores in their proper name. e.g. `scatter.error_y` and `layout.paper_bgcolor`.  These are kept track of as special cases.

Here's an example of using magic underscore logic alongside the `error_y` property:
```python
fig = go.Figure()
fig.add_scatter(
    y=[2, 3, 1],
    mode='markers',
    marker_color='green',
    error_y_array=[2, 1, 3]
)
fig.update(data_0_error_y_color='blue')
```
Note how integer data array indices can be specified directly in the argument.

## All together
Combining `update_traces` and magic-underscore support should make it much easier to selectively update trace properties.

For example, to update the line width of all scatter traces in line mode:
```python
fig.update_traces({'line.width': 4}, selector={'type': 'scatter', 'mode': 'lines'})
```
Or, only the line traces in subplot position 2, 1
```python
fig = make_subplots(3, 3, ...)
...
fig.update_traces({'line.width': 4}, selector={'type': 'scatter', 'mode': 'lines'}, row=2, col=1)
```
