### PR TITLE
Move imshow closer to px pattern

### DIFF
--- a/packages/python/plotly/plotly/express/_doc.py
+++ b/packages/python/plotly/plotly/express/_doc.py
@@ -283,7 +283,7 @@ docs = dict(
     ],
     title=["str", "The figure title."],
     template=[
-        "str or Plotly.py template object",
+        "or dict or plotly.graph_objects.layout.Template instance",
         "The figure template name or definition.",
     ],
     width=["int (default `None`)", "The figure width in pixels."],

--- a/packages/python/plotly/plotly/express/_imshow.py
+++ b/packages/python/plotly/plotly/express/_imshow.py
@@ -97,7 +97,9 @@ def imshow(
 
     color_continuous_scale : str or list of str
         colormap used to map scalar data to colors (for a 2D image). This parameter is
-        not used for RGB or RGBA images.
+        not used for RGB or RGBA images. If a string is provided, it should be the name
+        of a known color scale, and if a list is provided, it should be a list of CSS-
+        compatible colors.
 
     color_continuous_midpoint : number
         If set, computes the bounds of the continuous color scale to have the desired
@@ -106,6 +108,18 @@ def imshow(
     range_color : list of two numbers
         If provided, overrides auto-scaling on the continuous color scale, including
         overriding `color_continuous_midpoint`.
+
+    title : str
+        The figure title.
+
+    template : str or dict or plotly.graph_objects.layout.Template instance
+        The figure template name or definition.
+
+    width : number
+        The figure width in pixels.
+
+    height: number
+        The figure height in pixels, defaults to 600.
 
     Returns
     -------

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_imshow.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_imshow.py
@@ -50,9 +50,10 @@ def test_origin():
 
 def test_colorscale():
     fig = px.imshow(img_gray)
-    assert fig.data[0].colorscale[0] == (0.0, "rgb(0, 0, 0)")
-    fig = px.imshow(img_gray, colorscale="Viridis")
-    assert fig.data[0].colorscale[0] == (0.0, "#440154")
+    plasma_first_color = px.colors.sequential.Plasma[0]
+    assert fig.layout.coloraxis1.colorscale[0] == (0.0, plasma_first_color)
+    fig = px.imshow(img_gray, color_continuous_scale="Viridis")
+    assert fig.layout.coloraxis1.colorscale[0] == (0.0, "#440154")
 
 
 def test_wrong_dimensions():


### PR DESCRIPTION
@emmanuelle here's the first pass on the PX-ification of the `imshow` function. I'm realizing that to align better with the other `px` methods we should probably add `height`, `width` and `template` and the rest of the `px` defaulting machinery...