### PR TITLE
Add "overwrite" kwarg to all update* figure methods.

### DIFF
--- a/packages/python/plotly/codegen/figure.py
+++ b/packages/python/plotly/codegen/figure.py
@@ -313,6 +313,7 @@ class {fig_classname}({base_classname}):\n"""
             self,
             patch=None,
             selector=None,
+            overwrite=False,
             row=None, col=None{secondary_y_1},
             **kwargs):
         \"\"\"
@@ -330,6 +331,10 @@ class {fig_classname}({base_classname}):\n"""
             properties corresponding to all of the dictionary's keys, with
             values that exactly match the supplied values. If None
             (the default), all {singular_name} objects are selected.
+        overwrite: bool
+            If True, overwrite existing properties. If False, apply updates
+            to existing properties recursively, preserving existing
+            properties that are not specified in the update operation.
         row, col: int or None (default None)
             Subplot row and column index of {singular_name} objects to select.
             To select {singular_name} objects by row and column, the Figure
@@ -348,7 +353,7 @@ class {fig_classname}({base_classname}):\n"""
         \"\"\"
         for obj in self.select_{plural_name}(
                 selector=selector, row=row, col=col{secondary_y_2}):
-            obj.update(patch, **kwargs)
+            obj.update(patch, overwrite=overwrite, **kwargs)
 
         return self"""
         )

--- a/packages/python/plotly/plotly/graph_objs/_figure.py
+++ b/packages/python/plotly/plotly/graph_objs/_figure.py
@@ -15081,7 +15081,9 @@ class Figure(BaseFigure):
 
         return self
 
-    def update_coloraxes(self, patch=None, selector=None, row=None, col=None, **kwargs):
+    def update_coloraxes(
+        self, patch=None, selector=None, overwrite=False, row=None, col=None, **kwargs
+    ):
         """
         Perform a property update operation on all coloraxis objects
         that satisfy the specified selection criteria
@@ -15097,6 +15099,10 @@ class Figure(BaseFigure):
             properties corresponding to all of the dictionary's keys, with
             values that exactly match the supplied values. If None
             (the default), all coloraxis objects are selected.
+        overwrite: bool
+            If True, overwrite existing properties. If False, apply updates
+            to existing properties recursively, preserving existing
+            properties that are not specified in the update operation.
         row, col: int or None (default None)
             Subplot row and column index of coloraxis objects to select.
             To select coloraxis objects by row and column, the Figure
@@ -15113,7 +15119,7 @@ class Figure(BaseFigure):
             Returns the Figure object that the method was called on
         """
         for obj in self.select_coloraxes(selector=selector, row=row, col=col):
-            obj.update(patch, **kwargs)
+            obj.update(patch, overwrite=overwrite, **kwargs)
 
         return self
 
@@ -15175,7 +15181,9 @@ class Figure(BaseFigure):
 
         return self
 
-    def update_geos(self, patch=None, selector=None, row=None, col=None, **kwargs):
+    def update_geos(
+        self, patch=None, selector=None, overwrite=False, row=None, col=None, **kwargs
+    ):
         """
         Perform a property update operation on all geo objects
         that satisfy the specified selection criteria
@@ -15191,6 +15199,10 @@ class Figure(BaseFigure):
             properties corresponding to all of the dictionary's keys, with
             values that exactly match the supplied values. If None
             (the default), all geo objects are selected.
+        overwrite: bool
+            If True, overwrite existing properties. If False, apply updates
+            to existing properties recursively, preserving existing
+            properties that are not specified in the update operation.
         row, col: int or None (default None)
             Subplot row and column index of geo objects to select.
             To select geo objects by row and column, the Figure
@@ -15207,7 +15219,7 @@ class Figure(BaseFigure):
             Returns the Figure object that the method was called on
         """
         for obj in self.select_geos(selector=selector, row=row, col=col):
