### PR TITLE
Update _chart_types.py

### DIFF
--- a/packages/python/plotly/plotly/express/_chart_types.py
+++ b/packages/python/plotly/plotly/express/_chart_types.py
@@ -436,7 +436,7 @@ def box(
     log_y=False,
     range_x=None,
     range_y=None,
-    points=None,
+    points="outliers",
     notched=False,
     title=None,
     template=None,


### PR DESCRIPTION
`points` parameter in `plotly.express.box()` is default to `"outliers"` instead of `None`