### PR TITLE
Future flag to prevent generation of UIDs for traces added to plain Figure objects

### DIFF
--- a/_plotly_future_/trace_uids.py
+++ b/_plotly_future_/trace_uids.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import
+from _plotly_future_ import _future_flags, _assert_plotly_not_imported
+
+_assert_plotly_not_imported()
+_future_flags.add('trace_uids')

--- a/_plotly_future_/v4.py
+++ b/_plotly_future_/v4.py
@@ -6,5 +6,6 @@ from _plotly_future_ import (
     remove_deprecations,
     v4_subplots,
     orca_defaults,
+    trace_uids,
 )
 

--- a/plotly/basewidget.py
+++ b/plotly/basewidget.py
@@ -113,6 +113,8 @@ class BaseFigureWidget(BaseFigure, widgets.DOMWidget):
     _last_layout_edit_id = Integer(0).tag(sync=True)
     _last_trace_edit_id = Integer(0).tag(sync=True)
 
+    _set_trace_uid = True
+
     # Constructor
     # -----------
     def __init__(self,


### PR DESCRIPTION
Closes https://github.com/plotly/plotly.py/issues/1512 (for version 4)

## Overview
This PR introduces a `'trace_uids'` future flag that, when enabled, results in trace UIDs no longer being automatically generated for traces that belong to `Figure` objects.  UIDs are still auto-generated for traces that belong to `FigureWidget` instances because these are needed in order to sync the front-end and backend widget models.