-            obj.update(patch, **kwargs)
+            obj.update(patch, overwrite=overwrite, **kwargs)
 
         return self
 
@@ -15269,7 +15281,9 @@ class Figure(BaseFigure):
 
         return self
 
-    def update_mapboxes(self, patch=None, selector=None, row=None, col=None, **kwargs):
+    def update_mapboxes(
+        self, patch=None, selector=None, overwrite=False, row=None, col=None, **kwargs
+    ):
         """
         Perform a property update operation on all mapbox objects
         that satisfy the specified selection criteria
@@ -15285,6 +15299,10 @@ class Figure(BaseFigure):
             properties corresponding to all of the dictionary's keys, with
             values that exactly match the supplied values. If None
             (the default), all mapbox objects are selected.
+        overwrite: bool
+            If True, overwrite existing properties. If False, apply updates
+            to existing properties recursively, preserving existing
+            properties that are not specified in the update operation.
         row, col: int or None (default None)
             Subplot row and column index of mapbox objects to select.
             To select mapbox objects by row and column, the Figure
@@ -15301,7 +15319,7 @@ class Figure(BaseFigure):
             Returns the Figure object that the method was called on
         """
         for obj in self.select_mapboxes(selector=selector, row=row, col=col):
-            obj.update(patch, **kwargs)
+            obj.update(patch, overwrite=overwrite, **kwargs)
 
         return self
 
@@ -15363,7 +15381,9 @@ class Figure(BaseFigure):
 
         return self
 
-    def update_polars(self, patch=None, selector=None, row=None, col=None, **kwargs):
+    def update_polars(
+        self, patch=None, selector=None, overwrite=False, row=None, col=None, **kwargs
+    ):
         """
         Perform a property update operation on all polar objects
         that satisfy the specified selection criteria
@@ -15379,6 +15399,10 @@ class Figure(BaseFigure):
             properties corresponding to all of the dictionary's keys, with
             values that exactly match the supplied values. If None
             (the default), all polar objects are selected.
+        overwrite: bool
+            If True, overwrite existing properties. If False, apply updates
+            to existing properties recursively, preserving existing
+            properties that are not specified in the update operation.
         row, col: int or None (default None)
             Subplot row and column index of polar objects to select.
             To select polar objects by row and column, the Figure
@@ -15395,7 +15419,7 @@ class Figure(BaseFigure):
             Returns the Figure object that the method was called on
         """
         for obj in self.select_polars(selector=selector, row=row, col=col):
-            obj.update(patch, **kwargs)
+            obj.update(patch, overwrite=overwrite, **kwargs)
 
         return self
 
@@ -15457,7 +15481,9 @@ class Figure(BaseFigure):
 
         return self
 
-    def update_scenes(self, patch=None, selector=None, row=None, col=None, **kwargs):
+    def update_scenes(
+        self, patch=None, selector=None, overwrite=False, row=None, col=None, **kwargs
+    ):
         """
         Perform a property update operation on all scene objects
         that satisfy the specified selection criteria
@@ -15473,6 +15499,10 @@ class Figure(BaseFigure):
             properties corresponding to all of the dictionary's keys, with
             values that exactly match the supplied values. If None
             (the default), all scene objects are selected.
+        overwrite: bool
+            If True, overwrite existing properties. If False, apply updates
+            to existing properties recursively, preserving existing
+            properties that are not specified in the update operation.
         row, col: int or None (default None)
             Subplot row and column index of scene objects to select.
             To select scene objects by row and column, the Figure
@@ -15489,7 +15519,7 @@ class Figure(BaseFigure):
             Returns the Figure object that the method was called on
         """
         for obj in self.select_scenes(selector=selector, row=row, col=col):
-            obj.update(patch, **kwargs)
+            obj.update(patch, overwrite=overwrite, **kwargs)
 
         return self
 
@@ -15551,7 +15581,9 @@ class Figure(BaseFigure):
 
         return self
 
