### PR TITLE
subplot select/update methods for batch updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,7 @@ jobs:
       - checkout
       - run:
           name: Install tox
-          command: 'sudo pip install tox requests yapf pytz decorator retrying'
+          command: 'sudo pip install tox requests yapf pytz decorator retrying inflect'
       - run:
           name: Update plotlywidget version
           command: 'python setup.py updateplotlywidgetversion'

--- a/_plotly_utils/utils.py
+++ b/_plotly_utils/utils.py
@@ -2,6 +2,7 @@ import datetime
 import decimal
 import json as _json
 import sys
+import re
 
 import pytz
 
@@ -242,3 +243,18 @@ def template_doc(**names):
                 func.__doc__ = func.__doc__.format(**names)
         return func
     return _decorator
+
+
+def _natural_sort_strings(vals, reverse=False):
+
+    def key(v):
+        v_parts = re.split(r'(\d+)', v)
+        for i in range(len(v_parts)):
+            try:
+                v_parts[i] = int(v_parts[i])
+            except ValueError:
+                # not an int
+                pass
+        return tuple(v_parts)
+
+    return sorted(vals, key=key, reverse=reverse)

--- a/codegen/__init__.py
+++ b/codegen/__init__.py
@@ -126,6 +126,9 @@ def perform_codegen():
     all_layout_nodes = PlotlyNode.get_all_datatype_nodes(
         plotly_schema, LayoutNode)
 
+    subplot_nodes = [node for node in layout_node.child_compound_datatypes
+                     if node.node_data.get('_isSubplotObj', False)]
+
     # ### FrameNode ###
     compound_frame_nodes = PlotlyNode.get_all_compound_datatype_nodes(
         plotly_schema, FrameNode)
@@ -187,7 +190,8 @@ def perform_codegen():
                          base_traces_node,
                          data_validator,
                          layout_validator,
-                         frame_validator)
+                         frame_validator,
+                         subplot_nodes)
 
     # Write datatype __init__.py files
     # --------------------------------

--- a/codegen/figure.py
+++ b/codegen/figure.py
@@ -8,9 +8,12 @@ from codegen.datatypes import (reindent_validator_description,
                                add_constructor_params, add_docstring)
 from codegen.utils import PlotlyNode, format_and_write_source_py
 
+import inflect
+
 
 def build_figure_py(trace_node, base_package, base_classname, fig_classname,
-                    data_validator, layout_validator, frame_validator):
+                    data_validator, layout_validator, frame_validator,
+                    subplot_nodes):
     """
 
     Parameters
@@ -30,7 +33,8 @@ def build_figure_py(trace_node, base_package, base_classname, fig_classname,
         LayoutValidator instance
     frame_validator : CompoundArrayValidator
         FrameValidator instance
-
+    subplot_nodes: list of str
+        List of names of all of the layout subplot properties
     Returns
     -------
     str
@@ -53,6 +57,7 @@ def build_figure_py(trace_node, base_package, base_classname, fig_classname,
     # ### Import trace graph_obj classes ###
     trace_types_csv = ', '.join([n.name_datatype_class for n in trace_nodes])
     buffer.write(f'from plotly.graph_objs import ({trace_types_csv})\n')
+    buffer.write("from plotly.subplots import _validate_v4_subplots\n")
 
     # Write class definition
     # ----------------------
@@ -141,6 +146,111 @@ class {fig_classname}({base_classname}):\n""")
         buffer.write(f"""
         return self.add_trace(new_trace, row=row, col=col)""")
 
+    # update layout subplots
+    # ----------------------
+    inflect_eng = inflect.engine()
+    for subplot_node in subplot_nodes:
+        singular_name = subplot_node.name_property
+        plural_name = inflect_eng.plural_noun(singular_name)
+        buffer.write(f"""
+
+    def select_{plural_name}(self, selector=None, row=None, col=None):
+        \"\"\"
+        Select {singular_name} subplot objects from a particular subplot cell
+        and/or {singular_name} subplot objects that satisfy custom selection
+        criteria.
+
+        Parameters
+        ----------
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            {singular_name} objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all {singular_name} objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of {singular_name} objects to select.
+            To select {singular_name} objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all {singular_name} objects are selected.
+
+        Returns
+        -------
+        generator
+            Generator that iterates through all of the {singular_name}
+            objects that satisfy all of the specified selection criteria
+        \"\"\"
+        if row is not None or col is not None:
+            _validate_v4_subplots('select_{plural_name}')
+
+        return self._select_layout_subplots_by_prefix(
+            '{singular_name}', selector, row, col)
+
+    def for_each_{singular_name}(self, fn, selector=None, row=None, col=None):
+        \"\"\"
+        Apply a function to all {singular_name} objects that satisfy the
+        specified selection criteria
+        
+        Parameters
+        ----------
+        fn:
+            Function that inputs a single {singular_name} object.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            {singular_name} objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all {singular_name} objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of {singular_name} objects to select.
+            To select {singular_name} objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all {singular_name} objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        \"\"\"
+        for obj in self.select_{plural_name}(
+                selector=selector, row=row, col=col):
+            fn(obj)
+
+        return self
+
+    def update_{plural_name}(self, patch, selector=None, row=None, col=None):
+        \"\"\"
+        Perform a property update operation on all {singular_name} objects
+        that satisfy the specified selection criteria
+        
+        Parameters
+        ----------
+        patch: dict
+            Dictionary of property updates to be applied to all
+            {singular_name} objects that satisfy the selection criteria.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            {singular_name} objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all {singular_name} objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of {singular_name} objects to select.
+            To select {singular_name} objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all {singular_name} objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        \"\"\"
+        for obj in self.select_{plural_name}(
+                selector=selector, row=row, col=col):
+            obj.update(patch)
+
+        return self""")
+
     # Return source string
     # --------------------
     buffer.write('\n')
@@ -150,7 +260,8 @@ class {fig_classname}({base_classname}):\n""")
 def write_figure_classes(outdir, trace_node,
                          data_validator,
                          layout_validator,
-                         frame_validator):
+                         frame_validator,
+                         subplot_nodes):
     """
     Construct source code for the Figure and FigureWidget classes and
     write to graph_objs/_figure.py and graph_objs/_figurewidget.py
