### PR TITLE
create_choropleth figure factory returns go.Figure

### DIFF
--- a/plotly-package/plotly/figure_factory/_county_choropleth.py
+++ b/plotly-package/plotly/figure_factory/_county_choropleth.py
@@ -11,6 +11,7 @@ from plotly import optional_imports
 import plotly.colors as clrs
 from plotly.figure_factory import utils
 from plotly.exceptions import PlotlyError
+import plotly.graph_objs as go
 
 pd.options.mode.chained_assignment = None
 
@@ -950,4 +951,4 @@ $ conda install -c plotly plotly-geo
         fig['layout']['yaxis']['range'][0] = center[1] - new_height * 0.5
         fig['layout']['yaxis']['range'][1] = center[1] + new_height * 0.5
 
-    return fig
+    return go.Figure(fig)

--- a/plotly-package/plotly/tests/test_optional/test_figure_factory/test_figure_factory.py
+++ b/plotly-package/plotly/tests/test_optional/test_figure_factory/test_figure_factory.py
@@ -2817,7 +2817,7 @@ class TestChoropleth(NumpyTestUtilsMixin, TestCaseNoTemplate):
                 simplify_county=1
             )
 
-            exp_fig_head = [
+            exp_fig_head = (
                 -88.053375,
                 -88.02916499999999,
                 -88.02432999999999,
@@ -2868,7 +2868,7 @@ class TestChoropleth(NumpyTestUtilsMixin, TestCaseNoTemplate):
                 -85.142567,
                 -85.113329,
                 -85.10533699999999
-            ]
+            )
 
             self.assertEqual(fig['data'][2]['x'][:50], exp_fig_head)
 


### PR DESCRIPTION
With this PR, the `create_choropleth` returns a `go.Figure`, so that `fig.show()` is possible on the returned figure.