### PR TITLE
county_choropleth figure factory should return a go.Figure

### DIFF
--- a/plotly/figure_factory/_county_choropleth.py
+++ b/plotly/figure_factory/_county_choropleth.py
@@ -11,6 +11,7 @@ from plotly import optional_imports
 import plotly.colors as clrs
 from plotly.figure_factory import utils
 from plotly.exceptions import PlotlyError
+import plotly.graph_objs as go
 
 pd.options.mode.chained_assignment = None
 
@@ -938,4 +939,4 @@ def create_choropleth(fips, values, scope=['usa'], binning_endpoints=None,
         fig['layout']['yaxis']['range'][0] = center[1] - new_height * 0.5
         fig['layout']['yaxis']['range'][1] = center[1] + new_height * 0.5
 
-    return fig
+    return go.Figure(fig)


### PR DESCRIPTION
Should figure factories return a `go.Figure` object? It would be nicer to be able to do `fig.show()` on the returned object.