### PR TITLE
V4 Update add_trace, add_traces, and add_{trace} methods to return figure

### DIFF
--- a/packages/python/chart-studio/chart_studio/plotly/plotly.py
+++ b/packages/python/chart-studio/chart_studio/plotly/plotly.py
@@ -1793,7 +1793,7 @@ def _extract_grid_from_fig_like(fig, grid=None, path=''):
         trace_type = trace_dict.get('type', 'scatter')
         if trace_type not in reference_traces:
             reference_traces[trace_type] = reference_fig.add_trace(
-                {'type': trace_type})
+                {'type': trace_type}).data[-1]
 
         reference_trace = reference_traces[trace_type]
         _extract_grid_graph_obj(

--- a/packages/python/plotly/codegen/datatypes.py
+++ b/packages/python/plotly/codegen/datatypes.py
@@ -265,7 +265,13 @@ class {datatype_class}(_{node.name_base_datatype}):\n""")
                f'dict of properties compatible with this constructor '
                f'or an instance of {class_name}')]
 
-    add_docstring(buffer, node, header=header, prepend_extras=extras)
+    add_docstring(
+        buffer,
+        node,
+        header=header,
+        prepend_extras=extras,
+        return_type=node.name_datatype_class,
+    )
 
     buffer.write(f"""
         super({datatype_class}, self).__init__('{node.name_property}')
@@ -424,7 +430,14 @@ def add_constructor_params(buffer,
         ):""")
 
 
-def add_docstring(buffer, node, header, prepend_extras=(), append_extras=()):
+def add_docstring(
+        buffer,
+        node,
+        header,
+        prepend_extras=(),
+        append_extras=(),
+        return_type=None,
+):
     """
     Write docstring for a compound datatype node
 
@@ -443,6 +456,8 @@ def add_docstring(buffer, node, header, prepend_extras=(), append_extras=()):
     append_extras :
         List or tuple of propery name / description pairs that should be
         included at the end of the docstring
+    return_type :
+        The docstring return type
     Returns
     -------
 
@@ -511,7 +526,7 @@ def add_docstring(buffer, node, header, prepend_extras=(), append_extras=()):
 
         Returns
         -------
-        {node.name_datatype_class}
+        {return_type}
         \"\"\"""")
 
 

--- a/packages/python/plotly/codegen/figure.py
+++ b/packages/python/plotly/codegen/figure.py
@@ -151,7 +151,13 @@ class {fig_classname}({base_classname}):\n""")
 """)
             )
 
-        add_docstring(buffer, trace_node, header, append_extras=doc_extras)
+        add_docstring(
+            buffer,
+            trace_node,
+            header,
+            append_extras=doc_extras,
+            return_type=fig_classname,
+        )
 
         # #### Function body ####
         buffer.write(f"""

--- a/packages/python/plotly/codegen/figure.py
+++ b/packages/python/plotly/codegen/figure.py
@@ -110,26 +110,6 @@ class {fig_classname}({base_classname}):\n""")
             d for d in trace_node.child_datatypes
             if d.name_property == 'yaxis'
         ])
