### PR TITLE
Fix template error bar coloring for bar plots

### DIFF
--- a/templategen/utils/__init__.py
+++ b/templategen/utils/__init__.py
@@ -1,4 +1,5 @@
 from plotly import graph_objs as go
+from .colors import GRAY27
 
 colorscale_parent_paths = [
     ('histogram2dcontour',),
@@ -157,8 +158,12 @@ def initialize_template(annotation_defaults,
                                       'line': {'color': table_line_clr}}}]
 
     # Bar outline
+    # Changing marker line color also affects error color,
+    # so reset default error colors
     template.data.bar = [
-        {'marker': {'line': {'width': 0.5, 'color': panel_background_clr}}}]
+        {'marker': {'line': {'width': 0.5, 'color': panel_background_clr}},
+         'error_y': {'color': GRAY27},
+         'error_x': {'color': GRAY27}}]
     template.data.barpolar = [
         {'marker': {'line': {'width': 0.5, 'color': panel_background_clr}}}]
 


### PR DESCRIPTION
Previous addition of bar outline in templates also changed color of error bars, since errorbar seems to use the colorof marker line over default. This shows a minimum change to fix it back, but I suspect that it would be preferably to set correct color it a better way. Would be happy to adjust the PR, if any suggestions on that could be done. Maybe something like default_line_color should be passed as argument like initialize_template(..., default_line_color=GRAY27) to allow templates to set the color of error bars.

See this notebooks for error and fix: https://nbviewer.jupyter.org/github/Olof-Hojvall/plotly.py/blob/error_bar_notebook/Bar%20Plot%20Errorbar%20Template%20Example.ipynb