### PR TITLE
Adding support to plotly_unselect event

### DIFF
--- a/js/src/Figure.js
+++ b/js/src/Figure.js
@@ -750,6 +750,10 @@ var FigureView = widgets.DOMWidgetView.extend({
                     function (update) {
                         that.handle_plotly_selected(update)
                     });
+                that.el.on("plotly_deselect",
+                    function (update) {
+                        that.handle_plotly_deselect(update)
+                    });
                 that.el.on("plotly_doubleclick",
                     function (update) {
                         that.handle_plotly_doubleclick(update)
@@ -1080,6 +1084,17 @@ var FigureView = widgets.DOMWidgetView.extend({
     handle_plotly_selected: function (data) {
         this._send_points_callback_message(data, "plotly_selected");
     },
+    
+    /**
+     * Handle plotly_deselect events emitted by the Plotly.js library
+     * @param data
+     */
+    handle_plotly_deselect: function (data) {
+        data = {
+            points : []
+        }
+        this._send_points_callback_message(data, "plotly_deselect");
+    },    
 
     /**
      * Build and send a points callback message to the Python side

--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -4242,7 +4242,7 @@ class BaseTraceType(BaseTraceHierarchyType):
             # of the selection change.  This is a special case because no
             # restyle event is emitted by plotly.js on selection events
             # even though these events update the selectedpoints property.
-            self.selectedpoints = points.point_inds
+            self.selectedpoints = None
 
         for callback in self._deselect_callbacks:
             callback(self, points)

--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -4162,6 +4162,23 @@ class BaseTraceType(BaseTraceHierarchyType):
 
         if callback:
             self._select_callbacks.append(callback)
+        
+    def _dispatch_on_selection(self,
+                               points,
+                               selector):
+        """
+        Dispatch points and selector info to selection callbacks
+        """
+        if 'selectedpoints' in self:
+            # Update the selectedpoints property, which will notify all views
+            # of the selection change.  This is a special case because no
+            # restyle event is emitted by plotly.js on selection events
+            # even though these events update the selectedpoints property.
+            self.selectedpoints = points.point_inds
+
+        for callback in self._select_callbacks:
+            callback(self, points, selector)
+
 
     # deselect
     # ------
@@ -4216,23 +4233,7 @@ class BaseTraceType(BaseTraceHierarchyType):
 
         if callback:
             self._deselect_callbacks.append(callback)
-            
-    def _dispatch_on_selection(self,
-                               points,
-                               selector):
-        """
-        Dispatch points and selector info to selection callbacks
-        """
-        if 'selectedpoints' in self:
-            # Update the selectedpoints property, which will notify all views
-            # of the selection change.  This is a special case because no
-            # restyle event is emitted by plotly.js on selection events
-            # even though these events update the selectedpoints property.
-            self.selectedpoints = points.point_inds
-
-        for callback in self._select_callbacks:
-            callback(self, points, selector)
-
+                
     def _dispatch_on_deselect(self,
                                points):
         """
@@ -4245,7 +4246,7 @@ class BaseTraceType(BaseTraceHierarchyType):
             # even though these events update the selectedpoints property.
             self.selectedpoints = points.point_inds
 
-        for callback in self._select_callbacks:
+        for callback in self._deselect_callbacks:
             callback(self, points)
             
 class BaseFrameHierarchyType(BasePlotlyType):

--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -4205,7 +4205,7 @@ class BaseTraceType(BaseTraceHierarchyType):
 
         append : bool
             If False (the default), this callback replaces any previously
-            defined on_selection callbacks for this trace. If True,
+            defined on_deselect callbacks for this trace. If True,
             this callback is appended to the list of any previously defined
             callbacks.
 
@@ -4218,11 +4218,11 @@ class BaseTraceType(BaseTraceHierarchyType):
         >>> from plotly.callbacks import Points
         >>> points = Points()
 
-        >>> def selection_fn(trace, points, selector):
+        >>> def deselect_fn(trace, points):
         ...     inds = points.point_inds
         ...     # Do something
 
-        >>> trace.on_selection(selection_fn)
+        >>> trace.on_deselect(deselect_fn)
 
         Note: The creation of the `points` object is optional,
         it's simply a convenience to help the text editor perform completion

--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -4162,7 +4162,7 @@ class BaseTraceType(BaseTraceHierarchyType):
 
         if callback:
             self._select_callbacks.append(callback)
-        
+
     def _dispatch_on_selection(self,
                                points,
                                selector):
@@ -4179,15 +4179,14 @@ class BaseTraceType(BaseTraceHierarchyType):
         for callback in self._select_callbacks:
             callback(self, points, selector)
 
-
     # deselect
-    # ------
+    # --------
     def on_deselect(
             self,
             callback,
             append=False):
         """
-        Register function to be called when the user deselects points 
+        Register function to be called when the user deselects points
         in this trace using doubleclick.
 
         Note: Callbacks will only be triggered when the trace belongs to a
@@ -4233,9 +4232,8 @@ class BaseTraceType(BaseTraceHierarchyType):
 
         if callback:
             self._deselect_callbacks.append(callback)
-                
-    def _dispatch_on_deselect(self,
-                               points):
+
+    def _dispatch_on_deselect(self, points):
         """
         Dispatch points info to deselection callbacks
         """
@@ -4248,7 +4246,8 @@ class BaseTraceType(BaseTraceHierarchyType):
 
         for callback in self._deselect_callbacks:
             callback(self, points)
-            
+
+
 class BaseFrameHierarchyType(BasePlotlyType):
     """
     Base class for all types in the trace hierarchy

--- a/plotly/basewidget.py
+++ b/plotly/basewidget.py
@@ -736,7 +736,7 @@ class BaseFigureWidget(BaseFigure, widgets.DOMWidget):
             elif event_type == 'plotly_selected':
                 trace._dispatch_on_selection(points, selector)
             elif event_type == 'plotly_deselect':
-                trace._dispatch_on_selection(points)
+                trace._dispatch_on_deselect(points)
 
         self._js2py_pointsCallback = None
 

--- a/plotly/basewidget.py
+++ b/plotly/basewidget.py
@@ -735,6 +735,8 @@ class BaseFigureWidget(BaseFigure, widgets.DOMWidget):
                 trace._dispatch_on_unhover(points, state)
             elif event_type == 'plotly_selected':
                 trace._dispatch_on_selection(points, selector)
+            elif event_type == 'plotly_deselect':
+                trace._dispatch_on_selection(points)
 
         self._js2py_pointsCallback = None
 


### PR DESCRIPTION
When active selections are cleared using double-click interaction over a plotly plot,  python objects are not updated properly. This code enables plotly_deselect events to update points properly