-    def update_ternaries(self, patch=None, selector=None, row=None, col=None, **kwargs):
+    def update_ternaries(
+        self, patch=None, selector=None, overwrite=False, row=None, col=None, **kwargs
+    ):
         """
         Perform a property update operation on all ternary objects
         that satisfy the specified selection criteria
@@ -15567,6 +15599,10 @@ class Figure(BaseFigure):
             properties corresponding to all of the dictionary's keys, with
             values that exactly match the supplied values. If None
             (the default), all ternary objects are selected.
+        overwrite: bool
+            If True, overwrite existing properties. If False, apply updates
+            to existing properties recursively, preserving existing
+            properties that are not specified in the update operation.
         row, col: int or None (default None)
             Subplot row and column index of ternary objects to select.
             To select ternary objects by row and column, the Figure
@@ -15583,7 +15619,7 @@ class Figure(BaseFigure):
             Returns the Figure object that the method was called on
         """
         for obj in self.select_ternaries(selector=selector, row=row, col=col):
-            obj.update(patch, **kwargs)
+            obj.update(patch, overwrite=overwrite, **kwargs)
 
         return self
 
@@ -15645,7 +15681,9 @@ class Figure(BaseFigure):
 
         return self
 
-    def update_xaxes(self, patch=None, selector=None, row=None, col=None, **kwargs):
+    def update_xaxes(
+        self, patch=None, selector=None, overwrite=False, row=None, col=None, **kwargs
+    ):
         """
         Perform a property update operation on all xaxis objects
         that satisfy the specified selection criteria
@@ -15661,6 +15699,10 @@ class Figure(BaseFigure):
             properties corresponding to all of the dictionary's keys, with
             values that exactly match the supplied values. If None
             (the default), all xaxis objects are selected.
+        overwrite: bool
+            If True, overwrite existing properties. If False, apply updates
+            to existing properties recursively, preserving existing
+            properties that are not specified in the update operation.
         row, col: int or None (default None)
             Subplot row and column index of xaxis objects to select.
             To select xaxis objects by row and column, the Figure
@@ -15677,7 +15719,7 @@ class Figure(BaseFigure):
             Returns the Figure object that the method was called on
         """
         for obj in self.select_xaxes(selector=selector, row=row, col=col):
-            obj.update(patch, **kwargs)
+            obj.update(patch, overwrite=overwrite, **kwargs)
 
         return self
 
@@ -15768,7 +15810,14 @@ class Figure(BaseFigure):
         return self
 
     def update_yaxes(
-        self, patch=None, selector=None, row=None, col=None, secondary_y=None, **kwargs
+        self,
+        patch=None,
+        selector=None,
+        overwrite=False,
+        row=None,
+        col=None,
+        secondary_y=None,
+        **kwargs
     ):
         """
         Perform a property update operation on all yaxis objects
@@ -15785,6 +15834,10 @@ class Figure(BaseFigure):
             properties corresponding to all of the dictionary's keys, with
             values that exactly match the supplied values. If None
             (the default), all yaxis objects are selected.
+        overwrite: bool
+            If True, overwrite existing properties. If False, apply updates
+            to existing properties recursively, preserving existing
+            properties that are not specified in the update operation.
         row, col: int or None (default None)
             Subplot row and column index of yaxis objects to select.
             To select yaxis objects by row and column, the Figure
@@ -15815,6 +15868,6 @@ class Figure(BaseFigure):
         for obj in self.select_yaxes(
             selector=selector, row=row, col=col, secondary_y=secondary_y
         ):
-            obj.update(patch, **kwargs)
+            obj.update(patch, overwrite=overwrite, **kwargs)
 
         return self

--- a/packages/python/plotly/plotly/graph_objs/_figurewidget.py
+++ b/packages/python/plotly/plotly/graph_objs/_figurewidget.py
@@ -15081,7 +15081,9 @@ class FigureWidget(BaseFigureWidget):
 
         return self
 
-    def update_coloraxes(self, patch=None, selector=None, row=None, col=None, **kwargs):
+    def update_coloraxes(
+        self, patch=None, selector=None, overwrite=False, row=None, col=None, **kwargs
+    ):
         """
         Perform a property update operation on all coloraxis objects
         that satisfy the specified selection criteria
