### PR TITLE
Enable DDK compatibility

### DIFF
--- a/_plotly_utils/basevalidators.py
+++ b/_plotly_utils/basevalidators.py
@@ -1230,13 +1230,13 @@ class ColorValidator(BaseValidator):
                 # Valid rgb(a), hsl(a), hsv(a) color
                 # (e.g. rgba(10, 234, 200, 50%)
                 return v
-            elif v_normalized in ColorValidator.named_colors:
-                # Valid named color (e.g. 'coral')
-                return v
             elif fullmatch(ColorValidator.re_ddk, v_normalized):
                 # Valid var(--*) DDK theme variable, inspired by CSS syntax
                 # (e.g. var(--accent) )
                 # DDK will crawl & eval var(-- colors for Graph theming
+                return v
+            elif v_normalized in ColorValidator.named_colors:
+                # Valid named color (e.g. 'coral')
                 return v
             else:
                 # Not a valid color

--- a/_plotly_utils/basevalidators.py
+++ b/_plotly_utils/basevalidators.py
@@ -1033,6 +1033,7 @@ class ColorValidator(BaseValidator):
     """
     re_hex = re.compile('#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})')
     re_rgb_etc = re.compile('(rgb|hsl|hsv)a?\([\d.]+%?(,[\d.]+%?){2,3}\)')
+    re_ddk = re.compile('var\(\-\-.*\)')
 
     named_colors = [
         "aliceblue", "antiquewhite", "aqua", "aquamarine", "azure", "beige",
@@ -1231,6 +1232,11 @@ class ColorValidator(BaseValidator):
                 return v
             elif v_normalized in ColorValidator.named_colors:
                 # Valid named color (e.g. 'coral')
+                return v
+            elif fullmatch(ColorValidator.re_ddk, v_normalized):
+                # Valid var(--*) DDK theme variable, inspired by CSS syntax
+                # (e.g. var(--accent) )
+                # DDK will crawl & eval var(-- colors for Graph theming
                 return v
             else:
                 # Not a valid color

--- a/_plotly_utils/tests/validators/test_color_validator.py
+++ b/_plotly_utils/tests/validators/test_color_validator.py
@@ -28,7 +28,7 @@ def validator_aok_colorscale():
 # Array not ok, numbers not ok
 # ----------------------------
 @pytest.mark.parametrize('val',
-                         ['red', 'BLUE', 'rgb(255, 0, 0)', 'hsl(0, 100%, 50%)', 'hsla(0, 100%, 50%, 100%)',
+                         ['red', 'BLUE', 'rgb(255, 0, 0)', 'var(--accent)', 'hsl(0, 100%, 50%)', 'hsla(0, 100%, 50%, 100%)',
                           'hsv(0, 100%, 100%)', 'hsva(0, 100%, 100%, 50%)'])
 def test_acceptance(val, validator):
     assert validator.validate_coerce(val) == val
@@ -58,7 +58,7 @@ def test_rejection(val, validator):
 # ------------------------
 # ### Acceptance ###
 @pytest.mark.parametrize('val',
-                         ['red', 'BLUE', 23, 15, 'rgb(255, 0, 0)', 'hsl(0, 100%, 50%)', 'hsla(0, 100%, 50%, 100%)',
+                         ['red', 'BLUE', 23, 15, 'rgb(255, 0, 0)', 'var(--accent)', 'hsl(0, 100%, 50%)', 'hsla(0, 100%, 50%, 100%)',
                           'hsv(0, 100%, 100%)', 'hsva(0, 100%, 100%, 50%)'])
 def test_acceptance_colorscale(val, validator_colorscale):
     assert validator_colorscale.validate_coerce(val) == val


### PR DESCRIPTION
In Dash Design Kit, we allow for colors to be specified with `var(--*)` syntax, similar to CSS variable syntax. This will allow for Graph colors to dynamically match theme colors when the theme is changed with the Theme Editor.

When using `plotly.py` to generate Graph data, a `ValueError` is raised when using this syntax:

``` bash
 ValueError: 
 Invalid value of type 'builtins.str' received for the 'color' property of scatter.marker
 Received value: 'var(--colorway-1)'
```

This crashes the Dash app, despite the fact that DDK will safely evaluate colors with the above syntax based on the currently defined theme.

This PR allows for these dynamic variables to be passed. It's my first PR, so feedback is welcome, especially on my RegEx :sweat_smile: 

cc @nicolaskruchten — I've tested this with `px` as well as `plotly.graph_objs`