### PR TITLE
Fix get_config_plotly_server_url on .config load error

### DIFF
--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -1280,10 +1280,10 @@ def get_config_plotly_server_url():
         try:
             config_dict = json.load(f)
             if not isinstance(config_dict, dict):
-                data = {}
+                config_dict = {}
         except:
             # TODO: issue a warning and bubble it up
-            data = {}
+            config_dict = {}
 
     return config_dict.get('plotly_domain', default_server_url)
 


### PR DESCRIPTION
Closes https://github.com/plotly/plotly.py/issues/1550

If .config was not found or not loaded properly, it should be treated as empty, but it was resulting in an `UnboundLocalError`.

