### PR TITLE
Replace requests.compat.json with real json

### DIFF
--- a/chart_studio/api/v1/clientresp.py
+++ b/chart_studio/api/v1/clientresp.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import warnings
 
-from requests.compat import json as _json
+import json as _json
 
 
 from _plotly_utils.utils import PlotlyJSONEncoder

--- a/chart_studio/api/v2/utils.py
+++ b/chart_studio/api/v2/utils.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import requests
-from requests.compat import json as _json
+import json as _json
 from requests.exceptions import RequestException
 from retrying import retry
 

--- a/chart_studio/grid_objs/grid_objs.py
+++ b/chart_studio/grid_objs/grid_objs.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     from collections import MutableSequence
 
-from requests.compat import json as _json
+import json as _json
 
 from _plotly_utils.optional_imports import get_module
 from chart_studio import utils, exceptions

--- a/chart_studio/plotly/plotly.py
+++ b/chart_studio/plotly/plotly.py
@@ -26,7 +26,7 @@ import webbrowser
 
 import six
 import six.moves
-from requests.compat import json as _json
+import json as _json
 
 import _plotly_utils.utils
 import _plotly_utils.exceptions

--- a/chart_studio/tests/test_plot_ly/test_api/test_v1/test_utils.py
+++ b/chart_studio/tests/test_plot_ly/test_api/test_v1/test_utils.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from requests import Response
-from requests.compat import json as _json
+import json as _json
 from requests.exceptions import ConnectionError
 
 from chart_studio.api.utils import to_native_utf8_string

--- a/chart_studio/tests/test_plot_ly/test_api/test_v2/test_grids.py
+++ b/chart_studio/tests/test_plot_ly/test_api/test_v2/test_grids.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from requests.compat import json as _json
+import json as _json
 
 from chart_studio.api.v2 import grids
 from chart_studio.tests.test_plot_ly.test_api import PlotlyApiTestCase

--- a/chart_studio/tests/test_plot_ly/test_api/test_v2/test_images.py
+++ b/chart_studio/tests/test_plot_ly/test_api/test_v2/test_images.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from requests.compat import json as _json
+import json as _json
 
 from chart_studio.api.v2 import images
 from chart_studio.tests.test_plot_ly.test_api import PlotlyApiTestCase

--- a/chart_studio/tests/test_plot_ly/test_api/test_v2/test_utils.py
+++ b/chart_studio/tests/test_plot_ly/test_api/test_v2/test_utils.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from requests.compat import json as _json
+import json as _json
 from requests.exceptions import ConnectionError
 
 from plotly import version

--- a/chart_studio/tests/test_plot_ly/test_get_requests/test_get_requests.py
+++ b/chart_studio/tests/test_plot_ly/test_get_requests/test_get_requests.py
@@ -10,7 +10,7 @@ import copy
 import requests
 import six
 from nose.plugins.attrib import attr
-from requests.compat import json as _json
+import json as _json
 
 from chart_studio.tests.utils import PlotlyTestCase
 

--- a/chart_studio/tests/test_plot_ly/test_plotly/test_plot.py
+++ b/chart_studio/tests/test_plot_ly/test_plotly/test_plot.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 import requests
 import six
 import sys
-from requests.compat import json as _json
+import json as _json
 import warnings
 
 from nose.plugins.attrib import attr

--- a/chart_studio/utils.py
+++ b/chart_studio/utils.py
@@ -12,7 +12,7 @@ import re
 import threading
 import warnings
 
-from requests.compat import json as _json
+import json as _json
 
 from _plotly_utils.exceptions import PlotlyError
 from _plotly_utils.optional_imports import get_module

--- a/chart_studio/widgets/graph_widget.py
+++ b/chart_studio/widgets/graph_widget.py
@@ -6,7 +6,7 @@ import uuid
 from collections import deque
 import pkgutil
 
-from requests.compat import json as _json
+import json as _json
 
 # TODO: protected imports?
 import ipywidgets as widgets

--- a/plotly/graph_reference.py
+++ b/plotly/graph_reference.py
@@ -9,7 +9,7 @@ import re
 import pkgutil
 
 import six
-from requests.compat import json as _json
+import json as _json
 
 from plotly import utils
 