-        if include_secondary_y:
-            secondary_y_1 = ', secondary_y=None'
-            secondary_y_2 = ', secondary_y=secondary_y'
-            secondary_y_docstring = f"""
-        secondary_y: boolean or None (default None)
-            * If True, only select yaxis objects associated with the secondary
-              y-axis of the subplot.
-            * If False, only select yaxis objects associated with the primary
-              y-axis of the subplot.
-            * If None (the default), do not filter yaxis objects based on
-              a secondary y-axis condition. 
-
-            To select yaxis objects by secondary y-axis, the Figure must
-            have been created using plotly.subplots.make_subplots. See
-            the docstring for the specs argument to make_subplots for more
-            info on creating subplots with secondary y-axes."""
-        else:
-            secondary_y_1 = ''
-            secondary_y_2 = ''
-            secondary_y_docstring = ''
 
         # #### Function signature ####
         buffer.write(f"""

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -1447,12 +1447,12 @@ Invalid property path '{key_path_str}' for trace class {trace_class}
                 (scatter, bar, etc.)
         Returns
         -------
-        BaseTraceType
-            The newly added trace
+        BaseFigure
+            The Figure that add_trace was called on
 
         Examples
         --------
-        >>> from plotly import tools
+        >>> from plotly import subplots
         >>> import plotly.graph_objs as go
 
         Add two Scatter traces to a figure
@@ -1462,11 +1462,7 @@ Invalid property path '{key_path_str}' for trace class {trace_class}
 
 
         Add two Scatter traces to vertically stacked subplots
-        >>> fig = tools.make_subplots(rows=2)
-        This is the format of your plot grid:
-        [ (1,1) x1,y1 ]
-        [ (2,1) x2,y2 ]
-
+        >>> fig = subplots.make_subplots(rows=2)
         >>> fig.add_trace(go.Scatter(x=[1,2,3], y=[2,1,2]), row=1, col=1)
         >>> fig.add_trace(go.Scatter(x=[1,2,3], y=[2,1,2]), row=2, col=1)
         """
@@ -1492,7 +1488,7 @@ Invalid property path '{key_path_str}' for trace class {trace_class}
             rows=[row] if row is not None else None,
             cols=[col] if col is not None else None,
             secondary_ys=[secondary_y] if secondary_y is not None else None
-        )[0]
+        )
 
     def add_traces(self, data, rows=None, cols=None, secondary_ys=None):
         """
@@ -1528,12 +1524,12 @@ Invalid property path '{key_path_str}' for trace class {trace_class}
 
         Returns
         -------
-        tuple[BaseTraceType]
-            Tuple of the newly added traces
+        BaseFigure
+            The Figure that add_traces was called on
 
         Examples
         --------
-        >>> from plotly import tools
+        >>> from plotly import subplots
         >>> import plotly.graph_objs as go
 
         Add two Scatter traces to a figure
@@ -1542,11 +1538,7 @@ Invalid property path '{key_path_str}' for trace class {trace_class}
         ...                 go.Scatter(x=[1,2,3], y=[2,1,2])])
 
         Add two Scatter traces to vertically stacked subplots
-        >>> fig = tools.make_subplots(rows=2)
-        This is the format of your plot grid:
-        [ (1,1) x1,y1 ]
-        [ (2,1) x2,y2 ]
-
+        >>> fig = subplots.make_subplots(rows=2)
         >>> fig.add_traces([go.Scatter(x=[1,2,3], y=[2,1,2]),
         ...                 go.Scatter(x=[1,2,3], y=[2,1,2])],
         ...                 rows=[1, 2], cols=[1, 1])
@@ -1608,7 +1600,7 @@ Invalid property path '{key_path_str}' for trace class {trace_class}
         # Update messages
         self._send_addTraces_msg(new_traces_data)
 
-        return data
+        return self
 
     # Subplots
     # --------

--- a/packages/python/plotly/plotly/graph_objs/_figure.py
+++ b/packages/python/plotly/plotly/graph_objs/_figure.py
@@ -30,6 +30,8 @@ class Figure(BaseFigure):
             that may be specified as:
               - A list or tuple of trace instances
                 (e.g. [Scatter(...), Bar(...)])
+              - A single trace instance
+                (e.g. Scatter(...), Bar(...), etc.)
               - A list or tuple of dicts of string/value properties where:
                 - The 'type' property specifies the trace type
                     One of: ['area', 'bar', 'barpolar', 'box',
@@ -689,7 +691,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Area
+        Figure
         """
         new_trace = Area(
             customdata=customdata,
@@ -1073,7 +1075,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Bar
+        Figure
         """
         new_trace = Bar(
             alignmentgroup=alignmentgroup,
@@ -1386,7 +1388,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Barpolar
+        Figure
         """
         new_trace = Barpolar(
             base=base,
@@ -1755,7 +1757,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Box
+        Figure
         """
         new_trace = Box(
             alignmentgroup=alignmentgroup,
@@ -2040,7 +2042,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Candlestick
+        Figure
         """
         new_trace = Candlestick(
             close=close,
@@ -2300,7 +2302,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Carpet
+        Figure
         """
         new_trace = Carpet(
             a=a,
@@ -2598,7 +2600,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Choropleth
+        Figure
         """
         new_trace = Choropleth(
             autocolorscale=autocolorscale,
@@ -2947,7 +2949,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Cone
+        Figure
         """
         new_trace = Cone(
             anchor=anchor,
@@ -3346,7 +3348,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Contour
+        Figure
         """
         new_trace = Contour(
             autocolorscale=autocolorscale,
@@ -3716,7 +3718,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Contourcarpet
+        Figure
         """
         new_trace = Contourcarpet(
             a=a,
@@ -4094,7 +4096,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Funnel
+        Figure
         """
         new_trace = Funnel(
             alignmentgroup=alignmentgroup,
@@ -4391,7 +4393,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Funnelarea
+        Figure
         """
         new_trace = Funnelarea(
             aspectratio=aspectratio,
@@ -4764,7 +4766,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Heatmap
+        Figure
         """
         new_trace = Heatmap(
             autocolorscale=autocolorscale,
@@ -5082,7 +5084,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Heatmapgl
+        Figure
         """
         new_trace = Heatmapgl(
             autocolorscale=autocolorscale,
@@ -5459,7 +5461,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Histogram
+        Figure
         """
         new_trace = Histogram(
             alignmentgroup=alignmentgroup,
@@ -5874,7 +5876,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Histogram2d
+        Figure
         """
         new_trace = Histogram2d(
             autobinx=autobinx,
@@ -6313,7 +6315,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Histogram2dContour
+        Figure
         """
         new_trace = Histogram2dContour(
             autobinx=autobinx,
@@ -6673,7 +6675,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Isosurface
+        Figure
         """
         new_trace = Isosurface(
             autocolorscale=autocolorscale,
@@ -7103,7 +7105,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Mesh3d
+        Figure
         """
         new_trace = Mesh3d(
             alphahull=alphahull,
@@ -7394,7 +7396,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Ohlc
+        Figure
         """
         new_trace = Ohlc(
             close=close,
@@ -7607,7 +7609,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Parcats
+        Figure
         """
         new_trace = Parcats(
             arrangement=arrangement,
@@ -7760,7 +7762,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Parcoords
+        Figure
         """
         new_trace = Parcoords(
             customdata=customdata,
@@ -8053,7 +8055,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Pie
+        Figure
         """
         new_trace = Pie(
             customdata=customdata,
@@ -8320,7 +8322,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Pointcloud
+        Figure
         """
         new_trace = Pointcloud(
             customdata=customdata,
@@ -8518,7 +8520,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Sankey
+        Figure
         """
         new_trace = Sankey(
             arrangement=arrangement,
@@ -8936,7 +8938,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Scatter
+        Figure
         """
         new_trace = Scatter(
             cliponaxis=cliponaxis,
@@ -9266,7 +9268,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Scatter3d
+        Figure
         """
         new_trace = Scatter3d(
             connectgaps=connectgaps,
@@ -9597,7 +9599,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Scattercarpet
+        Figure
         """
         new_trace = Scattercarpet(
             a=a,
@@ -9909,7 +9911,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Scattergeo
+        Figure
         """
         new_trace = Scattergeo(
             connectgaps=connectgaps,
@@ -10265,7 +10267,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Scattergl
+        Figure
         """
         new_trace = Scattergl(
             connectgaps=connectgaps,
@@ -10564,7 +10566,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Scattermapbox
+        Figure
         """
         new_trace = Scattermapbox(
             connectgaps=connectgaps,
@@ -10901,7 +10903,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Scatterpolar
+        Figure
         """
         new_trace = Scatterpolar(
             cliponaxis=cliponaxis,
@@ -11243,7 +11245,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Scatterpolargl
+        Figure
         """
         new_trace = Scatterpolargl(
             connectgaps=connectgaps,
@@ -11586,7 +11588,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Scatterternary
+        Figure
         """
         new_trace = Scatterternary(
             a=a,
@@ -11864,7 +11866,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Splom
+        Figure
         """
         new_trace = Splom(
             customdata=customdata,
@@ -12191,7 +12193,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Streamtube
+        Figure
         """
         new_trace = Streamtube(
             autocolorscale=autocolorscale,
@@ -12474,7 +12476,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Sunburst
+        Figure
         """
         new_trace = Sunburst(
             branchvalues=branchvalues,
@@ -12810,7 +12812,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Surface
+        Figure
         """
         new_trace = Surface(
             autocolorscale=autocolorscale,
@@ -13007,7 +13009,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Table
+        Figure
         """
         new_trace = Table(
             cells=cells,
@@ -13380,7 +13382,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Violin
+        Figure
         """
         new_trace = Violin(
             alignmentgroup=alignmentgroup,
@@ -13749,7 +13751,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Volume
+        Figure
         """
         new_trace = Volume(
             autocolorscale=autocolorscale,
@@ -14148,7 +14150,7 @@ class Figure(BaseFigure):
 
         Returns
         -------
-        Waterfall
+        Figure
         """
         new_trace = Waterfall(
             alignmentgroup=alignmentgroup,

--- a/packages/python/plotly/plotly/graph_objs/_figurewidget.py
+++ b/packages/python/plotly/plotly/graph_objs/_figurewidget.py
@@ -30,6 +30,8 @@ class FigureWidget(BaseFigureWidget):
             that may be specified as:
               - A list or tuple of trace instances
                 (e.g. [Scatter(...), Bar(...)])
+              - A single trace instance
+                (e.g. Scatter(...), Bar(...), etc.)
               - A list or tuple of dicts of string/value properties where:
                 - The 'type' property specifies the trace type
                     One of: ['area', 'bar', 'barpolar', 'box',
@@ -689,7 +691,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Area
+        FigureWidget
         """
         new_trace = Area(
             customdata=customdata,
@@ -1073,7 +1075,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Bar
+        FigureWidget
         """
         new_trace = Bar(
             alignmentgroup=alignmentgroup,
@@ -1386,7 +1388,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Barpolar
+        FigureWidget
         """
         new_trace = Barpolar(
             base=base,
@@ -1755,7 +1757,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Box
+        FigureWidget
         """
         new_trace = Box(
             alignmentgroup=alignmentgroup,
@@ -2040,7 +2042,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Candlestick
+        FigureWidget
         """
         new_trace = Candlestick(
             close=close,
@@ -2300,7 +2302,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Carpet
+        FigureWidget
         """
         new_trace = Carpet(
             a=a,
@@ -2598,7 +2600,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Choropleth
+        FigureWidget
         """
         new_trace = Choropleth(
             autocolorscale=autocolorscale,
@@ -2947,7 +2949,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Cone
+        FigureWidget
         """
         new_trace = Cone(
             anchor=anchor,
@@ -3346,7 +3348,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Contour
+        FigureWidget
         """
         new_trace = Contour(
             autocolorscale=autocolorscale,
@@ -3716,7 +3718,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Contourcarpet
+        FigureWidget
         """
         new_trace = Contourcarpet(
             a=a,
@@ -4094,7 +4096,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Funnel
+        FigureWidget
         """
         new_trace = Funnel(
             alignmentgroup=alignmentgroup,
@@ -4391,7 +4393,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Funnelarea
+        FigureWidget
         """
         new_trace = Funnelarea(
             aspectratio=aspectratio,
@@ -4764,7 +4766,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Heatmap
+        FigureWidget
         """
         new_trace = Heatmap(
             autocolorscale=autocolorscale,
@@ -5082,7 +5084,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Heatmapgl
+        FigureWidget
         """
         new_trace = Heatmapgl(
             autocolorscale=autocolorscale,
@@ -5459,7 +5461,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Histogram
+        FigureWidget
         """
         new_trace = Histogram(
             alignmentgroup=alignmentgroup,
@@ -5874,7 +5876,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Histogram2d
+        FigureWidget
         """
         new_trace = Histogram2d(
             autobinx=autobinx,
@@ -6313,7 +6315,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Histogram2dContour
+        FigureWidget
         """
         new_trace = Histogram2dContour(
             autobinx=autobinx,
@@ -6673,7 +6675,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Isosurface
+        FigureWidget
         """
         new_trace = Isosurface(
             autocolorscale=autocolorscale,
@@ -7103,7 +7105,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Mesh3d
+        FigureWidget
         """
         new_trace = Mesh3d(
             alphahull=alphahull,
@@ -7394,7 +7396,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Ohlc
+        FigureWidget
         """
         new_trace = Ohlc(
             close=close,
@@ -7607,7 +7609,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Parcats
+        FigureWidget
         """
         new_trace = Parcats(
             arrangement=arrangement,
@@ -7760,7 +7762,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Parcoords
+        FigureWidget
         """
         new_trace = Parcoords(
             customdata=customdata,
@@ -8053,7 +8055,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Pie
+        FigureWidget
         """
         new_trace = Pie(
             customdata=customdata,
@@ -8320,7 +8322,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Pointcloud
+        FigureWidget
         """
         new_trace = Pointcloud(
             customdata=customdata,
@@ -8518,7 +8520,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Sankey
+        FigureWidget
         """
         new_trace = Sankey(
             arrangement=arrangement,
@@ -8936,7 +8938,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Scatter
+        FigureWidget
         """
         new_trace = Scatter(
             cliponaxis=cliponaxis,
@@ -9266,7 +9268,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Scatter3d
+        FigureWidget
         """
         new_trace = Scatter3d(
             connectgaps=connectgaps,
@@ -9597,7 +9599,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Scattercarpet
+        FigureWidget
         """
         new_trace = Scattercarpet(
             a=a,
@@ -9909,7 +9911,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Scattergeo
+        FigureWidget
         """
         new_trace = Scattergeo(
             connectgaps=connectgaps,
@@ -10265,7 +10267,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Scattergl
+        FigureWidget
         """
         new_trace = Scattergl(
             connectgaps=connectgaps,
@@ -10564,7 +10566,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Scattermapbox
+        FigureWidget
         """
         new_trace = Scattermapbox(
             connectgaps=connectgaps,
@@ -10901,7 +10903,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Scatterpolar
+        FigureWidget
         """
         new_trace = Scatterpolar(
             cliponaxis=cliponaxis,
@@ -11243,7 +11245,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Scatterpolargl
+        FigureWidget
         """
         new_trace = Scatterpolargl(
             connectgaps=connectgaps,
@@ -11586,7 +11588,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Scatterternary
+        FigureWidget
         """
         new_trace = Scatterternary(
             a=a,
@@ -11864,7 +11866,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Splom
+        FigureWidget
         """
         new_trace = Splom(
             customdata=customdata,
@@ -12191,7 +12193,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Streamtube
+        FigureWidget
         """
         new_trace = Streamtube(
             autocolorscale=autocolorscale,
@@ -12474,7 +12476,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Sunburst
+        FigureWidget
         """
         new_trace = Sunburst(
             branchvalues=branchvalues,
@@ -12810,7 +12812,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Surface
+        FigureWidget
         """
         new_trace = Surface(
             autocolorscale=autocolorscale,
@@ -13007,7 +13009,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Table
+        FigureWidget
         """
         new_trace = Table(
             cells=cells,
@@ -13380,7 +13382,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Violin
+        FigureWidget
         """
         new_trace = Violin(
             alignmentgroup=alignmentgroup,
@@ -13749,7 +13751,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Volume
+        FigureWidget
         """
         new_trace = Volume(
             autocolorscale=autocolorscale,
@@ -14148,7 +14150,7 @@ class FigureWidget(BaseFigureWidget):
 
         Returns
         -------
-        Waterfall
+        FigureWidget
         """
         new_trace = Waterfall(
             alignmentgroup=alignmentgroup,


### PR DESCRIPTION
This PR updates the `add_trace`, `add_traces`, and `add_{trace}` figure method to return the figure their called on, rather than the newly created trace(s).

This is a breaking change for v4, as these methods used to return the newly created traces.  The motivation for the change is to support method chaining. e.g.

```python
(make_subplots(rows=2)
 .add_scatter(y=[2, 1, 3], row=1, col=1)
 .add_bar(y=[2, 1, 3], row=2, col=1)
 .update_layout(title_text='Figure Title', template='plotly_white'))
```
![newplot](https://user-images.githubusercontent.com/15064365/59673530-7a512580-918f-11e9-860b-14f00b348ab6.png)

Code that formerly relied on the returned trace
```
bar = fig.add_bar(...)
```

will need to be updated for v4 compatibility to grab the newly added trace from the returned figure's data array
```python
bar = fig.add_bar(...).data[-1]
```
@nicolaskruchten 