### PR TITLE
V4 chart_studio: Delete existing file before creating rather than update

### DIFF
--- a/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_stream/test_stream.py
+++ b/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_stream/test_stream.py
@@ -35,7 +35,7 @@ class TestStreaming(PlotlyTestCase):
                       auto_open=False,
                       world_readable=True,
                       filename='stream-test')
-        self.assertEqual('https://plot.ly/~PythonAPI/461/', url)
+        self.assertTrue(url.startswith('https://plot.ly/~PythonAPI/'))
         time.sleep(.5)
 
     @attr('slow')


### PR DESCRIPTION
Hopefully addresses https://github.com/plotly/plotly.py/issues/1622.

It looks like the update endpoint (https://api.plot.ly/v2/files#update) only updates the metadata of a file, not the content. So with this PR we manually delete existing files/grids with the same name and then use `create` to upload.

cc @michaelbabyn 