### PR TITLE
more flexible type of input arguments for px functions

### DIFF
--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -778,7 +778,6 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
     ):
         args["data_frame"] = pd.DataFrame(args["data_frame"])
 
-
     # We start from an empty DataFrame except for the case of functions which
     # implicitely need all dimensions: Splom, Parcats, Parcoords
     # This could be refined when dimensions is given
@@ -851,16 +850,14 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
             # Case of index
             elif isinstance(argument, pd.core.indexes.multi.MultiIndex):
                 raise TypeError("pandas MultiIndex is not supported by plotly express")
-            elif isinstance(argument, pd.core.indexes.range.RangeIndex):
-                col_name = argument.name if argument.name else "index"
-                try:
-                    df.insert(0, col_name, argument)
-                except ValueError:  # if col named index already exists, replace
-                    df[col_name] = argument
             # Case of numpy array or df column
             else:
                 try:
                     col_name = argument.name  # pandas df
+                    if col_name is None and isinstance(
+                        argument, pd.core.indexes.range.RangeIndex
+                    ):
+                        col_name = "index"
                     if (
                         args.get("data_frame") is not None
                         and col_name in args["data_frame"]

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -754,16 +754,13 @@ def apply_default_cascade(args):
         args["marginal_x"] = None
 
 
-def build_or_augment_dataframe(args, attrables, array_attrables, constructor):
+def build_or_augment_dataframe(args, attrables, array_attrables):
     """
     Constructs an implicit dataframe and modifies `args` in-place.
 
     Parameters
     ----------
     args : OrderedDict
-        
-    constructor : go Trace object
-        trace function. It is used to fine-tune some options.
     `attrables` is a list of keys into `args`, all of whose corresponding
     values are converted into columns of a dataframe.
     Used to be support calls to plotting function that elide a dataframe
@@ -773,13 +770,14 @@ def build_or_augment_dataframe(args, attrables, array_attrables, constructor):
     # We start from an empty DataFrame except for the case of functions which
     # implicitely need all dimensions: Splom, Parcats, Parcoords
     # This could be refined when dimensions is given
-    if constructor in [go.Splom, go.Parcats, go.Parcoords]:  # we take all dimensions
-        df = args["data_frame"]
-    else:
-        df = pd.DataFrame()
+    df = pd.DataFrame()
 
-    # Retrieve labels (to change column names)
-    # labels = args.get("labels")  # labels or None
+    if "dimensions" in args and args["dimensions"] is None:
+        if args.get("data_frame") is None or args["data_frame"] is None:
+            raise ValueError("No data were provided")
+        else:
+            df_args = args["data_frame"]
+            df[df_args.columns] = df_args[df_args.columns]
 
     # Valid column names
     df_columns = (
@@ -857,7 +855,7 @@ def infer_config(args, constructor, trace_patch):
     group_attrables = ["animation_frame", "facet_row", "facet_col", "line_group"]
 
     all_attrables = attrables + group_attrables + ["color"]
-    build_or_augment_dataframe(args, all_attrables, array_attrables, constructor)
+    build_or_augment_dataframe(args, all_attrables, array_attrables)
 
     attrs = [k for k in attrables if k in args]
     grouped_attrs = []

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -928,8 +928,8 @@ def build_dataframe(args, attrables, array_attrables):
                         if is_index:
                             keep_name = df_provided and argument is df_input.index
                         else:
-                            keep_name = col_name in df_input and argument.equals(
-                                df_input[col_name]
+                            keep_name = (
+                                col_name in df_input and argument is df_input[col_name]
                             )
                         col_name = (
                             col_name

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -803,7 +803,8 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
             if field_name not in array_attrables
             else args.get(field_name)
         )
-        if argument_list is None:  # argument not specified, continue
+        # argument not specified, continue
+        if argument_list is None or argument_list is [None]:
             continue
         # Argument name: field_name if the argument is a list
         # Else we give names like ["hover_data_0, hover_data_1"] etc.

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -671,7 +671,7 @@ def one_group(x):
 
 
 def apply_default_cascade(args):
-    # https://github.com/plotly/dash-table/issues/597first we apply px.defaults to unspecified args
+    # first we apply px.defaults to unspecified args
     for param in (
         ["color_discrete_sequence", "color_continuous_scale"]
         + ["symbol_sequence", "line_dash_sequence", "template"]

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -762,12 +762,13 @@ def build_or_augment_dataframe(args, attrables, array_attrables, constructor):
     Used to be support calls to plotting function that elide a dataframe
     argument; for example `scatter(x=[1,2], y=[3,4])`.
     """
-    # This will be changed so that we start from an empty dataframe
-    if args.get("data_frame") is None:
-        df = pd.DataFrame()
-    else:
-        df = args["data_frame"]
+    df = pd.DataFrame()
     labels = args.get("labels")  # labels or None
+    df_columns = (
+        args["data_frame"].columns if args.get("data_frame") is not None else None
+    )
+    if "symbol" in args:
+        attrables += ["symbol"]
     for field_name in attrables:
         argument_list = (
             [args.get(field_name)]
@@ -785,7 +786,15 @@ def build_or_augment_dataframe(args, attrables, array_attrables, constructor):
             if argument is None:
                 continue
             elif isinstance(argument, str):  # needs to change
-                continue
+                try:
+                    df[argument] = args["data_frame"][argument]
+                    continue
+                except KeyError:
+                    raise ValueError(
+                        "Value of '%s' is not the name of a column in 'data_frame'. "
+                        "Expected one of %s but received: %s"
+                        % (field, str(list(df_columns)), argument)
+                    )
             # Case of index
             elif isinstance(argument, pd.core.indexes.range.RangeIndex):
                 col_name = argument.name if argument.name else "index"

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -829,6 +829,8 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
                 df[argument] = args["data_frame"][argument]
                 continue
             # Case of index
+            elif isinstance(argument, pd.core.indexes.multi.MultiIndex):
+                raise TypeError("pandas MultiIndex is not supported by plotly express")
             elif isinstance(argument, pd.core.indexes.range.RangeIndex):
                 col_name = argument.name if argument.name else "index"
                 try:

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -771,6 +771,11 @@ def _name_heuristic(argument, field_name, df):
         )
 
 
+def _get_reserved_names(args, attrables, array_attrables):
+    df = args['data_frame']
+    for field in args:
+
+
 def build_dataframe(args, attrables, array_attrables):
     """
     Constructs a dataframe and modifies `args` in-place.
@@ -795,6 +800,8 @@ def build_dataframe(args, attrables, array_attrables):
     ):
         args["data_frame"] = pd.DataFrame(args["data_frame"])
 
+    if args["data_frame"] is not None:
+        reserved_names = _get_reserved_names(args, attrables, array_attrables)
     # We start from an empty DataFrame except for the case of functions which
     # implicitely need all dimensions: Splom, Parcats, Parcoords
     # This could be refined when dimensions is given

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -817,15 +817,15 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
                         "is provided in the `data_frame` argument."
                     )
                 # Check validity of column name
-                try:
-                    df[argument] = args["data_frame"][argument]
-                    continue
-                except KeyError:
+                if argument not in df_columns:
                     raise ValueError(
                         "Value of '%s' is not the name of a column in 'data_frame'. "
                         "Expected one of %s but received: %s"
                         % (field, str(list(df_columns)), argument)
                     )
+
+                df[argument] = args["data_frame"][argument]
+                continue
             # Case of index
             elif isinstance(argument, pd.core.indexes.range.RangeIndex):
                 col_name = argument.name if argument.name else "index"

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -788,7 +788,7 @@ def _initialize_argument_col_names(args, attrables, array_attrables):
                 continue
             if isinstance(arg, str):
                 used_col_names.add(arg)
-            if isinstance(arg, pd.DataFrame) or isinstance(arg, pd.core.series.Series):
+            if isinstance(arg, pd.core.series.Series):
                 arg_name = arg.name
                 if arg_name and hasattr(df, arg_name):
                     in_df = arg is df[arg_name]

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -887,10 +887,15 @@ def build_dataframe(args, attrables, array_attrables):
                     )
                 if length and len(args["data_frame"][argument]) != length:
                     raise ValueError(
-                        "All arguments should have the same length."
-                        "The length of column argument `df[%s]` is %d, whereas the"
-                        "length of previous arguments is %d"
-                        % (field, len(args["data_frame"][argument]), length)
+                        "All arguments should have the same length. "
+                        "The length of column argument `df[%s]` is %d, whereas the "
+                        "length of previous arguments %s is %d"
+                        % (
+                            field,
+                            len(args["data_frame"][argument]),
+                            str(list(df.columns)),
+                            length,
+                        )
                     )
                 col_name = argument
                 if isinstance(argument, int):
@@ -935,8 +940,8 @@ def build_dataframe(args, attrables, array_attrables):
                     raise ValueError(
                         "All arguments should have the same length."
                         "The length of argument `%s` is %d, whereas the"
-                        "length of previous arguments is %d"
-                        % (field, len(argument), length)
+                        "length of previous arguments %s is %d"
+                        % (field, len(argument), str(list(df.columns)), length)
                     )
                 df[str(col_name)] = argument
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -767,8 +767,8 @@ def _name_heuristic(argument, field_name, df):
         raise NameError(
             "A name conflict was encountered for argument %s."
             "Columns with names %s, %s and %s are already used"
-            % (field_name, argument, field_name, field_name + '_' + argument)
-            )
+            % (field_name, argument, field_name, field_name + "_" + argument)
+        )
 
 
 def build_dataframe(args, attrables, array_attrables):

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -756,15 +756,21 @@ def apply_default_cascade(args):
 
 def build_or_augment_dataframe(args, attrables, array_attrables):
     """
-    Constructs an implicit dataframe and modifies `args` in-place.
+    Constructs a dataframe and modifies `args` in-place.
+
+    The argument values in `args` can be either strings corresponding to
+    existing columns of a dataframe, or data arrays (lists, numpy arrays,
+    pandas columns, series).
 
     Parameters
     ----------
     args : OrderedDict
-    `attrables` is a list of keys into `args`, all of whose corresponding
-    values are converted into columns of a dataframe.
-    Used to be support calls to plotting function that elide a dataframe
-    argument; for example `scatter(x=[1,2], y=[3,4])`.
+        arguments passed to the px function and subsequently modified
+    attrables : list
+        list of keys into `args`, all of whose corresponding values are
+        converted into columns of a dataframe.
+    array_attrables : list
+        argument names corresponding to iterables, such as `hover_data`, ...
     """
 
     # We start from an empty DataFrame except for the case of functions which
@@ -820,6 +826,11 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
                         "Value of '%s' is not the name of a column in 'data_frame'. "
                         "Expected one of %s but received: %s"
                         % (field, str(list(df_columns)), argument)
+                    )
+                except TypeError:
+                    raise ValueError(
+                        "String arguments are only possible when a DataFrame"
+                        "is provided in the `data_frame` argument."
                     )
             # Case of index
             elif isinstance(argument, pd.core.indexes.range.RangeIndex):

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -795,7 +795,7 @@ def _get_reserved_col_names(args, attrables, array_attrables):
     return reserved_names
 
 
-def build_dataframe(input_args, attrables, array_attrables):
+def build_dataframe(args, attrables, array_attrables):
     """
     Constructs a dataframe and modifies `args` in-place.
 
@@ -813,7 +813,6 @@ def build_dataframe(input_args, attrables, array_attrables):
     array_attrables : list
         argument names corresponding to iterables, such as `hover_data`, ...
     """
-    args = input_args.copy()
     for field in args:
         if field in array_attrables and args[field] is not None:
             args[field] = list(args[field])

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -870,7 +870,7 @@ def build_dataframe(args, attrables, array_attrables):
             # Case of multiindex
             if isinstance(argument, pd.MultiIndex):
                 raise TypeError(
-                    "Argument '%s' is a pandas MultiIndex."
+                    "Argument '%s' is a pandas MultiIndex. "
                     "pandas MultiIndex is not supported by plotly express "
                     "at the moment." % field
                 )
@@ -880,10 +880,10 @@ def build_dataframe(args, attrables, array_attrables):
             ):  # just a column name given as str or int
                 if not df_provided:
                     raise ValueError(
-                        "String or int arguments are only possible when a"
-                        "DataFrame or an array is provided in the `data_frame`"
-                        "argument. No DataFrame was provided, but argument '%s'"
-                        "is of type str or int." % field
+                        "String or int arguments are only possible when a "
+                        "DataFrame or an array is provided in the `data_frame` "
+                        "argument. No DataFrame was provided, but argument "
+                        "'%s' is of type str or int." % field
                     )
                 # Check validity of column name
                 if argument not in df_input.columns:
@@ -941,8 +941,8 @@ def build_dataframe(args, attrables, array_attrables):
                     col_name = _check_name_not_reserved(field, reserved_names)
                 if length and len(argument) != length:
                     raise ValueError(
-                        "All arguments should have the same length."
-                        "The length of argument `%s` is %d, whereas the"
+                        "All arguments should have the same length. "
+                        "The length of argument `%s` is %d, whereas the "
                         "length of previous arguments %s is %d"
                         % (field, len(argument), str(list(df_output.columns)), length)
                     )

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -779,7 +779,7 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
     df = pd.DataFrame()
 
     if "dimensions" in args and args["dimensions"] is None:
-        if args.get("data_frame") is None or args["data_frame"] is None:
+        if args["data_frame"] is None:
             raise ValueError(
                 "No data were provided. Please provide data either with the `data_frame` or with the `dimensions` argument."
             )
@@ -788,9 +788,7 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
             df[df_args.columns] = df_args[df_args.columns]
 
     # Valid column names
-    df_columns = (
-        args["data_frame"].columns if args.get("data_frame") is not None else None
-    )
+    df_columns = args["data_frame"].columns if args["data_frame"] is not None else None
     group_attrs = ["symbol", "line_dash"]
     for group_attr in group_attrs:
         if group_attr in args:

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -815,7 +815,11 @@ def build_dataframe(args, attrables, array_attrables):
     """
     for field in args:
         if field in array_attrables and args[field] is not None:
-            args[field] = list(args[field])
+            args[field] = (
+                dict(args[field])
+                if isinstance(args[field], dict)
+                else list(args[field])
+            )
     # Cast data_frame argument to DataFrame (it could be a numpy array, dict etc.)
     df_provided = args["data_frame"] is not None
     if df_provided and not isinstance(args["data_frame"], pd.DataFrame):

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -762,13 +762,18 @@ def build_or_augment_dataframe(args, attrables, array_attrables, constructor):
     Used to be support calls to plotting function that elide a dataframe
     argument; for example `scatter(x=[1,2], y=[3,4])`.
     """
-    df = pd.DataFrame()
+    if constructor in [go.Splom, go.Parcats, go.Parcoords]:  # we take all dimensions
+        df = args["data_frame"]
+    else:
+        df = pd.DataFrame()
     labels = args.get("labels")  # labels or None
     df_columns = (
         args["data_frame"].columns if args.get("data_frame") is not None else None
     )
-    if "symbol" in args:
-        attrables += ["symbol"]
+    group_attrs = ["symbol", "line_dash"]
+    for group_attr in group_attrs:
+        if group_attr in args:
+            attrables += [group_attr]
     for field_name in attrables:
         argument_list = (
             [args.get(field_name)]

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -754,9 +754,7 @@ def apply_default_cascade(args):
         args["marginal_x"] = None
 
 
-def _name_heuristic(argument, field_name, reserved_names):
-    if isinstance(argument, int):
-        argument = str(argument)
+def _check_name_not_reserved(field_name, reserved_names):
     if field_name not in reserved_names:
         return field_name
     else:
@@ -783,9 +781,9 @@ def _get_reserved_col_names(args, attrables, array_attrables):
         for arg in names:
             if arg is None:
                 continue
-            if isinstance(arg, str):
+            elif isinstance(arg, str):  # no need to add ints since kw arg are not ints
                 reserved_names.add(arg)
-            if isinstance(arg, pd.core.series.Series):
+            elif isinstance(arg, pd.Series):
                 arg_name = arg.name
                 if arg_name and hasattr(df, arg_name):
                     in_df = arg is df[arg_name]
@@ -870,7 +868,7 @@ def build_dataframe(args, attrables, array_attrables):
             if argument is None:
                 continue
             # Case of multiindex
-            if isinstance(argument, pd.core.indexes.multi.MultiIndex):
+            if isinstance(argument, pd.MultiIndex):
                 raise TypeError(
                     "Argument '%s' is a pandas MultiIndex."
                     "pandas MultiIndex is not supported by plotly express "
@@ -911,13 +909,11 @@ def build_dataframe(args, attrables, array_attrables):
                             length,
                         )
                     )
-                col_name = argument
-                if isinstance(argument, int):
-                    col_name = _name_heuristic(argument, field, reserved_names)
+                col_name = str(argument)
                 df_output[col_name] = df_input[argument]
             # ----------------- argument is a column / array / list.... -------
             else:
-                is_index = isinstance(argument, pd.core.indexes.range.RangeIndex)
+                is_index = isinstance(argument, pd.RangeIndex)
                 # First pandas
                 # pandas series have a name but it's None
                 if (
@@ -939,10 +935,10 @@ def build_dataframe(args, attrables, array_attrables):
                         col_name = (
                             col_name
                             if keep_name
-                            else _name_heuristic(col_name, field, reserved_names)
+                            else _check_name_not_reserved(field, reserved_names)
                         )
                 else:  # numpy array, list...
-                    col_name = _name_heuristic(field, field, reserved_names)
+                    col_name = _check_name_not_reserved(field, reserved_names)
                 if length and len(argument) != length:
                     raise ValueError(
                         "All arguments should have the same length."

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -768,14 +768,14 @@ def build_or_augment_dataframe(args, attrables, array_attrables, constructor):
     else:
         df = args["data_frame"]
     for field in attrables:
-        labels = args.get("labels") # labels or None
+        labels = args.get("labels")  # labels or None
         # hack, needs to be changed when we start from empty df
         if field in array_attrables:
             continue
         argument = args.get(field)
         if argument is None:
             continue
-        elif isinstance(argument, str): # needs to change
+        elif isinstance(argument, str):  # needs to change
             continue
         # Case of index
         elif isinstance(argument, pd.core.indexes.range.RangeIndex):
@@ -783,8 +783,8 @@ def build_or_augment_dataframe(args, attrables, array_attrables, constructor):
             col_name = labels[field] if labels and labels.get(field) else col_name
             try:
                 df.insert(0, col_name, argument)
-            except ValueError: # if col named index already exists, replace
-                df['col_name'] = argument
+            except ValueError:  # if col named index already exists, replace
+                df["col_name"] = argument
         else:  # args[field] should be an array or df column
             try:
                 col_name = argument.name  # pandas df

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -877,11 +877,16 @@ def build_dataframe(args, attrables, array_attrables):
                     )
                 # Check validity of column name
                 if argument not in args["data_frame"].columns:
-                    raise ValueError(
+                    err_msg = (
                         "Value of '%s' is not the name of a column in 'data_frame'. "
                         "Expected one of %s but received: %s"
                         % (field, str(list(args["data_frame"].columns)), argument)
                     )
+                    if argument == "index":
+                        err_msg += (
+                            "\n To use the index, pass it in directly as `df.index`."
+                        )
+                    raise ValueError(err_msg)
                 if length and len(args["data_frame"][argument]) != length:
                     raise ValueError(
                         "All arguments should have the same length. "

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -929,9 +929,9 @@ def build_dataframe(args, attrables, array_attrables):
                             keep_name = df_provided and argument is df_input.index
                         else:
                             # we use getattr/hasattr because of index
-                            keep_name = hasattr(
-                                df_input, col_name
-                            ) and argument is getattr(df_input, col_name)
+                            keep_name = col_name in df_input and argument.equals(
+                                df_input[col_name]
+                            )
                         col_name = (
                             col_name
                             if keep_name

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -757,6 +757,13 @@ def apply_default_cascade(args):
 def build_or_augment_dataframe(args, attrables, array_attrables, constructor):
     """
     Constructs an implicit dataframe and modifies `args` in-place.
+
+    Parameters
+    ----------
+    args : OrderedDict
+        
+    constructor : go Trace object
+        trace function. It is used to fine-tune some options.
     `attrables` is a list of keys into `args`, all of whose corresponding
     values are converted into columns of a dataframe.
     Used to be support calls to plotting function that elide a dataframe
@@ -772,7 +779,7 @@ def build_or_augment_dataframe(args, attrables, array_attrables, constructor):
         df = pd.DataFrame()
 
     # Retrieve labels (to change column names)
-    labels = args.get("labels")  # labels or None
+    # labels = args.get("labels")  # labels or None
 
     # Valid column names
     df_columns = (
@@ -817,7 +824,6 @@ def build_or_augment_dataframe(args, attrables, array_attrables, constructor):
             # Case of index
             elif isinstance(argument, pd.core.indexes.range.RangeIndex):
                 col_name = argument.name if argument.name else "index"
-                col_name = labels[field] if labels and labels.get(field) else col_name
                 try:
                     df.insert(0, col_name, argument)
                 except ValueError:  # if col named index already exists, replace
@@ -827,7 +833,7 @@ def build_or_augment_dataframe(args, attrables, array_attrables, constructor):
                 try:
                     col_name = argument.name  # pandas df
                 except AttributeError:
-                    col_name = labels[field] if labels and labels.get(field) else field
+                    col_name = field
                 df[col_name] = argument
             # Update argument with column name now that column exists
             if field_name not in array_attrables:

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -859,11 +859,13 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
                 )
             # Case of numpy array or df column
             else:
-                if hasattr(argument, "name"):
+                is_index = isinstance(argument, pd.core.indexes.range.RangeIndex)
+                # pandas series have a name but it's None
+                if (
+                    hasattr(argument, "name") and argument.name is not None
+                ) or is_index:
                     col_name = argument.name  # pandas df
-                    if col_name is None and isinstance(
-                        argument, pd.core.indexes.range.RangeIndex
-                    ):
+                    if col_name is None and is_index:
                         col_name = "index"
                     if (
                         args.get("data_frame") is not None

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -767,33 +767,44 @@ def build_or_augment_dataframe(args, attrables, array_attrables, constructor):
         df = pd.DataFrame()
     else:
         df = args["data_frame"]
-    for field in attrables:
-        labels = args.get("labels")  # labels or None
-        # hack, needs to be changed when we start from empty df
-        if field in array_attrables:
+    labels = args.get("labels")  # labels or None
+    for field_name in attrables:
+        argument_list = (
+            [args.get(field_name)]
+            if field_name not in array_attrables
+            else args.get(field_name)
+        )
+        if argument_list is None:
             continue
-        argument = args.get(field)
-        if argument is None:
-            continue
-        elif isinstance(argument, str):  # needs to change
-            continue
-        # Case of index
-        elif isinstance(argument, pd.core.indexes.range.RangeIndex):
-            col_name = argument.name if argument.name else "index"
-            col_name = labels[field] if labels and labels.get(field) else col_name
-            try:
-                df.insert(0, col_name, argument)
-            except ValueError:  # if col named index already exists, replace
-                df["col_name"] = argument
-        else:  # args[field] should be an array or df column
-            try:
-                col_name = argument.name  # pandas df
-            except AttributeError:
-                col_name = labels[field] if labels and labels.get(field) else field
-            df[col_name] = argument
-        # This sets the label of an attribute to be
-        # the name of the attribute.
-        args[field] = col_name
+        field_list = (
+            [field_name]
+            if field_name not in array_attrables
+            else [field_name + "_" + str(i) for i in range(len(argument_list))]
+        )
+        for i, (argument, field) in enumerate(zip(argument_list, field_list)):
+            if argument is None:
+                continue
+            elif isinstance(argument, str):  # needs to change
+                continue
+            # Case of index
+            elif isinstance(argument, pd.core.indexes.range.RangeIndex):
+                col_name = argument.name if argument.name else "index"
+                col_name = labels[field] if labels and labels.get(field) else col_name
+                try:
+                    df.insert(0, col_name, argument)
+                except ValueError:  # if col named index already exists, replace
+                    df["col_name"] = argument
+            else:  # args[field] should be an array or df column
+                try:
+                    col_name = argument.name  # pandas df
+                except AttributeError:
+                    col_name = labels[field] if labels and labels.get(field) else field
+                df[col_name] = argument
+            # This sets the label of an attribute to be
+            if field_name not in array_attrables:
+                args[field_name] = col_name
+            else:
+                args[field_name][i] = col_name
     args["data_frame"] = df
     return args
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -787,6 +787,12 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
             df_args = args["data_frame"]
             df[df_args.columns] = df_args[df_args.columns]
 
+    # Cast data_frame argument to DataFrame (it could be a numpy array, dict etc.)
+    if args["data_frame"] is not None and not isinstance(
+        args["data_frame"], pd.DataFrame
+    ):
+        args["data_frame"] = pd.DataFrame(args["data_frame"])
+
     # Valid column names
     df_columns = (
         args["data_frame"].columns
@@ -822,8 +828,9 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
                     args.get("data_frame"), pd.DataFrame
                 ) and not isinstance(args.get("data_frame"), np.ndarray):
                     raise ValueError(
-                        "String arguments are only possible when a DataFrame"
-                        "is provided in the `data_frame` argument."
+                        "String or int arguments are only possible when a"
+                        "DataFrame or an array is provided in the `data_frame`"
+                        "argument."
                     )
                 # Check validity of column name
                 if df_columns is not None and argument not in df_columns:

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -774,7 +774,9 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
 
     if "dimensions" in args and args["dimensions"] is None:
         if args.get("data_frame") is None or args["data_frame"] is None:
-            raise ValueError("No data were provided")
+            raise ValueError(
+                "No data were provided. Please provide data either with the `data_frame` or with the `dimensions` argument."
+            )
         else:
             df_args = args["data_frame"]
             df[df_args.columns] = df_args[df_args.columns]
@@ -830,7 +832,18 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
             else:
                 try:
                     col_name = argument.name  # pandas df
-                except AttributeError:
+                    if (
+                        args.get("data_frame") is not None
+                        and col_name in args["data_frame"]
+                    ):
+                        # If the name exists but the values have changed
+                        # we do not want to keep the name, revert to field
+                        col_name = (
+                            col_name
+                            if args["data_frame"][col_name].equals(argument)
+                            else field
+                        )
+                except AttributeError:  # numpy array, list...
                     col_name = field
                 df[col_name] = argument
             # Update argument with column name now that column exists

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -824,7 +824,7 @@ def build_dataframe(args, attrables, array_attrables):
     else:
         reserved_names = []
     canbechanged_names = {}
-    forbidden_names = reserved_names.copy()
+    forbidden_names = list(reserved_names)  # copy method compatible with Py2
     # We start from an empty DataFrame except for the case of functions which
     # implicitely need all dimensions: Splom, Parcats, Parcoords
     # This could be refined when dimensions is given

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -813,11 +813,9 @@ def build_dataframe(input_args, attrables, array_attrables):
     array_attrables : list
         argument names corresponding to iterables, such as `hover_data`, ...
     """
-    args = dict(input_args)
+    args = input_args.copy()
     for field in args:
-        if field in array_attrables and isinstance(
-            args[field], pd.core.indexes.base.Index
-        ):
+        if field in array_attrables and args[field] is not None:
             args[field] = list(args[field])
     # Cast data_frame argument to DataFrame (it could be a numpy array, dict etc.)
     df_provided = args["data_frame"] is not None

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -770,6 +770,11 @@ def _name_heuristic(argument, field_name, reserved_names):
 
 
 def _get_reserved_names(args, attrables, array_attrables):
+    """
+    This function builds a list of columns of the data_frame argument used
+    as arguments, either as str/int arguments or given as columns
+    (pandas series type).
+    """
     df = args["data_frame"]
     reserved_names = []
     for field in args:

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -754,10 +754,10 @@ def apply_default_cascade(args):
         args["marginal_x"] = None
 
 
-def _name_heuristic(argument, field_name, used_col_names):
+def _name_heuristic(argument, field_name, reserved_names):
     if isinstance(argument, int):
         argument = str(argument)
-    if field_name not in used_col_names:
+    if field_name not in reserved_names:
         return field_name
     else:
         raise NameError(
@@ -766,14 +766,14 @@ def _name_heuristic(argument, field_name, used_col_names):
         )
 
 
-def _initialize_argument_col_names(args, attrables, array_attrables):
+def _get_reserved_col_names(args, attrables, array_attrables):
     """
     This function builds a list of columns of the data_frame argument used
     as arguments, either as str/int arguments or given as columns
     (pandas series type).
     """
     df = args["data_frame"]
-    used_col_names = set()
+    reserved_names = set()
     for field in args:
         if field not in attrables:
             continue
@@ -784,15 +784,15 @@ def _initialize_argument_col_names(args, attrables, array_attrables):
             if arg is None:
                 continue
             if isinstance(arg, str):
-                used_col_names.add(arg)
+                reserved_names.add(arg)
             if isinstance(arg, pd.core.series.Series):
                 arg_name = arg.name
                 if arg_name and hasattr(df, arg_name):
                     in_df = arg is df[arg_name]
                     if in_df:
-                        used_col_names.add(arg_name)
+                        reserved_names.add(arg_name)
 
-    return used_col_names
+    return reserved_names
 
 
 def build_dataframe(input_args, attrables, array_attrables):
@@ -828,9 +828,7 @@ def build_dataframe(input_args, attrables, array_attrables):
     # Initialize set of column names
     # These are reserved names
     if df_provided:
-        reserved_names = _initialize_argument_col_names(
-            args, attrables, array_attrables
-        )
+        reserved_names = _get_reserved_col_names(args, attrables, array_attrables)
     else:
         reserved_names = set()
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -772,6 +772,12 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
     array_attrables : list
         argument names corresponding to iterables, such as `hover_data`, ...
     """
+    # Cast data_frame argument to DataFrame (it could be a numpy array, dict etc.)
+    if args["data_frame"] is not None and not isinstance(
+        args["data_frame"], pd.DataFrame
+    ):
+        args["data_frame"] = pd.DataFrame(args["data_frame"])
+
 
     # We start from an empty DataFrame except for the case of functions which
     # implicitely need all dimensions: Splom, Parcats, Parcoords
@@ -786,12 +792,6 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
         else:
             df_args = args["data_frame"]
             df[df_args.columns] = df_args[df_args.columns]
-
-    # Cast data_frame argument to DataFrame (it could be a numpy array, dict etc.)
-    if args["data_frame"] is not None and not isinstance(
-        args["data_frame"], pd.DataFrame
-    ):
-        args["data_frame"] = pd.DataFrame(args["data_frame"])
 
     # Valid column names
     df_columns = (

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -776,7 +776,7 @@ def _get_reserved_names(args, attrables, array_attrables):
     (pandas series type).
     """
     df = args["data_frame"]
-    reserved_names = []
+    reserved_names = set()
     for field in args:
         if field not in attrables:
             continue
@@ -786,16 +786,15 @@ def _get_reserved_names(args, attrables, array_attrables):
         for arg in names:
             if arg is None:
                 continue
-            if isinstance(arg, str) and arg not in reserved_names:
-                reserved_names.append(arg)
-            if isinstance(arg, int) and str(arg) not in reserved_names:
-                reserved_names.append(str(arg))
+            if isinstance(arg, str):
+                reserved_names.add(arg)
+            if isinstance(arg, int):
+                reserved_names.add(str(arg))
             if isinstance(arg, pd.DataFrame) or isinstance(arg, pd.core.series.Series):
                 arg_name = arg.name
                 if arg_name:
                     in_df = arg is df[arg_name]
-                    if arg_name not in reserved_names:
-                        reserved_names.append(arg_name)
+                    reserved_names.add(arg_name)
 
     return reserved_names
 
@@ -827,9 +826,9 @@ def build_dataframe(args, attrables, array_attrables):
     if args["data_frame"] is not None:
         reserved_names = _get_reserved_names(args, attrables, array_attrables)
     else:
-        reserved_names = []
+        reserved_names = set()
     canbechanged_names = {}
-    forbidden_names = list(reserved_names)  # copy method compatible with Py2
+    forbidden_names = set(reserved_names)  # copy method compatible with Py2
     # We start from an empty DataFrame except for the case of functions which
     # implicitely need all dimensions: Splom, Parcats, Parcoords
     # This could be refined when dimensions is given
@@ -956,10 +955,9 @@ def build_dataframe(args, attrables, array_attrables):
                         % (field, len(argument), length)
                     )
                 df[str(col_name)] = argument
-                if col_name not in reserved_names:
-                    reserved_names.append(str(col_name))
-                    forbidden_names.append(str(col_name))
-                    canbechanged_names[str(col_name)] = (field_name, i)
+                reserved_names.add(str(col_name))
+                forbidden_names.add(str(col_name))
+                canbechanged_names[str(col_name)] = (field_name, i)
             # Update argument with column name now that column exists
             if field_name not in array_attrables:
                 args[field_name] = str(col_name)

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -928,7 +928,6 @@ def build_dataframe(args, attrables, array_attrables):
                         if is_index:
                             keep_name = df_provided and argument is df_input.index
                         else:
-                            # we use getattr/hasattr because of index
                             keep_name = col_name in df_input and argument.equals(
                                 df_input[col_name]
                             )

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -759,13 +759,10 @@ def _name_heuristic(argument, field_name, used_col_names):
         argument = str(argument)
     if field_name not in used_col_names:
         return field_name
-    elif field_name + argument not in used_col_names:
-        return field_name + "_" + argument
     else:
         raise NameError(
-            "A name conflict was encountered for argument %s."
-            "Columns with names %s, %s and %s are already used"
-            % (field_name, argument, field_name, field_name + "_" + argument)
+            "A name conflict was encountered for argument %s. "
+            "A column with name %s is already used." % (field_name, field_name)
         )
 
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -818,6 +818,11 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
             if argument is None:
                 continue
             elif isinstance(argument, str):  # just a column name
+                if not isinstance(args.get("data_frame"), pd.DataFrame):
+                    raise ValueError(
+                        "String arguments are only possible when a DataFrame"
+                        "is provided in the `data_frame` argument."
+                    )
                 # Check validity of column name
                 try:
                     df[argument] = args["data_frame"][argument]
@@ -827,11 +832,6 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
                         "Value of '%s' is not the name of a column in 'data_frame'. "
                         "Expected one of %s but received: %s"
                         % (field, str(list(df_columns)), argument)
-                    )
-                except TypeError:
-                    raise ValueError(
-                        "String arguments are only possible when a DataFrame"
-                        "is provided in the `data_frame` argument."
                     )
             # Case of index
             elif isinstance(argument, pd.core.indexes.range.RangeIndex):

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -764,7 +764,7 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
 
     Parameters
     ----------
-    args : OrderedDict
+placebo    args : OrderedDict
         arguments passed to the px function and subsequently modified
     attrables : list
         list of keys into `args`, all of whose corresponding values are
@@ -789,11 +789,6 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
 
     # Valid column names
     df_columns = args["data_frame"].columns if args["data_frame"] is not None else None
-    group_attrs = ["symbol", "line_dash"]
-    for group_attr in group_attrs:
-        if group_attr in args:
-            attrables += [group_attr]
-
     # Loop over possible arguments
     for field_name in attrables:
         argument_list = (
@@ -876,8 +871,12 @@ def infer_config(args, constructor, trace_patch):
     )
     array_attrables = ["dimensions", "custom_data", "hover_data"]
     group_attrables = ["animation_frame", "facet_row", "facet_col", "line_group"]
-
     all_attrables = attrables + group_attrables + ["color"]
+    group_attrs = ["symbol", "line_dash"]
+    for group_attr in group_attrs:
+        if group_attr in args:
+            all_attrables += [group_attr]
+
     build_or_augment_dataframe(args, all_attrables, array_attrables)
 
     attrs = [k for k in attrables if k in args]

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -910,7 +910,8 @@ def build_dataframe(args, attrables, array_attrables):
             elif isinstance(argument, pd.core.indexes.multi.MultiIndex):
                 raise TypeError(
                     "Argument '%s' is a pandas MultiIndex."
-                    "pandas MultiIndex is not supported by plotly express" % field
+                    "pandas MultiIndex is not supported by plotly express "
+                    "at the moment." % field
                 )
             # ----------------- argument is a column / array / list.... -------
             else:

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -764,7 +764,7 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
 
     Parameters
     ----------
-placebo    args : OrderedDict
+    args : OrderedDict
         arguments passed to the px function and subsequently modified
     attrables : list
         list of keys into `args`, all of whose corresponding values are
@@ -845,7 +845,7 @@ placebo    args : OrderedDict
                         # we do not want to keep the name, revert to field
                         col_name = (
                             col_name
-                            if args["data_frame"][col_name].equals(argument)
+                            if argument is args["data_frame"][col_name]
                             else field
                         )
                 except AttributeError:  # numpy array, list...

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -755,19 +755,20 @@ def apply_default_cascade(args):
 
 
 def _name_heuristic(argument, field_name, df):
-    print (argument, field_name, df.columns)
     if isinstance(argument, int):
         argument = str(argument)
     if argument not in df.columns:
-        print ("no pb", argument)
         return argument
     elif field_name not in df.columns:
-        print ("fallback field", field_name)
         return field_name
     elif field_name + argument not in df.columns:
         return field_name + "_" + argument
     else:
-        raise NameError("A name conflict was encountered.")
+        raise NameError(
+            "A name conflict was encountered for argument %s."
+            "Columns with names %s, %s and %s are already used"
+            % (field_name, argument, field_name, field_name + '_' + argument)
+            )
 
 
 def build_dataframe(args, attrables, array_attrables):
@@ -913,7 +914,6 @@ def build_dataframe(args, attrables, array_attrables):
             else:
                 args[field_name][i] = col_name
     args["data_frame"] = df
-    print (df)
     return args
 
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -927,9 +927,14 @@ def build_dataframe(args, attrables, array_attrables):
                     if not df_provided:
                         col_name = field
                     else:
-                        keep_name = hasattr(
-                            args["data_frame"], col_name
-                        ) and argument is getattr(args["data_frame"], col_name)
+                        if is_index:
+                            keep_name = (
+                                df_provided and argument is args["data_frame"].index
+                            )
+                        else:
+                            keep_name = hasattr(
+                                args["data_frame"], col_name
+                            ) and argument is getattr(args["data_frame"], col_name)
                         col_name = (
                             col_name
                             if keep_name

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -762,30 +762,30 @@ def build_or_augment_dataframe(args, attrables, array_attrables, constructor):
     Used to be support calls to plotting function that elide a dataframe
     argument; for example `scatter(x=[1,2], y=[3,4])`.
     """
+    # This will be changed so that we start from an empty dataframe
     if args.get("data_frame") is None:
         df = pd.DataFrame()
     else:
         df = args["data_frame"]
-    data_frame_columns = {}
     for field in attrables:
-        labels = args.get("labels")
+        labels = args.get("labels") # labels or None
+        # hack, needs to be changed when we start from empty df
         if field in array_attrables:
             continue
         argument = args.get(field)
         if argument is None:
             continue
-        elif isinstance(argument, str):
+        elif isinstance(argument, str): # needs to change
             continue
+        # Case of index
         elif isinstance(argument, pd.core.indexes.range.RangeIndex):
             col_name = argument.name if argument.name else "index"
-            print (col_name, labels)
             col_name = labels[field] if labels and labels.get(field) else col_name
-            print (col_name)
             try:
                 df.insert(0, col_name, argument)
-            except ValueError:
-                pass
-        else:  # args[field] should be an array or df or index now
+            except ValueError: # if col named index already exists, replace
+                df['col_name'] = argument
+        else:  # args[field] should be an array or df column
             try:
                 col_name = argument.name  # pandas df
             except AttributeError:

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -880,11 +880,11 @@ def build_dataframe(args, attrables, array_attrables):
                         "is of type str or int." % field
                     )
                 # Check validity of column name
-                if argument not in args['data_frame'].columns:
+                if argument not in args["data_frame"].columns:
                     raise ValueError(
                         "Value of '%s' is not the name of a column in 'data_frame'. "
                         "Expected one of %s but received: %s"
-                        % (field, str(list(args['data_frame'].columns)), argument)
+                        % (field, str(list(args["data_frame"].columns)), argument)
                     )
                 if length and len(args["data_frame"][argument]) != length:
                     raise ValueError(
@@ -921,7 +921,11 @@ def build_dataframe(args, attrables, array_attrables):
                         col_name = field
                     else:
                         keep_name = argument is getattr(args["data_frame"], col_name)
-                        col_name = col_name if keep_name else _name_heuristic(col_name, field, used_col_names)
+                        col_name = (
+                            col_name
+                            if keep_name
+                            else _name_heuristic(col_name, field, used_col_names)
+                        )
                 else:  # numpy array, list...
                     col_name = _name_heuristic(field, field, used_col_names)
                 if length and len(argument) != length:

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -808,6 +808,7 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
         )
         # argument_list and field_list ready, iterate over them
         for i, (argument, field) in enumerate(zip(argument_list, field_list)):
+            length = len(df)
             if argument is None:
                 continue
             elif isinstance(argument, str):  # just a column name
@@ -823,7 +824,8 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
                         "Expected one of %s but received: %s"
                         % (field, str(list(df_columns)), argument)
                     )
-
+                if length and len(args["data_frame"][argument]) != length:
+                    raise ValueError("All arguments should have the same length.")
                 df[argument] = args["data_frame"][argument]
                 continue
             # Case of index
@@ -850,6 +852,8 @@ def build_or_augment_dataframe(args, attrables, array_attrables):
                         )
                 except AttributeError:  # numpy array, list...
                     col_name = field
