### PR TITLE
Bug fix - animation_opts docstring example

### DIFF
--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -511,7 +511,7 @@ def plot(figure_or_data, show_link=False, link_text='Export to plot.ly',
                          {'data': [{'x': [1, 4], 'y': [1, 4]}]},
                          {'data': [{'x': [3, 4], 'y': [3, 4]}],
                           'layout': {'title': 'End Title'}}]}
-    iplot(figure, animation_opts={'frame': {'duration': 1}})
+    plot(figure, animation_opts={'frame': {'duration': 1}})
     ```
     """
     import plotly.io as pio

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -316,10 +316,11 @@ def iplot(figure_or_data, show_link=False, link_text='Export to plot.ly',
         `show_link` and `link_text` set the associated options in this
         dictionary if it doesn't contain them already.
     auto_play (default=True) -- Whether to automatically start the animation
-        sequence if the figure contains frames. Has no effect if the figure
-        does not contain frames.
-    animation_opts (default=None) -- dict of custom animation parameters to be
-        passed to the function Plotly.animate in Plotly.js. See
+        sequence on page load, if the figure contains frames. Has no effect if 
+        the figure does not contain frames.
+    animation_opts (default=None) -- Dict of custom animation parameters that 
+        are used for the automatically started animation on page load. This 
+        dict is passed to the function Plotly.animate in Plotly.js. See
         https://github.com/plotly/plotly.js/blob/master/src/plots/animation_attributes.js
         for available options.  Has no effect if the figure
         does not contain frames, or auto_play is False.
@@ -345,7 +346,7 @@ def iplot(figure_or_data, show_link=False, link_text='Export to plot.ly',
                          {'data': [{'x': [1, 4], 'y': [1, 4]}]},
                          {'data': [{'x': [3, 4], 'y': [3, 4]}],
                           'layout': {'title': 'End Title'}}]}
-    iplot(figure,animation_opts="{frame: {duration: 1}}")
+    iplot(figure, animation_opts={'frame': {'duration': 1}})
     ```
     """
     import plotly.io as pio
@@ -492,11 +493,12 @@ def plot(figure_or_data, show_link=False, link_text='Export to plot.ly',
     auto_play (default=True) -- Whether to automatically start the animation
         sequence on page load if the figure contains frames. Has no effect if
         the figure does not contain frames.
-    animation_opts (default=None) -- dict of custom animation parameters to be
-        passed to the function Plotly.animate in Plotly.js. See
+    animation_opts (default=None) -- Dict of custom animation parameters that 
+        are used for the automatically started animation on page load. This 
+        dict is passed to the function Plotly.animate in Plotly.js. See
         https://github.com/plotly/plotly.js/blob/master/src/plots/animation_attributes.js
-        for available options. Has no effect if the figure does not contain
-        frames, or auto_play is False.
+        for available options.  Has no effect if the figure
+        does not contain frames, or auto_play is False.
 
     Example:
     ```
@@ -509,7 +511,7 @@ def plot(figure_or_data, show_link=False, link_text='Export to plot.ly',
                          {'data': [{'x': [1, 4], 'y': [1, 4]}]},
                          {'data': [{'x': [3, 4], 'y': [3, 4]}],
                           'layout': {'title': 'End Title'}}]}
-    plot(figure,animation_opts="{frame: {duration: 1}}")
+    iplot(figure, animation_opts={'frame': {'duration': 1}})
     ```
     """
     import plotly.io as pio

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -322,7 +322,7 @@ def iplot(figure_or_data, show_link=False, link_text='Export to plot.ly',
         are used for the automatically started animation on page load. This 
         dict is passed to the function Plotly.animate in Plotly.js. See
         https://github.com/plotly/plotly.js/blob/master/src/plots/animation_attributes.js
-        for available options.  Has no effect if the figure
+        for available options. Has no effect if the figure
         does not contain frames, or auto_play is False.
 
     Example:
@@ -497,7 +497,7 @@ def plot(figure_or_data, show_link=False, link_text='Export to plot.ly',
         are used for the automatically started animation on page load. This 
         dict is passed to the function Plotly.animate in Plotly.js. See
         https://github.com/plotly/plotly.js/blob/master/src/plots/animation_attributes.js
-        for available options.  Has no effect if the figure
+        for available options. Has no effect if the figure
         does not contain frames, or auto_play is False.
 
     Example:


### PR DESCRIPTION
Bug fix: The example for the animation_opts argument in the doc strings of the plot and iplot functions doesn't work. 