@@ -15097,6 +15099,10 @@ class FigureWidget(BaseFigureWidget):
             properties corresponding to all of the dictionary's keys, with
             values that exactly match the supplied values. If None
             (the default), all coloraxis objects are selected.
+        overwrite: bool
+            If True, overwrite existing properties. If False, apply updates
+            to existing properties recursively, preserving existing
+            properties that are not specified in the update operation.
         row, col: int or None (default None)
             Subplot row and column index of coloraxis objects to select.
             To select coloraxis objects by row and column, the Figure
@@ -15113,7 +15119,7 @@ class FigureWidget(BaseFigureWidget):
             Returns the Figure object that the method was called on
         """
         for obj in self.select_coloraxes(selector=selector, row=row, col=col):
-            obj.update(patch, **kwargs)
+            obj.update(patch, overwrite=overwrite, **kwargs)
 
         return self
 
@@ -15175,7 +15181,9 @@ class FigureWidget(BaseFigureWidget):
 
         return self
 
-    def update_geos(self, patch=None, selector=None, row=None, col=None, **kwargs):
+    def update_geos(
+        self, patch=None, selector=None, overwrite=False, row=None, col=None, **kwargs
+    ):
         """
         Perform a property update operation on all geo objects
         that satisfy the specified selection criteria
@@ -15191,6 +15199,10 @@ class FigureWidget(BaseFigureWidget):
             properties corresponding to all of the dictionary's keys, with
             values that exactly match the supplied values. If None
             (the default), all geo objects are selected.
+        overwrite: bool
+            If True, overwrite existing properties. If False, apply updates
+            to existing properties recursively, preserving existing
+            properties that are not specified in the update operation.
         row, col: int or None (default None)
             Subplot row and column index of geo objects to select.
             To select geo objects by row and column, the Figure
@@ -15207,7 +15219,7 @@ class FigureWidget(BaseFigureWidget):
             Returns the Figure object that the method was called on
         """
         for obj in self.select_geos(selector=selector, row=row, col=col):
-            obj.update(patch, **kwargs)
+            obj.update(patch, overwrite=overwrite, **kwargs)
 
         return self
 
@@ -15269,7 +15281,9 @@ class FigureWidget(BaseFigureWidget):
 
         return self
 
-    def update_mapboxes(self, patch=None, selector=None, row=None, col=None, **kwargs):
+    def update_mapboxes(
+        self, patch=None, selector=None, overwrite=False, row=None, col=None, **kwargs
+    ):
         """
         Perform a property update operation on all mapbox objects
         that satisfy the specified selection criteria
@@ -15285,6 +15299,10 @@ class FigureWidget(BaseFigureWidget):
             properties corresponding to all of the dictionary's keys, with
             values that exactly match the supplied values. If None
             (the default), all mapbox objects are selected.
+        overwrite: bool
+            If True, overwrite existing properties. If False, apply updates
+            to existing properties recursively, preserving existing
+            properties that are not specified in the update operation.
         row, col: int or None (default None)
             Subplot row and column index of mapbox objects to select.
             To select mapbox objects by row and column, the Figure
@@ -15301,7 +15319,7 @@ class FigureWidget(BaseFigureWidget):
             Returns the Figure object that the method was called on
         """
         for obj in self.select_mapboxes(selector=selector, row=row, col=col):
-            obj.update(patch, **kwargs)
+            obj.update(patch, overwrite=overwrite, **kwargs)
 
         return self
 
@@ -15363,7 +15381,9 @@ class FigureWidget(BaseFigureWidget):
 
         return self
 
-    def update_polars(self, patch=None, selector=None, row=None, col=None, **kwargs):
+    def update_polars(
+        self, patch=None, selector=None, overwrite=False, row=None, col=None, **kwargs
+    ):
         """
         Perform a property update operation on all polar objects
         that satisfy the specified selection criteria