+                if length and len(argument) != length:
+                    raise ValueError("All arguments should have the same length.")
                 df[col_name] = argument
             # Update argument with column name now that column exists
             if field_name not in array_attrables:

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -757,7 +757,7 @@ def apply_default_cascade(args):
 def _name_heuristic(argument, field_name, used_col_names):
     if isinstance(argument, int):
         argument = str(argument)
-    elif field_name not in used_col_names:
+    if field_name not in used_col_names:
         return field_name
     elif field_name + argument not in used_col_names:
         return field_name + "_" + argument
@@ -788,8 +788,6 @@ def _initialize_argument_col_names(args, attrables, array_attrables):
                 continue
             if isinstance(arg, str):
                 used_col_names.add(arg)
-            if isinstance(arg, int):
-                used_col_names.add(str(arg))
             if isinstance(arg, pd.DataFrame) or isinstance(arg, pd.core.series.Series):
                 arg_name = arg.name
                 if arg_name and hasattr(df, arg_name):
@@ -894,12 +892,14 @@ def build_dataframe(args, attrables, array_attrables):
                         "length of previous arguments is %d"
                         % (field, len(args["data_frame"][argument]), length)
                     )
-                df[str(argument)] = args["data_frame"][argument]
+                col_name = argument
                 if isinstance(argument, int):
