### PR TITLE
PX templates should override, not merge into default

### DIFF
--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1295,7 +1295,7 @@ def make_figure(args, constructor, trace_patch={}, layout_patch={}):
     # Add traces, layout and frames to figure
     fig.add_traces(frame_list[0]["data"] if len(frame_list) > 0 else [])
     fig.layout.update(layout_patch)
-     if "template" in args and args["template"] is not None:
+    if "template" in args and args["template"] is not None:
         fig.update_layout(template=args["template"], overwrite=True)
 
     fig.frames = frame_list if len(frames) > 1 else []

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1264,7 +1264,7 @@ def make_figure(args, constructor, trace_patch={}, layout_patch={}):
             cmax=range_color[1],
             colorbar=dict(title=get_decorated_label(args, args[colorvar], colorvar)),
         )
-    for v in ["title", "height", "width", "template"]:
+    for v in ["title", "height", "width"]:
         if args[v]:
             layout_patch[v] = args[v]
     layout_patch["legend"] = {"tracegroupgap": 0}
@@ -1295,6 +1295,9 @@ def make_figure(args, constructor, trace_patch={}, layout_patch={}):
     # Add traces, layout and frames to figure
     fig.add_traces(frame_list[0]["data"] if len(frame_list) > 0 else [])
     fig.layout.update(layout_patch)
+     if "template" in args and args["template"] is not None:
+        fig.update_layout(template=args["template"], overwrite=True)
+
     fig.frames = frame_list if len(frames) > 1 else []
 
     fig._px_trendlines = pd.DataFrame(trendline_rows)

--- a/test/percy/plotly-express.py
+++ b/test/percy/plotly-express.py
@@ -470,3 +470,13 @@ fig = px.choropleth(
     range_color=[20, 80],
 )
 fig.write_html(os.path.join(dir_name, "choropleth.html"), auto_play=False)
+
+### test template overriding (should be white background, courier font)
+
+import plotly.express as px
+
+iris = px.data.iris()
+fig = px.scatter(
+    iris, x="sepal_width", y="sepal_length", template=dict(layout_font_family="Courier")
+)
+fig.write_html(os.path.join(dir_name, "scatter.html"))


### PR DESCRIPTION
Right now, passing `template={}` to any `px` method gives strange output: it uses the `pio.templates.default` for most things but then uses `px`'s internal defaults for colors. This is pretty weird and annoying, and it means that if a user wants to inline any template information, they *first* have to set `pio.templates.default` to `"none"`, or they have to override the entire default template. Also they can't use `template={}`, they have to use `template="none"`.

I think the behaviour in this PR is better, but I welcome feedback.