@@ -15379,6 +15399,10 @@ class FigureWidget(BaseFigureWidget):
             properties corresponding to all of the dictionary's keys, with
             values that exactly match the supplied values. If None
             (the default), all polar objects are selected.
+        overwrite: bool
+            If True, overwrite existing properties. If False, apply updates
+            to existing properties recursively, preserving existing
+            properties that are not specified in the update operation.
         row, col: int or None (default None)
             Subplot row and column index of polar objects to select.
             To select polar objects by row and column, the Figure
@@ -15395,7 +15419,7 @@ class FigureWidget(BaseFigureWidget):
             Returns the Figure object that the method was called on
         """
         for obj in self.select_polars(selector=selector, row=row, col=col):
-            obj.update(patch, **kwargs)
+            obj.update(patch, overwrite=overwrite, **kwargs)
 
         return self
 
@@ -15457,7 +15481,9 @@ class FigureWidget(BaseFigureWidget):
 
         return self
 
-    def update_scenes(self, patch=None, selector=None, row=None, col=None, **kwargs):
+    def update_scenes(
+        self, patch=None, selector=None, overwrite=False, row=None, col=None, **kwargs
+    ):
         """
         Perform a property update operation on all scene objects
         that satisfy the specified selection criteria
@@ -15473,6 +15499,10 @@ class FigureWidget(BaseFigureWidget):
             properties corresponding to all of the dictionary's keys, with
             values that exactly match the supplied values. If None
             (the default), all scene objects are selected.
+        overwrite: bool
+            If True, overwrite existing properties. If False, apply updates
+            to existing properties recursively, preserving existing
+            properties that are not specified in the update operation.
         row, col: int or None (default None)
             Subplot row and column index of scene objects to select.
             To select scene objects by row and column, the Figure
@@ -15489,7 +15519,7 @@ class FigureWidget(BaseFigureWidget):
             Returns the Figure object that the method was called on
         """
         for obj in self.select_scenes(selector=selector, row=row, col=col):
-            obj.update(patch, **kwargs)
+            obj.update(patch, overwrite=overwrite, **kwargs)
 
         return self
 
@@ -15551,7 +15581,9 @@ class FigureWidget(BaseFigureWidget):
 
         return self
 
-    def update_ternaries(self, patch=None, selector=None, row=None, col=None, **kwargs):
+    def update_ternaries(
+        self, patch=None, selector=None, overwrite=False, row=None, col=None, **kwargs
+    ):
         """
         Perform a property update operation on all ternary objects
         that satisfy the specified selection criteria
@@ -15567,6 +15599,10 @@ class FigureWidget(BaseFigureWidget):
             properties corresponding to all of the dictionary's keys, with
             values that exactly match the supplied values. If None
             (the default), all ternary objects are selected.
+        overwrite: bool
+            If True, overwrite existing properties. If False, apply updates
+            to existing properties recursively, preserving existing
+            properties that are not specified in the update operation.
         row, col: int or None (default None)
             Subplot row and column index of ternary objects to select.
             To select ternary objects by row and column, the Figure
@@ -15583,7 +15619,7 @@ class FigureWidget(BaseFigureWidget):
             Returns the Figure object that the method was called on
         """
         for obj in self.select_ternaries(selector=selector, row=row, col=col):
-            obj.update(patch, **kwargs)
+            obj.update(patch, overwrite=overwrite, **kwargs)
 
         return self
 
@@ -15645,7 +15681,9 @@ class FigureWidget(BaseFigureWidget):
 
         return self
 
-    def update_xaxes(self, patch=None, selector=None, row=None, col=None, **kwargs):
+    def update_xaxes(
+        self, patch=None, selector=None, overwrite=False, row=None, col=None, **kwargs
+    ):
         """
         Perform a property update operation on all xaxis objects
         that satisfy the specified selection criteria
