### PR TITLE
Only attempt to import np/pd once in basevalidators

### DIFF
--- a/packages/python/plotly/_plotly_utils/optional_imports.py
+++ b/packages/python/plotly/_plotly_utils/optional_imports.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 
 from importlib import import_module
 import logging
+import sys
 
 logger = logging.getLogger(__name__)
 _not_importable = set()
@@ -20,6 +21,8 @@ def get_module(name):
     :return: (module|None) If import succeeds, the module will be returned.
 
     """
+    if name in sys.modules:
+        return sys.modules[name]
     if name not in _not_importable:
         try:
             return import_module(name)


### PR DESCRIPTION
Use get_module to import numpy and pandas once at the load of _plotly_utils.basevalidators

Significantly speeds up graph rendering when using large (10K entry)
pandas dataframe columns.

Graph rendering time changed when using Dash, updating a graph after a slider change from 1200-1500ms to 240-350ms by avoiding
many (~10K) calls to get_module().

2 potential downsides, but both seem minor:

1.) numpy and pandas will only be attempted to be imported once. If they're somehow added after the application has started, it would have previously worked, now will require application restart to get numpy / pandas functionality

2.) Loading the numpy and pandas modules (if available), even when they won't be used.


Both of these seem pretty minor in the grand scheme of things, particularly with the significant performance difference in graph setup.