### PR TITLE
Template specification fixes

### DIFF
--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -492,7 +492,10 @@ class BaseFigure(object):
                             else:
                                 # Accept v
                                 self[k] = v
-                        elif isinstance(update_target, BasePlotlyType) or (
+                        elif (
+                            isinstance(update_target, BasePlotlyType)
+                            and isinstance(v, (dict, BasePlotlyType))
+                        ) or (
                             isinstance(update_target, tuple)
                             and isinstance(update_target[0], BasePlotlyType)
                         ):

--- a/packages/python/plotly/plotly/tests/test_core/test_graph_objs/test_template.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_graph_objs/test_template.py
@@ -513,6 +513,13 @@ class TestMergeTemplates(TestCase):
         expected = self.expected1_2
         self.assertEqual(result, expected)
 
+    def test_update_template_with_flaglist(self):
+        fig = go.Figure()
+        fig.update(layout_template="template1+template2")
+        result = fig.layout.template
+        expected = self.expected1_2
+        self.assertEqual(result, expected)
+
     def test_set_default_template(self):
         orig_default = pio.templates.default
         pio.templates.default = "plotly"

--- a/packages/python/plotly/plotly/tests/test_core/test_graph_objs/test_template.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_graph_objs/test_template.py
@@ -508,6 +508,11 @@ class TestMergeTemplates(TestCase):
         self.assertEqual(self.template1, self.template1_orig)
         self.assertEqual(self.template2, self.template2_orig)
 
+    def test_flaglist_string_getitem(self):
+        result = pio.templates["template1+template2"]
+        expected = self.expected1_2
+        self.assertEqual(result, expected)
+
     def test_set_default_template(self):
         orig_default = pio.templates.default
         pio.templates.default = "plotly"


### PR DESCRIPTION
Closes https://github.com/plotly/plotly.py/issues/1807

Also fixes the case where a template is specified as a string to `fig.update`