@@ -15661,6 +15699,10 @@ class FigureWidget(BaseFigureWidget):
             properties corresponding to all of the dictionary's keys, with
             values that exactly match the supplied values. If None
             (the default), all xaxis objects are selected.
+        overwrite: bool
+            If True, overwrite existing properties. If False, apply updates
+            to existing properties recursively, preserving existing
+            properties that are not specified in the update operation.
         row, col: int or None (default None)
             Subplot row and column index of xaxis objects to select.
             To select xaxis objects by row and column, the Figure
@@ -15677,7 +15719,7 @@ class FigureWidget(BaseFigureWidget):
             Returns the Figure object that the method was called on
         """
         for obj in self.select_xaxes(selector=selector, row=row, col=col):
-            obj.update(patch, **kwargs)
+            obj.update(patch, overwrite=overwrite, **kwargs)
 
         return self
 
@@ -15768,7 +15810,14 @@ class FigureWidget(BaseFigureWidget):
         return self
 
     def update_yaxes(
-        self, patch=None, selector=None, row=None, col=None, secondary_y=None, **kwargs
+        self,
+        patch=None,
+        selector=None,
+        overwrite=False,
+        row=None,
+        col=None,
+        secondary_y=None,
+        **kwargs
     ):
         """
         Perform a property update operation on all yaxis objects
@@ -15785,6 +15834,10 @@ class FigureWidget(BaseFigureWidget):
             properties corresponding to all of the dictionary's keys, with
             values that exactly match the supplied values. If None
             (the default), all yaxis objects are selected.
+        overwrite: bool
+            If True, overwrite existing properties. If False, apply updates
+            to existing properties recursively, preserving existing
+            properties that are not specified in the update operation.
         row, col: int or None (default None)
             Subplot row and column index of yaxis objects to select.
             To select yaxis objects by row and column, the Figure
@@ -15815,6 +15868,6 @@ class FigureWidget(BaseFigureWidget):
         for obj in self.select_yaxes(
             selector=selector, row=row, col=col, secondary_y=secondary_y
         ):
-            obj.update(patch, **kwargs)
+            obj.update(patch, overwrite=overwrite, **kwargs)
 
         return self

--- a/packages/python/plotly/plotly/tests/test_core/test_graph_objs/test_update.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_graph_objs/test_update.py
@@ -157,3 +157,51 @@ class TestUpdateMethod(TestCase):
         }
 
         self.assertEqual(layout.to_plotly_json(), expected)
+
+    def test_overwrite_compound_prop(self):
+        layout = go.Layout(title_font_family="Courier")
+
+        # First update with default (recursive) behavior
+        layout.update(title={"text": "Fig Title"})
+        expected = {"title": {"text": "Fig Title", "font": {"family": "Courier"}}}
+        self.assertEqual(layout.to_plotly_json(), expected)
+
+        # Update with overwrite behavior
+        layout.update(title={"text": "Fig Title2"}, overwrite=True)
+        expected = {"title": {"text": "Fig Title2"}}
+        self.assertEqual(layout.to_plotly_json(), expected)
+
+    def test_overwrite_tuple_prop(self):
+        layout = go.Layout(
+            annotations=[
+                go.layout.Annotation(text="one"),
+                go.layout.Annotation(text="two"),
+            ]
+        )
+
+        layout.update(
+            overwrite=True,
+            annotations=[
+                go.layout.Annotation(width=10),
+                go.layout.Annotation(width=20),
+                go.layout.Annotation(width=30),
+                go.layout.Annotation(width=40),
+                go.layout.Annotation(width=50),
+            ],
+        )
+
+        expected = {
+            "annotations": [
+                {"width": 10},
+                {"width": 20},
+                {"width": 30},
+                {"width": 40},
+                {"width": 50},
+            ]
+        }
+
+        self.assertEqual(layout.to_plotly_json(), expected)
+
+        # Remove all annotations
+        layout.update(overwrite=True, annotations=None)
+        self.assertEqual(layout.to_plotly_json(), {})