@@ -169,6 +280,8 @@ def write_figure_classes(outdir, trace_node,
         LayoutValidator instance
     frame_validator : CompoundArrayValidator
         FrameValidator instance
+    subplot_nodes: list of str
+        List of names of all of the layout subplot properties
 
     Returns
     -------
@@ -195,7 +308,8 @@ def write_figure_classes(outdir, trace_node,
                                         fig_classname,
                                         data_validator,
                                         layout_validator,
-                                        frame_validator)
+                                        frame_validator,
+                                        subplot_nodes)
 
         # ### Format and write to file###
         filepath = opath.join(outdir, 'graph_objs',

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -23,6 +23,7 @@ psutil
 
 ## codegen dependencies ##
 yapf
+inflect
 
 ## template generation ##
 colorcet

--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -666,26 +666,36 @@ class BaseFigure(object):
         if not selector:
             selector = {}
 
-        if row is not None and col is not None:
+        if row is not None or col is not None:
             _validate_v4_subplots('select_traces')
             grid_ref = self._validate_get_grid_ref()
-            grid_subplot_ref = grid_ref[row-1][col-1]
             filter_by_subplot = True
+
+            if row is None:
+                # All rows for column
+                grid_subplot_refs = [ref_row[col-1] for ref_row in grid_ref]
+            elif col is None:
+                # All columns for row
+                grid_subplot_refs = grid_ref[row-1]
+            else:
+                # Single grid cell
+                grid_subplot_refs = [grid_ref[row-1][col-1]]
+
         else:
             filter_by_subplot = False
-            grid_subplot_ref = None
+            grid_subplot_refs = None
 
         return self._perform_select_traces(
-            filter_by_subplot, grid_subplot_ref, selector)
+            filter_by_subplot, grid_subplot_refs, selector)
 
     def _perform_select_traces(
-            self, filter_by_subplot, grid_subplot_ref, selector):
+            self, filter_by_subplot, grid_subplot_refs, selector):
 
         for trace in self.data:
             # Filter by subplot
             if filter_by_subplot:
                 trace_subplot_ref = _get_subplot_ref_for_trace(trace)
-                if grid_subplot_ref != trace_subplot_ref:
+                if trace_subplot_ref not in grid_subplot_refs:
                     continue
 
             # Filter by selector

--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -9,6 +9,7 @@ import warnings
 from contextlib import contextmanager
 from copy import deepcopy, copy
 
+from _plotly_utils.utils import _natural_sort_strings
 from plotly.subplots import (
     _set_trace_grid_reference,
     _get_grid_subplot,
@@ -810,7 +811,10 @@ class BaseFigure(object):
         else:
             container_to_row_col = None
 
-        for k in self.layout:
+        # Natural sort keys so that xaxis20 is after xaxis3
+        layout_keys = _natural_sort_strings(list(self.layout))
+
+        for k in layout_keys:
             if k.startswith(prefix) and self.layout[k] is not None:
 
                 # Filter by row/col

--- a/plotly/basewidget.py
+++ b/plotly/basewidget.py
@@ -558,7 +558,7 @@ class BaseFigureWidget(BaseFigure, widgets.DOMWidget):
             # may include axes that weren't explicitly defined by the user.
             for proppath in delta_transform:
                 prop = proppath[0]
-                match = self.layout._subplotid_prop_re.match(prop)
+                match = self.layout._subplot_re_match(prop)
                 if match and prop not in self.layout:
                     # We need to create a subplotid object
                     self.layout[prop] = {}

--- a/plotly/graph_objs/__init__.py
+++ b/plotly/graph_objs/__init__.py
@@ -6,6 +6,42 @@ import copy as _copy
 
 class Layout(_BaseLayoutType):
 
+    _subplotid_prop_names = [
+        'geo', 'mapbox', 'polar', 'scene', 'ternary', 'xaxis', 'yaxis'
+    ]
+
+    import re
+    _subplotid_prop_re = re.compile(
+        '^(' + '|'.join(_subplotid_prop_names) + ')(\d+)$'
+    )
+
+    @property
+    def _subplotid_validators(self):
+        """
+        dict of validator classes for each subplot type
+
+        Returns
+        -------
+        dict
+        """
+        from plotly.validators.layout import (
+            GeoValidator, MapboxValidator, PolarValidator, SceneValidator,
+            TernaryValidator, XAxisValidator, YAxisValidator
+        )
+
+        return {
+            'geo': GeoValidator,
+            'mapbox': MapboxValidator,
+            'polar': PolarValidator,
+            'scene': SceneValidator,
+            'ternary': TernaryValidator,
+            'xaxis': XAxisValidator,
+            'yaxis': YAxisValidator
+        }
+
+    def _subplot_re_match(self, prop):
+        return self._subplotid_prop_re.match(prop)
+
     # angularaxis
     # -----------
     @property

--- a/plotly/graph_objs/_figure.py
+++ b/plotly/graph_objs/_figure.py
@@ -7,6 +7,7 @@ from plotly.graph_objs import (
     Scattergl, Scattermapbox, Scatterpolar, Scatterpolargl, Scatterternary,
     Splom, Streamtube, Sunburst, Surface, Table, Violin, Volume, Waterfall
 )
+from plotly.subplots import _validate_v4_subplots
 
 
 class Figure(BaseFigure):
@@ -12300,3 +12301,675 @@ class Figure(BaseFigure):
             **kwargs
         )
         return self.add_trace(new_trace, row=row, col=col)
