### PR TITLE
Custom template for trace labels

### DIFF
--- a/packages/python/plotly/plotly/express/_chart_types.py
+++ b/packages/python/plotly/plotly/express/_chart_types.py
@@ -45,6 +45,7 @@ def scatter(
     template=None,
     width=None,
     height=None,
+    template_label=None,
 ):
     """
     In a scatter plot, each row of `data_frame` is represented by a symbol mark in 2D space.


### PR DESCRIPTION
Hi!

Thank you so much for plotly express!

Previously, I was using custom hand-made grouper loop to do what I can do now in one line.
However, I had full control of the label of the trace, which is no more the case.

This PR aims to give full access to the trace label, thanks to `template_label` kwarg.
I just made it available for `scatter` right now, and didn't run any test yet (I'm default to python 3.5, have to setup env and co first...). 

Are you interested in such feature? If so, I may continue on it.

Example:

```python
data = {"group": ["group1"]*2 + ["group2"]*2, "color": ["1","1","1","2"], "value": [1,2,3,4], "x": [10, 20, 30, 40]} 

df = pd.DataFrame(data) 
fig = px.scatter(df, x="x", y="value", color="color", symbol="group", 
             template_label="{color_key} = {color_val} ({toto_val})", 
             labels={"group": "toto", "color": "color"} 
) 
fig.show()
```

![trace_labels_px](https://user-images.githubusercontent.com/25247745/62062958-4b1be280-b22a-11e9-890a-d4f7c3dc6c85.png)


PS : I needed it because I have plots with `station` and `specie`, and all traces was displayed as `station=A, specie=SP1`, and I want to display only `A (SP1)`