--- a/packages/python/plotly/plotly/tests/test_core/test_update_objects/test_update_layout.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_update_objects/test_update_layout.py
@@ -3,6 +3,11 @@ import plotly.graph_objects as go
 
 
 class TestUpdateLayout(TestCase):
+    def setUp(self):
+        import plotly.io as pio
+
+        pio.templates.default = None
+
     def test_update_layout_kwargs(self):
         # Create initial figure
         fig = go.Figure()
@@ -26,3 +31,41 @@ class TestUpdateLayout(TestCase):
         fig.update_layout(dict(title=dict(font=dict(family="Courier New"))))
         orig_fig.layout.update(title_font_family="Courier New")
         self.assertEqual(fig, orig_fig)
+
+    def test_update_layout_overwrite(self):
+        fig = go.Figure(
+            layout=go.Layout(
+                annotations=[
+                    go.layout.Annotation(text="one"),
+                    go.layout.Annotation(text="two"),
+                ]
+            )
+        )
+
+        fig.update_layout(
+            overwrite=True,
+            annotations=[
+                go.layout.Annotation(width=10),
+                go.layout.Annotation(width=20),
+                go.layout.Annotation(width=30),
+                go.layout.Annotation(width=40),
+                go.layout.Annotation(width=50),
+            ],
+        )
+
+        expected = {
+            "annotations": [
+                {"width": 10},
+                {"width": 20},
+                {"width": 30},
+                {"width": 40},
+                {"width": 50},
+            ]
+        }
+
+        fig.layout.pop("template")
+        self.assertEqual(fig.layout.to_plotly_json(), expected)
+
+        # Remove all annotations
+        fig.update_layout(overwrite=True, annotations=None)
+        self.assertEqual(fig.layout.annotations, ())

--- a/packages/python/plotly/plotly/tests/test_core/test_update_objects/test_update_subplots.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_update_objects/test_update_subplots.py
@@ -563,3 +563,12 @@ class TestSelectForEachUpdateSubplots(TestCase):
             row=1,
             selector={"title.text": "A"},
         )
+
+    def test_update_subplot_overwrite(self):
+        fig = go.Figure(layout_xaxis_title_text="Axis title")
+        fig.update_xaxes(overwrite=True, title={"font": {"family": "Courier"}})
+
+        self.assertEqual(
+            fig.layout.xaxis.to_plotly_json(),
+            {"title": {"font": {"family": "Courier"}}},
+        )

--- a/packages/python/plotly/plotly/tests/test_core/test_update_objects/test_update_traces.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_update_objects/test_update_traces.py
@@ -362,3 +362,18 @@ class TestSelectForEachUpdateTraces(TestCase):
         )
 
         self.assert_update_traces([9], {"marker.size": 6}, col=1, secondary_y=True)
+
+    def test_update_traces_overwrite(self):
+        fig = go.Figure(
+            data=[go.Scatter(marker_line_color="red"), go.Bar(marker_line_color="red")]
+        )
+
+        fig.update_traces(overwrite=True, marker={"line": {"width": 10}})
+
+        self.assertEqual(
+            fig.to_plotly_json()["data"],
+            [
+                {"type": "scatter", "marker": {"line": {"width": 10}}},
+                {"type": "bar", "marker": {"line": {"width": 10}}},
+            ],
+        )


### PR DESCRIPTION
Closes https://github.com/plotly/plotly.py/issues/1717

This PR adds a new `overwrite` kwarg to all of the figure `update*` methods.  The default behavior, with `overwrite=False`, is to apply updates recursively to the existing nested property structure.  With `overwrite=True`, the prior value of existing properties is overwritten with the provided value.

