### PR TITLE
Avoid crash in iframe renderers when running outside iPython

### DIFF
--- a/packages/python/plotly/plotly/io/_base_renderers.py
+++ b/packages/python/plotly/plotly/io/_base_renderers.py
@@ -598,8 +598,8 @@ class IFrameRenderer(MimetypeRenderer):
         return {"text/html": iframe_html}
 
     def build_filename(self):
-        ip = IPython.get_ipython()
-        cell_number = list(ip.history_manager.get_tail(1))[0][1] + 1
+        ip = IPython.get_ipython() if IPython else None
+        cell_number = list(ip.history_manager.get_tail(1))[0][1] + 1 if ip else 0
         filename = "{dirname}/figure_{cell_number}.html".format(
             dirname=self.html_directory, cell_number=cell_number
         )


### PR DESCRIPTION
when running

```
echo '{"hour":"2019-01-01T00:00:00Z","perf":1}' | python <(                     
echo "                                                                                                                        
import pandas as pd                                                                                                           
from plotly import express as px                                                                                              
import sys                                                                                                                    
data = pd.read_json(sys.stdin.read(), lines=True, convert_dates=['hour'])                                                     
fig = px.line(data, x='hour', y='perf')                                                                                       
fig.show(renderer='iframe')                                                                                                   
")
```

if `ipython` is not installed you get:

```
Traceback (most recent call last):
  File "/dev/fd/63", line 7, in <module>
  File "/home/marco/src/plotly.py/packages/python/plotly/plotly/basedatatypes.py", line 2658, in show
    return pio.show(self, *args, **kwargs)
  File "/home/marco/src/plotly.py/packages/python/plotly/plotly/io/_renderers.py", line 376, in show
    bundle = renderers._build_mime_bundle(fig_dict, renderers_string=renderer, **kwargs)
  File "/home/marco/src/plotly.py/packages/python/plotly/plotly/io/_renderers.py", line 296, in _build_mime_bundle
    bundle.update(renderer.to_mimebundle(fig_dict))
  File "/home/marco/src/plotly.py/packages/python/plotly/plotly/io/_base_renderers.py", line 564, in to_mimebundle
    filename = self.build_filename()
  File "/home/marco/src/plotly.py/packages/python/plotly/plotly/io/_base_renderers.py", line 601, in build_filename
    ip = IPython.get_ipython()
AttributeError: 'NoneType' object has no attribute 'get_ipython'
```

if instead `ipython` is installed
```
Traceback (most recent call last):
  File "/dev/fd/63", line 7, in <module>
  File "/home/marco/src/plotly.py/packages/python/plotly/plotly/basedatatypes.py", line 2658, in show
    return pio.show(self, *args, **kwargs)
  File "/home/marco/src/plotly.py/packages/python/plotly/plotly/io/_renderers.py", line 376, in show
    bundle = renderers._build_mime_bundle(fig_dict, renderers_string=renderer, **kwargs)
  File "/home/marco/src/plotly.py/packages/python/plotly/plotly/io/_renderers.py", line 296, in _build_mime_bundle
    bundle.update(renderer.to_mimebundle(fig_dict))
  File "/home/marco/src/plotly.py/packages/python/plotly/plotly/io/_base_renderers.py", line 564, in to_mimebundle
    filename = self.build_filename()
  File "/home/marco/src/plotly.py/packages/python/plotly/plotly/io/_base_renderers.py", line 602, in build_filename
    cell_number = list(ip.history_manager.get_tail(1))[0][1] + 1
AttributeError: 'NoneType' object has no attribute 'history_manager'
```