### PR TITLE
A few renderers default updates

### DIFF
--- a/plotly/io/_renderers.py
+++ b/plotly/io/_renderers.py
@@ -133,7 +133,7 @@ Renderer must be a subclass of MimetypeRenderer or ExternalRenderer.
         self._default_renderers = [self[name] for name in renderer_names]
 
         # Register renderers for activation before their next use
-        self._to_activate.extend(self._default_renderers)
+        self._to_activate = list(self._default_renderers)
 
     @property
     def render_on_display(self):

--- a/plotly/io/_renderers.py
+++ b/plotly/io/_renderers.py
@@ -420,17 +420,10 @@ if 'renderer_defaults' in _future_flags:
             default_renderer = 'vscode'
 
         # Fallback to renderer combination that will work automatically
-        # in the classic notebook, jupyterlab, nteract, vscode, and
-        # nbconvert HTML export. We use 'notebook_connected' rather than
-        # 'notebook' to avoid bloating notebook size and slowing down
-        # plotly.py initial import. This comes at the cost of requiring
-        # internet connectivity to view, but that is a preferable
-        # trade-off to adding ~3MB to each saved notebook.
-        #
-        # Note that this doesn't cause any problem for offline
-        # JupyterLab users.
+        # in the classic notebook (offline), jupyterlab, nteract, vscode, and
+        # nbconvert HTML export.
         if not default_renderer:
-            default_renderer = 'notebook_connected+plotly_mimetype'
+            default_renderer = 'plotly_mimetype+notebook'
     else:
         # If ipython isn't available, try to display figures in the default
         # browser

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -272,9 +272,9 @@ def init_notebook_mode(connected=False):
         raise ImportError('`iplot` can only run inside an IPython Notebook.')
 
     if connected:
-        pio.renderers.default = 'notebook_connected+plotly_mimetype'
+        pio.renderers.default = 'plotly_mimetype+notebook_connected'
     else:
-        pio.renderers.default = 'notebook+plotly_mimetype'
+        pio.renderers.default = 'plotly_mimetype+notebook'
 
     # Trigger immediate activation of notebook. This way the plotly.js
     # library reference is available to the notebook immediately


### PR DESCRIPTION
 - init notebook* renderers at the end when set with `init_notebook_mode` to work around https://github.com/plotly/plotly_express/issues/75
 - Use `notebook` rather than `notebook_connected` in default v4 renderer defaults so it works offline by default.