--- a/plotly/tests/test_core/test_graph_reference/test_graph_reference.py
+++ b/plotly/tests/test_core/test_graph_reference/test_graph_reference.py
@@ -8,7 +8,7 @@ import os
 from unittest import TestCase
 
 from nose.plugins.attrib import attr
-from requests.compat import json as _json
+import json as _json
 
 from plotly import graph_reference as gr
 from plotly.api import v2

--- a/plotly/tests/test_core/test_offline/test_offline.py
+++ b/plotly/tests/test_core/test_offline/test_offline.py
@@ -8,7 +8,7 @@ import os
 from unittest import TestCase
 
 from nose.plugins.attrib import attr
-from requests.compat import json as _json
+import json as _json
 
 import plotly
 import json

--- a/plotly/tests/test_core/test_utils/test_utils.py
+++ b/plotly/tests/test_core/test_utils/test_utils.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from inspect import getargspec
 from unittest import TestCase
 
-from requests.compat import json as _json
+import json as _json
 
 from plotly.utils import (PlotlyJSONEncoder, get_by_path, memoize,
                           node_generator)

--- a/plotly/tests/test_optional/test_offline/test_offline.py
+++ b/plotly/tests/test_optional/test_offline/test_offline.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 import re
 from nose.tools import raises
 from nose.plugins.attrib import attr
-from requests.compat import json as _json
+import json as _json
 
 from unittest import TestCase
 

--- a/plotly/tests/test_optional/test_utils/test_utils.py
+++ b/plotly/tests/test_optional/test_utils/test_utils.py
@@ -15,7 +15,7 @@ import pandas as pd
 import pytz
 from nose.plugins.attrib import attr
 from pandas.util.testing import assert_series_equal
-from requests.compat import json as _json
+import json as _json
 
 from plotly import optional_imports, utils
 from plotly.graph_objs import Scatter, Scatter3d, Figure, Data

--- a/plotly/tests/test_plot_ly/test_api/test_v1/test_utils.py
+++ b/plotly/tests/test_plot_ly/test_api/test_v1/test_utils.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from unittest import TestCase
 
 from requests import Response
-from requests.compat import json as _json
+import json as _json
 from requests.exceptions import ConnectionError
 
 from plotly.api.utils import to_native_utf8_string

--- a/plotly/tests/test_plot_ly/test_api/test_v2/test_grids.py
+++ b/plotly/tests/test_plot_ly/test_api/test_v2/test_grids.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from requests.compat import json as _json
+import json as _json
 
 from plotly.api.v2 import grids
 from plotly.tests.test_plot_ly.test_api import PlotlyApiTestCase

--- a/plotly/tests/test_plot_ly/test_api/test_v2/test_images.py
+++ b/plotly/tests/test_plot_ly/test_api/test_v2/test_images.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from requests.compat import json as _json
+import json as _json
 
 from plotly.api.v2 import images
 from plotly.tests.test_plot_ly.test_api import PlotlyApiTestCase

--- a/plotly/tests/test_plot_ly/test_api/test_v2/test_utils.py
+++ b/plotly/tests/test_plot_ly/test_api/test_v2/test_utils.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from requests.compat import json as _json
+import json as _json
 from requests.exceptions import ConnectionError
 
 from plotly import version

--- a/plotly/tests/test_plot_ly/test_get_requests/test_get_requests.py
+++ b/plotly/tests/test_plot_ly/test_get_requests/test_get_requests.py
@@ -10,7 +10,7 @@ import copy
 import requests
 import six
 from nose.plugins.attrib import attr
-from requests.compat import json as _json
+import json as _json
 
 from plotly.tests.utils import PlotlyTestCase
 

--- a/plotly/tests/test_plot_ly/test_plotly/test_plot.py
+++ b/plotly/tests/test_plot_ly/test_plotly/test_plot.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import
 import requests
 import six
 import sys
-from requests.compat import json as _json
+import json as _json
 import warnings
 
 from nose.plugins.attrib import attr


### PR DESCRIPTION
requests.compat.json may use simplejson, which is incompatible
with plotly.py usage of json.

Fixes https://github.com/plotly/plotly.py/issues/1556