### PR TITLE
Fix typo in the documentation.

### DIFF
--- a/plotly/graph_objs/scatter/__init__.py
+++ b/plotly/graph_objs/scatter/__init__.py
@@ -1198,7 +1198,7 @@ class Marker(_BaseTraceHierarchyType):
         containing arrays mapping a normalized value to an rgb, rgba,
         hex, hsl, hsv, or named color string. At minimum, a mapping for
         the lowest (0) and highest (1) values are required. For
-        example, `[[0, 'rgb(0,0,255)', [1, 'rgb(255,0,0)']]`. To
+        example, `[[0, 'rgb(0,0,255)'], [1, 'rgb(255,0,0)']]`. To
         control the bounds of the colorscale in color space,
         use`marker.cmin` and `marker.cmax`. Alternatively, `colorscale`
         may be a palette name string of the following list: Greys,YlGnB


### PR DESCRIPTION
Fix typo in the docstring.