+                    col_name = _name_heuristic(argument, field, reserved_names)
                     if field_name not in array_attrables:
-                        args[field_name] = str(argument)
+                        args[field_name] = col_name
                     else:
-                        args[field_name][i] = str(argument)
+                        args[field_name][i] = col_name
+                df[col_name] = args["data_frame"][argument]
                 continue
             # Case of multiindex
             elif isinstance(argument, pd.core.indexes.multi.MultiIndex):

--- a/packages/python/plotly/plotly/express/_doc.py
+++ b/packages/python/plotly/plotly/express/_doc.py
@@ -1,8 +1,8 @@
 import inspect
 
-colref = "(string: name of column in `data_frame`, or array_like object)"
+colref = "(string or int: name of column in `data_frame`, or array_like object)"
 colref_list = (
-    "(list of string: names of columns in `data_frame`, or array_like objects)"
+    "(list of string or int: names of columns in `data_frame`, or array_like objects)"
 )
 
 # TODO contents of columns

--- a/packages/python/plotly/plotly/express/_doc.py
+++ b/packages/python/plotly/plotly/express/_doc.py
@@ -14,7 +14,11 @@ colref_list = (
 # TODO standardize positioning and casing of 'default'
 
 docs = dict(
-    data_frame=["A 'tidy' `pandas.DataFrame`"],
+    data_frame=[
+        "A `pandas.DataFrame`, or a `NumPy` array or a dictionary",
+        "which are tranformed internally to `pandas.DataFrame`. This argument needs"
+        "to be passed for column names (and not keyword names) to be used.",
+    ],
     x=[
         colref,
         "Values from this column or array_like are used to position marks along the x axis in cartesian coordinates.",

--- a/packages/python/plotly/plotly/express/_doc.py
+++ b/packages/python/plotly/plotly/express/_doc.py
@@ -1,7 +1,7 @@
 import inspect
 
-colref = "(string: name of column in `data_frame`)"
-colref_list = "(list of string: names of columns in `data_frame`)"
+colref = "(string: name of column in `data_frame`, or array_like object)"
+colref_list = "(list of string: names of columns in `data_frame`, or array_like objects)"
 
 # TODO contents of columns
 # TODO explain categorical
@@ -15,50 +15,50 @@ docs = dict(
     data_frame=["A 'tidy' `pandas.DataFrame`"],
     x=[
         colref,
-        "Values from this column are used to position marks along the x axis in cartesian coordinates.",
+        "Values from this column or array_like are used to position marks along the x axis in cartesian coordinates.",
         "For horizontal `histogram`s, these values are used as inputs to `histfunc`.",
     ],
     y=[
         colref,
-        "Values from this column are used to position marks along the y axis in cartesian coordinates.",
+        "Values from this column or array_like are used to position marks along the y axis in cartesian coordinates.",
         "For vertical `histogram`s, these values are used as inputs to `histfunc`.",
     ],
     z=[
         colref,
-        "Values from this column are used to position marks along the z axis in cartesian coordinates.",
+        "Values from this column or array_like are used to position marks along the z axis in cartesian coordinates.",
         "For `density_heatmap` and `density_contour` these values are used as the inputs to `histfunc`.",
     ],
     a=[
         colref,
-        "Values from this column are used to position marks along the a axis in ternary coordinates.",
+        "Values from this column or array_like are used to position marks along the a axis in ternary coordinates.",
     ],
     b=[
         colref,
-        "Values from this column are used to position marks along the b axis in ternary coordinates.",
+        "Values from this column or array_like are used to position marks along the b axis in ternary coordinates.",
     ],
     c=[
         colref,
-        "Values from this column are used to position marks along the c axis in ternary coordinates.",
+        "Values from this column or array_like are used to position marks along the c axis in ternary coordinates.",
     ],
     r=[
         colref,
-        "Values from this column are used to position marks along the radial axis in polar coordinates.",
+        "Values from this column or array_like are used to position marks along the radial axis in polar coordinates.",
     ],
     theta=[
         colref,
-        "Values from this column are used to position marks along the angular axis in polar coordinates.",
+        "Values from this column or array_like are used to position marks along the angular axis in polar coordinates.",
     ],
     lat=[
         colref,
-        "Values from this column are used to position marks according to latitude on a map.",
+        "Values from this column or array_like are used to position marks according to latitude on a map.",
     ],
     lon=[
         colref,
-        "Values from this column are used to position marks according to longitude on a map.",
+        "Values from this column or array_like are used to position marks according to longitude on a map.",
     ],
     locations=[
         colref,
-        "Values from this column are be interpreted according to `locationmode` and mapped to longitude/latitude.",
+        "Values from this column or array_like are be interpreted according to `locationmode` and mapped to longitude/latitude.",
     ],
     dimensions=[
         "(list of strings, names of columns in `data_frame`)",
@@ -66,47 +66,47 @@ docs = dict(
     ],
     error_x=[
         colref,
-        "Values from this column are used to size x-axis error bars.",
+        "Values from this column or array_like are used to size x-axis error bars.",
         "If `error_x_minus` is `None`, error bars will be symmetrical, otherwise `error_x` is used for the positive direction only.",
     ],
     error_x_minus=[
         colref,
-        "Values from this column are used to size x-axis error bars in the negative direction.",
+        "Values from this column or array_like are used to size x-axis error bars in the negative direction.",
         "Ignored if `error_x` is `None`.",
     ],
     error_y=[
         colref,
-        "Values from this column are used to size y-axis error bars.",
+        "Values from this column or array_like are used to size y-axis error bars.",
         "If `error_y_minus` is `None`, error bars will be symmetrical, otherwise `error_y` is used for the positive direction only.",
     ],
     error_y_minus=[
         colref,
-        "Values from this column are used to size y-axis error bars in the negative direction.",
+        "Values from this column or array_like are used to size y-axis error bars in the negative direction.",
         "Ignored if `error_y` is `None`.",
     ],
     error_z=[
         colref,
-        "Values from this column are used to size z-axis error bars.",
+        "Values from this column or array_like are used to size z-axis error bars.",
         "If `error_z_minus` is `None`, error bars will be symmetrical, otherwise `error_z` is used for the positive direction only.",
     ],
     error_z_minus=[
         colref,
-        "Values from this column are used to size z-axis error bars in the negative direction.",
+        "Values from this column or array_like are used to size z-axis error bars in the negative direction.",
         "Ignored if `error_z` is `None`.",
     ],
-    color=[colref, "Values from this column are used to assign color to marks."],
+    color=[colref, "Values from this column or array_like are used to assign color to marks."],
     opacity=["(number, between 0 and 1) Sets the opacity for markers."],
     line_dash=[
         colref,
-        "Values from this column are used to assign dash-patterns to lines.",
+        "Values from this column or array_like are used to assign dash-patterns to lines.",
     ],
     line_group=[
         colref,
-        "Values from this column are used to group rows of `data_frame` into lines.",
+        "Values from this column or array_like are used to group rows of `data_frame` into lines.",
     ],
-    symbol=[colref, "Values from this column are used to assign symbols to marks."],
-    size=[colref, "Values from this column are used to assign mark sizes."],
-    hover_name=[colref, "Values from this column appear in bold in the hover tooltip."],
+    symbol=[colref, "Values from this column or array_like are used to assign symbols to marks."],
+    size=[colref, "Values from this column or array_like are used to assign mark sizes."],
+    hover_name=[colref, "Values from this column or array_like appear in bold in the hover tooltip."],
     hover_data=[
         colref_list,
         "Values from these columns appear as extra data in the hover tooltip.",
@@ -115,26 +115,26 @@ docs = dict(
         colref_list,
         "Values from these columns are extra data, to be used in widgets or Dash callbacks for example. This data is not user-visible but is included in events emitted by the figure (lasso selection etc.)",
     ],
-    text=[colref, "Values from this column appear in the figure as text labels."],
+    text=[colref, "Values from this column or array_like appear in the figure as text labels."],
     locationmode=[
         "(string, one of 'ISO-3', 'USA-states', 'country names')",
         "Determines the set of locations used to match entries in `locations` to regions on the map.",
     ],
     facet_row=[
         colref,
-        "Values from this column are used to assign marks to facetted subplots in the vertical direction.",
+        "Values from this column or array_like are used to assign marks to facetted subplots in the vertical direction.",
     ],
     facet_col=[
         colref,
-        "Values from this column are used to assign marks to facetted subplots in the horizontal direction.",
+        "Values from this column or array_like are used to assign marks to facetted subplots in the horizontal direction.",
     ],
     animation_frame=[
         colref,
-        "Values from this column are used to assign marks to animation frames.",
+        "Values from this column or array_like are used to assign marks to animation frames.",
     ],
     animation_group=[
         colref,
-        "Values from this column are used to provide object-constancy across animation frames: rows with matching `animation_group`s will be treated as if they describe the same object in each frame.",
+        "Values from this column or array_like are used to provide object-constancy across animation frames: rows with matching `animation_group`s will be treated as if they describe the same object in each frame.",
     ],
     symbol_sequence=[
         "(list of strings defining plotly.js symbols)",

--- a/packages/python/plotly/plotly/express/_doc.py
+++ b/packages/python/plotly/plotly/express/_doc.py
@@ -1,7 +1,9 @@
 import inspect
 
 colref = "(string: name of column in `data_frame`, or array_like object)"
-colref_list = "(list of string: names of columns in `data_frame`, or array_like objects)"
+colref_list = (
+    "(list of string: names of columns in `data_frame`, or array_like objects)"
+)
 
 # TODO contents of columns
 # TODO explain categorical
@@ -94,7 +96,10 @@ docs = dict(
         "Values from this column or array_like are used to size z-axis error bars in the negative direction.",
         "Ignored if `error_z` is `None`.",
     ],
-    color=[colref, "Values from this column or array_like are used to assign color to marks."],
+    color=[
+        colref,
+        "Values from this column or array_like are used to assign color to marks.",
+    ],
     opacity=["(number, between 0 and 1) Sets the opacity for markers."],
     line_dash=[
         colref,
@@ -104,9 +109,18 @@ docs = dict(
         colref,
         "Values from this column or array_like are used to group rows of `data_frame` into lines.",
     ],
-    symbol=[colref, "Values from this column or array_like are used to assign symbols to marks."],
-    size=[colref, "Values from this column or array_like are used to assign mark sizes."],
-    hover_name=[colref, "Values from this column or array_like appear in bold in the hover tooltip."],
+    symbol=[
+        colref,
+        "Values from this column or array_like are used to assign symbols to marks.",
+    ],
+    size=[
+        colref,
+        "Values from this column or array_like are used to assign mark sizes.",
+    ],
+    hover_name=[
+        colref,
+        "Values from this column or array_like appear in bold in the hover tooltip.",
+    ],
     hover_data=[
         colref_list,
         "Values from these columns appear as extra data in the hover tooltip.",
@@ -115,7 +129,10 @@ docs = dict(
         colref_list,
         "Values from these columns are extra data, to be used in widgets or Dash callbacks for example. This data is not user-visible but is included in events emitted by the figure (lasso selection etc.)",
     ],
-    text=[colref, "Values from this column or array_like appear in the figure as text labels."],
+    text=[
+        colref,
+        "Values from this column or array_like appear in the figure as text labels.",
+    ],
     locationmode=[
         "(string, one of 'ISO-3', 'USA-states', 'country names')",
         "Determines the set of locations used to match entries in `locations` to regions on the map.",

--- a/packages/python/plotly/plotly/express/_doc.py
+++ b/packages/python/plotly/plotly/express/_doc.py
@@ -1,9 +1,7 @@
 import inspect
 
-colref = "(string or int: name of column in `data_frame`, or array_like object)"
-colref_list = (
-    "(list of string or int: names of columns in `data_frame`, or array_like objects)"
-)
+colref = "(string or int: name of column in `data_frame`, or pandas Series, or array_like object)"
+colref_list = "(list of string or int: names of columns in `data_frame`, or pandas Series, or array_like objects)"
 
 # TODO contents of columns
 # TODO explain categorical

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -102,7 +102,7 @@ def test_build_df_from_lists():
     args = dict(x=[1, 2, 3], y=[2, 3, 4], color=[1, 3, 9])
     output = {key: key for key in args}
     df = pd.DataFrame(args)
-    out = build_or_augment_dataframe(args, all_attrables, array_attrables, go.Scatter)
+    out = build_or_augment_dataframe(args, all_attrables, array_attrables)
     assert_frame_equal(df.sort_index(axis=1), out["data_frame"].sort_index(axis=1))
     out.pop("data_frame")
     assert out == output
@@ -111,7 +111,7 @@ def test_build_df_from_lists():
     args = dict(x=np.array([1, 2, 3]), y=np.array([2, 3, 4]), color=[1, 3, 9])
     output = {key: key for key in args}
     df = pd.DataFrame(args)
-    out = build_or_augment_dataframe(args, all_attrables, array_attrables, go.Scatter)
+    out = build_or_augment_dataframe(args, all_attrables, array_attrables)
     assert_frame_equal(df.sort_index(axis=1), out["data_frame"].sort_index(axis=1))
     out.pop("data_frame")
     assert out == output
@@ -121,7 +121,7 @@ def test_build_df_with_index():
     tips = px.data.tips()
     args = dict(data_frame=tips, x=tips.index, y="total_bill")
     changed_output = dict(x="index")
-    out = build_or_augment_dataframe(args, all_attrables, array_attrables, go.Scatter)
+    out = build_or_augment_dataframe(args, all_attrables, array_attrables)
     assert_frame_equal(tips.reset_index()[out["data_frame"].columns], out["data_frame"])
     out.pop("data_frame")
     assert out == args

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -5,6 +5,7 @@ import pytest
 import plotly.graph_objects as go
 import plotly
 from plotly.express._core import build_or_augment_dataframe
+from pandas.util.testing import assert_frame_equal
 
 attrables = (
     ["x", "y", "z", "a", "b", "c", "r", "theta", "size", "dimensions"]
@@ -60,7 +61,7 @@ def test_build_df_from_lists():
     output = {key: key for key in args}
     df = pd.DataFrame(args)
     out = build_or_augment_dataframe(args, all_attrables, array_attrables, go.Scatter)
-    assert df.sort_index(axis=1) == out["data_frame"].sort_index(axis=1)
+    assert_frame_equal(df.sort_index(axis=1), out["data_frame"].sort_index(axis=1))
     out.pop("data_frame")
     assert out == output
 
@@ -69,7 +70,7 @@ def test_build_df_from_lists():
     output = {key: key for key in args}
     df = pd.DataFrame(args)
     out = build_or_augment_dataframe(args, all_attrables, array_attrables, go.Scatter)
-    assert df.sort_index(axis=1) == out["data_frame"].sort_index(axis=1)
+    assert_frame_equal(df.sort_index(axis=1), out["data_frame"].sort_index(axis=1))
     out.pop("data_frame")
     assert out == output
 
@@ -82,7 +83,7 @@ def test_build_df_from_lists():
     _ = args_wo_labels.pop("labels")
     df = pd.DataFrame(args_wo_labels).rename(columns=labels)
     out = build_or_augment_dataframe(args, all_attrables, array_attrables, go.Scatter)
-    assert df.equals(out["data_frame"])
+    assert_frame_equal(df.sort_index(axis=1), out["data_frame"].sort_index(axis=1))
 
 
 def test_build_df_with_index():
@@ -90,13 +91,13 @@ def test_build_df_with_index():
     args = dict(data_frame=tips, x=tips.index, y="total_bill")
     changed_output = dict(x="index")
     out = build_or_augment_dataframe(args, all_attrables, array_attrables, go.Scatter)
-    assert out["data_frame"].equals(tips)
+    assert_frame_equal(tips.sort_index(axis=1), out["data_frame"].sort_index(axis=1))
     out.pop("data_frame")
     assert out == args
 
     tips = px.data.tips()
     args = dict(data_frame=tips, x="index", y=tips.total_bill)
     out = build_or_augment_dataframe(args, all_attrables, array_attrables, go.Scatter)
-    assert out["data_frame"].equals(tips)
+    assert_frame_equal(tips.sort_index(axis=1), out["data_frame"].sort_index(axis=1))
     out.pop("data_frame")
     assert out == args

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -169,9 +169,9 @@ def test_splom_case():
     iris = px.data.iris()
     fig = px.scatter_matrix(iris)
     assert len(fig.data[0].dimensions) == len(iris.columns)
-    dic = {'a':[1, 2, 3], 'b':[4, 5, 6], 'c':[7, 8, 9]}
+    dic = {"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]}
     fig = px.scatter_matrix(dic)
-    assert np.all(fig.data[0].dimensions[0].values == np.array(dic['a']))
+    assert np.all(fig.data[0].dimensions[0].values == np.array(dic["a"]))
     ar = np.arange(9).reshape((3, 3))
     fig = px.scatter_matrix(ar)
     assert np.all(fig.data[0].dimensions[0].values == ar[:, 0])

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 import plotly.graph_objects as go
 import plotly
-from plotly.express._core import build_or_augment_dataframe
+from plotly.express._core import build_dataframe
 from pandas.util.testing import assert_frame_equal
 
 attrables = (
@@ -56,6 +56,17 @@ def test_pandas_series():
     before_tip = tips.total_bill - tips.tip
     fig = px.bar(tips, x="day", y=before_tip, labels={"y": "bill"})
     assert fig.data[0].hovertemplate == "day=%{x}<br>bill=%{y}"
+
+
+def test_name_conflict():
+    df = pd.DataFrame(dict(x=[0, 1], y=[3, 4]))
+    fig = px.scatter(df, x=[10, 1], y="y", color="x")
+    assert np.all(fig.data[0].x == np.array([10, 1]))
+    fig = px.scatter(df, x=[10, 1], y="y", color=df.x)
+    assert np.all(fig.data[0].x == np.array([10, 1]))
+    df = pd.DataFrame(dict(x=[0, 1], y=[3, 4], color=[1, 2]))
+    fig = px.scatter(df, x=[10, 1], y="y", size="color", color=df.x)
+    assert np.all(fig.data[0].x == np.array([10, 1]))
 
 
 def test_mixed_case():
@@ -146,7 +157,7 @@ def test_build_df_from_lists():
     output = {key: key for key in args}
     df = pd.DataFrame(args)
     args["data_frame"] = None
-    out = build_or_augment_dataframe(args, all_attrables, array_attrables)
+    out = build_dataframe(args, all_attrables, array_attrables)
     assert_frame_equal(df.sort_index(axis=1), out["data_frame"].sort_index(axis=1))
     out.pop("data_frame")
     assert out == output
@@ -156,7 +167,7 @@ def test_build_df_from_lists():
     output = {key: key for key in args}
     df = pd.DataFrame(args)
     args["data_frame"] = None
-    out = build_or_augment_dataframe(args, all_attrables, array_attrables)
+    out = build_dataframe(args, all_attrables, array_attrables)
     assert_frame_equal(df.sort_index(axis=1), out["data_frame"].sort_index(axis=1))
     out.pop("data_frame")
     assert out == output
@@ -166,7 +177,7 @@ def test_build_df_with_index():
     tips = px.data.tips()
     args = dict(data_frame=tips, x=tips.index, y="total_bill")
     changed_output = dict(x="index")
-    out = build_or_augment_dataframe(args, all_attrables, array_attrables)
+    out = build_dataframe(args, all_attrables, array_attrables)
     assert_frame_equal(tips.reset_index()[out["data_frame"].columns], out["data_frame"])
     out.pop("data_frame")
     assert out == args

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -58,6 +58,15 @@ def test_pandas_series():
     assert fig.data[0].hovertemplate == "day=%{x}<br>bill=%{y}"
 
 
+def test_several_dataframes():
+    df = pd.DataFrame(dict(x=[0, 1], y=[1, 10], z=[0.1, 0.8]))
+    df2 = pd.DataFrame(dict(time=[23, 26], money=[100, 200]))
+    fig = px.scatter(df, x="z", y=df2.money, size="y")
+    assert fig.data[0].hovertemplate == "z=%{x}<br>y_money=%{y}<br>y=%{marker.size}"
+    fig = px.scatter(df2, x=df.z, y=df2.money, size=df.y)
+    assert fig.data[0].hovertemplate == "x=%{x}<br>money=%{y}<br>size=%{marker.size}"
+
+
 def test_name_conflict():
     df = pd.DataFrame(dict(x=[0, 1], y=[3, 4]))
     fig = px.scatter(df, x=[10, 1], y="y", color="x")

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -40,9 +40,6 @@ def test_with_index():
     assert fig.data[0]["hovertemplate"] == "index=%{x}<br>total_bill=%{y}"
     fig = px.scatter(tips, x=tips.index, y=tips.total_bill)
     assert fig.data[0]["hovertemplate"] == "index=%{x}<br>total_bill=%{y}"
-    # If we tinker with the column then the name is the one of the kw argument
-    fig = px.scatter(tips, x=tips.index, y=10 * tips.total_bill)
-    assert fig.data[0]["hovertemplate"] == "index=%{x}<br>y=%{y}"
     fig = px.scatter(tips, x=tips.index, y=tips.total_bill, labels={"index": "number"})
     assert fig.data[0]["hovertemplate"] == "number=%{x}<br>total_bill=%{y}"
     # We do not allow "x=index"
@@ -57,6 +54,8 @@ def test_with_index():
 def test_pandas_series():
     tips = px.data.tips()
     before_tip = tips.total_bill - tips.tip
+    fig = px.bar(tips, x="day", y=before_tip)
+    assert fig.data[0].hovertemplate == "day=%{x}<br>y=%{y}"
     fig = px.bar(tips, x="day", y=before_tip, labels={"y": "bill"})
     assert fig.data[0].hovertemplate == "day=%{x}<br>bill=%{y}"
 

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -73,17 +73,28 @@ def test_name_conflict():
     df = pd.DataFrame(dict(x=[0, 1], y=[3, 4]))
     df2 = pd.DataFrame(dict(x=[3, 5], y=[23, 24]))
     fig = px.scatter(x=df.y, y=df2.y)
+    assert np.all(fig.data[0].x == np.array([3, 4]))
+    assert np.all(fig.data[0].y == np.array([23, 24]))
+    assert fig.data[0].hovertemplate == "x=%{x}<br>y=%{y}"
+
+    df = pd.DataFrame(dict(x=[0, 1], y=[3, 4]))
+    df2 = pd.DataFrame(dict(x=[3, 5], y=[23, 24]))
+    df3 = pd.DataFrame(dict(y=[0.1, 0.2]))
+    fig = px.scatter(x=df.y, y=df2.y, size=df3.y)
+    assert np.all(fig.data[0].x == np.array([3, 4]))
+    assert np.all(fig.data[0].y == np.array([23, 24]))
+    assert fig.data[0].hovertemplate == "x=%{x}<br>y=%{y}<br>size=%{marker.size}"
 
 
 def test_repeated_name():
     iris = px.data.iris()
     fig = px.scatter(
-            iris,
-            x="sepal_width",
-            y="sepal_length",
-            hover_data=["petal_length", "petal_width", "species_id"],
-            custom_data=["species_id", "species"],
-        )
+        iris,
+        x="sepal_width",
+        y="sepal_length",
+        hover_data=["petal_length", "petal_width", "species_id"],
+        custom_data=["species_id", "species"],
+    )
     assert fig.data[0].customdata.shape[1] == 4
 
 

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -121,6 +121,20 @@ def test_wrong_dimensions():
         # assert "All arguments should have the same length." in str(err_msg.value)
 
 
+def test_multiindex_raise_error():
+    index = pd.MultiIndex.from_product(
+        [[1, 2, 3], ["a", "b"]], names=["first", "second"]
+    )
+    df = pd.DataFrame(np.random.random((6, 3)), index=index, columns=["A", "B", "C"])
+    # This is ok
+    fig = px.scatter(df, x="A", y="B")
+    with pytest.raises(TypeError) as err_msg:
+        fig = px.scatter(df, x=df.index, y="B")
+        assert "pandas MultiIndex is not supported by plotly express" in str(
+            err_msg.value
+        )
+
+
 def test_build_df_from_lists():
     # Just lists
     args = dict(x=[1, 2, 3], y=[2, 3, 4], color=[1, 3, 9])

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -51,6 +51,13 @@ def test_with_index():
         )
 
 
+def test_pandas_series():
+    tips = px.data.tips()
+    before_tip = tips.total_bill - tips.tip
+    fig = px.bar(tips, x="day", y=before_tip, labels={"y": "bill"})
+    assert fig.data[0].hovertemplate == "day=%{x}<br>bill=%{y}"
+
+
 def test_mixed_case():
     df = pd.DataFrame(dict(time=[1, 2, 3], temperature=[20, 30, 25]))
     fig = px.scatter(df, x="time", y="temperature", color=[1, 3, 9])

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -90,9 +90,7 @@ def test_wrong_column_name():
 def test_missing_data_frame():
     with pytest.raises(ValueError) as err_msg:
         fig = px.scatter(x="arg1", y="arg2")
-        assert "String arguments are only possible when a DataFrame" in str(
-            err_msg.value
-        )
+        assert "String or int arguments are only possible" in str(err_msg.value)
 
 
 def test_wrong_dimensions_of_array():
@@ -181,4 +179,10 @@ def test_int_col_names():
     # Numpy array
     ar = np.arange(100).reshape((10, 10))
     fig = px.scatter(ar, x=2, y=8)
-    assert np.all(fig.data[0].x == ar[2])
+    assert np.all(fig.data[0].x == ar[:, 2])
+
+
+def test_data_frame_from_dict():
+    fig = px.scatter({"time": [0, 1], "money": [1, 2]}, x="time", y="money")
+    assert fig.data[0].hovertemplate == "time=%{x}<br>money=%{y}"
+    assert np.all(fig.data[0].x == [0, 1])

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -22,6 +22,9 @@ all_attrables = attrables + group_attrables + ["color"]
 
 def test_numpy():
     fig = px.scatter(x=[1, 2, 3], y=[2, 3, 4], color=[1, 3, 9])
+    assert np.all(fig.data[0].x == np.array([1, 2, 3]))
+    assert np.all(fig.data[0].y == np.array([2, 3, 4]))
+    assert np.all(fig.data[0].marker.color == np.array([1, 3, 9]))
 
 
 def test_numpy_labels():

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -98,14 +98,27 @@ def test_missing_data_frame():
 def test_wrong_dimensions_of_array():
     with pytest.raises(ValueError) as err_msg:
         fig = px.scatter(x=[1, 2, 3], y=[2, 3, 4, 5])
-        assert "Length of values does not match length of index" in str(err_msg.value)
+        assert "All arguments should have the same length." in str(err_msg.value)
 
 
-def test_wrong_dimensions_mixed_cqse():
+def test_wrong_dimensions_mixed_case():
     with pytest.raises(ValueError) as err_msg:
         df = pd.DataFrame(dict(time=[1, 2, 3], temperature=[20, 30, 25]))
         fig = px.scatter(df, x="time", y="temperature", color=[1, 3, 9, 5])
-        assert "Length of values does not match length of index" in str(err_msg.value)
+        assert "All arguments should have the same length." in str(err_msg.value)
+
+
+def test_wrong_dimensions():
+    with pytest.raises(ValueError) as err_msg:
+        fig = px.scatter(px.data.tips(), x="tip", y=[1, 2, 3])
+        assert "All arguments should have the same length." in str(err_msg.value)
+    # the order matters
+    with pytest.raises(ValueError) as err_msg:
+        fig = px.scatter(px.data.tips(), x=[1, 2, 3], y="tip")
+        assert "All arguments should have the same length." in str(err_msg.value)
+    with pytest.raises(ValueError):
+        fig = px.scatter(px.data.tips(), x=px.data.iris().index, y="tip")
+        # assert "All arguments should have the same length." in str(err_msg.value)
 
 
 def test_build_df_from_lists():

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -110,6 +110,7 @@ def test_build_df_from_lists():
     args = dict(x=[1, 2, 3], y=[2, 3, 4], color=[1, 3, 9])
     output = {key: key for key in args}
     df = pd.DataFrame(args)
+    args["data_frame"] = None
     out = build_or_augment_dataframe(args, all_attrables, array_attrables)
     assert_frame_equal(df.sort_index(axis=1), out["data_frame"].sort_index(axis=1))
     out.pop("data_frame")
@@ -119,6 +120,7 @@ def test_build_df_from_lists():
     args = dict(x=np.array([1, 2, 3]), y=np.array([2, 3, 4]), color=[1, 3, 9])
     output = {key: key for key in args}
     df = pd.DataFrame(args)
+    args["data_frame"] = None
     out = build_or_augment_dataframe(args, all_attrables, array_attrables)
     assert_frame_equal(df.sort_index(axis=1), out["data_frame"].sort_index(axis=1))
     out.pop("data_frame")

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -62,11 +62,29 @@ def test_name_conflict():
     df = pd.DataFrame(dict(x=[0, 1], y=[3, 4]))
     fig = px.scatter(df, x=[10, 1], y="y", color="x")
     assert np.all(fig.data[0].x == np.array([10, 1]))
+
     fig = px.scatter(df, x=[10, 1], y="y", color=df.x)
     assert np.all(fig.data[0].x == np.array([10, 1]))
+
     df = pd.DataFrame(dict(x=[0, 1], y=[3, 4], color=[1, 2]))
     fig = px.scatter(df, x=[10, 1], y="y", size="color", color=df.x)
     assert np.all(fig.data[0].x == np.array([10, 1]))
+
+    df = pd.DataFrame(dict(x=[0, 1], y=[3, 4]))
+    df2 = pd.DataFrame(dict(x=[3, 5], y=[23, 24]))
+    fig = px.scatter(x=df.y, y=df2.y)
+
+
+def test_repeated_name():
+    iris = px.data.iris()
+    fig = px.scatter(
+            iris,
+            x="sepal_width",
+            y="sepal_length",
+            hover_data=["petal_length", "petal_width", "species_id"],
+            custom_data=["species_id", "species"],
+        )
+    assert fig.data[0].customdata.shape[1] == 4
 
 
 def test_mixed_case():

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -49,6 +49,10 @@ def test_with_index():
             "ValueError: Value of 'x' is not the name of a column in 'data_frame'"
             in str(err_msg.value)
         )
+    tips = px.data.tips()
+    tips.index.name = "item"
+    fig = px.scatter(tips, x=tips.index, y="total_bill")
+    assert fig.data[0]["hovertemplate"] == "item=%{x}<br>total_bill=%{y}"
 
 
 def test_pandas_series():

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -45,9 +45,8 @@ def test_with_index():
     # We do not allow "x=index"
     with pytest.raises(ValueError) as err_msg:
         fig = px.scatter(tips, x="index", y="total_bill")
-        assert (
-            "ValueError: Value of 'x' is not the name of a column in 'data_frame'"
-            in str(err_msg.value)
+        assert "To use the index, pass it in directly as `df.index`." in str(
+            err_msg.value
         )
     tips = px.data.tips()
     tips.index.name = "item"

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -57,6 +57,7 @@ def test_pandas_series():
     fig = px.bar(tips, x="day", y=before_tip, labels={"y": "bill"})
     assert fig.data[0].hovertemplate == "day=%{x}<br>bill=%{y}"
 
+
 def test_name_conflict():
     df = pd.DataFrame(dict(x=[0, 1], y=[3, 4]))
     fig = px.scatter(df, x=[10, 1], y="y", color="x")
@@ -70,7 +71,10 @@ def test_name_conflict():
     df = pd.DataFrame(dict(x=[0, 1], y=[3, 4], color=[1, 2]))
     fig = px.scatter(df, x=[10, 1], y="y", size="color", color=df.x)
     assert np.all(fig.data[0].x == np.array([10, 1]))
-    assert fig.data[0].hovertemplate == "x_x=%{x}<br>y=%{y}<br>color=%{marker.size}<br>x=%{marker.color}"
+    assert (
+        fig.data[0].hovertemplate
+        == "x_x=%{x}<br>y=%{y}<br>color=%{marker.size}<br>x=%{marker.color}"
+    )
 
     df = pd.DataFrame(dict(x=[0, 1], y=[3, 4]))
     df2 = pd.DataFrame(dict(x=[3, 5], y=[23, 24]))
@@ -114,7 +118,6 @@ def test_repeated_name():
         custom_data=["species_id", "species"],
     )
     assert fig.data[0].customdata.shape[1] == 4
-
 
 
 def test_arrayattrable_numpy():

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -34,7 +34,7 @@ def test_numpy_labels():
 def test_with_index():
     tips = px.data.tips()
     fig = px.scatter(tips, x=tips.index, y="total_bill")
-    fig = px.scatter(tips, x=tips.index, y=tips.total_bill)
+    assert fig.data[0]["hovertemplate"] == "index=%{x}<br>total_bill=%{y}"
     fig = px.scatter(tips, x=tips.index, y=tips.total_bill)
     assert fig.data[0]["hovertemplate"] == "index=%{x}<br>total_bill=%{y}"
     # If we tinker with the column then the name is the one of the kw argument
@@ -61,13 +61,16 @@ def test_name_conflict():
     df = pd.DataFrame(dict(x=[0, 1], y=[3, 4]))
     fig = px.scatter(df, x=[10, 1], y="y", color="x")
     assert np.all(fig.data[0].x == np.array([10, 1]))
+    assert fig.data[0].hovertemplate == "x_x=%{x}<br>y=%{y}<br>x=%{marker.color}"
 
     fig = px.scatter(df, x=[10, 1], y="y", color=df.x)
     assert np.all(fig.data[0].x == np.array([10, 1]))
+    assert fig.data[0].hovertemplate == "x_x=%{x}<br>y=%{y}<br>x=%{marker.color}"
 
     df = pd.DataFrame(dict(x=[0, 1], y=[3, 4], color=[1, 2]))
     fig = px.scatter(df, x=[10, 1], y="y", size="color", color=df.x)
     assert np.all(fig.data[0].x == np.array([10, 1]))
+    assert fig.data[0].hovertemplate == "x_x=%{x}<br>y=%{y}<br>color=%{marker.size}<br>x=%{marker.color}"
 
     df = pd.DataFrame(dict(x=[0, 1], y=[3, 4]))
     df2 = pd.DataFrame(dict(x=[3, 5], y=[23, 24]))
@@ -98,7 +101,7 @@ def test_name_conflict():
     fig = px.scatter(df, x=df.y, y=df.x, size=df.y)
     assert np.all(fig.data[0].x == np.array([3, 4]))
     assert np.all(fig.data[0].y == np.array([0, 1]))
-    assert fig.data[0].hovertemplate == "y=%{x}<br>x=%{y}"
+    assert fig.data[0].hovertemplate == "y=%{marker.size}<br>x=%{y}"
 
 
 def test_repeated_name():
@@ -112,10 +115,6 @@ def test_repeated_name():
     )
     assert fig.data[0].customdata.shape[1] == 4
 
-
-def test_mixed_case():
-    df = pd.DataFrame(dict(time=[1, 2, 3], temperature=[20, 30, 25]))
-    fig = px.scatter(df, x="time", y="temperature", color=[1, 3, 9])
 
 
 def test_arrayattrable_numpy():

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -85,6 +85,16 @@ def test_name_conflict():
     assert np.all(fig.data[0].y == np.array([23, 24]))
     assert fig.data[0].hovertemplate == "x=%{x}<br>y=%{y}<br>size=%{marker.size}"
 
+    df = pd.DataFrame(dict(x=[0, 1], y=[3, 4]))
+    df2 = pd.DataFrame(dict(x=[3, 5], y=[23, 24]))
+    df3 = pd.DataFrame(dict(y=[0.1, 0.2]))
+    fig = px.scatter(x=df.y, y=df2.y, hover_data=[df3.y])
+    assert np.all(fig.data[0].x == np.array([3, 4]))
+    assert np.all(fig.data[0].y == np.array([23, 24]))
+    assert (
+        fig.data[0].hovertemplate == "x=%{x}<br>y=%{y}<br>hover_data_0=%{customdata[0]}"
+    )
+
 
 def test_repeated_name():
     iris = px.data.iris()

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -60,9 +60,7 @@ def test_build_df_from_lists():
     output = {key: key for key in args}
     df = pd.DataFrame(args)
     out = build_or_augment_dataframe(args, all_attrables, array_attrables, go.Scatter)
-    print(df)
-    print(out["data_frame"])
-    assert df.equals(out["data_frame"])
+    assert df.sort_index(axis=1) == out["data_frame"].sort_index(axis=1)
     out.pop("data_frame")
     assert out == output
 
@@ -71,7 +69,7 @@ def test_build_df_from_lists():
     output = {key: key for key in args}
     df = pd.DataFrame(args)
     out = build_or_augment_dataframe(args, all_attrables, array_attrables, go.Scatter)
-    assert df.equals(out["data_frame"])
+    assert df.sort_index(axis=1) == out["data_frame"].sort_index(axis=1)
     out.pop("data_frame")
     assert out == output
 

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -169,6 +169,12 @@ def test_splom_case():
     iris = px.data.iris()
     fig = px.scatter_matrix(iris)
     assert len(fig.data[0].dimensions) == len(iris.columns)
+    dic = {'a':[1, 2, 3], 'b':[4, 5, 6], 'c':[7, 8, 9]}
+    fig = px.scatter_matrix(dic)
+    assert np.all(fig.data[0].dimensions[0].values == np.array(dic['a']))
+    ar = np.arange(9).reshape((3, 3))
+    fig = px.scatter_matrix(ar)
+    assert np.all(fig.data[0].dimensions[0].values == ar[:, 0])
 
 
 def test_int_col_names():

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -227,11 +227,8 @@ def test_build_df_from_lists():
 def test_build_df_with_index():
     tips = px.data.tips()
     args = dict(data_frame=tips, x=tips.index, y="total_bill")
-    changed_output = dict(x="index")
     out = build_dataframe(args, all_attrables, array_attrables)
     assert_frame_equal(tips.reset_index()[out["data_frame"].columns], out["data_frame"])
-    out.pop("data_frame")
-    assert out == args
 
 
 def test_splom_case():
@@ -261,3 +258,23 @@ def test_data_frame_from_dict():
     fig = px.scatter({"time": [0, 1], "money": [1, 2]}, x="time", y="money")
     assert fig.data[0].hovertemplate == "time=%{x}<br>money=%{y}"
     assert np.all(fig.data[0].x == [0, 1])
+
+
+def test_arguments_not_modified():
+    iris = px.data.iris()
+    petal_length = iris.petal_length
+    fig = px.scatter(iris, x=petal_length, y="petal_width")
+    assert iris.petal_length.equals(petal_length)
+
+
+def test_pass_df_columns():
+    tips = px.data.tips()
+    fig = px.histogram(
+        tips,
+        x="total_bill",
+        y="tip",
+        color="sex",
+        marginal="rug",
+        hover_data=tips.columns,
+    )
+    assert fig.data[1].hovertemplate.count("customdata") == len(tips.columns)

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -171,3 +171,14 @@ def test_splom_case():
     iris = px.data.iris()
     fig = px.scatter_matrix(iris)
     assert len(fig.data[0].dimensions) == len(iris.columns)
+
+
+def test_int_col_names():
+    # DataFrame with int column names
+    lengths = pd.DataFrame(np.random.random(100))
+    fig = px.histogram(lengths, x=0)
+    assert np.all(np.array(lengths).flatten() == fig.data[0].x)
+    # Numpy array
+    ar = np.arange(100).reshape((10, 10))
+    fig = px.scatter(ar, x=2, y=8)
+    assert np.all(fig.data[0].x == ar[2])

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -116,17 +116,6 @@ def test_build_df_from_lists():
     out.pop("data_frame")
     assert out == output
 
-    # Lists, changing one label
-    labels = {"x": "time"}
-    args = dict(x=[1, 2, 3], y=[2, 3, 4], color=[1, 3, 9], labels=labels)
-    output = {key: key for key in args}
-    output.update(labels)
-    args_wo_labels = args.copy()
-    _ = args_wo_labels.pop("labels")
-    df = pd.DataFrame(args_wo_labels).rename(columns=labels)
-    out = build_or_augment_dataframe(args, all_attrables, array_attrables, go.Scatter)
-    assert_frame_equal(df.sort_index(axis=1), out["data_frame"].sort_index(axis=1))
-
 
 def test_build_df_with_index():
     tips = px.data.tips()

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -84,6 +84,14 @@ def test_wrong_column_name():
         fig = px.scatter(px.data.tips(), x="bla", y="wrong")
 
 
+def test_missing_data_frame():
+    with pytest.raises(ValueError) as err_msg:
+        fig = px.scatter(x="arg1", y="arg2")
+        assert "String arguments are only possible when a DataFrame" in str(
+            err_msg.value
+        )
+
+
 def test_wrong_dimensions_of_array():
     with pytest.raises(ValueError) as err_msg:
         fig = px.scatter(x=[1, 2, 3], y=[2, 3, 4, 5])

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -282,3 +282,9 @@ def test_pass_df_columns():
     assert fig.data[1].hovertemplate.count("customdata") == len(tips.columns)
     tips_copy = px.data.tips()
     assert tips_copy.columns.equals(tips.columns)
+
+
+def test_size_column():
+    df = px.data.tips()
+    fig = px.scatter(df, x=df["size"], y=df.tip)
+    assert fig.data[0].hovertemplate == "size=%{x}<br>tip=%{y}"

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -57,7 +57,6 @@ def test_pandas_series():
     fig = px.bar(tips, x="day", y=before_tip, labels={"y": "bill"})
     assert fig.data[0].hovertemplate == "day=%{x}<br>bill=%{y}"
 
-
 def test_name_conflict():
     df = pd.DataFrame(dict(x=[0, 1], y=[3, 4]))
     fig = px.scatter(df, x=[10, 1], y="y", color="x")
@@ -96,10 +95,10 @@ def test_name_conflict():
     )
 
     df = pd.DataFrame(dict(x=[0, 1], y=[3, 4], z=[0.1, 0.2]))
-    fig = px.scatter(x=df.y, y=df.x, size=df.y)
+    fig = px.scatter(df, x=df.y, y=df.x, size=df.y)
     assert np.all(fig.data[0].x == np.array([3, 4]))
     assert np.all(fig.data[0].y == np.array([0, 1]))
-    assert fig.data[0].hovertemplate == "y=%{x}<br>x=%{y}<br>size=%{marker.size}"
+    assert fig.data[0].hovertemplate == "y=%{x}<br>x=%{y}"
 
 
 def test_repeated_name():

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -136,3 +136,9 @@ def test_build_df_with_index():
     assert_frame_equal(tips.reset_index()[out["data_frame"].columns], out["data_frame"])
     out.pop("data_frame")
     assert out == args
+
+
+def test_splom_case():
+    iris = px.data.iris()
+    fig = px.scatter_matrix(iris)
+    assert len(fig.data[0].dimensions) == len(iris.columns)

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -60,6 +60,8 @@ def test_build_df_from_lists():
     output = {key: key for key in args}
     df = pd.DataFrame(args)
     out = build_or_augment_dataframe(args, all_attrables, array_attrables, go.Scatter)
+    print(df)
+    print(out["data_frame"])
     assert df.equals(out["data_frame"])
     out.pop("data_frame")
     assert out == output

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -280,3 +280,5 @@ def test_pass_df_columns():
         hover_data=tips.columns,
     )
     assert fig.data[1].hovertemplate.count("customdata") == len(tips.columns)
+    tips_copy = px.data.tips()
+    assert tips_copy.columns.equals(tips.columns)

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -263,8 +263,10 @@ def test_data_frame_from_dict():
 def test_arguments_not_modified():
     iris = px.data.iris()
     petal_length = iris.petal_length
-    fig = px.scatter(iris, x=petal_length, y="petal_width")
+    hover_data = [iris.sepal_length]
+    fig = px.scatter(iris, x=petal_length, y="petal_width", hover_data=hover_data)
     assert iris.petal_length.equals(petal_length)
+    assert iris.sepal_length.equals(hover_data[0])
 
 
 def test_pass_df_columns():

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -50,9 +50,45 @@ def test_mixed_case():
     fig = px.scatter(df, x="time", y="temperature", color=[1, 3, 9])
 
 
+def test_arrayattrable_numpy():
+    tips = px.data.tips()
+    fig = px.scatter(
+        tips, x="total_bill", y="tip", hover_data=[np.random.random(tips.shape[0])]
+    )
+    assert (
+        fig.data[0]["hovertemplate"]
+        == "total_bill=%{x}<br>tip=%{y}<br>hover_data_0=%{customdata[0]}"
+    )
+    tips = px.data.tips()
+    fig = px.scatter(
+        tips,
+        x="total_bill",
+        y="tip",
+        hover_data=[np.random.random(tips.shape[0])],
+        labels={"hover_data_0": "suppl"},
+    )
+    assert (
+        fig.data[0]["hovertemplate"]
+        == "total_bill=%{x}<br>tip=%{y}<br>suppl=%{customdata[0]}"
+    )
+
+
 def test_wrong_column_name():
     with pytest.raises(ValueError):
         fig = px.scatter(px.data.tips(), x="bla", y="wrong")
+
+
+def test_wrong_dimensions_of_array():
+    with pytest.raises(ValueError) as err_msg:
+        fig = px.scatter(x=[1, 2, 3], y=[2, 3, 4, 5])
+        assert "Length of values does not match length of index" in str(err_msg.value)
+
+
+def test_wrong_dimensions_mixed_cqse():
+    with pytest.raises(ValueError) as err_msg:
+        df = pd.DataFrame(dict(time=[1, 2, 3], temperature=[20, 30, 25]))
+        fig = px.scatter(df, x="time", y="temperature", color=[1, 3, 9, 5])
+        assert "Length of values does not match length of index" in str(err_msg.value)
 
 
 def test_build_df_from_lists():

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -95,6 +95,12 @@ def test_name_conflict():
         fig.data[0].hovertemplate == "x=%{x}<br>y=%{y}<br>hover_data_0=%{customdata[0]}"
     )
 
+    df = pd.DataFrame(dict(x=[0, 1], y=[3, 4], z=[0.1, 0.2]))
+    fig = px.scatter(x=df.y, y=df.x, size=df.y)
+    assert np.all(fig.data[0].x == np.array([3, 4]))
+    assert np.all(fig.data[0].y == np.array([0, 1]))
+    assert fig.data[0].hovertemplate == "y=%{x}<br>x=%{y}<br>size=%{marker.size}"
+
 
 def test_repeated_name():
     iris = px.data.iris()

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -80,8 +80,11 @@ def test_arrayattrable_numpy():
 
 
 def test_wrong_column_name():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as err_msg:
         fig = px.scatter(px.data.tips(), x="bla", y="wrong")
+        assert "Value of 'x' is not the name of a column in 'data_frame'" in str(
+            err_msg.value
+        )
 
 
 def test_missing_data_frame():

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -37,9 +37,9 @@ def test_with_index():
     fig = px.scatter(tips, x=tips.index, y=tips.total_bill)
     fig = px.scatter(tips, x=tips.index, y=tips.total_bill)
     assert fig.data[0]["hovertemplate"] == "index=%{x}<br>total_bill=%{y}"
-    # I was not expecting this to work but it does...
+    # If we tinker with the column then the name is the one of the kw argument
     fig = px.scatter(tips, x=tips.index, y=10 * tips.total_bill)
-    assert fig.data[0]["hovertemplate"] == "index=%{x}<br>total_bill=%{y}"
+    assert fig.data[0]["hovertemplate"] == "index=%{x}<br>y=%{y}"
     fig = px.scatter(tips, x=tips.index, y=tips.total_bill, labels={"index": "number"})
     assert fig.data[0]["hovertemplate"] == "number=%{x}<br>total_bill=%{y}"
     # We do not allow "x=index"


### PR DESCRIPTION
This is a first a draft for accepting more flexible types of input arguments for `px` functions, eg numpy arrays, dataframe columns, mixed type etc. At the moment the transformation done by `build_or_augment_dataframe` is done argument by argument, so having different arguments with different types is ok. 

Todo:
- write more tests
- decide what to do with arguments which are lists, such as `hover_data`, `custom_data`, `dimensions`. At the moment they are just skipped so they should be column names. I did this because I wanted to discuss the names they should have, should it be `customdata_0`, `customdata_1` etc. ?

For the cases which are taken into account, please see the test file.

Closes #1767 , follow-up on https://github.com/plotly/plotly_express/pull/87 (thank you @malmaud !)