### PR TITLE
don't override plotlyServerURL if one is set in iplot/plot

### DIFF
--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -161,7 +161,7 @@ Unrecognized config options supplied: {bad_config}"""
 
     plotly_platform_url = plotly.tools.get_config_plotly_server_url()
 
-    if not clean_config.get('plotlyServerURL'):
+    if not clean_config.get('plotlyServerURL', None):
         clean_config['plotlyServerURL'] = plotly_platform_url
 
     if (plotly_platform_url != 'https://plot.ly' and

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -161,7 +161,8 @@ Unrecognized config options supplied: {bad_config}"""
 
     plotly_platform_url = plotly.tools.get_config_plotly_server_url()
 
-    clean_config['plotlyServerURL'] = plotly_platform_url
+    if not clean_config.get('plotlyServerURL'):
+        clean_config['plotlyServerURL'] = plotly_platform_url
 
     if (plotly_platform_url != 'https://plot.ly' and
         clean_config.get('linkText', None) == 'Export to plot.ly'):


### PR DESCRIPTION
This resolves #1609.

I tested this out locally using so that first example mentioned in the issue which didn't set the base url for the edit in chart studio button before the change does after.

```python
import plotly.offline as py
import plotly.graph_objs as go
py.init_notebook_mode()

py.iplot([go.Scatter(y=[2,3,4])], config=dict(showSendToCloud = True, plotlyServerURL='https://myserver.com'))
```