### PR TITLE
Stop auto-converting timezones to UTC and stripping timezone info

### DIFF
--- a/_plotly_future_/timezones.py
+++ b/_plotly_future_/timezones.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import
+from _plotly_future_ import _future_flags, _assert_plotly_not_imported
+
+_assert_plotly_not_imported()
+_future_flags.add('timezones')

--- a/_plotly_future_/v4.py
+++ b/_plotly_future_/v4.py
@@ -6,5 +6,6 @@ from _plotly_future_ import (
     remove_deprecations,
     v4_subplots,
     orca_defaults,
+    timezones,
 )
 

--- a/_plotly_utils/utils.py
+++ b/_plotly_utils/utils.py
@@ -3,8 +3,8 @@ import decimal
 import json as _json
 import sys
 import re
-
 import pytz
+from _plotly_future_ import _future_flags
 
 from _plotly_utils.optional_imports import get_module
 
@@ -104,7 +104,9 @@ class PlotlyJSONEncoder(_json.JSONEncoder):
             self.encode_as_sage,
             self.encode_as_numpy,
             self.encode_as_pandas,
-            self.encode_as_datetime,
+            (self.encode_as_datetime_v4
+             if 'timezones' in _future_flags
+             else self.encode_as_datetime),
             self.encode_as_date,
             self.encode_as_list,  # because some values have `tolist` do last.
             self.encode_as_decimal
@@ -168,6 +170,14 @@ class PlotlyJSONEncoder(_json.JSONEncoder):
         if obj is numpy.ma.core.masked:
             return float('nan')
         else:
+            raise NotEncodable
+
+    @staticmethod
+    def encode_as_datetime_v4(obj):
+        """Convert datetime objects to iso-format strings"""
+        try:
+            return obj.isoformat()
+        except AttributeError:
             raise NotEncodable
 
     @staticmethod


### PR DESCRIPTION
## Overview
This PR introduces a new v4 `timezones` future flag that changes the behavior of datetime serialization in plotly.py.

The current (version 3) behavior for datetimes with timezone info is for plotly.py to automatically convert datetimes to UTC and then remove the timezone info during serialization.  This has resulted in a lot of confusion over the years (See https://github.com/plotly/plotly.py/issues/209).

The new behavior is for plotly.py to stop performing the UTC conversion and leave the timezone info in the string that is passed along to plotly.js.  Plotly.js currently drops the timezone info (https://github.com/plotly/plotly.js/issues/1532) and displays everything in local time, but hopefully at some point in the future Plotly.js will process the timezone info and provide a way to specify the desired display timezone in the figure specification.

## Example
v3 behavior

```python
from _plotly_future_ import renderer_defaults
import plotly.graph_objs as go
import plotly.io as pio
import pandas as pd
import sys, datetime

x1 = pd.to_datetime(
        ['2015-04-04 12:00:00', '2015-04-04 13:00:00', '2015-04-04 15:00:00'])
x2 = x1.tz_localize('UTC').tz_convert('US/Eastern')

fig1 = go.Figure(data=[go.Scatter(x=x2, y=[1, 3, 2])])
fig1
```
![newplot-1](https://user-images.githubusercontent.com/15064365/58420409-315bf480-805b-11e9-9697-b63173d8846c.png)

```python
print(pio.to_json(fig1, pretty=True))
```
```
{
  "data": [
    {
      "type": "scatter",
      "x": [
        "2015-04-04 12:00:00",
        "2015-04-04 13:00:00",
        "2015-04-04 15:00:00"
      ],
      "y": [
        1,
        3,
        2
      ]
    }
  ],
  "layout": {}
}
```

v4 behavior
```python
from _plotly_future_ import renderer_defaults, timezones
import plotly.graph_objs as go
import plotly.io as pio
import pandas as pd
import sys, datetime

x1 = pd.to_datetime(
        ['2015-04-04 12:00:00', '2015-04-04 13:00:00', '2015-04-04 15:00:00'])
x2 = x1.tz_localize('UTC').tz_convert('US/Eastern')

fig1 = go.Figure(data=[go.Scatter(x=x2, y=[1, 3, 2])])
fig1
```
![newplot-2](https://user-images.githubusercontent.com/15064365/58420551-91529b00-805b-11e9-9a7f-95a681a9769b.png)

```python
print(pio.to_json(fig1, pretty=True))
```
```
{
  "data": [
    {
      "type": "scatter",
      "x": [
        "2015-04-04T08:00:00-04:00",
        "2015-04-04T09:00:00-04:00",
        "2015-04-04T11:00:00-04:00"
      ],
      "y": [
        1,
        3,
        2
      ]
    }
  ],
  "layout": {}
}

```

cc @nicolaskruchten @chriddyp @alexcjohnson 