### PR TITLE
FIX: fix incorrect import in deprecation warning for Scene class

### DIFF
--- a/packages/python/plotly/codegen/compatibility.py
+++ b/packages/python/plotly/codegen/compatibility.py
@@ -26,7 +26,7 @@ DEPRECATED_DATATYPES = {
     "Margin": {"base_type": dict, "new": ["layout"]},
     "Marker": {"base_type": dict, "new": ["scatter", "histogram.selected", "etc."]},
     "RadialAxis": {"base_type": dict, "new": ["layout", "layout.polar"]},
-    "Scene": {"base_type": dict, "new": ["Scene"]},
+    "Scene": {"base_type": dict, "new": ["layout"]},
     "Stream": {"base_type": dict, "new": ["scatter", "area"]},
     "XAxis": {"base_type": dict, "new": ["layout", "layout.scene"]},
     "YAxis": {"base_type": dict, "new": ["layout", "layout.scene"]},

--- a/packages/python/plotly/plotly/graph_objs/_deprecations.py
+++ b/packages/python/plotly/plotly/graph_objs/_deprecations.py
@@ -475,7 +475,7 @@ class Scene(dict):
     """
     plotly.graph_objs.Scene is deprecated.
 Please replace it with one of the following more specific types
-  - plotly.graph_objs.Scene
+  - plotly.graph_objs.layout.Scene
 
     """
 
@@ -483,13 +483,13 @@ Please replace it with one of the following more specific types
         """
         plotly.graph_objs.Scene is deprecated.
 Please replace it with one of the following more specific types
-  - plotly.graph_objs.Scene
+  - plotly.graph_objs.layout.Scene
 
         """
         warnings.warn(
             """plotly.graph_objs.Scene is deprecated.
 Please replace it with one of the following more specific types
-  - plotly.graph_objs.Scene
+  - plotly.graph_objs.layout.Scene
 """,
             DeprecationWarning,
         )


### PR DESCRIPTION
I noticed a minor issue in the text of a deprecation warning on the `Scene` class the other day, where the recommended fully-qualified class name is the same as the one being used:
```
In [1]: from plotly.graph_objs import Scene

In [2]: Scene()
/Users/skern/.edm/envs/mb_test_plotly3/lib/python3.6/site-packages/plotly/graph_objs/_deprecations.py:477: DeprecationWarning:

plotly.graph_objs.Scene is deprecated.
Please replace it with one of the following more specific types
  - plotly.graph_objs.Scene
```

The correct class that should be recommended is `plotly.graph_objs.layout.Scene`. This PR just corrects the few occurrences of that.