+
+    def select_geos(self, selector=None, row=None, col=None):
+        """
+        Select geo subplot objects from a particular subplot cell
+        and/or geo subplot objects that satisfy custom selection
+        criteria.
+
+        Parameters
+        ----------
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            geo objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all geo objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of geo objects to select.
+            To select geo objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all geo objects are selected.
+
+        Returns
+        -------
+        generator
+            Generator that iterates through all of the geo
+            objects that satisfy all of the specified selection criteria
+        """
+        if row is not None or col is not None:
+            _validate_v4_subplots('select_geos')
+
+        return self._select_layout_subplots_by_prefix(
+            'geo', selector, row, col
+        )
+
+    def for_each_geo(self, fn, selector=None, row=None, col=None):
+        """
+        Apply a function to all geo objects that satisfy the
+        specified selection criteria
+        
+        Parameters
+        ----------
+        fn:
+            Function that inputs a single geo object.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            geo objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all geo objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of geo objects to select.
+            To select geo objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all geo objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_geos(selector=selector, row=row, col=col):
+            fn(obj)
+
+        return self
+
+    def update_geos(self, patch, selector=None, row=None, col=None):
+        """
+        Perform a property update operation on all geo objects
+        that satisfy the specified selection criteria
+        
+        Parameters
+        ----------
+        patch: dict
+            Dictionary of property updates to be applied to all
+            geo objects that satisfy the selection criteria.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            geo objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all geo objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of geo objects to select.
+            To select geo objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all geo objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_geos(selector=selector, row=row, col=col):
+            obj.update(patch)
+
+        return self
+
+    def select_mapboxes(self, selector=None, row=None, col=None):
+        """
+        Select mapbox subplot objects from a particular subplot cell
+        and/or mapbox subplot objects that satisfy custom selection
+        criteria.
+
+        Parameters
+        ----------
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            mapbox objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all mapbox objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of mapbox objects to select.
+            To select mapbox objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all mapbox objects are selected.
+
+        Returns
+        -------
+        generator
+            Generator that iterates through all of the mapbox
+            objects that satisfy all of the specified selection criteria
+        """
+        if row is not None or col is not None:
+            _validate_v4_subplots('select_mapboxes')
+
+        return self._select_layout_subplots_by_prefix(
+            'mapbox', selector, row, col
+        )
+
+    def for_each_mapbox(self, fn, selector=None, row=None, col=None):
+        """
+        Apply a function to all mapbox objects that satisfy the
+        specified selection criteria
+        
+        Parameters
+        ----------
+        fn:
+            Function that inputs a single mapbox object.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            mapbox objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all mapbox objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of mapbox objects to select.
+            To select mapbox objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all mapbox objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_mapboxes(selector=selector, row=row, col=col):
+            fn(obj)
+
+        return self
+
+    def update_mapboxes(self, patch, selector=None, row=None, col=None):
+        """
+        Perform a property update operation on all mapbox objects
+        that satisfy the specified selection criteria
+        
+        Parameters
+        ----------
+        patch: dict
+            Dictionary of property updates to be applied to all
+            mapbox objects that satisfy the selection criteria.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            mapbox objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all mapbox objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of mapbox objects to select.
+            To select mapbox objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all mapbox objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_mapboxes(selector=selector, row=row, col=col):
+            obj.update(patch)
+
+        return self
+
+    def select_polars(self, selector=None, row=None, col=None):
+        """
+        Select polar subplot objects from a particular subplot cell
+        and/or polar subplot objects that satisfy custom selection
+        criteria.
+
+        Parameters
+        ----------
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            polar objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all polar objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of polar objects to select.
+            To select polar objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all polar objects are selected.
+
+        Returns
+        -------
+        generator
+            Generator that iterates through all of the polar
+            objects that satisfy all of the specified selection criteria
+        """
+        if row is not None or col is not None:
+            _validate_v4_subplots('select_polars')
+
+        return self._select_layout_subplots_by_prefix(
+            'polar', selector, row, col
+        )
+
+    def for_each_polar(self, fn, selector=None, row=None, col=None):
+        """
+        Apply a function to all polar objects that satisfy the
+        specified selection criteria
+        
+        Parameters
+        ----------
+        fn:
+            Function that inputs a single polar object.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            polar objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all polar objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of polar objects to select.
+            To select polar objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all polar objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_polars(selector=selector, row=row, col=col):
+            fn(obj)
+
+        return self
+
+    def update_polars(self, patch, selector=None, row=None, col=None):
+        """
+        Perform a property update operation on all polar objects
+        that satisfy the specified selection criteria
+        
+        Parameters
+        ----------
+        patch: dict
+            Dictionary of property updates to be applied to all
+            polar objects that satisfy the selection criteria.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            polar objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all polar objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of polar objects to select.
+            To select polar objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all polar objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_polars(selector=selector, row=row, col=col):
+            obj.update(patch)
+
+        return self
+
+    def select_scenes(self, selector=None, row=None, col=None):
+        """
+        Select scene subplot objects from a particular subplot cell
+        and/or scene subplot objects that satisfy custom selection
+        criteria.
+
+        Parameters
+        ----------
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            scene objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all scene objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of scene objects to select.
+            To select scene objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all scene objects are selected.
+
+        Returns
+        -------
+        generator
+            Generator that iterates through all of the scene
+            objects that satisfy all of the specified selection criteria
+        """
+        if row is not None or col is not None:
+            _validate_v4_subplots('select_scenes')
+
+        return self._select_layout_subplots_by_prefix(
+            'scene', selector, row, col
+        )
+
+    def for_each_scene(self, fn, selector=None, row=None, col=None):
+        """
+        Apply a function to all scene objects that satisfy the
+        specified selection criteria
+        
+        Parameters
+        ----------
+        fn:
+            Function that inputs a single scene object.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            scene objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all scene objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of scene objects to select.
+            To select scene objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all scene objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_scenes(selector=selector, row=row, col=col):
+            fn(obj)
+
+        return self
+
+    def update_scenes(self, patch, selector=None, row=None, col=None):
+        """
+        Perform a property update operation on all scene objects
+        that satisfy the specified selection criteria
+        
+        Parameters
+        ----------
+        patch: dict
+            Dictionary of property updates to be applied to all
+            scene objects that satisfy the selection criteria.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            scene objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all scene objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of scene objects to select.
+            To select scene objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all scene objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_scenes(selector=selector, row=row, col=col):
+            obj.update(patch)
+
+        return self
+
+    def select_ternaries(self, selector=None, row=None, col=None):
+        """
+        Select ternary subplot objects from a particular subplot cell
+        and/or ternary subplot objects that satisfy custom selection
+        criteria.
+
+        Parameters
+        ----------
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            ternary objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all ternary objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of ternary objects to select.
+            To select ternary objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all ternary objects are selected.
+
+        Returns
+        -------
+        generator
+            Generator that iterates through all of the ternary
+            objects that satisfy all of the specified selection criteria
+        """
+        if row is not None or col is not None:
+            _validate_v4_subplots('select_ternaries')
+
+        return self._select_layout_subplots_by_prefix(
+            'ternary', selector, row, col
+        )
+
+    def for_each_ternary(self, fn, selector=None, row=None, col=None):
+        """
+        Apply a function to all ternary objects that satisfy the
+        specified selection criteria
+        
+        Parameters
+        ----------
+        fn:
+            Function that inputs a single ternary object.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            ternary objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all ternary objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of ternary objects to select.
+            To select ternary objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all ternary objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_ternaries(selector=selector, row=row, col=col):
+            fn(obj)
+
+        return self
+
+    def update_ternaries(self, patch, selector=None, row=None, col=None):
+        """
+        Perform a property update operation on all ternary objects
+        that satisfy the specified selection criteria
+        
+        Parameters
+        ----------
+        patch: dict
+            Dictionary of property updates to be applied to all
+            ternary objects that satisfy the selection criteria.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            ternary objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all ternary objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of ternary objects to select.
+            To select ternary objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all ternary objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_ternaries(selector=selector, row=row, col=col):
+            obj.update(patch)
+
+        return self
+
+    def select_xaxes(self, selector=None, row=None, col=None):
+        """
+        Select xaxis subplot objects from a particular subplot cell
+        and/or xaxis subplot objects that satisfy custom selection
+        criteria.
+
+        Parameters
+        ----------
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            xaxis objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all xaxis objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of xaxis objects to select.
+            To select xaxis objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all xaxis objects are selected.
+
+        Returns
+        -------
+        generator
+            Generator that iterates through all of the xaxis
+            objects that satisfy all of the specified selection criteria
+        """
+        if row is not None or col is not None:
+            _validate_v4_subplots('select_xaxes')
+
+        return self._select_layout_subplots_by_prefix(
+            'xaxis', selector, row, col
+        )
+
+    def for_each_xaxis(self, fn, selector=None, row=None, col=None):
+        """
+        Apply a function to all xaxis objects that satisfy the
+        specified selection criteria
+        
+        Parameters
+        ----------
+        fn:
+            Function that inputs a single xaxis object.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            xaxis objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all xaxis objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of xaxis objects to select.
+            To select xaxis objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all xaxis objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_xaxes(selector=selector, row=row, col=col):
+            fn(obj)
+
+        return self
+
+    def update_xaxes(self, patch, selector=None, row=None, col=None):
+        """
+        Perform a property update operation on all xaxis objects
+        that satisfy the specified selection criteria
+        
+        Parameters
+        ----------
+        patch: dict
+            Dictionary of property updates to be applied to all
+            xaxis objects that satisfy the selection criteria.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            xaxis objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all xaxis objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of xaxis objects to select.
+            To select xaxis objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all xaxis objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_xaxes(selector=selector, row=row, col=col):
+            obj.update(patch)
+
+        return self
+
+    def select_yaxes(self, selector=None, row=None, col=None):
+        """
+        Select yaxis subplot objects from a particular subplot cell
+        and/or yaxis subplot objects that satisfy custom selection
+        criteria.
+
+        Parameters
+        ----------
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            yaxis objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all yaxis objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of yaxis objects to select.
+            To select yaxis objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all yaxis objects are selected.
+
+        Returns
+        -------
+        generator
+            Generator that iterates through all of the yaxis
+            objects that satisfy all of the specified selection criteria
+        """
+        if row is not None or col is not None:
+            _validate_v4_subplots('select_yaxes')
+
+        return self._select_layout_subplots_by_prefix(
+            'yaxis', selector, row, col
+        )
+
+    def for_each_yaxis(self, fn, selector=None, row=None, col=None):
+        """
+        Apply a function to all yaxis objects that satisfy the
+        specified selection criteria
+        
+        Parameters
+        ----------
+        fn:
+            Function that inputs a single yaxis object.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            yaxis objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all yaxis objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of yaxis objects to select.
+            To select yaxis objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all yaxis objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_yaxes(selector=selector, row=row, col=col):
+            fn(obj)
+
+        return self
+
+    def update_yaxes(self, patch, selector=None, row=None, col=None):
+        """
+        Perform a property update operation on all yaxis objects
+        that satisfy the specified selection criteria
+        
+        Parameters
+        ----------
+        patch: dict
+            Dictionary of property updates to be applied to all
+            yaxis objects that satisfy the selection criteria.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            yaxis objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all yaxis objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of yaxis objects to select.
+            To select yaxis objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all yaxis objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_yaxes(selector=selector, row=row, col=col):
+            obj.update(patch)
+
+        return self

