### PR TITLE
Use the default template's background color for swatches

### DIFF
--- a/packages/python/plotly/_plotly_utils/colors/_swatches.py
+++ b/packages/python/plotly/_plotly_utils/colors/_swatches.py
@@ -6,6 +6,7 @@ def _swatches(module_names, module_contents):
         template's background.
     """
     import plotly.graph_objs as go
+    import plotly.express as px
 
     sequences = [
         (k, v)
@@ -29,6 +30,7 @@ def _swatches(module_names, module_contents):
             title=module_names,
             barmode="stack",
             barnorm="fraction",
+            template=px.defaults.template,
             bargap=0.5,
             showlegend=False,
             xaxis=dict(range=[-0.02, 1.02], showticklabels=False, showgrid=False),

--- a/packages/python/plotly/_plotly_utils/colors/_swatches.py
+++ b/packages/python/plotly/_plotly_utils/colors/_swatches.py
@@ -27,7 +27,7 @@ def _swatches(module_names, module_contents):
             for name, colors in reversed(sequences)
         ],
         layout=dict(
-            title=module_names.split('.')[-1].capitalize() + ' colorscales',
+            title=module_names.split(".")[-1].capitalize() + " colorscales",
             barmode="stack",
             barnorm="fraction",
             template=px.defaults.template,
@@ -35,6 +35,6 @@ def _swatches(module_names, module_contents):
             showlegend=False,
             xaxis=dict(range=[-0.02, 1.02], showticklabels=False, showgrid=False),
             height=max(px.defaults.height, 40 * len(sequences)),
-            width=px.defaults.width
+            width=px.defaults.width,
         ),
     )

--- a/packages/python/plotly/_plotly_utils/colors/_swatches.py
+++ b/packages/python/plotly/_plotly_utils/colors/_swatches.py
@@ -2,7 +2,8 @@ def _swatches(module_names, module_contents):
     """
     Returns:
         A `Figure` object. This figure demonstrates the color scales and
-        sequences in this module, as stacked bar charts.
+        sequences in this module as stacked bar charts against the default
+        template's background.
     """
     import plotly.graph_objs as go
 
@@ -28,7 +29,6 @@ def _swatches(module_names, module_contents):
             title=module_names,
             barmode="stack",
             barnorm="fraction",
-            template="plotly",
             bargap=0.5,
             showlegend=False,
             xaxis=dict(range=[-0.02, 1.02], showticklabels=False, showgrid=False),

--- a/packages/python/plotly/_plotly_utils/colors/_swatches.py
+++ b/packages/python/plotly/_plotly_utils/colors/_swatches.py
@@ -27,7 +27,7 @@ def _swatches(module_names, module_contents):
             for name, colors in reversed(sequences)
         ],
         layout=dict(
-            title=module_names,
+            title=module_names.split('.')[-1].capitalize() + ' colorscales',
             barmode="stack",
             barnorm="fraction",
             template=px.defaults.template,

--- a/packages/python/plotly/_plotly_utils/colors/_swatches.py
+++ b/packages/python/plotly/_plotly_utils/colors/_swatches.py
@@ -34,6 +34,7 @@ def _swatches(module_names, module_contents):
             bargap=0.5,
             showlegend=False,
             xaxis=dict(range=[-0.02, 1.02], showticklabels=False, showgrid=False),
-            height=max(600, 40 * len(sequences)),
+            height=max(px.defaults.height, 40 * len(sequences)),
+            width=px.defaults.width
         ),
     )


### PR DESCRIPTION
This is a suggestion to use the default template's background color for swatches Instead of always using the plotly template. The potential benefit of this change would be that it is easier to tell which colors sequence go well with the currently used template.

It would be neat if this also checked if there was a PX template set, and I asked a related question about how PX and PIO templates synergize in #1869.

Screenshots:

![image](https://user-images.githubusercontent.com/4560057/68197772-1226a300-ffbb-11e9-9042-b7b7ab772807.png)
---

![image](https://user-images.githubusercontent.com/4560057/68198161-ce806900-ffbb-11e9-84c6-0860cda6c254.png)
---

![image](https://user-images.githubusercontent.com/4560057/68198029-924d0880-ffbb-11e9-8a89-352020257189.png)
---

![image](https://user-images.githubusercontent.com/4560057/68198089-ab55b980-ffbb-11e9-8d30-09317b7c70cb.png)
---

![image](https://user-images.githubusercontent.com/4560057/68198134-bdcff300-ffbb-11e9-975d-657dc9db3065.png)
---

![image](https://user-images.githubusercontent.com/4560057/68197994-85c8b000-ffbb-11e9-8391-a3b10b04fd92.png)
