### PR TITLE
Fix "The truth value of an array with more than one element is ambiguous"

### DIFF
--- a/packages/python/plotly/plotly/subplots.py
+++ b/packages/python/plotly/plotly/subplots.py
@@ -511,13 +511,13 @@ The {arg} argument to make_subplots must be one of: {valid_vals}
 
     # ### vertical_spacing ###
     if vertical_spacing is None:
-        if subplot_titles:
+        if subplot_titles is not None:
             vertical_spacing = 0.5 / rows
         else:
             vertical_spacing = 0.3 / rows
 
     # ### subplot titles ###
-    if not subplot_titles:
+    if subplot_titles is None:
         subplot_titles = [""] * rows * cols
 
     # ### column_widths ###

--- a/packages/python/plotly/plotly/tests/test_core/test_subplots/test_make_subplots.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_subplots/test_make_subplots.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import numpy as np
+
 from unittest import TestCase
 from plotly.graph_objs import (
     Annotation,
@@ -1539,6 +1541,41 @@ class TestMakeSubplots(TestCase):
         )
         fig = tls.make_subplots(
             insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}], subplot_titles=("", "Inset")
+        )
+        self.assertEqual(fig, expected)
+
+    def test_subplot_titles_array(self):
+        # Pass python array
+        expected = tls.make_subplots(
+            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}],
+            subplot_titles=("", "Inset"),
+        )
+        fig = tls.make_subplots(
+            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}],
+            subplot_titles=["", "Inset"],
+        )
+        self.assertEqual(fig, expected)
+
+    def test_subplot_titles_empty(self):
+        # Pass empty array
+        expected = tls.make_subplots(
+            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}],
+        )
+        fig = tls.make_subplots(
+            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}],
+            subplot_titles=[],
+        )
+        self.assertEqual(fig, expected)
+
+    def test_subplot_titles_numpy_array(self):
+        # Pass numpy array
+        expected = tls.make_subplots(
+            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}],
+            subplot_titles=("", "Inset"),
+        )
+        fig = tls.make_subplots(
+            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}],
+            subplot_titles=np.array(["", "Inset"]),
         )
         self.assertEqual(fig, expected)
 

--- a/packages/python/plotly/plotly/tests/test_core/test_subplots/test_make_subplots.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_subplots/test_make_subplots.py
@@ -1547,31 +1547,25 @@ class TestMakeSubplots(TestCase):
     def test_subplot_titles_array(self):
         # Pass python array
         expected = tls.make_subplots(
-            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}],
-            subplot_titles=("", "Inset"),
+            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}], subplot_titles=("", "Inset")
         )
         fig = tls.make_subplots(
-            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}],
-            subplot_titles=["", "Inset"],
+            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}], subplot_titles=["", "Inset"]
         )
         self.assertEqual(fig, expected)
 
     def test_subplot_titles_empty(self):
         # Pass empty array
-        expected = tls.make_subplots(
-            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}],
-        )
+        expected = tls.make_subplots(insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}])
         fig = tls.make_subplots(
-            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}],
-            subplot_titles=[],
+            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}], subplot_titles=[]
         )
         self.assertEqual(fig, expected)
 
     def test_subplot_titles_numpy_array(self):
         # Pass numpy array
         expected = tls.make_subplots(
-            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}],
-            subplot_titles=("", "Inset"),
+            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}], subplot_titles=("", "Inset")
         )
         fig = tls.make_subplots(
             insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}],

--- a/packages/python/plotly/plotly/tests/test_core/test_subplots/test_make_subplots.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_subplots/test_make_subplots.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-import numpy as np
-
 from unittest import TestCase
 from plotly.graph_objs import (
     Annotation,
@@ -1559,17 +1557,6 @@ class TestMakeSubplots(TestCase):
         expected = tls.make_subplots(insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}])
         fig = tls.make_subplots(
             insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}], subplot_titles=[]
-        )
-        self.assertEqual(fig, expected)
-
-    def test_subplot_titles_numpy_array(self):
-        # Pass numpy array
-        expected = tls.make_subplots(
-            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}], subplot_titles=("", "Inset")
-        )
-        fig = tls.make_subplots(
-            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}],
-            subplot_titles=np.array(["", "Inset"]),
         )
         self.assertEqual(fig, expected)
 

--- a/packages/python/plotly/plotly/tests/test_optional/test_subplots/test_make_subplots.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_subplots/test_make_subplots.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+from unittest import TestCase
+
+import plotly.tools as tls
+
+
+class TestMakeSubplots(TestCase):
+    def test_subplot_titles_numpy_array(self):
+        # Pass numpy array
+        expected = tls.make_subplots(
+            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}], subplot_titles=("", "Inset")
+        )
+        fig = tls.make_subplots(
+            insets=[{"cell": (1, 1), "l": 0.7, "b": 0.3}],
+            subplot_titles=np.array(["", "Inset"]),
+        )
+        self.assertEqual(fig, expected)


### PR DESCRIPTION
Fixes "ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()"