### PR TITLE
remove pywavelets from CI

### DIFF
--- a/packages/python/plotly/tox.ini
+++ b/packages/python/plotly/tox.ini
@@ -74,7 +74,6 @@ deps=
     optional: pillow==5.2.0
     optional: matplotlib==2.2.3
     optional: xarray==0.10.9
-    optional: pywavelets==1.0.3
     optional: scikit-image==0.14.4
 
 ; CORE ENVIRONMENTS


### PR DESCRIPTION
The pywavelets team has been pretty quick at fixing the py2 issue, so let's remove this tox dep before we forget why it was introduced....