### PR TITLE
V4: Have side-effect renderers show figure on display

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,8 +373,9 @@ workflows:
       # 3.7 optional disabled due to current shapely incompatibility
       # - python-3.7-optional
       - python-2.7-plot_ly
-      - python-3.5-plot_ly
-      - python-3.7-plot_ly
+      - python-3.7-plot_ly:
+          requires:
+            - python-2.7-plot_ly
       - python-2-7-orca
       - python-3-5-orca
       - python-3-7-orca

--- a/packages/python/chart-studio/chart_studio/api/v2/grids.py
+++ b/packages/python/chart-studio/chart_studio/api/v2/grids.py
@@ -95,6 +95,18 @@ def permanent_delete(fid):
     return request("delete", url)
 
 
+def destroy(fid):
+    """
+    Permanently delete a grid file from Plotly.
+
+    :param (str) fid: The `{username}:{idlocal}` identifier. E.g. `foo:88`.
+    :returns: (requests.Response) Returns response directly from requests.
+
+    """
+    url = build_url(RESOURCE, id=fid)
+    return request("delete", url)
+
+
 def lookup(path, parent=None, user=None, exists=None):
     """
     Retrieve a grid file from Plotly without needing a fid.

--- a/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_plotly/test_plot.py
+++ b/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_plotly/test_plot.py
@@ -166,7 +166,7 @@ class TestPlot(PlotlyTestCase):
             self.simple_figure, validate
         )
         kwargs = {
-            "filename": "is_share_key_included",
+            "filename": "is_share_key_included2",
             "world_readable": False,
             "auto_open": False,
             "sharing": "secret",
@@ -182,7 +182,7 @@ class TestPlot(PlotlyTestCase):
         # be 200
 
         kwargs = {
-            "filename": "is_share_key_included",
+            "filename": "is_share_key_included2",
             "auto_open": False,
             "world_readable": False,
             "sharing": "secret",
@@ -203,7 +203,7 @@ class TestPlot(PlotlyTestCase):
         # share_key is added it should be 200
 
         kwargs = {
-            "filename": "is_share_key_included",
+            "filename": "is_share_key_included2",
             "world_readable": False,
             "auto_open": False,
             "sharing": "private",

--- a/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_stream/test_stream.py
+++ b/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_stream/test_stream.py
@@ -36,7 +36,7 @@ class TestStreaming(PlotlyTestCase):
             [Scatter(x=[], y=[], mode="markers", stream=stream)],
             auto_open=False,
             world_readable=True,
-            filename="stream-test",
+            filename="stream-test2",
         )
         self.assertTrue(url.startswith("https://plot.ly/~PythonAPI/"))
         time.sleep(0.5)
@@ -49,7 +49,7 @@ class TestStreaming(PlotlyTestCase):
             [Scatter(x=[], y=[], mode="markers", stream=stream)],
             auto_open=False,
             world_readable=True,
-            filename="stream-test",
+            filename="stream-test2",
         )
         time.sleep(0.5)
         my_stream = py.Stream(tk)
@@ -66,7 +66,7 @@ class TestStreaming(PlotlyTestCase):
             [Scatter(x=[], y=[], mode="markers", stream=stream)],
             auto_open=False,
             world_readable=True,
-            filename="stream-test",
+            filename="stream-test2",
         )
         time.sleep(0.5)
         my_stream = py.Stream(tk)
@@ -83,7 +83,7 @@ class TestStreaming(PlotlyTestCase):
             [Scatter(x=[], y=[], mode="markers", stream=stream)],
             auto_open=False,
             world_readable=True,
-            filename="stream-test",
+            filename="stream-test2",
         )
         time.sleep(0.5)
         title_0 = "some title i picked first"

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -427,22 +427,16 @@ class BaseFigure(object):
 
         return repr_str
 
-    def _repr_mimebundle_(self, include, exclude, **kwargs):
+    def _ipython_display_(self):
         """
-        repr_mimebundle should accept include, exclude and **kwargs
+        Handle rich display of figures in ipython contexts
         """
         import plotly.io as pio
 
-        if pio.renderers.render_on_display:
-            data = pio.renderers._build_mime_bundle(self.to_dict())
-
-            if include:
-                data = {k: v for (k, v) in data.items() if k in include}
-            if exclude:
-                data = {k: v for (k, v) in data.items() if k not in exclude}
-            return data
+        if pio.renderers.render_on_display and pio.renderers.default:
+            pio.show(self)
         else:
-            return None
+            print (repr(self))
 
     def update(self, dict1=None, **kwargs):
         """

--- a/packages/python/plotly/plotly/basewidget.py
+++ b/packages/python/plotly/plotly/basewidget.py
@@ -730,6 +730,15 @@ class BaseFigureWidget(BaseFigure, widgets.DOMWidget):
 
         self._js2py_pointsCallback = None
 
+    # Display
+    # -------
+    def _ipython_display_(self):
+        """
+        Handle rich display of figures in ipython contexts
+        """
+        # Override BaseFigure's display to make sure we display the widget version
+        widgets.DOMWidget._ipython_display_(self)
+
     # Callbacks
     # ---------
     def on_edits_completed(self, fn):

--- a/packages/python/plotly/plotly/io/_orca.py
+++ b/packages/python/plotly/plotly/io/_orca.py
@@ -1387,7 +1387,7 @@ Install using conda:
             orca_state["shutdown_timer"] = t
 
 
