### PR TITLE
Fix honouring of `validate=False` for interactive plots.

### DIFF
--- a/plotly/io/_base_renderers.py
+++ b/plotly/io/_base_renderers.py
@@ -122,7 +122,9 @@ class ImageRenderer(MimetypeRenderer):
             format=self.format,
             width=self.width,
             height=self.height,
-            scale=self.scale)
+            scale=self.scale,
+            validate=False,
+        )
 
         if self.b64_encode:
             image_str = base64.b64encode(image_bytes).decode('utf8')
@@ -354,6 +356,7 @@ if (outputEl) {{
             animation_opts=self.animation_opts,
             default_width='100%',
             default_height=525,
+            validate=False,
         )
 
         return {'text/html': html}
@@ -503,18 +506,20 @@ class IFrameRenderer(MimetypeRenderer):
         # Make directory for
         os.makedirs(dirname, exist_ok=True)
 
-        write_html(fig_dict,
-                   filename,
-                   config=self.config,
-                   auto_play=self.auto_play,
-                   include_plotlyjs='directory',
-                   include_mathjax='cdn',
-                   auto_open=False,
-                   post_script=self.post_script,
-                   animation_opts=self.animation_opts,
-                   default_width='100%',
-                   default_height=525,
-                   validate=False)
+        write_html(
+            fig_dict,
+            filename,
+            config=self.config,
+            auto_play=self.auto_play,
+            include_plotlyjs='directory',
+            include_mathjax='cdn',
+            auto_open=False,
+            post_script=self.post_script,
+            animation_opts=self.animation_opts,
+            default_width='100%',
+            default_height=525,
+            validate=False,
+        )
 
         # Build IFrame
         iframe_html = """\
@@ -629,5 +634,6 @@ class BrowserRenderer(ExternalRenderer):
             animation_opts=self.animation_opts,
             default_width='100%',
             default_height='100%',
+            validate=False,
         )
         open_html_in_browser(html, self.using, self.new, self.autoraise)


### PR DESCRIPTION
Greetings!

We have been working with Plotly recently and attempting to plot Plotly JSON blobs generated from R in Python, and (as it happens) these blobs are not conformant to the Plotly JSON schema. Passing `validate=False` to the `plotly.offline.plot` method works fine, but not for `plotly.offline.iplot`, due to validation being enabled by default for some of the rendering backends. One approach to fixing this would be to pass `validate` down to the renderers, but it appears based on `validate=False` being passed by default to some backends that this may have been an oversight in the default passed to these mimebundle renderers. This patch makes this consistent, and causes all mimebundle generations to no longer validate. Since validation would have happened earlier if not explicitly passing `validate=False`, I believe this should be okay.

