### PR TITLE
Remove marginal plot grids as hardcoded default

### DIFF
--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -375,11 +375,11 @@ def configure_cartesian_marginal_axes(args, fig, orders):
 
     # Configure axis ticks on marginal subplots
     if args["marginal_x"]:
-        fig.update_yaxes(showticklabels=False, row=nrows)
+        fig.update_yaxes(showticklabels=False, showline=False, ticks="", row=nrows)
         fig.update_xaxes(row=nrows)
 
     if args["marginal_y"]:
-        fig.update_xaxes(showticklabels=False, col=ncols)
+        fig.update_xaxes(showticklabels=False, showline=False, ticks="", col=ncols)
         fig.update_yaxes(col=ncols)
 
     # Add axis titles to non-marginal subplots

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -375,16 +375,12 @@ def configure_cartesian_marginal_axes(args, fig, orders):
 
     # Configure axis ticks on marginal subplots
     if args["marginal_x"]:
-        fig.update_yaxes(
-            showticklabels=False, showgrid=args["marginal_x"] == "histogram", row=nrows
-        )
-        fig.update_xaxes(showgrid=True, row=nrows)
+        fig.update_yaxes(showticklabels=False, row=nrows)
+        fig.update_xaxes(row=nrows)
 
     if args["marginal_y"]:
-        fig.update_xaxes(
-            showticklabels=False, showgrid=args["marginal_y"] == "histogram", col=ncols
-        )
-        fig.update_yaxes(showgrid=True, col=ncols)
+        fig.update_xaxes(showticklabels=False, col=ncols)
+        fig.update_yaxes(col=ncols)
 
     # Add axis titles to non-marginal subplots
     y_title = get_decorated_label(args, args["y"], "y")

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -375,12 +375,11 @@ def configure_cartesian_marginal_axes(args, fig, orders):
 
     # Configure axis ticks on marginal subplots
     # Don't change the marginal grid settings if the template already specifies `showgrid`
-    if isinstance(
-        pio.templates[args["template"]].layout.xaxis.showgrid, bool
-    ) or isinstance(pio.templates[args["template"]].layout.yaxis.showgrid, bool):
-        grid_set = True
-    else:
+    if (pio.templates[args["template"]].layout.xaxis.showgrid is None
+            or pio.templates[args["template"]].layout.yaxis.showgrid is None):
         grid_set = False
+    else:
+        grid_set = True
 
     if args["marginal_x"]:
         fig.update_yaxes(showticklabels=False, showline=False, ticks="", row=nrows)

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -384,14 +384,12 @@ def configure_cartesian_marginal_axes(args, fig, orders):
 
     if args["marginal_x"]:
         fig.update_yaxes(showticklabels=False, showline=False, ticks="", row=nrows)
-        fig.update_xaxes(row=nrows)
         if not grid_set:
             fig.update_yaxes(showgrid=args["marginal_x"] == "histogram", row=nrows)
             fig.update_xaxes(showgrid=True, row=nrows)
 
     if args["marginal_y"]:
         fig.update_xaxes(showticklabels=False, showline=False, ticks="", col=ncols)
-        fig.update_yaxes(col=ncols)
         if not grid_set:
             fig.update_xaxes(showgrid=args["marginal_y"] == "histogram", col=ncols)
             fig.update_yaxes(showgrid=True, col=ncols)

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -374,13 +374,27 @@ def configure_cartesian_marginal_axes(args, fig, orders):
         set_cartesian_axis_opts(args, xaxis, "x", orders)
 
     # Configure axis ticks on marginal subplots
+    # Don't change the marginal grid settings if the template already specifies `showgrid`
+    if isinstance(
+        pio.templates[args["template"]].layout.xaxis.showgrid, bool
+    ) or isinstance(pio.templates[args["template"]].layout.yaxis.showgrid, bool):
+        grid_set = True
+    else:
+        grid_set = False
+
     if args["marginal_x"]:
         fig.update_yaxes(showticklabels=False, showline=False, ticks="", row=nrows)
         fig.update_xaxes(row=nrows)
+        if not grid_set:
+            fig.update_yaxes(showgrid=args["marginal_x"] == "histogram", row=nrows)
+            fig.update_xaxes(showgrid=True, row=nrows)
 
     if args["marginal_y"]:
         fig.update_xaxes(showticklabels=False, showline=False, ticks="", col=ncols)
         fig.update_yaxes(col=ncols)
+        if not grid_set:
+            fig.update_xaxes(showgrid=args["marginal_y"] == "histogram", col=ncols)
+            fig.update_yaxes(showgrid=True, col=ncols)
 
     # Add axis titles to non-marginal subplots
     y_title = get_decorated_label(args, args["y"], "y")

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -375,8 +375,10 @@ def configure_cartesian_marginal_axes(args, fig, orders):
 
     # Configure axis ticks on marginal subplots
     # Don't change the marginal grid settings if the template already specifies `showgrid`
-    if (pio.templates[args["template"]].layout.xaxis.showgrid is None
-            or pio.templates[args["template"]].layout.yaxis.showgrid is None):
+    if (
+        args["template"].layout.xaxis.showgrid is None
+        or args["template"].layout.yaxis.showgrid is None
+    ):
         grid_set = False
     else:
         grid_set = True


### PR DESCRIPTION
I suggest to remove that hardcoded grids for marignal plots and instead inherit the grid settings from the template. This is particularly useful for templates that don't use grids.

The second commit sets two defaults that I think are almost always wanted: No y-axis line or ticks for the marginal plots. I am happy to drop this change with the same logic as above if you think these should be configurable from templates as well. 