-@retrying.retry(wait_random_min=5, wait_random_max=10, stop_max_delay=30000)
+@retrying.retry(wait_random_min=5, wait_random_max=10, stop_max_delay=60000)
 def request_image_with_retrying(**kwargs):
     """
     Helper method to perform an image request to a running orca server process
@@ -1404,7 +1404,9 @@ def request_image_with_retrying(**kwargs):
     response = post(server_url + "/", data=json_str)
 
     if response.status_code == 522:
-        # Retry on "522: client socket timeout"
+        # On "522: client socket timeout", return server and keep trying
+        shutdown_server()
+        ensure_server()
         raise OSError("522: client socket timeout")
 
     return response

--- a/packages/python/plotly/plotly/io/_orca.py
+++ b/packages/python/plotly/plotly/io/_orca.py
@@ -1402,6 +1402,11 @@ def request_image_with_retrying(**kwargs):
     request_params = {k: v for k, v, in kwargs.items() if v is not None}
     json_str = json.dumps(request_params, cls=_plotly_utils.utils.PlotlyJSONEncoder)
     response = post(server_url + "/", data=json_str)
+
+    if response.status_code == 522:
+        # Retry on "522: client socket timeout"
+        raise OSError("522: client socket timeout")
+
     return response
 
 
@@ -1546,6 +1551,7 @@ with the following error:
         # orca code base.
         # statusMsg: {
         #     400: 'invalid or malformed request syntax',
+        #     522: client socket timeout
         #     525: 'plotly.js error',
         #     526: 'plotly.js version 1.11.0 or up required',
         #     530: 'image conversion error'

--- a/packages/python/plotly/plotly/tests/test_io/test_renderers.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_renderers.py
@@ -43,11 +43,17 @@ def test_json_renderer_mimetype(fig1):
     expected = {"application/json": json.loads(pio.to_json(fig1, remove_uids=False))}
 
     pio.renderers.render_on_display = False
-    assert fig1._repr_mimebundle_(None, None) is None
+
+    with mock.patch("IPython.display.display") as mock_display:
+        fig1._ipython_display_()
+
+    mock_display.assert_not_called()
 
     pio.renderers.render_on_display = True
-    bundle = fig1._repr_mimebundle_(None, None)
-    assert bundle == expected
+    with mock.patch("IPython.display.display") as mock_display:
+        fig1._ipython_display_()
+
+    mock_display.assert_called_once_with(expected, raw=True)
 
 
 def test_json_renderer_show(fig1):
@@ -88,11 +94,17 @@ def test_plotly_mimetype_renderer_mimetype(fig1, renderer):
     expected[plotly_mimetype]["config"] = {"plotlyServerURL": "https://plot.ly"}
 
     pio.renderers.render_on_display = False
-    assert fig1._repr_mimebundle_(None, None) is None
+
+    with mock.patch("IPython.display.display") as mock_display:
+        fig1._ipython_display_()
+
+    mock_display.assert_not_called()
 
     pio.renderers.render_on_display = True
-    bundle = fig1._repr_mimebundle_(None, None)
-    assert bundle == expected
+    with mock.patch("IPython.display.display") as mock_display:
+        fig1._ipython_display_()
+
+    mock_display.assert_called_once_with(expected, raw=True)
 
 
 @pytest.mark.parametrize("renderer", plotly_mimetype_renderers)

--- a/packages/python/plotly/plotly/tests/test_orca/test_image_renderers.py
+++ b/packages/python/plotly/plotly/tests/test_orca/test_image_renderers.py
@@ -49,11 +49,18 @@ def test_png_renderer_mimetype(fig1):
     expected = {"image/png": image_str}
 
     pio.renderers.render_on_display = False
-    assert fig1._repr_mimebundle_(None, None) is None
+
+    with mock.patch("IPython.display.display") as mock_display:
+        fig1._ipython_display_()
+
+    # assert fig1._repr_mimebundle_(None, None) is None
+    mock_display.assert_not_called()
 
     pio.renderers.render_on_display = True
-    bundle = fig1._repr_mimebundle_(None, None)
-    assert bundle == expected
+    with mock.patch("IPython.display.display") as mock_display:
+        fig1._ipython_display_()
+
+    mock_display.assert_called_once_with(expected, raw=True)
 
 
 def test_svg_renderer_show(fig1):
@@ -131,8 +138,15 @@ def test_mimetype_combination(fig1):
     expected = {"image/png": image_str, plotly_mimetype: plotly_mimetype_dict}
 
     pio.renderers.render_on_display = False
-    assert fig1._repr_mimebundle_(None, None) is None
+
+    with mock.patch("IPython.display.display") as mock_display:
+        fig1._ipython_display_()
+
+    # assert fig1._repr_mimebundle_(None, None) is None
+    mock_display.assert_not_called()
 
     pio.renderers.render_on_display = True
-    bundle = fig1._repr_mimebundle_(None, None)
-    assert bundle == expected
+    with mock.patch("IPython.display.display") as mock_display:
+        fig1._ipython_display_()
+
+    mock_display.assert_called_once_with(expected, raw=True)


### PR DESCRIPTION
The mimetype renderers already did this.

Now, px can be used easily with the 'browser' renderer for non-jupyter contexts.