--- a/plotly/graph_objs/_figurewidget.py
+++ b/plotly/graph_objs/_figurewidget.py
@@ -7,6 +7,7 @@ from plotly.graph_objs import (
     Scattergl, Scattermapbox, Scatterpolar, Scatterpolargl, Scatterternary,
     Splom, Streamtube, Sunburst, Surface, Table, Violin, Volume, Waterfall
 )
+from plotly.subplots import _validate_v4_subplots
 
 
 class FigureWidget(BaseFigureWidget):
@@ -12300,3 +12301,675 @@ class FigureWidget(BaseFigureWidget):
             **kwargs
         )
         return self.add_trace(new_trace, row=row, col=col)
+
+    def select_geos(self, selector=None, row=None, col=None):
+        """
+        Select geo subplot objects from a particular subplot cell
+        and/or geo subplot objects that satisfy custom selection
+        criteria.
+
+        Parameters
+        ----------
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            geo objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all geo objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of geo objects to select.
+            To select geo objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all geo objects are selected.
+
+        Returns
+        -------
+        generator
+            Generator that iterates through all of the geo
+            objects that satisfy all of the specified selection criteria
+        """
+        if row is not None or col is not None:
+            _validate_v4_subplots('select_geos')
+
+        return self._select_layout_subplots_by_prefix(
+            'geo', selector, row, col
+        )
+
+    def for_each_geo(self, fn, selector=None, row=None, col=None):
+        """
+        Apply a function to all geo objects that satisfy the
+        specified selection criteria
+        
+        Parameters
+        ----------
+        fn:
+            Function that inputs a single geo object.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            geo objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all geo objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of geo objects to select.
+            To select geo objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all geo objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_geos(selector=selector, row=row, col=col):
+            fn(obj)
+
+        return self
+
+    def update_geos(self, patch, selector=None, row=None, col=None):
+        """
+        Perform a property update operation on all geo objects
+        that satisfy the specified selection criteria
+        
+        Parameters
+        ----------
+        patch: dict
+            Dictionary of property updates to be applied to all
+            geo objects that satisfy the selection criteria.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            geo objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all geo objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of geo objects to select.
+            To select geo objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all geo objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_geos(selector=selector, row=row, col=col):
+            obj.update(patch)
+
+        return self
+
+    def select_mapboxes(self, selector=None, row=None, col=None):
+        """
+        Select mapbox subplot objects from a particular subplot cell
+        and/or mapbox subplot objects that satisfy custom selection
+        criteria.
+
+        Parameters
+        ----------
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            mapbox objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all mapbox objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of mapbox objects to select.
+            To select mapbox objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all mapbox objects are selected.
+
+        Returns
+        -------
+        generator
+            Generator that iterates through all of the mapbox
+            objects that satisfy all of the specified selection criteria
+        """
+        if row is not None or col is not None:
+            _validate_v4_subplots('select_mapboxes')
+
+        return self._select_layout_subplots_by_prefix(
+            'mapbox', selector, row, col
+        )
+
+    def for_each_mapbox(self, fn, selector=None, row=None, col=None):
+        """
+        Apply a function to all mapbox objects that satisfy the
+        specified selection criteria
+        
+        Parameters
+        ----------
+        fn:
+            Function that inputs a single mapbox object.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            mapbox objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all mapbox objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of mapbox objects to select.
+            To select mapbox objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all mapbox objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_mapboxes(selector=selector, row=row, col=col):
+            fn(obj)
+
+        return self
+
+    def update_mapboxes(self, patch, selector=None, row=None, col=None):
+        """
+        Perform a property update operation on all mapbox objects
+        that satisfy the specified selection criteria
+        
+        Parameters
+        ----------
+        patch: dict
+            Dictionary of property updates to be applied to all
+            mapbox objects that satisfy the selection criteria.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            mapbox objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all mapbox objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of mapbox objects to select.
+            To select mapbox objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all mapbox objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_mapboxes(selector=selector, row=row, col=col):
+            obj.update(patch)
+
+        return self
+
+    def select_polars(self, selector=None, row=None, col=None):
+        """
+        Select polar subplot objects from a particular subplot cell
+        and/or polar subplot objects that satisfy custom selection
+        criteria.
+
+        Parameters
+        ----------
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            polar objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all polar objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of polar objects to select.
+            To select polar objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all polar objects are selected.
+
+        Returns
+        -------
+        generator
+            Generator that iterates through all of the polar
+            objects that satisfy all of the specified selection criteria
+        """
+        if row is not None or col is not None:
+            _validate_v4_subplots('select_polars')
+
+        return self._select_layout_subplots_by_prefix(
+            'polar', selector, row, col
+        )
+
+    def for_each_polar(self, fn, selector=None, row=None, col=None):
+        """
+        Apply a function to all polar objects that satisfy the
+        specified selection criteria
+        
+        Parameters
+        ----------
+        fn:
+            Function that inputs a single polar object.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            polar objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all polar objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of polar objects to select.
+            To select polar objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all polar objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_polars(selector=selector, row=row, col=col):
+            fn(obj)
+
+        return self
+
+    def update_polars(self, patch, selector=None, row=None, col=None):
+        """
+        Perform a property update operation on all polar objects
+        that satisfy the specified selection criteria
+        
+        Parameters
+        ----------
+        patch: dict
+            Dictionary of property updates to be applied to all
+            polar objects that satisfy the selection criteria.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            polar objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all polar objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of polar objects to select.
+            To select polar objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all polar objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_polars(selector=selector, row=row, col=col):
+            obj.update(patch)
+
+        return self
+
+    def select_scenes(self, selector=None, row=None, col=None):
+        """
+        Select scene subplot objects from a particular subplot cell
+        and/or scene subplot objects that satisfy custom selection
+        criteria.
+
+        Parameters
+        ----------
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            scene objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all scene objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of scene objects to select.
+            To select scene objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all scene objects are selected.
+
+        Returns
+        -------
+        generator
+            Generator that iterates through all of the scene
+            objects that satisfy all of the specified selection criteria
+        """
+        if row is not None or col is not None:
+            _validate_v4_subplots('select_scenes')
+
+        return self._select_layout_subplots_by_prefix(
+            'scene', selector, row, col
+        )
+
+    def for_each_scene(self, fn, selector=None, row=None, col=None):
+        """
+        Apply a function to all scene objects that satisfy the
+        specified selection criteria
+        
+        Parameters
+        ----------
+        fn:
+            Function that inputs a single scene object.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            scene objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all scene objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of scene objects to select.
+            To select scene objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all scene objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_scenes(selector=selector, row=row, col=col):
+            fn(obj)
+
+        return self
+
+    def update_scenes(self, patch, selector=None, row=None, col=None):
+        """
+        Perform a property update operation on all scene objects
+        that satisfy the specified selection criteria
+        
+        Parameters
+        ----------
+        patch: dict
+            Dictionary of property updates to be applied to all
+            scene objects that satisfy the selection criteria.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            scene objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all scene objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of scene objects to select.
+            To select scene objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all scene objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_scenes(selector=selector, row=row, col=col):
+            obj.update(patch)
+
+        return self
+
+    def select_ternaries(self, selector=None, row=None, col=None):
+        """
+        Select ternary subplot objects from a particular subplot cell
+        and/or ternary subplot objects that satisfy custom selection
+        criteria.
+
+        Parameters
+        ----------
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            ternary objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all ternary objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of ternary objects to select.
+            To select ternary objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all ternary objects are selected.
+
+        Returns
+        -------
+        generator
+            Generator that iterates through all of the ternary
+            objects that satisfy all of the specified selection criteria
+        """
+        if row is not None or col is not None:
+            _validate_v4_subplots('select_ternaries')
+
+        return self._select_layout_subplots_by_prefix(
+            'ternary', selector, row, col
+        )
+
+    def for_each_ternary(self, fn, selector=None, row=None, col=None):
+        """
+        Apply a function to all ternary objects that satisfy the
+        specified selection criteria
+        
+        Parameters
+        ----------
+        fn:
+            Function that inputs a single ternary object.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            ternary objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all ternary objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of ternary objects to select.
+            To select ternary objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all ternary objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_ternaries(selector=selector, row=row, col=col):
+            fn(obj)
+
+        return self
+
+    def update_ternaries(self, patch, selector=None, row=None, col=None):
+        """
+        Perform a property update operation on all ternary objects
+        that satisfy the specified selection criteria
+        
+        Parameters
+        ----------
+        patch: dict
+            Dictionary of property updates to be applied to all
+            ternary objects that satisfy the selection criteria.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            ternary objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all ternary objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of ternary objects to select.
+            To select ternary objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all ternary objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_ternaries(selector=selector, row=row, col=col):
+            obj.update(patch)
+
+        return self
+
+    def select_xaxes(self, selector=None, row=None, col=None):
+        """
+        Select xaxis subplot objects from a particular subplot cell
+        and/or xaxis subplot objects that satisfy custom selection
+        criteria.
+
+        Parameters
+        ----------
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            xaxis objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all xaxis objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of xaxis objects to select.
+            To select xaxis objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all xaxis objects are selected.
+
+        Returns
+        -------
+        generator
+            Generator that iterates through all of the xaxis
+            objects that satisfy all of the specified selection criteria
+        """
+        if row is not None or col is not None:
+            _validate_v4_subplots('select_xaxes')
+
+        return self._select_layout_subplots_by_prefix(
+            'xaxis', selector, row, col
+        )
+
+    def for_each_xaxis(self, fn, selector=None, row=None, col=None):
+        """
+        Apply a function to all xaxis objects that satisfy the
+        specified selection criteria
+        
+        Parameters
+        ----------
+        fn:
+            Function that inputs a single xaxis object.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            xaxis objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all xaxis objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of xaxis objects to select.
+            To select xaxis objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all xaxis objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_xaxes(selector=selector, row=row, col=col):
+            fn(obj)
+
+        return self
+
+    def update_xaxes(self, patch, selector=None, row=None, col=None):
+        """
+        Perform a property update operation on all xaxis objects
+        that satisfy the specified selection criteria
+        
+        Parameters
+        ----------
+        patch: dict
+            Dictionary of property updates to be applied to all
+            xaxis objects that satisfy the selection criteria.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            xaxis objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all xaxis objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of xaxis objects to select.
+            To select xaxis objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all xaxis objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_xaxes(selector=selector, row=row, col=col):
+            obj.update(patch)
+
+        return self
+
+    def select_yaxes(self, selector=None, row=None, col=None):
+        """
+        Select yaxis subplot objects from a particular subplot cell
+        and/or yaxis subplot objects that satisfy custom selection
+        criteria.
+
+        Parameters
+        ----------
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            yaxis objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all yaxis objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of yaxis objects to select.
+            To select yaxis objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all yaxis objects are selected.
+
+        Returns
+        -------
+        generator
+            Generator that iterates through all of the yaxis
+            objects that satisfy all of the specified selection criteria
+        """
+        if row is not None or col is not None:
+            _validate_v4_subplots('select_yaxes')
+
+        return self._select_layout_subplots_by_prefix(
+            'yaxis', selector, row, col
+        )
+
+    def for_each_yaxis(self, fn, selector=None, row=None, col=None):
+        """
+        Apply a function to all yaxis objects that satisfy the
+        specified selection criteria
+        
+        Parameters
+        ----------
+        fn:
+            Function that inputs a single yaxis object.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            yaxis objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all yaxis objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of yaxis objects to select.
+            To select yaxis objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all yaxis objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_yaxes(selector=selector, row=row, col=col):
+            fn(obj)
+
+        return self
+
+    def update_yaxes(self, patch, selector=None, row=None, col=None):
+        """
+        Perform a property update operation on all yaxis objects
+        that satisfy the specified selection criteria
+        
+        Parameters
+        ----------
+        patch: dict
+            Dictionary of property updates to be applied to all
+            yaxis objects that satisfy the selection criteria.
+        selector: dict or None (default None)
+            Dict to use as selection criteria.
+            yaxis objects will be selected if they contain
+            properties corresponding to all of the dictionary's keys, with
+            values that exactly match the supplied values. If None
+            (the default), all yaxis objects are selected.
+        row, col: int or None (default None)
+            Subplot row and column index of yaxis objects to select.
+            To select yaxis objects by row and column, the Figure
+            must have been created using plotly.subplots.make_subplots.
+            If None (the default), all yaxis objects are selected.
+        
+        Returns
+        -------
+        self
+            Returns the Figure object that the method was called on
+        """
+        for obj in self.select_yaxes(selector=selector, row=row, col=col):
+            obj.update(patch)
+
+        return self

--- a/plotly/subplots.py
+++ b/plotly/subplots.py
@@ -904,7 +904,7 @@ def _init_subplot_single(
         'trace_kwargs': {trace_key: label}}
 
     # increment max_subplot_id
-    max_subplot_ids['scene'] = cnt
+    max_subplot_ids[subplot_type] = cnt
 
     return ref_element
 

--- a/plotly/tests/test_core/test_graph_objs/test_frames.py
+++ b/plotly/tests/test_core/test_graph_objs/test_frames.py
@@ -4,6 +4,8 @@ from unittest import TestCase
 
 from plotly.graph_objs import Bar, Frames, Frame, Layout
 
+from nose.plugins.attrib import attr
+
 import re
 
 
@@ -44,6 +46,7 @@ class FramesTest(TestCase):
         # with self.assertRaises(exceptions.PlotlyListEntryError):
         #     frames.append(0)
 
+    @attr('nodev')
     def test_deeply_nested_layout_attributes(self):
         frames = Frame
         frames.layout = [Layout()]
@@ -58,6 +61,7 @@ class FramesTest(TestCase):
             {'color', 'family', 'size'}
         )
 
+    @attr('nodev')
     def test_deeply_nested_data_attributes(self):
         frames = Frame
         frames.data = [Bar()]

--- a/plotly/tests/test_core/test_update_objects/test_update_subplots.py
+++ b/plotly/tests/test_core/test_update_objects/test_update_subplots.py
@@ -1,0 +1,472 @@
+from __future__ import absolute_import
+
+import copy
+from unittest import TestCase
+
+import plotly.graph_objs as go
+from plotly.graph_objs import Figure
+from plotly.subplots import make_subplots
+from _plotly_future_ import _future_flags
+
+
+class TestSelectForEachUpdateSubplots(TestCase):
+
+    def setUp(self):
+        _future_flags.add('v4_subplots')
+
+        fig = make_subplots(
+            rows=3,
+            cols=3,
+            specs=[[{}, {'type': 'scene'}, {}],
+                   [{}, {'type': 'polar'}, {'type': 'polar'}],
+                   [{'type': 'xy', 'colspan': 2}, None, {'type': 'ternary'}]]
+        ).update(layout={'height': 800})
+
+        fig.layout.xaxis.title.text = 'A'
+        fig.layout.xaxis2.title.text = 'A'
+        fig.layout.xaxis3.title.text = 'B'
+        fig.layout.xaxis4.title.text = 'B'
+
+        fig.layout.yaxis.title.text = 'A'
+        fig.layout.yaxis2.title.text = 'B'
+        fig.layout.yaxis3.title.text = 'A'
+        fig.layout.yaxis4.title.text = 'B'
+
+        fig.layout.polar.angularaxis.rotation = 45
+        fig.layout.polar2.angularaxis.rotation = 45
+        fig.layout.polar.radialaxis.title.text = 'A'
+        fig.layout.polar2.radialaxis.title.text = 'B'
+
+        fig.layout.scene.xaxis.title.text = 'A'
+        fig.layout.scene.yaxis.title.text = 'B'
+
+        fig.layout.ternary.aaxis.title.text = 'A'
+
+        self.fig = fig
+        self.fig_no_grid = go.Figure(self.fig.to_dict())
+
+    def tearDown(self):
+        _future_flags.remove('v4_subplots')
+
+    def assert_select_subplots(
+            self, subplot_type, subplots_name, expected_nums,
+            selector=None, row=None, col=None, test_no_grid=False):
+
+        select_fn = getattr(Figure, 'select_' + subplots_name)
+        for_each_fn = getattr(Figure, 'for_each_' + subplot_type)
+
+        def check_select(fig):
+            # Check select_*
+            subplots = list(
+                select_fn(fig, selector=selector, row=row, col=col))
+            expected_keys = [
+                subplot_type + (str(cnt) if cnt > 1 else '')
+                for cnt in expected_nums
+            ]
+
+            self.assertEqual(len(subplots), len(expected_keys))
+            self.assertTrue(all(
+                v1 is fig.layout[k]
+                for v1, k in zip(subplots, expected_keys)))
+
+            # Check for_each_*
+            subplots = []
+            res = for_each_fn(
+                fig, lambda obj: subplots.append(obj),
+                selector=selector, row=row, col=col
+            )
+
+            self.assertIs(res, fig)
+
+            self.assertEqual(len(subplots), len(expected_keys))
+            self.assertTrue(all(
+                v1 is fig.layout[k]
+                for v1, k in zip(subplots, expected_keys)))
+
+        check_select(self.fig)
+        if test_no_grid:
+            check_select(self.fig_no_grid)
+
+    def test_select_by_type(self):
+        self.assert_select_subplots(
+            'xaxis', 'xaxes', [1, 2, 3, 4], test_no_grid=True)
+
+        self.assert_select_subplots(
+            'yaxis', 'yaxes', [1, 2, 3, 4], test_no_grid=True)
+
+        self.assert_select_subplots(
+            'scene', 'scenes', [1], test_no_grid=True)
+
+        self.assert_select_subplots(
+            'polar', 'polars', [1, 2], test_no_grid=True)
+
+        self.assert_select_subplots(
+            'ternary', 'ternaries', [1], test_no_grid=True)
+
+        # No 'geo' or 'mapbox' subplots initialized, but the first subplot
+        # object is always present
+        self.assert_select_subplots(
+            'geo', 'geos', [1], test_no_grid=True)
+
+        self.assert_select_subplots(
+            'mapbox', 'mapboxes', [1], test_no_grid=True)
+
+    def test_select_by_type_and_grid(self):
+        self.assert_select_subplots(
+            'xaxis', 'xaxes', [1, 2], row=1)
+
+        self.assert_select_subplots(
+            'xaxis', 'xaxes', [1, 3, 4], col=1)
+
+        self.assert_select_subplots(
+            'xaxis', 'xaxes', [2], col=3)
+
+        self.assert_select_subplots(
+            'xaxis', 'xaxes', [4], row=3, col=1)
+
+        self.assert_select_subplots(
+            'xaxis', 'xaxes', [], row=2, col=2)
+
+    def test_select_by_type_and_selector(self):
+        # xaxis
+        self.assert_select_subplots(
+            'xaxis', 'xaxes', [1, 2],
+            selector={'title.text': 'A'}, test_no_grid=True)
+
+        self.assert_select_subplots(
+            'xaxis', 'xaxes', [3, 4],
+            selector={'title.text': 'B'}, test_no_grid=True)
+
+        self.assert_select_subplots(
+            'xaxis', 'xaxes', [],
+            selector={'title.text': 'C'}, test_no_grid=True)
+
+        # yaxis
+        self.assert_select_subplots(
+            'yaxis', 'yaxes', [1, 3],
+            selector={'title.text': 'A'}, test_no_grid=True)
+
+        self.assert_select_subplots(
+            'yaxis', 'yaxes', [2, 4],
+            selector={'title.text': 'B'}, test_no_grid=True)
+
+        self.assert_select_subplots(
+            'yaxis', 'yaxes', [],
+            selector={'title.text': 'C'}, test_no_grid=True)
+
+        # scene
+        self.assert_select_subplots(
+            'scene', 'scenes', [1],
+            selector={'xaxis.title.text': 'A'}, test_no_grid=True)
+
+        self.assert_select_subplots(
+            'scene', 'scenes', [1],
+            selector={'xaxis.title.text': 'A',
+                      'yaxis.title.text': 'B'},
+            test_no_grid=True)
+
+        self.assert_select_subplots(
+            'scene', 'scenes', [],
+            selector={'xaxis.title.text': 'A',
+                      'yaxis.title.text': 'C'},
+            test_no_grid=True)
+
+        # polar
+        self.assert_select_subplots(
+            'polar', 'polars', [1, 2],
+            selector={'angularaxis.rotation': 45},
+            test_no_grid=True)
+
+        self.assert_select_subplots(
+            'polar', 'polars', [2],
+            selector={'angularaxis.rotation': 45,
+                      'radialaxis_title_text': 'B'},
+            test_no_grid=True)
+
+        self.assert_select_subplots(
+            'polar', 'polars', [],
+            selector={'angularaxis.rotation': 45,
+                      'radialaxis_title_text': 'C'},
+            test_no_grid=True)
+
+        # ternary
+        self.assert_select_subplots(
+            'ternary', 'ternaries', [1],
+            selector={'aaxis.title.text': 'A'},
+            test_no_grid=True)
+
+        self.assert_select_subplots(
+            'ternary', 'ternaries', [],
+            selector={'aaxis.title.text': 'C'},
+            test_no_grid=True)
+
+        self.assert_select_subplots(
+            'ternary', 'ternaries', [],
+            selector={'aaxis.bogus.text': 'A'},
+            test_no_grid=True)
+
+        # No 'geo' or 'mapbox' subplots initialized, but the first subplot
+        # object is always present
+        self.assert_select_subplots(
+            'geo', 'geos', [],
+            selector={'bgcolor': 'blue'},
+            test_no_grid=True)
+
+        self.assert_select_subplots(
+            'geo', 'geos', [],
+            selector={'bogus': 'blue'},
+            test_no_grid=True)
+
+        self.assert_select_subplots(
+            'mapbox', 'mapboxes', [],
+            selector={'pitch': 45},
+            test_no_grid=True)
+
+    def test_select_by_type_and_grid_and_selector(self):
+        # xaxis
+        self.assert_select_subplots(
+            'xaxis', 'xaxes', [1, 2],
+            row=1,
+            selector={'title.text': 'A'})
+
+        self.assert_select_subplots(
+            'xaxis', 'xaxes', [1],
+            col=1,
+            selector={'title.text': 'A'})
+
+        self.assert_select_subplots(
+            'xaxis', 'xaxes', [],
+            col=2,
+            selector={'title.text': 'A'})
+
+        self.assert_select_subplots(
+            'xaxis', 'xaxes', [3, 4],
+            col=1,
+            selector={'title.text': 'B'})
+
+        self.assert_select_subplots(
+            'xaxis', 'xaxes', [3],
+            row=2,
+            selector={'title.text': 'B'})
+
+        self.assert_select_subplots(
+            'xaxis', 'xaxes', [4],
+            row=3, col=1,
+            selector={'title.text': 'B'})
+
+        # yaxis
+        self.assert_select_subplots(
+            'yaxis', 'yaxes', [1, 3],
+            col=1,
+            selector={'title.text': 'A'})
+
+        self.assert_select_subplots(
+            'yaxis', 'yaxes', [4],
+            col=1,
+            selector={'title.text': 'B'})
+
+        # polar
+        self.assert_select_subplots(
+            'polar', 'polars', [1, 2],
+            row=2,
+            selector={'angularaxis.rotation': 45})
+
+        self.assert_select_subplots(
+            'polar', 'polars', [1],
+            col=2,
+            selector={'angularaxis.rotation': 45})
+
+        self.assert_select_subplots(
+            'polar', 'polars', [2],
+            row=2, col=3,
+            selector={'angularaxis.rotation': 45})
+
+        self.assert_select_subplots(
+            'polar', 'polars', [],
+            row=2, col=3,
+            selector={'angularaxis.rotation': 0})
+
+    def assert_update_subplots(
+            self, subplot_type, subplots_name, expected_nums, patch,
+            selector=None, row=None, col=None, test_no_grid=False):
+
+        update_fn = getattr(Figure, 'update_' + subplots_name)
+
+        def check_update(fig):
+
+            # Copy input figure so that we don't modify it
+            fig_orig = fig
+            fig = copy.deepcopy(fig)
+
+            # perform update_*
+            update_res = update_fn(
+                fig, patch, selector=selector, row=row, col=col)
+            self.assertIs(update_res, fig)
+
+            # Build expected layout keys
+            expected_keys = [
+                subplot_type + (str(cnt) if cnt > 1 else '')
+                for cnt in expected_nums
+            ]
+
+            # Iterate over all layout keys
+            for k in fig.layout:
+                orig_obj = copy.deepcopy(fig_orig.layout[k])
+                new_obj = fig.layout[k]
+                if k in expected_keys:
+                    # Make sure sure there is an initial difference
+                    self.assertNotEqual(orig_obj, new_obj)
+                    orig_obj.update(patch)
+
+                self.assertEqual(new_obj, orig_obj)
+
+        check_update(self.fig)
+        if test_no_grid:
+            check_update(self.fig_no_grid)
+
+    def test_update_by_type(self):
+        self.assert_update_subplots(
+            'xaxis', 'xaxes', [1, 2, 3, 4],
+            {'title.font.family': 'Rockwell'},
+            test_no_grid=True)
+
+        self.assert_update_subplots(
+            'yaxis', 'yaxes', [1, 2, 3, 4],
+            {'range': [5, 10]},
+            test_no_grid=True)
+
+        self.assert_update_subplots(
+            'scene', 'scenes', [1],
+            {'zaxis.title.text': 'Z-AXIS'},
+            test_no_grid=True)
+
+        self.assert_update_subplots(
+            'polar', 'polars', [1, 2],
+            {'angularaxis.rotation': 15},
+            test_no_grid=True)
+
+        self.assert_update_subplots(
+            'ternary', 'ternaries', [1],
+            {'aaxis.title.font.family': 'Rockwell'},
+            test_no_grid=True)
+
+        # No 'geo' or 'mapbox' subplots initialized, but the first subplot
+        # object is always present
+        self.assert_update_subplots(
+            'geo', 'geos', [1],
+            {'bgcolor': 'purple'},
+            test_no_grid=True)
+
+        self.assert_update_subplots(
+            'mapbox', 'mapboxes', [1],
+            {'pitch': 99},
+            test_no_grid=True)
+
+    def test_update_by_type_and_grid(self):
+        self.assert_update_subplots(
+            'xaxis', 'xaxes', [1, 3, 4],
+            {'title.font.family': 'Rockwell'},
+            col=1)
+
+        self.assert_update_subplots(
+            'xaxis', 'xaxes', [1, 2],
+            {'title.font.family': 'Rockwell'},
+            row=1)
+
+        self.assert_update_subplots(
+            'xaxis', 'xaxes', [1],
+            {'title.font.family': 'Rockwell'},
+            row=1,
+            col=1)
+
+        self.assert_update_subplots(
+            'polar', 'polars', [1, 2],
+            {'angularaxis.rotation': 15},
+            row=2)
+
+        self.assert_update_subplots(
+            'polar', 'polars', [1],
+            {'angularaxis.rotation': 15},
+            col=2)
+
+        self.assert_update_subplots(
+            'polar', 'polars', [2],
+            {'angularaxis.rotation': 15},
+            row=2,
+            col=3)
+
+    def test_update_by_type_and_grid_and_selector(self):
+        # xaxis
+        self.assert_update_subplots(
+            'xaxis', 'xaxes', [1, 2],
+            {'title.font.family': 'Rockwell'},
+            row=1,
+            selector={'title.text': 'A'})
+
+        self.assert_update_subplots(
+            'xaxis', 'xaxes', [1],
+            {'title.font.family': 'Rockwell'},
+            col=1,
+            selector={'title.text': 'A'})
+
+        self.assert_update_subplots(
+            'xaxis', 'xaxes', [],
+            {'title.font.family': 'Rockwell'},
+            col=2,
+            selector={'title.text': 'A'})
+
+        self.assert_update_subplots(
+            'xaxis', 'xaxes', [3, 4],
+            {'title.font.family': 'Rockwell'},
+            col=1,
+            selector={'title.text': 'B'})
+
+        self.assert_update_subplots(
+            'xaxis', 'xaxes', [3],
+            {'title.font.family': 'Rockwell'},
+            row=2,
+            selector={'title.text': 'B'})
+
+        self.assert_update_subplots(
+            'xaxis', 'xaxes', [4],
+            {'title.font.family': 'Rockwell'},
+            row=3, col=1,
+            selector={'title.text': 'B'})
+
+        # yaxis
+        self.assert_update_subplots(
+            'yaxis', 'yaxes', [1, 3],
+            {'title.font.family': 'Rockwell'},
+            col=1,
+            selector={'title.text': 'A'})
+
+        self.assert_update_subplots(
+            'yaxis', 'yaxes', [4],
+            {'title.font.family': 'Rockwell'},
+            col=1,
+            selector={'title.text': 'B'})
+
+        # polar
+        self.assert_update_subplots(
+            'polar', 'polars', [1, 2],
+            {'radialaxis.title.font.family': 'Rockwell'},
+            row=2,
+            selector={'angularaxis.rotation': 45})
+
+        self.assert_update_subplots(
+            'polar', 'polars', [1],
+            {'radialaxis.title.font.family': 'Rockwell'},
+            col=2,
+            selector={'angularaxis.rotation': 45})
+
+        self.assert_update_subplots(
+            'polar', 'polars', [2],
+            {'radialaxis.title.font.family': 'Rockwell'},
+            row=2, col=3,
+            selector={'angularaxis.rotation': 45})
+
+        self.assert_update_subplots(
+            'polar', 'polars', [],
+            {'radialaxis.title.font.family': 'Rockwell'},
+            row=2, col=3,
+            selector={'angularaxis.rotation': 0})

--- a/plotly/tests/test_core/test_update_objects/test_update_traces.py
+++ b/plotly/tests/test_core/test_update_objects/test_update_traces.py
@@ -158,11 +158,21 @@ class TestSelectForEachUpdateTraces(TestCase):
             [], selector={'type': 'pie'}, test_no_grid=True)
 
     def test_select_by_grid(self):
+        # Row and column
         self.assert_select_traces([0, 1], row=1, col=1)
         self.assert_select_traces([2, 3], row=2, col=1)
         self.assert_select_traces([4, 5], row=1, col=2)
         self.assert_select_traces([6, 7], row=2, col=2)
         self.assert_select_traces([8], row=3, col=1)
+
+        # Row only
+        self.assert_select_traces([0, 1, 4, 5], row=1)
+        self.assert_select_traces([2, 3, 6, 7], row=2)
+        self.assert_select_traces([8], row=3)
+
+        # Col only
+        self.assert_select_traces([0, 1, 2, 3, 8], col=1)
+        self.assert_select_traces([4, 5, 6, 7], col=2)
 
     def test_select_by_property_across_trace_types(self):
         self.assert_select_traces(
@@ -321,4 +331,26 @@ class TestSelectForEachUpdateTraces(TestCase):
         self.assert_update_traces(
             {'hoverinfo': 'label+percent'},
             [], selector={'type': 'pie'}
+        )
+
+    def test_update_traces_by_grid_and_selector(self):
+        self.assert_update_traces(
+            {'marker.size': 5},
+            [4, 6],
+            selector={'marker.color': 'green'},
+            col=2
+        )
+
+        self.assert_update_traces(
+            {'marker.size': 6},
+            [0, 4],
+            selector={'marker.color': 'green'},
+            row=1
+        )
+
+        self.assert_update_traces(
+            {'marker.size': 6},
+            [6],
+            selector={'marker.color': 'green'},
+            row=2, col=2
         )


### PR DESCRIPTION
## Overview
This PR is part two of https://github.com/plotly/plotly.py/issues/1484 and a follow-on to https://github.com/plotly/plotly.py/pull/1534.

This adds `select_*`, `for_each_*`, and `update_*` methods to the figure class for each subplot container type.  These methods work exactly like the trace counterparts from https://github.com/plotly/plotly.py/pull/1534.

These will be especially useful when used with `plotly_express`.  Note that the `row`/`col` filtering will not work with `plotly_express` until it is updated to use the new v4 subplot logic (https://github.com/plotly/plotly.py/pull/1528) for faceting.  But the `selector` based filtering should work now.

## Examples
Here are some examples:

Set the `tickprefix` of all xaxis objects to '$';
```
fig.update_xaxes({'tickprefix': '$'})
```
Or only those in the first column
```
fig.update_xaxes({'tickprefix': '$'}, col=1)
```

In addition to row/col filters. updates can also be filtered on selectors as described in https://github.com/plotly/plotly.py/pull/1534.

So if, for some reason, you needed to update only the y axis objects that were configured in log scale to show length 5 ticks:
```
fig.update_yaxes({'ticks': 'outside', 'ticklen': 5}, selector={'type': 'log'})
```

## Other notes
With this PR, we now rely on code generation to determine the set of subplot types.  So when new ones show up, like coloraxis, these should now be handled automatically.

cc @nicolaskruchten 
