### PR TITLE
load plotly.js from unminified dist bundle in plotlywidget

### DIFF
--- a/packages/javascript/plotlywidget/package-lock.json
+++ b/packages/javascript/plotlywidget/package-lock.json
@@ -9,9 +9,9 @@
       "resolved": "https://registry.npmjs.org/3d-view/-/3d-view-2.0.0.tgz",
       "integrity": "sha1-gxrpQtdQjFCAHj4G+v4ejFdOF74=",
       "requires": {
-        "matrix-camera-controller": "2.1.3",
-        "orbit-camera-controller": "4.0.0",
-        "turntable-camera-controller": "3.0.1"
+        "matrix-camera-controller": "^2.1.1",
+        "orbit-camera-controller": "^4.0.0",
+        "turntable-camera-controller": "^3.0.0"
       }
     },
     "@jupyter-widgets/base": {
@@ -19,16 +19,16 @@
       "resolved": "https://registry.npmjs.org/@jupyter-widgets/base/-/base-2.0.1.tgz",
       "integrity": "sha512-jRNeQzvEf6MMGUaEPfBzgZ+IT4XOInpw8Ef+CunNUmUCiQZ8WfNpFR671S0Vu3xO6yGKMTU2QPdk8/aCsJRw9w==",
       "requires": {
-        "@jupyterlab/services": "4.0.0",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/messaging": "1.2.3",
-        "@phosphor/widgets": "1.8.1",
-        "@types/backbone": "1.4.1",
-        "@types/lodash": "4.14.135",
+        "@jupyterlab/services": "^4.0.0",
+        "@phosphor/coreutils": "^1.2.0",
+        "@phosphor/messaging": "^1.2.1",
+        "@phosphor/widgets": "^1.3.0",
+        "@types/backbone": "^1.4.1",
+        "@types/lodash": "^4.14.134",
         "backbone": "1.2.3",
-        "base64-js": "1.2.3",
-        "jquery": "3.4.1",
-        "lodash": "4.17.5"
+        "base64-js": "^1.2.1",
+        "jquery": "^3.1.1",
+        "lodash": "^4.17.4"
       }
     },
     "@jupyterlab/coreutils": {
@@ -36,17 +36,17 @@
       "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.0.0.tgz",
       "integrity": "sha512-l48G1qhff4CZpsxjje92S6caLUixzfDMAD5vjNZL9obexUAMF+344cpVWsm2r2CQROUW7bPB8wjAtFbp8nK/QQ==",
       "requires": {
-        "@phosphor/commands": "1.6.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/properties": "1.1.3",
-        "@phosphor/signaling": "1.2.3",
-        "ajv": "6.10.0",
-        "json5": "2.1.0",
-        "minimist": "1.2.0",
-        "moment": "2.24.0",
-        "path-posix": "1.0.0",
-        "url-parse": "1.4.7"
+        "@phosphor/commands": "^1.6.3",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.2.0",
+        "@phosphor/properties": "^1.1.3",
+        "@phosphor/signaling": "^1.2.3",
+        "ajv": "^6.5.5",
+        "json5": "^2.1.0",
+        "minimist": "~1.2.0",
+        "moment": "^2.24.0",
+        "path-posix": "~1.0.0",
+        "url-parse": "~1.4.3"
       },
       "dependencies": {
         "json5": {
@@ -54,7 +54,7 @@
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
           "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
           "requires": {
-            "minimist": "1.2.0"
+            "minimist": "^1.2.0"
           }
         }
       }
@@ -64,11 +64,11 @@
       "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.2.0.tgz",
       "integrity": "sha512-/oi7vl70yAX5QTXmZafyDSwU8fT1Oa/MdpDDYGkc5IklW0kU3NDqSoawfLovkdgGZvCOCM+6JQqUPRdhn8VZqg==",
       "requires": {
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/messaging": "1.2.3",
-        "@phosphor/signaling": "1.2.3"
+        "@phosphor/algorithm": "^1.1.3",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.2.0",
+        "@phosphor/messaging": "^1.2.3",
+        "@phosphor/signaling": "^1.2.3"
       }
     },
     "@jupyterlab/services": {
@@ -76,14 +76,14 @@
       "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.0.0.tgz",
       "integrity": "sha512-yCchogfzZqGWXagDJDRxsEMbKwsmf+EFVJRzf5H5OKZs7c/0yNemhG2qjRSmcErD87nUezB3NHkJSVPqz11D3g==",
       "requires": {
-        "@jupyterlab/coreutils": "3.0.0",
-        "@jupyterlab/observables": "2.2.0",
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/signaling": "1.2.3",
-        "node-fetch": "2.6.0",
-        "ws": "7.0.1"
+        "@jupyterlab/coreutils": "^3.0.0",
+        "@jupyterlab/observables": "^2.2.0",
+        "@phosphor/algorithm": "^1.1.3",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.2.0",
+        "@phosphor/signaling": "^1.2.3",
+        "node-fetch": "^2.6.0",
+        "ws": "^7.0.0"
       }
     },
     "@mapbox/geojson-area": {
@@ -100,9 +100,9 @@
       "integrity": "sha512-b+1uPWBERW4Pet/969BNu61ZPDyH2ilIxBjJDFzxyS9TyszF9UrTQyYIl/G38clux3rtpAGGFSGTCSF/qR6UjA==",
       "requires": {
         "@mapbox/geojson-area": "0.2.2",
-        "concat-stream": "1.6.2",
+        "concat-stream": "~1.6.0",
         "minimist": "1.2.0",
-        "sharkdown": "0.1.1"
+        "sharkdown": "^0.1.0"
       }
     },
     "@mapbox/geojson-types": {
@@ -140,7 +140,7 @@
       "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
       "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
       "requires": {
-        "@mapbox/point-geometry": "0.1.0"
+        "@mapbox/point-geometry": "~0.1.0"
       }
     },
     "@mapbox/whoots-js": {
@@ -158,7 +158,7 @@
       "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.1.3.tgz",
       "integrity": "sha512-J2U1xd2e5LtqoOJt4kynrjDNeHhVpJjuY2/zA0InS5kyOuWmvy79pt/KJ22n0LBNcU/fjkImqtQmbrC2Z4q2xQ==",
       "requires": {
-        "@phosphor/algorithm": "1.1.3"
+        "@phosphor/algorithm": "^1.1.3"
       }
     },
     "@phosphor/commands": {
@@ -166,12 +166,12 @@
       "resolved": "https://registry.npmjs.org/@phosphor/commands/-/commands-1.6.3.tgz",
       "integrity": "sha512-PYNHWv6tbXAfAtKiqXuT0OBJvwbJ+RRTV60MBykMF7Vqz9UaZ9n2e/eB2EAGEFccF0PnjTCvBEZgarwwMVi8Hg==",
       "requires": {
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/domutils": "1.1.3",
-        "@phosphor/keyboard": "1.1.3",
-        "@phosphor/signaling": "1.2.3"
+        "@phosphor/algorithm": "^1.1.3",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.2.0",
+        "@phosphor/domutils": "^1.1.3",
+        "@phosphor/keyboard": "^1.1.3",
+        "@phosphor/signaling": "^1.2.3"
       }
     },
     "@phosphor/coreutils": {
@@ -184,8 +184,8 @@
       "resolved": "https://registry.npmjs.org/@phosphor/disposable/-/disposable-1.2.0.tgz",
       "integrity": "sha512-4PoWoffdrLyWOW5Qv7I8//owvZmv57YhaxetAMWeJl13ThXc901RprL0Gxhtue2ZxL2PtUjM1207HndKo2FVjA==",
       "requires": {
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/signaling": "1.2.3"
+        "@phosphor/algorithm": "^1.1.3",
+        "@phosphor/signaling": "^1.2.3"
       }
     },
     "@phosphor/domutils": {
@@ -198,8 +198,8 @@
       "resolved": "https://registry.npmjs.org/@phosphor/dragdrop/-/dragdrop-1.3.3.tgz",
       "integrity": "sha512-+SrlGsVQwY8OHCWxE/Zvihpk6Rc6bytJDqOUUTZqdL8hvM9QZeopAFioPDxuo1pTj87Um6cR4ekvbTU4KZ/90w==",
       "requires": {
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0"
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.2.0"
       }
     },
     "@phosphor/keyboard": {
@@ -212,8 +212,8 @@
       "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.2.3.tgz",
       "integrity": "sha512-89Ps4uSRNOEQoepB/0SDoyPpNUWd6VZnmbMetmeXZJHsuJ1GLxtnq3WBdl7UCVNsw3W9NC610pWaDCy/BafRlg==",
       "requires": {
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/collections": "1.1.3"
+        "@phosphor/algorithm": "^1.1.3",
+        "@phosphor/collections": "^1.1.3"
       }
     },
     "@phosphor/properties": {
@@ -226,7 +226,7 @@
       "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.2.3.tgz",
       "integrity": "sha512-DMwS0m9OgfY5ljpTsklRQPUQpTyg4obz85FyImRDacUVxUVbas95djIDEbU4s1TMzdHBBO+gfki3V4giXUvXzw==",
       "requires": {
-        "@phosphor/algorithm": "1.1.3"
+        "@phosphor/algorithm": "^1.1.3"
       }
     },
     "@phosphor/virtualdom": {
@@ -234,7 +234,7 @@
       "resolved": "https://registry.npmjs.org/@phosphor/virtualdom/-/virtualdom-1.1.3.tgz",
       "integrity": "sha512-V8PHhhnZCRa5esrC4q5VthqlLtxTo9ZV1mZ6b4YEloapca1S1nggZSQhrSlltXQjtYNUaWJZUZ/BlFD8wFtIEQ==",
       "requires": {
-        "@phosphor/algorithm": "1.1.3"
+        "@phosphor/algorithm": "^1.1.3"
       }
     },
     "@phosphor/widgets": {
@@ -242,17 +242,17 @@
       "resolved": "https://registry.npmjs.org/@phosphor/widgets/-/widgets-1.8.1.tgz",
       "integrity": "sha512-OY5T0nAioYTitPks/lCHm7a6QpjRB/XviIT2j6WtYm5J1U8MluIPpClqZ/NQbZfm23BYpmJeiQQyZA+5YphsDA==",
       "requires": {
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/commands": "1.6.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/domutils": "1.1.3",
-        "@phosphor/dragdrop": "1.3.3",
-        "@phosphor/keyboard": "1.1.3",
-        "@phosphor/messaging": "1.2.3",
-        "@phosphor/properties": "1.1.3",
-        "@phosphor/signaling": "1.2.3",
-        "@phosphor/virtualdom": "1.1.3"
+        "@phosphor/algorithm": "^1.1.3",
+        "@phosphor/commands": "^1.6.3",
+        "@phosphor/coreutils": "^1.3.1",
+        "@phosphor/disposable": "^1.2.0",
+        "@phosphor/domutils": "^1.1.3",
+        "@phosphor/dragdrop": "^1.3.3",
+        "@phosphor/keyboard": "^1.1.3",
+        "@phosphor/messaging": "^1.2.3",
+        "@phosphor/properties": "^1.1.3",
+        "@phosphor/signaling": "^1.2.3",
+        "@phosphor/virtualdom": "^1.1.3"
       }
     },
     "@plotly/d3-sankey": {
@@ -260,9 +260,9 @@
       "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
       "integrity": "sha512-2jdVos1N3mMp3QW0k2q1ph7Gd6j5PY1YihBrwpkFnKqO+cqtZq3AdEYUeSGXMeLsBDQYiqTVcihYfk8vr5tqhw==",
       "requires": {
-        "d3-array": "1.2.4",
-        "d3-collection": "1.0.7",
-        "d3-shape": "1.3.5"
+        "d3-array": "1",
+        "d3-collection": "1",
+        "d3-shape": "^1.2.0"
       }
     },
     "@plotly/d3-sankey-circular": {
@@ -270,10 +270,10 @@
       "resolved": "https://registry.npmjs.org/@plotly/d3-sankey-circular/-/d3-sankey-circular-0.33.1.tgz",
       "integrity": "sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==",
       "requires": {
-        "d3-array": "1.2.4",
-        "d3-collection": "1.0.7",
-        "d3-shape": "1.3.5",
-        "elementary-circuits-directed-graph": "1.0.4"
+        "d3-array": "^1.2.1",
+        "d3-collection": "^1.0.4",
+        "d3-shape": "^1.2.0",
+        "elementary-circuits-directed-graph": "^1.0.4"
       }
     },
     "@turf/area": {
@@ -281,8 +281,8 @@
       "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.0.1.tgz",
       "integrity": "sha512-Zv+3N1ep9P5JvR0YOYagLANyapGWQBh8atdeR3bKpWcigVXFsEKNUw03U/5xnh+cKzm7yozHD6MFJkqQv55y0g==",
       "requires": {
-        "@turf/helpers": "6.1.4",
-        "@turf/meta": "6.0.2"
+        "@turf/helpers": "6.x",
+        "@turf/meta": "6.x"
       }
     },
     "@turf/centroid": {
@@ -290,8 +290,8 @@
       "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.0.2.tgz",
       "integrity": "sha512-auyDauOtC4eddH7GC3CHFTDu2PKhpSeKCRhwhHhXtJqn2dWCJQNIoCeJRmfXRIbzCWhWvgvQafvvhq8HNvmvWw==",
       "requires": {
-        "@turf/helpers": "6.1.4",
-        "@turf/meta": "6.0.2"
+        "@turf/helpers": "6.x",
+        "@turf/meta": "6.x"
       }
     },
     "@turf/helpers": {
@@ -304,7 +304,7 @@
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
       "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
       "requires": {
-        "@turf/helpers": "6.1.4"
+        "@turf/helpers": "6.x"
       }
     },
     "@types/backbone": {
@@ -312,8 +312,8 @@
       "resolved": "https://registry.npmjs.org/@types/backbone/-/backbone-1.4.1.tgz",
       "integrity": "sha512-KYfGuQy4d2vvYXbn0uHFZ6brFLndatTMomxBlljpbWf4kFpA3BG/6LA3ec+J9iredrX6eAVI7sm9SVAvwiIM6g==",
       "requires": {
-        "@types/jquery": "3.3.30",
-        "@types/underscore": "1.9.2"
+        "@types/jquery": "*",
+        "@types/underscore": "*"
       }
     },
     "@types/jquery": {
@@ -321,7 +321,7 @@
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.30.tgz",
       "integrity": "sha512-chB+QbLulamShZAFcTJtl8opZwHFBpDOP6nRLrPGkhC6N1aKWrDXg2Nc71tEg6ny6E8SQpRwbWSi9GdstH5VJA==",
       "requires": {
-        "@types/sizzle": "2.3.2"
+        "@types/sizzle": "*"
       }
     },
     "@types/lodash": {
@@ -344,9 +344,9 @@
       "resolved": "https://registry.npmjs.org/a-big-triangle/-/a-big-triangle-1.0.3.tgz",
       "integrity": "sha1-7v0wsCqPUl6LH3K7a7GwwWdRx5Q=",
       "requires": {
-        "gl-buffer": "2.1.2",
-        "gl-vao": "1.3.0",
-        "weak-map": "1.0.5"
+        "gl-buffer": "^2.1.1",
+        "gl-vao": "^1.2.0",
+        "weak-map": "^1.0.5"
       }
     },
     "abs-svg-path": {
@@ -365,7 +365,7 @@
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.3"
       },
       "dependencies": {
         "acorn": {
@@ -386,7 +386,7 @@
       "resolved": "https://registry.npmjs.org/add-line-numbers/-/add-line-numbers-1.0.1.tgz",
       "integrity": "sha1-SNu96kfb0jTer+rGyTzqb3C0t+M=",
       "requires": {
-        "pad-left": "1.0.2"
+        "pad-left": "^1.0.2"
       }
     },
     "affine-hull": {
@@ -394,7 +394,7 @@
       "resolved": "https://registry.npmjs.org/affine-hull/-/affine-hull-1.0.0.tgz",
       "integrity": "sha1-dj/x040GPOt+Jy8X7k17vK+QXF0=",
       "requires": {
-        "robust-orientation": "1.1.3"
+        "robust-orientation": "^1.1.3"
       }
     },
     "ajv": {
@@ -402,10 +402,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
       "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "requires": {
-        "fast-deep-equal": "2.0.1",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       },
       "dependencies": {
         "fast-deep-equal": {
@@ -431,9 +431,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "almost-equal": {
@@ -446,8 +446,8 @@
       "resolved": "https://registry.npmjs.org/alpha-complex/-/alpha-complex-1.0.0.tgz",
       "integrity": "sha1-kIZYcNawVCrnPAwTHU75iWabctI=",
       "requires": {
-        "circumradius": "1.0.0",
-        "delaunay-triangulate": "1.1.6"
+        "circumradius": "^1.0.0",
+        "delaunay-triangulate": "^1.1.6"
       }
     },
     "alpha-shape": {
@@ -455,8 +455,8 @@
       "resolved": "https://registry.npmjs.org/alpha-shape/-/alpha-shape-1.0.0.tgz",
       "integrity": "sha1-yDEJkj7P2mZ9IWP+Tyb+JHJvZKk=",
       "requires": {
-        "alpha-complex": "1.0.0",
-        "simplicial-complex-boundary": "1.0.1"
+        "alpha-complex": "^1.0.0",
+        "simplicial-complex-boundary": "^1.0.0"
       }
     },
     "amdefine": {
@@ -476,7 +476,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "ansicolors": {
@@ -490,8 +490,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "arr-diff": {
@@ -500,7 +500,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -518,7 +518,7 @@
       "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.4.tgz",
       "integrity": "sha512-fCp0wKFLjvSPmCn4F5Tiw4M3lpMZoHlCjfcs7nNzuj3vqQQ1/a8cgB9DXcpDSn18c+coLnaW7rqfcYCvKbyJXg==",
       "requires": {
-        "array-bounds": "1.0.1"
+        "array-bounds": "^1.0.0"
       }
     },
     "array-range": {
@@ -543,9 +543,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -563,7 +563,7 @@
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.5"
+        "lodash": "^4.14.0"
       }
     },
     "async-each": {
@@ -587,7 +587,7 @@
       "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.2.3.tgz",
       "integrity": "sha1-wiz9B/yG676uYdGJKe0RXpmdZbk=",
       "requires": {
-        "underscore": "1.9.1"
+        "underscore": ">=1.7.0"
       }
     },
     "balanced-match": {
@@ -600,7 +600,7 @@
       "resolved": "https://registry.npmjs.org/barycentric/-/barycentric-1.0.1.tgz",
       "integrity": "sha1-8VYruJGyb0/sRjqC7to2V4AOxog=",
       "requires": {
-        "robust-linear-solve": "1.0.0"
+        "robust-linear-solve": "^1.0.0"
       }
     },
     "base64-js": {
@@ -613,9 +613,9 @@
       "resolved": "https://registry.npmjs.org/big-rat/-/big-rat-1.0.4.tgz",
       "integrity": "sha1-do0JO7V5MN0Y7Vdcf8on3FORreo=",
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "bn.js": "4.11.8",
-        "double-bits": "1.1.1"
+        "bit-twiddle": "^1.0.2",
+        "bn.js": "^4.11.6",
+        "double-bits": "^1.1.1"
       }
     },
     "big.js": {
@@ -645,7 +645,7 @@
       "resolved": "https://registry.npmjs.org/bitmap-sdf/-/bitmap-sdf-1.0.3.tgz",
       "integrity": "sha512-ojYySSvWTx21cbgntR942zgEgqj38wHctN64vr4vYRFf3GKVmI23YlA94meWGkFslidwLwGCsMy2laJ3g/94Sg==",
       "requires": {
-        "clamp": "1.0.1"
+        "clamp": "^1.0.1"
       }
     },
     "bl": {
@@ -653,7 +653,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "requires": {
-        "readable-stream": "2.3.4"
+        "readable-stream": "^2.0.5"
       },
       "dependencies": {
         "isarray": {
@@ -666,13 +666,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
           "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -680,7 +680,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -695,7 +695,7 @@
       "resolved": "https://registry.npmjs.org/boundary-cells/-/boundary-cells-2.0.1.tgz",
       "integrity": "sha1-6QWo0UGc9Hyza+Pb9SXbXiTeAEI=",
       "requires": {
-        "tape": "4.11.0"
+        "tape": "^4.0.0"
       }
     },
     "box-intersect": {
@@ -703,8 +703,8 @@
       "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.2.tgz",
       "integrity": "sha512-yJeMwlmFPG1gIa7Rs/cGXeI6iOj6Qz5MG5PE61xLKpElUGzmJ4abm+qsLpzxKJFpsSDq742BQEocr8dI2t8Nxw==",
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "typedarray-pool": "1.1.0"
+        "bit-twiddle": "^1.0.2",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "brace-expansion": {
@@ -712,7 +712,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -722,9 +722,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "brorand": {
@@ -739,12 +739,12 @@
       "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -753,9 +753,9 @@
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.1.1",
-        "browserify-des": "1.0.0",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -764,9 +764,9 @@
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "browserify-rsa": {
@@ -775,8 +775,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -785,13 +785,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.0"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -800,7 +800,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "1.0.6"
+        "pako": "~1.0.5"
       }
     },
     "buble": {
@@ -808,14 +808,14 @@
       "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.8.tgz",
       "integrity": "sha512-IoGZzrUTY5fKXVkgGHw3QeXFMUNBFv+9l8a4QJKG1JhG3nCMHTdEX1DCOg8568E2Q9qvAQIiSokv6Jsgx8p2cA==",
       "requires": {
-        "acorn": "6.3.0",
-        "acorn-dynamic-import": "4.0.0",
-        "acorn-jsx": "5.1.0",
-        "chalk": "2.4.2",
-        "magic-string": "0.25.4",
-        "minimist": "1.2.0",
-        "os-homedir": "2.0.0",
-        "regexpu-core": "4.6.0"
+        "acorn": "^6.1.1",
+        "acorn-dynamic-import": "^4.0.0",
+        "acorn-jsx": "^5.0.1",
+        "chalk": "^2.4.2",
+        "magic-string": "^0.25.3",
+        "minimist": "^1.2.0",
+        "os-homedir": "^2.0.0",
+        "regexpu-core": "^4.5.4"
       },
       "dependencies": {
         "acorn": {
@@ -835,7 +835,7 @@
       "resolved": "https://registry.npmjs.org/bubleify/-/bubleify-1.2.1.tgz",
       "integrity": "sha512-vp3NHmaQVoKaKWvi15FTMinPNjfp+47+/kFJ9ifezdMF/CBLArCxDVUh+FQE3qRxCRj1qyjJqilTBHHqlM8MaQ==",
       "requires": {
-        "buble": "0.19.8"
+        "buble": "^0.19.3"
       }
     },
     "buffer": {
@@ -844,9 +844,9 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "1.2.3",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -890,7 +890,7 @@
       "resolved": "https://registry.npmjs.org/canvas-fit/-/canvas-fit-1.5.0.tgz",
       "integrity": "sha1-rhO+Zq3kL1vg5IfjRfzjCl5bXl8=",
       "requires": {
-        "element-size": "1.1.1"
+        "element-size": "^1.1.1"
       }
     },
     "cardinal": {
@@ -898,8 +898,8 @@
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
       "integrity": "sha1-ylu2iltRG5D+k7ms6km97lwyv+I=",
       "requires": {
-        "ansicolors": "0.2.1",
-        "redeyed": "0.4.4"
+        "ansicolors": "~0.2.1",
+        "redeyed": "~0.4.0"
       }
     },
     "cdt2d": {
@@ -907,9 +907,9 @@
       "resolved": "https://registry.npmjs.org/cdt2d/-/cdt2d-1.0.0.tgz",
       "integrity": "sha1-TyEkNLzWe9s9aLj+9KzcLFRBUUE=",
       "requires": {
-        "binary-search-bounds": "2.0.4",
-        "robust-in-sphere": "1.1.3",
-        "robust-orientation": "1.1.3"
+        "binary-search-bounds": "^2.0.3",
+        "robust-in-sphere": "^1.1.3",
+        "robust-orientation": "^1.1.3"
       }
     },
     "cell-orientation": {
@@ -922,8 +922,8 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -931,9 +931,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chokidar": {
@@ -942,15 +942,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "cipher-base": {
@@ -959,8 +959,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "circumcenter": {
@@ -968,8 +968,8 @@
       "resolved": "https://registry.npmjs.org/circumcenter/-/circumcenter-1.0.0.tgz",
       "integrity": "sha1-INeqE7F/usUvUtpPVMasi5Bu5Sk=",
       "requires": {
-        "dup": "1.0.0",
-        "robust-linear-solve": "1.0.0"
+        "dup": "^1.0.0",
+        "robust-linear-solve": "^1.0.0"
       }
     },
     "circumradius": {
@@ -977,7 +977,7 @@
       "resolved": "https://registry.npmjs.org/circumradius/-/circumradius-1.0.0.tgz",
       "integrity": "sha1-cGxEfj5VzR7T0RvRM+N8JSzDBbU=",
       "requires": {
-        "circumcenter": "1.0.0"
+        "circumcenter": "^1.0.0"
       }
     },
     "clamp": {
@@ -990,13 +990,13 @@
       "resolved": "https://registry.npmjs.org/clean-pslg/-/clean-pslg-1.1.2.tgz",
       "integrity": "sha1-vTXHRgt+irWp92Gl7VF5aqPIbBE=",
       "requires": {
-        "big-rat": "1.0.4",
-        "box-intersect": "1.0.2",
-        "nextafter": "1.0.0",
-        "rat-vec": "1.1.1",
-        "robust-segment-intersect": "1.0.1",
-        "union-find": "1.0.2",
-        "uniq": "1.0.1"
+        "big-rat": "^1.0.3",
+        "box-intersect": "^1.0.1",
+        "nextafter": "^1.0.0",
+        "rat-vec": "^1.1.1",
+        "robust-segment-intersect": "^1.0.1",
+        "union-find": "^1.0.2",
+        "uniq": "^1.0.1"
       }
     },
     "cliui": {
@@ -1004,8 +1004,8 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -1027,7 +1027,7 @@
       "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.4.tgz",
       "integrity": "sha512-lr8/t5NPozTSqli+duAN+x+no/2WaKTeWvxhHGN+aXT6AJ8vPlzLa7UriyjWak0pSC2jHol9JgjBYnnHsGha9A==",
       "requires": {
-        "color-parse": "1.3.8"
+        "color-parse": "^1.3.8"
       }
     },
     "color-convert": {
@@ -1050,7 +1050,7 @@
       "resolved": "https://registry.npmjs.org/color-id/-/color-id-1.1.0.tgz",
       "integrity": "sha512-2iRtAn6dC/6/G7bBIo0uupVrIne1NsQJvJxZOBCzQOfk7jRq97feaDZ3RdzuHakRXXnHGNwglto3pqtRx1sX0g==",
       "requires": {
-        "clamp": "1.0.1"
+        "clamp": "^1.0.1"
       }
     },
     "color-name": {
@@ -1063,9 +1063,9 @@
       "resolved": "https://registry.npmjs.org/color-normalize/-/color-normalize-1.5.0.tgz",
       "integrity": "sha512-rUT/HDXMr6RFffrR53oX3HGWkDOP9goSAQGBkUaAYKjOE2JxozccdGyufageWDlInRAjm/jYPrf/Y38oa+7obw==",
       "requires": {
-        "clamp": "1.0.1",
-        "color-rgba": "2.1.1",
-        "dtype": "2.0.0"
+        "clamp": "^1.0.1",
+        "color-rgba": "^2.1.1",
+        "dtype": "^2.0.0"
       }
     },
     "color-parse": {
@@ -1073,9 +1073,9 @@
       "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.8.tgz",
       "integrity": "sha512-1Y79qFv0n1xair3lNMTNeoFvmc3nirMVBij24zbs1f13+7fPpQClMg5b4AuKXLt3szj7BRlHMCXHplkce6XlmA==",
       "requires": {
-        "color-name": "1.1.4",
-        "defined": "1.0.0",
-        "is-plain-obj": "1.1.0"
+        "color-name": "^1.0.0",
+        "defined": "^1.0.0",
+        "is-plain-obj": "^1.1.0"
       }
     },
     "color-rgba": {
@@ -1083,9 +1083,9 @@
       "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.1.1.tgz",
       "integrity": "sha512-VaX97wsqrMwLSOR6H7rU1Doa2zyVdmShabKrPEIFywLlHoibgD3QW9Dw6fSqM4+H/LfjprDNAUUW31qEQcGzNw==",
       "requires": {
-        "clamp": "1.0.1",
-        "color-parse": "1.3.8",
-        "color-space": "1.16.0"
+        "clamp": "^1.0.1",
+        "color-parse": "^1.3.8",
+        "color-space": "^1.14.6"
       }
     },
     "color-space": {
@@ -1093,8 +1093,8 @@
       "resolved": "https://registry.npmjs.org/color-space/-/color-space-1.16.0.tgz",
       "integrity": "sha512-A6WMiFzunQ8KEPFmj02OnnoUnqhmSaHaZ/0LVFcPTdlvm8+3aMJ5x1HRHy3bDHPkovkf4sS0f4wsVvwk71fKkg==",
       "requires": {
-        "hsluv": "0.0.3",
-        "mumath": "3.3.4"
+        "hsluv": "^0.0.3",
+        "mumath": "^3.3.4"
       }
     },
     "colormap": {
@@ -1102,7 +1102,7 @@
       "resolved": "https://registry.npmjs.org/colormap/-/colormap-2.3.1.tgz",
       "integrity": "sha512-TEzNlo/qYp6pBoR2SK9JiV+DG1cmUcVO/+DEJqVPSHIKNlWh5L5L4FYog7b/h0bAnhKhpOAvx/c1dFp2QE9sFw==",
       "requires": {
-        "lerp": "1.0.3"
+        "lerp": "^1.0.3"
       }
     },
     "colors": {
@@ -1121,11 +1121,11 @@
       "resolved": "https://registry.npmjs.org/compare-angle/-/compare-angle-1.0.1.tgz",
       "integrity": "sha1-pOtjQW6jx0f8a9bItjZotN5PoSk=",
       "requires": {
-        "robust-orientation": "1.1.3",
-        "robust-product": "1.0.0",
-        "robust-sum": "1.0.0",
-        "signum": "0.0.0",
-        "two-sum": "1.0.0"
+        "robust-orientation": "^1.0.2",
+        "robust-product": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "signum": "^0.0.0",
+        "two-sum": "^1.0.0"
       }
     },
     "compare-cell": {
@@ -1138,8 +1138,8 @@
       "resolved": "https://registry.npmjs.org/compare-oriented-cell/-/compare-oriented-cell-1.0.1.tgz",
       "integrity": "sha1-ahSf7vnfxPj8YjWOUd1C7/u9w54=",
       "requires": {
-        "cell-orientation": "1.0.1",
-        "compare-cell": "1.0.0"
+        "cell-orientation": "^1.0.1",
+        "compare-cell": "^1.0.0"
       }
     },
     "compute-dims": {
@@ -1147,11 +1147,11 @@
       "resolved": "https://registry.npmjs.org/compute-dims/-/compute-dims-1.1.0.tgz",
       "integrity": "sha512-YHMiIKjH/8Eom8zATk3g8/lH3HxGCZcVQyEfEoVrfWI7od/WRpTgRGShnei3jArYSx77mQqPxZNokjGHCdLfxg==",
       "requires": {
-        "utils-copy": "1.1.1",
-        "validate.io-array": "1.0.6",
-        "validate.io-matrix-like": "1.0.2",
-        "validate.io-ndarray-like": "1.0.0",
-        "validate.io-positive-integer": "1.0.0"
+        "utils-copy": "^1.0.0",
+        "validate.io-array": "^1.0.6",
+        "validate.io-matrix-like": "^1.0.2",
+        "validate.io-ndarray-like": "^1.0.0",
+        "validate.io-positive-integer": "^1.0.0"
       }
     },
     "concat-map": {
@@ -1164,10 +1164,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       },
       "dependencies": {
         "isarray": {
@@ -1180,13 +1180,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -1194,7 +1194,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -1205,7 +1205,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "const-max-uint32": {
@@ -1229,9 +1229,9 @@
       "resolved": "https://registry.npmjs.org/convex-hull/-/convex-hull-1.0.3.tgz",
       "integrity": "sha1-IKOqbOh/St6i/30XlxyfwcZ+H/8=",
       "requires": {
-        "affine-hull": "1.0.0",
-        "incremental-convex-hull": "1.0.1",
-        "monotone-convex-hull-2d": "1.0.1"
+        "affine-hull": "^1.0.0",
+        "incremental-convex-hull": "^1.0.1",
+        "monotone-convex-hull-2d": "^1.0.1"
       }
     },
     "core-util-is": {
@@ -1250,8 +1250,8 @@
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-hash": {
@@ -1260,10 +1260,10 @@
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "sha.js": "2.4.10"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -1272,12 +1272,12 @@
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "cross-spawn": {
@@ -1286,9 +1286,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "crypto-browserify": {
@@ -1297,17 +1297,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.0",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.0",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "diffie-hellman": "5.0.2",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.14",
-        "public-encrypt": "4.0.0",
-        "randombytes": "2.0.6",
-        "randomfill": "1.0.4"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "css-font": {
@@ -1315,15 +1315,15 @@
       "resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
       "integrity": "sha512-V4U4Wps4dPDACJ4WpgofJ2RT5Yqwe1lEH6wlOOaIxMi0gTjdIijsc5FmxQlZ7ZZyKQkkutqqvULOp07l9c7ssA==",
       "requires": {
-        "css-font-size-keywords": "1.0.0",
-        "css-font-stretch-keywords": "1.0.1",
-        "css-font-style-keywords": "1.0.1",
-        "css-font-weight-keywords": "1.0.0",
-        "css-global-keywords": "1.0.1",
-        "css-system-font-keywords": "1.0.0",
-        "pick-by-alias": "1.2.0",
-        "string-split-by": "1.0.0",
-        "unquote": "1.1.1"
+        "css-font-size-keywords": "^1.0.0",
+        "css-font-stretch-keywords": "^1.0.1",
+        "css-font-style-keywords": "^1.0.1",
+        "css-font-weight-keywords": "^1.0.0",
+        "css-global-keywords": "^1.0.1",
+        "css-system-font-keywords": "^1.0.0",
+        "pick-by-alias": "^1.2.0",
+        "string-split-by": "^1.0.0",
+        "unquote": "^1.1.0"
       }
     },
     "css-font-size-keywords": {
@@ -1371,10 +1371,10 @@
       "resolved": "https://registry.npmjs.org/cwise/-/cwise-1.0.10.tgz",
       "integrity": "sha1-JO7mBy69/WuMb12tsXCQtkmxK+8=",
       "requires": {
-        "cwise-compiler": "1.1.3",
-        "cwise-parser": "1.0.3",
-        "static-module": "1.5.0",
-        "uglify-js": "2.8.29"
+        "cwise-compiler": "^1.1.1",
+        "cwise-parser": "^1.0.0",
+        "static-module": "^1.0.0",
+        "uglify-js": "^2.6.0"
       }
     },
     "cwise-compiler": {
@@ -1382,7 +1382,7 @@
       "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
       "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
       "requires": {
-        "uniq": "1.0.1"
+        "uniq": "^1.0.0"
       }
     },
     "cwise-parser": {
@@ -1390,8 +1390,8 @@
       "resolved": "https://registry.npmjs.org/cwise-parser/-/cwise-parser-1.0.3.tgz",
       "integrity": "sha1-jkk8F9VPl8sDCp6YVLyGyd+zVP4=",
       "requires": {
-        "esprima": "1.2.5",
-        "uniq": "1.0.1"
+        "esprima": "^1.0.3",
+        "uniq": "^1.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -1406,7 +1406,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.39"
+        "es5-ext": "^0.10.9"
       }
     },
     "d3": {
@@ -1439,10 +1439,10 @@
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
       "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
       "requires": {
-        "d3-collection": "1.0.7",
-        "d3-dispatch": "1.0.5",
-        "d3-quadtree": "1.0.6",
-        "d3-timer": "1.0.9"
+        "d3-collection": "1",
+        "d3-dispatch": "1",
+        "d3-quadtree": "1",
+        "d3-timer": "1"
       }
     },
     "d3-hierarchy": {
@@ -1455,7 +1455,7 @@
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.3.2.tgz",
       "integrity": "sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==",
       "requires": {
-        "d3-color": "1.4.0"
+        "d3-color": "1"
       }
     },
     "d3-path": {
@@ -1473,7 +1473,7 @@
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.5.tgz",
       "integrity": "sha512-VKazVR3phgD+MUCldapHD7P9kcrvPcexeX/PkMJmkUov4JM8IxsSg1DvbYoYich9AtdTsa5nNk2++ImPiDiSxg==",
       "requires": {
-        "d3-path": "1.0.8"
+        "d3-path": "1"
       }
     },
     "d3-timer": {
@@ -1507,7 +1507,7 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "requires": {
-        "object-keys": "1.1.1"
+        "object-keys": "^1.0.12"
       }
     },
     "defined": {
@@ -1520,8 +1520,8 @@
       "resolved": "https://registry.npmjs.org/delaunay-triangulate/-/delaunay-triangulate-1.1.6.tgz",
       "integrity": "sha1-W7yiGweBmNS8PHV5ajXLuYwllUw=",
       "requires": {
-        "incremental-convex-hull": "1.0.1",
-        "uniq": "1.0.1"
+        "incremental-convex-hull": "^1.0.1",
+        "uniq": "^1.0.1"
       }
     },
     "des.js": {
@@ -1530,8 +1530,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "detect-kerning": {
@@ -1545,9 +1545,9 @@
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "domain-browser": {
@@ -1566,8 +1566,8 @@
       "resolved": "https://registry.npmjs.org/draw-svg-path/-/draw-svg-path-1.0.0.tgz",
       "integrity": "sha1-bxFtli3TFLmepTTW9Y3WbNvWk3k=",
       "requires": {
-        "abs-svg-path": "0.1.1",
-        "normalize-svg-path": "0.1.0"
+        "abs-svg-path": "~0.1.1",
+        "normalize-svg-path": "~0.1.0"
       }
     },
     "dtype": {
@@ -1585,7 +1585,7 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "~1.1.9"
       },
       "dependencies": {
         "readable-stream": {
@@ -1593,10 +1593,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         }
       }
@@ -1606,10 +1606,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "requires": {
-        "end-of-stream": "1.4.4",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -1622,13 +1622,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -1636,7 +1636,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -1651,7 +1651,7 @@
       "resolved": "https://registry.npmjs.org/edges-to-adjacency-list/-/edges-to-adjacency-list-1.0.0.tgz",
       "integrity": "sha1-wUbS4ISt37p0pRKTxuAZmkn3V/E=",
       "requires": {
-        "uniq": "1.0.1"
+        "uniq": "^1.0.0"
       }
     },
     "element-size": {
@@ -1664,7 +1664,7 @@
       "resolved": "https://registry.npmjs.org/elementary-circuits-directed-graph/-/elementary-circuits-directed-graph-1.0.4.tgz",
       "integrity": "sha512-+xpVxSimU+fcHiTRPWrRN1IFOKaygwotCtZGSBle/rnFaFAoI+4Y8/pimAY1cKiDIHTek2Zox1R7SEQAB/AQ1g==",
       "requires": {
-        "strongly-connected-components": "1.0.1"
+        "strongly-connected-components": "^1.0.1"
       }
     },
     "elliptic": {
@@ -1673,13 +1673,13 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "emojis-list": {
@@ -1693,7 +1693,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "enhanced-resolve": {
@@ -1702,10 +1702,10 @@
       "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.8"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "object-assign": "^4.0.1",
+        "tapable": "^0.2.7"
       }
     },
     "errno": {
@@ -1714,7 +1714,7 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
-        "prr": "1.0.1"
+        "prr": "~1.0.1"
       }
     },
     "error-ex": {
@@ -1723,7 +1723,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -1731,16 +1731,16 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
       "integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
       "requires": {
-        "es-to-primitive": "1.2.0",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "has-symbols": "1.0.0",
-        "is-callable": "1.1.4",
-        "is-regex": "1.0.4",
-        "object-inspect": "1.6.0",
-        "object-keys": "1.1.1",
-        "string.prototype.trimleft": "2.1.0",
-        "string.prototype.trimright": "2.1.0"
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.0",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-inspect": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "string.prototype.trimleft": "^2.1.0",
+        "string.prototype.trimright": "^2.1.0"
       }
     },
     "es-to-primitive": {
@@ -1748,9 +1748,9 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "requires": {
-        "is-callable": "1.1.4",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.2"
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "es5-ext": {
@@ -1758,8 +1758,8 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz",
       "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1"
       }
     },
     "es6-iterator": {
@@ -1767,9 +1767,9 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-map": {
@@ -1778,12 +1778,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-promise": {
@@ -1797,11 +1797,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39",
-        "es6-iterator": "2.0.3",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -1809,8 +1809,8 @@
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-weak-map": {
@@ -1819,10 +1819,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -1835,11 +1835,11 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
       "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.3",
-        "optionator": "0.8.2",
-        "source-map": "0.6.1"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -1856,10 +1856,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "esprima": {
@@ -1873,8 +1873,8 @@
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "^4.1.0",
+        "object-assign": "^4.0.1"
       }
     },
     "estraverse": {
@@ -1893,8 +1893,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "events": {
@@ -1908,8 +1908,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "execa": {
@@ -1918,13 +1918,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "expand-brackets": {
@@ -1933,7 +1933,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -1942,7 +1942,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "ext": {
@@ -1950,7 +1950,7 @@
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.1.2.tgz",
       "integrity": "sha512-/KLjJdTNyDepCihrk4HQt57nAE1IRCEo5jUt+WgWGCr1oARhibDvmI2DMcSNWood1T9AUWwq+jaV1wvRqaXfnA==",
       "requires": {
-        "type": "2.0.0"
+        "type": "^2.0.0"
       },
       "dependencies": {
         "type": {
@@ -1966,7 +1966,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extract-frustum-planes": {
@@ -1979,10 +1979,10 @@
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
       "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
       "requires": {
-        "acorn": "5.4.1",
-        "foreach": "2.0.5",
+        "acorn": "^5.0.0",
+        "foreach": "^2.0.5",
         "isarray": "0.0.1",
-        "object-keys": "1.1.1"
+        "object-keys": "^1.0.6"
       }
     },
     "fast-deep-equal": {
@@ -1996,7 +1996,7 @@
       "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.3.tgz",
       "integrity": "sha512-MdojHkfLx8pjRNZyGjOhX4HxNPaf0l5R/v5rGZ1bGXCnRPyQIUAe4I1H7QtrlUwuuiDHKdpQTjT3lmueVH2otw==",
       "requires": {
-        "is-string-blank": "1.0.1"
+        "is-string-blank": "^1.0.1"
       }
     },
     "fast-json-stable-stringify": {
@@ -2021,11 +2021,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "filtered-vector": {
@@ -2033,8 +2033,8 @@
       "resolved": "https://registry.npmjs.org/filtered-vector/-/filtered-vector-1.2.4.tgz",
       "integrity": "sha1-VkU8A030MC0pPKjs3qw/kKvGeNM=",
       "requires": {
-        "binary-search-bounds": "1.0.0",
-        "cubic-hermite": "1.0.0"
+        "binary-search-bounds": "^1.0.0",
+        "cubic-hermite": "^1.0.0"
       },
       "dependencies": {
         "binary-search-bounds": {
@@ -2050,7 +2050,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "findup": {
@@ -2059,8 +2059,8 @@
       "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
       "dev": true,
       "requires": {
-        "colors": "0.6.2",
-        "commander": "2.1.0"
+        "colors": "~0.6.0-1",
+        "commander": "~2.1.0"
       }
     },
     "flatten-vertex-data": {
@@ -2068,7 +2068,7 @@
       "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.2.tgz",
       "integrity": "sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==",
       "requires": {
-        "dtype": "2.0.0"
+        "dtype": "^2.0.0"
       }
     },
     "flip-pixels": {
@@ -2081,7 +2081,7 @@
       "resolved": "https://registry.npmjs.org/font-atlas/-/font-atlas-2.1.0.tgz",
       "integrity": "sha512-kP3AmvX+HJpW4w3d+PiPR2X6E1yvsBXt2yhuCw+yReO9F1WYhvZwx3c95DGZGwg9xYzDGrgJYa885xmVA+28Cg==",
       "requires": {
-        "css-font": "1.2.0"
+        "css-font": "^1.0.0"
       }
     },
     "font-measure": {
@@ -2089,7 +2089,7 @@
       "resolved": "https://registry.npmjs.org/font-measure/-/font-measure-1.2.2.tgz",
       "integrity": "sha512-mRLEpdrWzKe9hbfaF3Qpr06TAjquuBVP5cHy4b3hyeNdjc9i0PO6HniGsX5vjL5OWv7+Bd++NiooNpT/s8BvIA==",
       "requires": {
-        "css-font": "1.2.0"
+        "css-font": "^1.2.0"
       }
     },
     "for-each": {
@@ -2097,7 +2097,7 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "requires": {
-        "is-callable": "1.1.4"
+        "is-callable": "^1.1.3"
       }
     },
     "for-in": {
@@ -2112,7 +2112,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -2125,8 +2125,8 @@
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -2139,13 +2139,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
           "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -2153,7 +2153,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -2164,7 +2164,7 @@
       "integrity": "sha1-6vwWtl9uJxm81X/cGGkAWsEzLNY=",
       "dev": true,
       "requires": {
-        "from2": "2.3.0"
+        "from2": "^2.0.3"
       }
     },
     "fs.realpath": {
@@ -2179,8 +2179,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.8.0",
-        "node-pre-gyp": "0.6.39"
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -2195,8 +2195,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ansi-regex": {
@@ -2216,8 +2216,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "asn1": {
@@ -2261,7 +2261,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "block-stream": {
@@ -2269,7 +2269,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "~2.0.0"
           }
         },
         "boom": {
@@ -2277,7 +2277,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "brace-expansion": {
@@ -2285,7 +2285,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
           }
         },
@@ -2316,7 +2316,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
@@ -2339,7 +2339,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "dashdash": {
@@ -2348,7 +2348,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -2397,7 +2397,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "extend": {
@@ -2438,10 +2438,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "fstream-ignore": {
@@ -2450,9 +2450,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
+            "fstream": "^1.0.0",
+            "inherits": "2",
+            "minimatch": "^3.0.0"
           }
         },
         "gauge": {
@@ -2461,14 +2461,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "getpass": {
@@ -2477,7 +2477,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -2493,12 +2493,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -2533,10 +2533,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -2550,9 +2550,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "inflight": {
@@ -2560,8 +2560,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -2606,7 +2606,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "jsbn": {
@@ -2627,7 +2627,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -2708,17 +2708,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.2",
+            "detect-libc": "^1.0.2",
             "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
+            "mkdirp": "^0.5.1",
+            "nopt": "^4.0.1",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
             "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^2.2.1",
+            "tar-pack": "^3.4.0"
           }
         },
         "nopt": {
@@ -2727,8 +2727,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npmlog": {
@@ -2737,10 +2737,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -2765,7 +2765,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -2786,8 +2786,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -2824,10 +2824,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -2843,13 +2843,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
           }
         },
         "request": {
@@ -2858,28 +2858,28 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
           }
         },
         "rimraf": {
@@ -2887,7 +2887,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -2918,7 +2918,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "sshpk": {
@@ -2927,15 +2927,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jodid25519": "^1.0.0",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -2951,9 +2951,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -2961,7 +2961,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "stringstream": {
@@ -2975,7 +2975,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -2989,9 +2989,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           }
         },
         "tar-pack": {
@@ -3000,14 +3000,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
+            "debug": "^2.2.0",
+            "fstream": "^1.0.10",
+            "fstream-ignore": "^1.0.5",
+            "once": "^1.3.3",
+            "readable-stream": "^2.1.4",
+            "rimraf": "^2.5.1",
+            "tar": "^2.2.1",
+            "uid-number": "^0.0.6"
           }
         },
         "tough-cookie": {
@@ -3016,7 +3016,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "tunnel-agent": {
@@ -3025,7 +3025,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -3066,7 +3066,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -3118,19 +3118,19 @@
       "resolved": "https://registry.npmjs.org/gl-axes3d/-/gl-axes3d-1.5.2.tgz",
       "integrity": "sha512-47Cfh5KhUVRFtYXgufR4lGY5cyXH7SPgAlS1FlvTGK84spIYFCBMlOGUN3AdavGLGUOcXS4ml+tMM61cY6M3gg==",
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "dup": "1.0.0",
-        "extract-frustum-planes": "1.0.0",
-        "gl-buffer": "2.1.2",
-        "gl-mat4": "1.2.0",
-        "gl-shader": "4.2.1",
-        "gl-state": "1.0.0",
-        "gl-vao": "1.3.0",
-        "gl-vec4": "1.0.1",
-        "glslify": "7.0.0",
-        "robust-orientation": "1.1.3",
-        "split-polygon": "1.0.0",
-        "vectorize-text": "3.2.1"
+        "bit-twiddle": "^1.0.2",
+        "dup": "^1.0.0",
+        "extract-frustum-planes": "^1.0.0",
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
+        "gl-state": "^1.0.0",
+        "gl-vao": "^1.3.0",
+        "gl-vec4": "^1.0.1",
+        "glslify": "^7.0.0",
+        "robust-orientation": "^1.1.3",
+        "split-polygon": "^1.0.0",
+        "vectorize-text": "^3.2.1"
       }
     },
     "gl-buffer": {
@@ -3138,9 +3138,9 @@
       "resolved": "https://registry.npmjs.org/gl-buffer/-/gl-buffer-2.1.2.tgz",
       "integrity": "sha1-LbjZwaVSf7oM25EonCBuiCuInNs=",
       "requires": {
-        "ndarray": "1.0.18",
-        "ndarray-ops": "1.2.2",
-        "typedarray-pool": "1.1.0"
+        "ndarray": "^1.0.15",
+        "ndarray-ops": "^1.1.0",
+        "typedarray-pool": "^1.0.0"
       }
     },
     "gl-cone3d": {
@@ -3148,18 +3148,18 @@
       "resolved": "https://registry.npmjs.org/gl-cone3d/-/gl-cone3d-1.5.1.tgz",
       "integrity": "sha512-R8m2lPfVN5ip/IPzykvMNgUUGWTkp9rMuCrVknKIkhjH+gaQeGfwF3+WrB0kwq3FRWvlYWcfdvabv37sZ2rKYA==",
       "requires": {
-        "colormap": "2.3.1",
-        "gl-buffer": "2.1.2",
-        "gl-mat4": "1.2.0",
-        "gl-shader": "4.2.1",
-        "gl-texture2d": "2.1.0",
-        "gl-vao": "1.3.0",
-        "gl-vec3": "1.1.3",
-        "glsl-inverse": "1.0.0",
-        "glsl-out-of-range": "1.0.4",
-        "glsl-specular-cook-torrance": "2.0.1",
-        "glslify": "7.0.0",
-        "ndarray": "1.0.18"
+        "colormap": "^2.3.1",
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
+        "gl-texture2d": "^2.1.0",
+        "gl-vao": "^1.3.0",
+        "gl-vec3": "^1.1.3",
+        "glsl-inverse": "^1.0.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-cook-torrance": "^2.0.1",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.18"
       }
     },
     "gl-constants": {
@@ -3172,15 +3172,15 @@
       "resolved": "https://registry.npmjs.org/gl-contour2d/-/gl-contour2d-1.1.6.tgz",
       "integrity": "sha512-n8nEFb4VRYooBo3+hbAgiXGELVn7PtYyVbj/hWmTNtrkxFK39Yr8LUczcT2uOOyzqq7sO3FH8+J8PSMFh+z+5A==",
       "requires": {
-        "binary-search-bounds": "2.0.4",
-        "cdt2d": "1.0.0",
-        "clean-pslg": "1.1.2",
-        "gl-buffer": "2.1.2",
-        "gl-shader": "4.2.1",
-        "glslify": "7.0.0",
-        "iota-array": "1.0.0",
-        "ndarray": "1.0.18",
-        "surface-nets": "1.0.2"
+        "binary-search-bounds": "^2.0.4",
+        "cdt2d": "^1.0.0",
+        "clean-pslg": "^1.1.2",
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "glslify": "^7.0.0",
+        "iota-array": "^1.0.0",
+        "ndarray": "^1.0.18",
+        "surface-nets": "^1.0.2"
       }
     },
     "gl-error3d": {
@@ -3188,11 +3188,11 @@
       "resolved": "https://registry.npmjs.org/gl-error3d/-/gl-error3d-1.0.15.tgz",
       "integrity": "sha512-7mB1zU22Vzdvq0KzzYRzE0xvCRF9nHd1+9ElUqkvt0GMH0gVIpxKk+m3hNPM/iQHmNupcXaE1cBcOQE2agN3uA==",
       "requires": {
-        "gl-buffer": "2.1.2",
-        "gl-shader": "4.2.1",
-        "gl-vao": "1.3.0",
-        "glsl-out-of-range": "1.0.4",
-        "glslify": "7.0.0"
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "gl-vao": "^1.3.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glslify": "^7.0.0"
       }
     },
     "gl-fbo": {
@@ -3200,7 +3200,7 @@
       "resolved": "https://registry.npmjs.org/gl-fbo/-/gl-fbo-2.0.5.tgz",
       "integrity": "sha1-D6daSXz3h2lVMGkcjwSrtvtV+iI=",
       "requires": {
-        "gl-texture2d": "2.1.0"
+        "gl-texture2d": "^2.0.0"
       }
     },
     "gl-format-compiler-error": {
@@ -3208,10 +3208,10 @@
       "resolved": "https://registry.npmjs.org/gl-format-compiler-error/-/gl-format-compiler-error-1.0.3.tgz",
       "integrity": "sha1-DHmxdRiZzpcy6GJA8JCqQemEcag=",
       "requires": {
-        "add-line-numbers": "1.0.1",
-        "gl-constants": "1.0.0",
-        "glsl-shader-name": "1.0.0",
-        "sprintf-js": "1.1.2"
+        "add-line-numbers": "^1.0.1",
+        "gl-constants": "^1.0.0",
+        "glsl-shader-name": "^1.0.0",
+        "sprintf-js": "^1.0.3"
       }
     },
     "gl-heatmap2d": {
@@ -3219,12 +3219,12 @@
       "resolved": "https://registry.npmjs.org/gl-heatmap2d/-/gl-heatmap2d-1.0.5.tgz",
       "integrity": "sha512-nki9GIh0g4OXKNIrlnAT/gy/uXxkwrFKgI+XwRcUO6nLBM1WbI2hl8EPykNFXCqsyd08HJQbXKiqaHPW7cNpJg==",
       "requires": {
-        "binary-search-bounds": "2.0.4",
-        "gl-buffer": "2.1.2",
-        "gl-shader": "4.2.1",
-        "glslify": "7.0.0",
-        "iota-array": "1.0.0",
-        "typedarray-pool": "1.1.0"
+        "binary-search-bounds": "^2.0.3",
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.0.5",
+        "glslify": "^7.0.0",
+        "iota-array": "^1.0.0",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-line3d": {
@@ -3232,15 +3232,15 @@
       "resolved": "https://registry.npmjs.org/gl-line3d/-/gl-line3d-1.1.11.tgz",
       "integrity": "sha512-EitFKPEEYdn/ivFOxJ8khSi0BzNum4sXZFLq6SQq21MX5YPCYb0o+XzjpWNuU32BoXORBC78B1JTiQqnTaWhWQ==",
       "requires": {
-        "binary-search-bounds": "2.0.4",
-        "gl-buffer": "2.1.2",
-        "gl-shader": "4.2.1",
-        "gl-texture2d": "2.1.0",
-        "gl-vao": "1.3.0",
-        "glsl-out-of-range": "1.0.4",
-        "glsl-read-float": "1.1.0",
-        "glslify": "7.0.0",
-        "ndarray": "1.0.18"
+        "binary-search-bounds": "^2.0.4",
+        "gl-buffer": "^2.0.8",
+        "gl-shader": "^4.2.1",
+        "gl-texture2d": "^2.0.2",
+        "gl-vao": "^1.1.3",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-read-float": "^1.0.0",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.16"
       }
     },
     "gl-mat2": {
@@ -3268,9 +3268,9 @@
       "resolved": "https://registry.npmjs.org/gl-matrix-invert/-/gl-matrix-invert-1.0.0.tgz",
       "integrity": "sha1-o2173jZUxFkKEn7nxo9uE/6oxj0=",
       "requires": {
-        "gl-mat2": "1.0.1",
-        "gl-mat3": "1.0.0",
-        "gl-mat4": "1.2.0"
+        "gl-mat2": "^1.0.0",
+        "gl-mat3": "^1.0.0",
+        "gl-mat4": "^1.0.0"
       }
     },
     "gl-mesh3d": {
@@ -3278,21 +3278,21 @@
       "resolved": "https://registry.npmjs.org/gl-mesh3d/-/gl-mesh3d-2.1.1.tgz",
       "integrity": "sha512-UuDnuSE/xX8y9/B6EtDsBKllEmKDVmuiD9lsFoQdUq4FPSvwFOo9rKH3fsjK2pfxsTigguF6GhFjHqq+sJKQWg==",
       "requires": {
-        "barycentric": "1.0.1",
-        "colormap": "2.3.1",
-        "gl-buffer": "2.1.2",
-        "gl-mat4": "1.2.0",
-        "gl-shader": "4.2.1",
-        "gl-texture2d": "2.1.0",
-        "gl-vao": "1.3.0",
-        "glsl-out-of-range": "1.0.4",
-        "glsl-specular-cook-torrance": "2.0.1",
-        "glslify": "7.0.0",
-        "ndarray": "1.0.18",
-        "normals": "1.1.0",
-        "polytope-closest-point": "1.0.0",
-        "simplicial-complex-contour": "1.0.2",
-        "typedarray-pool": "1.1.0"
+        "barycentric": "^1.0.1",
+        "colormap": "^2.3.1",
+        "gl-buffer": "^2.0.8",
+        "gl-mat4": "^1.0.0",
+        "gl-shader": "^4.2.1",
+        "gl-texture2d": "^2.0.8",
+        "gl-vao": "^1.1.3",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-cook-torrance": "^2.0.1",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.15",
+        "normals": "^1.0.1",
+        "polytope-closest-point": "^1.0.0",
+        "simplicial-complex-contour": "^1.0.0",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-plot2d": {
@@ -3300,13 +3300,13 @@
       "resolved": "https://registry.npmjs.org/gl-plot2d/-/gl-plot2d-1.4.2.tgz",
       "integrity": "sha512-YLFiu/vgDCYZ/Qnz0wn0gV60IYCtImSnx0OTMsZ5fP1XZAhFztrRb2fJfnjfEVe15yZ+G+9zJ36RlWmJsNQYjQ==",
       "requires": {
-        "binary-search-bounds": "2.0.4",
-        "gl-buffer": "2.1.2",
-        "gl-select-static": "2.0.4",
-        "gl-shader": "4.2.1",
-        "glsl-inverse": "1.0.0",
-        "glslify": "7.0.0",
-        "text-cache": "4.2.1"
+        "binary-search-bounds": "^2.0.4",
+        "gl-buffer": "^2.1.2",
+        "gl-select-static": "^2.0.4",
+        "gl-shader": "^4.2.1",
+        "glsl-inverse": "^1.0.0",
+        "glslify": "^7.0.0",
+        "text-cache": "^4.2.1"
       }
     },
     "gl-plot3d": {
@@ -3314,22 +3314,22 @@
       "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-2.3.0.tgz",
       "integrity": "sha512-qg269QiLpaw16d2D5Gz9fa8vsLcA8kbX/cv1u9S7BsH6jD9qGYxsY8iWJ8ea9/68WhPS5En2kUavkXINkmHsOQ==",
       "requires": {
-        "3d-view": "2.0.0",
-        "a-big-triangle": "1.0.3",
-        "gl-axes3d": "1.5.2",
-        "gl-fbo": "2.0.5",
-        "gl-mat4": "1.2.0",
-        "gl-select-static": "2.0.4",
-        "gl-shader": "4.2.1",
-        "gl-spikes3d": "1.0.9",
-        "glslify": "7.0.0",
-        "has-passive-events": "1.0.0",
-        "is-mobile": "2.1.0",
-        "mouse-change": "1.4.0",
-        "mouse-event-offset": "3.0.2",
-        "mouse-wheel": "1.2.0",
-        "ndarray": "1.0.18",
-        "right-now": "1.0.0"
+        "3d-view": "^2.0.0",
+        "a-big-triangle": "^1.0.3",
+        "gl-axes3d": "^1.5.2",
+        "gl-fbo": "^2.0.5",
+        "gl-mat4": "^1.2.0",
+        "gl-select-static": "^2.0.4",
+        "gl-shader": "^4.2.1",
+        "gl-spikes3d": "^1.0.9",
+        "glslify": "^7.0.0",
+        "has-passive-events": "^1.0.0",
+        "is-mobile": "^2.1.0",
+        "mouse-change": "^1.4.0",
+        "mouse-event-offset": "^3.0.2",
+        "mouse-wheel": "^1.2.0",
+        "ndarray": "^1.0.18",
+        "right-now": "^1.0.0"
       }
     },
     "gl-pointcloud2d": {
@@ -3337,10 +3337,10 @@
       "resolved": "https://registry.npmjs.org/gl-pointcloud2d/-/gl-pointcloud2d-1.0.2.tgz",
       "integrity": "sha512-KDfuJLg1dFWNPo6eJYgwUpNdVcIdK5y29ZiYpzzP0qh3eg0bSLMq8ZkaqvPmSJsFksUryT73IRunsuxJtTJkvA==",
       "requires": {
-        "gl-buffer": "2.1.2",
-        "gl-shader": "4.2.1",
-        "glslify": "7.0.0",
-        "typedarray-pool": "1.1.0"
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "glslify": "^7.0.0",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-quat": {
@@ -3348,9 +3348,9 @@
       "resolved": "https://registry.npmjs.org/gl-quat/-/gl-quat-1.0.0.tgz",
       "integrity": "sha1-CUXskjOG9FMpvl3DV7HIwtR1hsU=",
       "requires": {
-        "gl-mat3": "1.0.0",
-        "gl-vec3": "1.1.3",
-        "gl-vec4": "1.0.1"
+        "gl-mat3": "^1.0.0",
+        "gl-vec3": "^1.0.3",
+        "gl-vec4": "^1.0.0"
       }
     },
     "gl-scatter3d": {
@@ -3358,15 +3358,15 @@
       "resolved": "https://registry.npmjs.org/gl-scatter3d/-/gl-scatter3d-1.2.2.tgz",
       "integrity": "sha512-oZh3WQ0bVXnpASpZmYmiEp7eUiD0oU6J4G5C9KUOhUo5d2gucvZEILAtfWmzCT3zsOltoROn4jGuuP2tlLN88Q==",
       "requires": {
-        "gl-buffer": "2.1.2",
-        "gl-mat4": "1.2.0",
-        "gl-shader": "4.2.1",
-        "gl-vao": "1.3.0",
-        "glsl-out-of-range": "1.0.4",
-        "glslify": "7.0.0",
-        "is-string-blank": "1.0.1",
-        "typedarray-pool": "1.1.0",
-        "vectorize-text": "3.2.1"
+        "gl-buffer": "^2.0.6",
+        "gl-mat4": "^1.0.0",
+        "gl-shader": "^4.2.0",
+        "gl-vao": "^1.1.2",
+        "glsl-out-of-range": "^1.0.4",
+        "glslify": "^7.0.0",
+        "is-string-blank": "^1.0.1",
+        "typedarray-pool": "^1.0.2",
+        "vectorize-text": "^3.2.1"
       }
     },
     "gl-select-box": {
@@ -3374,9 +3374,9 @@
       "resolved": "https://registry.npmjs.org/gl-select-box/-/gl-select-box-1.0.3.tgz",
       "integrity": "sha512-sQb18g1aZ6PJAsvsC8nNYhuhc2TYXNbzVbI0bP9AH9770NjrDnd7TC8HHcfu8nJXGPG69HjqR6EzS+QSqiXPSA==",
       "requires": {
-        "gl-buffer": "2.1.2",
-        "gl-shader": "4.2.1",
-        "glslify": "7.0.0"
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.0.5",
+        "glslify": "^7.0.0"
       }
     },
     "gl-select-static": {
@@ -3384,11 +3384,11 @@
       "resolved": "https://registry.npmjs.org/gl-select-static/-/gl-select-static-2.0.4.tgz",
       "integrity": "sha512-4Kqx5VjeT8nmV+j6fry3UBFNL2B7ktQU4o508QGVPKWCILlV44rTDq3mnBFThup8rMIH9kJQx6xWsg9jTmfeMw==",
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "cwise": "1.0.10",
-        "gl-fbo": "2.0.5",
-        "ndarray": "1.0.18",
-        "typedarray-pool": "1.1.0"
+        "bit-twiddle": "^1.0.2",
+        "cwise": "^1.0.3",
+        "gl-fbo": "^2.0.3",
+        "ndarray": "^1.0.15",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-shader": {
@@ -3396,8 +3396,8 @@
       "resolved": "https://registry.npmjs.org/gl-shader/-/gl-shader-4.2.1.tgz",
       "integrity": "sha1-vJuAjpKTxRtmjojeYVsMETcI3C8=",
       "requires": {
-        "gl-format-compiler-error": "1.0.3",
-        "weakmap-shim": "1.1.1"
+        "gl-format-compiler-error": "^1.0.2",
+        "weakmap-shim": "^1.1.0"
       }
     },
     "gl-spikes2d": {
@@ -3410,10 +3410,10 @@
       "resolved": "https://registry.npmjs.org/gl-spikes3d/-/gl-spikes3d-1.0.9.tgz",
       "integrity": "sha512-laMxydgGdnE8kvd1YD9cNWrx0uSmrPj1Oi02cHhnxWIklut97w3F7mZKnmLMEyUkxpRLkEeQ7YkYy7Y+aUEblw==",
       "requires": {
-        "gl-buffer": "2.1.2",
-        "gl-shader": "4.2.1",
-        "gl-vao": "1.3.0",
-        "glslify": "7.0.0"
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "gl-vao": "^1.3.0",
+        "glslify": "^7.0.0"
       }
     },
     "gl-state": {
@@ -3421,7 +3421,7 @@
       "resolved": "https://registry.npmjs.org/gl-state/-/gl-state-1.0.0.tgz",
       "integrity": "sha1-Ji+qdYNbC5xTLBLzitxCXR0wzRc=",
       "requires": {
-        "uniq": "1.0.1"
+        "uniq": "^1.0.0"
       }
     },
     "gl-streamtube3d": {
@@ -3429,13 +3429,13 @@
       "resolved": "https://registry.npmjs.org/gl-streamtube3d/-/gl-streamtube3d-1.4.0.tgz",
       "integrity": "sha512-WgRtdB77uFCN1lBZ6ogz7VTK4J8WwW5DGHvyB3LaBSZF3t5lf/KWeXPgm+xnNINlOy4JqJIgny+CtzwTHAk3Ew==",
       "requires": {
-        "gl-cone3d": "1.5.1",
-        "gl-vec3": "1.1.3",
-        "gl-vec4": "1.0.1",
-        "glsl-inverse": "1.0.0",
-        "glsl-out-of-range": "1.0.4",
-        "glsl-specular-cook-torrance": "2.0.1",
-        "glslify": "7.0.0"
+        "gl-cone3d": "^1.5.0",
+        "gl-vec3": "^1.1.3",
+        "gl-vec4": "^1.0.1",
+        "glsl-inverse": "^1.0.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-cook-torrance": "^2.0.1",
+        "glslify": "^7.0.0"
       }
     },
     "gl-surface3d": {
@@ -3443,25 +3443,25 @@
       "resolved": "https://registry.npmjs.org/gl-surface3d/-/gl-surface3d-1.4.6.tgz",
       "integrity": "sha512-aItWQTNUX3JJc6i2FbXX82ljPZgDV3kXzkzANcBGoAnKwRpJw12WcMKKTL4sOCs9BW+3sx6BhR0P5+2zh5Scfw==",
       "requires": {
-        "binary-search-bounds": "2.0.4",
-        "bit-twiddle": "1.0.2",
-        "colormap": "2.3.1",
-        "dup": "1.0.0",
-        "gl-buffer": "2.1.2",
-        "gl-mat4": "1.2.0",
-        "gl-shader": "4.2.1",
-        "gl-texture2d": "2.1.0",
-        "gl-vao": "1.3.0",
-        "glsl-out-of-range": "1.0.4",
-        "glsl-specular-beckmann": "1.1.2",
-        "glslify": "7.0.0",
-        "ndarray": "1.0.18",
-        "ndarray-gradient": "1.0.0",
-        "ndarray-ops": "1.2.2",
-        "ndarray-pack": "1.2.1",
-        "ndarray-scratch": "1.2.0",
-        "surface-nets": "1.0.2",
-        "typedarray-pool": "1.1.0"
+        "binary-search-bounds": "^2.0.4",
+        "bit-twiddle": "^1.0.2",
+        "colormap": "^2.3.1",
+        "dup": "^1.0.0",
+        "gl-buffer": "^2.0.3",
+        "gl-mat4": "^1.0.0",
+        "gl-shader": "^4.2.0",
+        "gl-texture2d": "^2.0.0",
+        "gl-vao": "^1.1.1",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-beckmann": "^1.1.2",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.16",
+        "ndarray-gradient": "^1.0.0",
+        "ndarray-ops": "^1.2.1",
+        "ndarray-pack": "^1.0.1",
+        "ndarray-scratch": "^1.1.1",
+        "surface-nets": "^1.0.2",
+        "typedarray-pool": "^1.0.0"
       }
     },
     "gl-text": {
@@ -3469,23 +3469,23 @@
       "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.1.8.tgz",
       "integrity": "sha512-whnq9DEFYbW92C4ONwk2eT0YkzmVPHoADnEtuzMOmit87XhgAhBrNs3lK9EgGjU/MoWYvlF6RkI8Kl7Yuo1hUw==",
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "color-normalize": "1.5.0",
-        "css-font": "1.2.0",
-        "detect-kerning": "2.1.2",
-        "es6-weak-map": "2.0.3",
-        "flatten-vertex-data": "1.0.2",
-        "font-atlas": "2.1.0",
-        "font-measure": "1.2.2",
-        "gl-util": "3.1.2",
-        "is-plain-obj": "1.1.0",
-        "object-assign": "4.1.1",
-        "parse-rect": "1.2.0",
-        "parse-unit": "1.0.1",
-        "pick-by-alias": "1.2.0",
-        "regl": "1.3.13",
-        "to-px": "1.1.0",
-        "typedarray-pool": "1.1.0"
+        "bit-twiddle": "^1.0.2",
+        "color-normalize": "^1.5.0",
+        "css-font": "^1.2.0",
+        "detect-kerning": "^2.1.2",
+        "es6-weak-map": "^2.0.3",
+        "flatten-vertex-data": "^1.0.2",
+        "font-atlas": "^2.1.0",
+        "font-measure": "^1.2.2",
+        "gl-util": "^3.1.2",
+        "is-plain-obj": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "parse-unit": "^1.0.1",
+        "pick-by-alias": "^1.2.0",
+        "regl": "^1.3.11",
+        "to-px": "^1.0.1",
+        "typedarray-pool": "^1.1.0"
       },
       "dependencies": {
         "es5-ext": {
@@ -3493,9 +3493,9 @@
           "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.52.tgz",
           "integrity": "sha512-bWCbE9fbpYQY4CU6hJbJ1vSz70EClMlDgJ7BmwI+zEJhxrwjesZRPglGJlsZhu0334U3hI+gaspwksH9IGD6ag==",
           "requires": {
-            "es6-iterator": "2.0.3",
-            "es6-symbol": "3.1.3",
-            "next-tick": "1.0.0"
+            "es6-iterator": "~2.0.3",
+            "es6-symbol": "~3.1.2",
+            "next-tick": "~1.0.0"
           },
           "dependencies": {
             "d": {
@@ -3503,8 +3503,8 @@
               "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
               "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
               "requires": {
-                "es5-ext": "0.10.52",
-                "type": "1.2.0"
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
               }
             },
             "es6-symbol": {
@@ -3512,8 +3512,8 @@
               "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
               "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
               "requires": {
-                "d": "1.0.1",
-                "ext": "1.1.2"
+                "d": "^1.0.1",
+                "ext": "^1.1.2"
               }
             }
           }
@@ -3523,10 +3523,10 @@
           "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
           "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.52",
-            "es6-iterator": "2.0.3",
-            "es6-symbol": "3.1.1"
+            "d": "1",
+            "es5-ext": "^0.10.46",
+            "es6-iterator": "^2.0.3",
+            "es6-symbol": "^3.1.1"
           }
         }
       }
@@ -3536,9 +3536,9 @@
       "resolved": "https://registry.npmjs.org/gl-texture2d/-/gl-texture2d-2.1.0.tgz",
       "integrity": "sha1-/2gk5+fDGoum/c2+nlxpXX4hh8c=",
       "requires": {
-        "ndarray": "1.0.18",
-        "ndarray-ops": "1.2.2",
-        "typedarray-pool": "1.1.0"
+        "ndarray": "^1.0.15",
+        "ndarray-ops": "^1.2.2",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-util": {
@@ -3546,13 +3546,13 @@
       "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.2.tgz",
       "integrity": "sha512-8czWhGTGp/H4S35X1UxGbFlJ1hjtTFhm2mc85GcymEi1CDf633WJgtkCddEiSjIa4BnNxBrqOIhj6jlF6naPqw==",
       "requires": {
-        "is-browser": "2.1.0",
-        "is-firefox": "1.0.3",
-        "is-plain-obj": "1.1.0",
-        "number-is-integer": "1.0.1",
-        "object-assign": "4.1.1",
-        "pick-by-alias": "1.2.0",
-        "weak-map": "1.0.5"
+        "is-browser": "^2.0.1",
+        "is-firefox": "^1.0.3",
+        "is-plain-obj": "^1.1.0",
+        "number-is-integer": "^1.0.1",
+        "object-assign": "^4.1.0",
+        "pick-by-alias": "^1.2.0",
+        "weak-map": "^1.0.5"
       }
     },
     "gl-vao": {
@@ -3576,12 +3576,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -3590,8 +3590,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -3600,7 +3600,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "glsl-inject-defines": {
@@ -3608,9 +3608,9 @@
       "resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
       "integrity": "sha1-3RqswsF/yyvT/DJBHGYz0Ne2D9Q=",
       "requires": {
-        "glsl-token-inject-block": "1.1.0",
-        "glsl-token-string": "1.0.1",
-        "glsl-tokenizer": "2.1.5"
+        "glsl-token-inject-block": "^1.0.0",
+        "glsl-token-string": "^1.0.1",
+        "glsl-tokenizer": "^2.0.2"
       }
     },
     "glsl-inverse": {
@@ -3633,8 +3633,8 @@
       "resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",
       "integrity": "sha1-iUvvc5ENeSyBtRQxgANdCnivdtM=",
       "requires": {
-        "resolve": "0.6.3",
-        "xtend": "2.2.0"
+        "resolve": "^0.6.1",
+        "xtend": "^2.1.2"
       },
       "dependencies": {
         "resolve": {
@@ -3654,8 +3654,8 @@
       "resolved": "https://registry.npmjs.org/glsl-shader-name/-/glsl-shader-name-1.0.0.tgz",
       "integrity": "sha1-osMLO6c0mb77DMcYTXx3M91LSH0=",
       "requires": {
-        "atob-lite": "1.0.0",
-        "glsl-tokenizer": "2.1.5"
+        "atob-lite": "^1.0.0",
+        "glsl-tokenizer": "^2.0.2"
       }
     },
     "glsl-specular-beckmann": {
@@ -3668,7 +3668,7 @@
       "resolved": "https://registry.npmjs.org/glsl-specular-cook-torrance/-/glsl-specular-cook-torrance-2.0.1.tgz",
       "integrity": "sha1-qJHMBsjHtPRyhwK0gk/ay7ln148=",
       "requires": {
-        "glsl-specular-beckmann": "1.1.2"
+        "glsl-specular-beckmann": "^1.1.1"
       }
     },
     "glsl-token-assignments": {
@@ -3681,7 +3681,7 @@
       "resolved": "https://registry.npmjs.org/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz",
       "integrity": "sha1-y4kqqVmTYjFyhHDU90AySJaX+p0=",
       "requires": {
-        "glsl-tokenizer": "2.1.5"
+        "glsl-tokenizer": "^2.0.0"
       }
     },
     "glsl-token-depth": {
@@ -3694,10 +3694,10 @@
       "resolved": "https://registry.npmjs.org/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz",
       "integrity": "sha1-D8kKsyYYa4L1l7LnfcniHvzTIHY=",
       "requires": {
-        "glsl-token-assignments": "2.0.2",
-        "glsl-token-depth": "1.1.2",
-        "glsl-token-properties": "1.0.1",
-        "glsl-token-scope": "1.1.2"
+        "glsl-token-assignments": "^2.0.0",
+        "glsl-token-depth": "^1.1.0",
+        "glsl-token-properties": "^1.0.0",
+        "glsl-token-scope": "^1.1.0"
       }
     },
     "glsl-token-inject-block": {
@@ -3730,7 +3730,7 @@
       "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz",
       "integrity": "sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==",
       "requires": {
-        "through2": "0.6.5"
+        "through2": "^0.6.3"
       }
     },
     "glslify": {
@@ -3738,21 +3738,21 @@
       "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
       "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
       "requires": {
-        "bl": "1.2.1",
-        "concat-stream": "1.6.2",
-        "duplexify": "3.7.1",
-        "falafel": "2.1.0",
-        "from2": "2.3.0",
+        "bl": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "duplexify": "^3.4.5",
+        "falafel": "^2.1.0",
+        "from2": "^2.3.0",
         "glsl-resolve": "0.0.1",
-        "glsl-token-whitespace-trim": "1.0.0",
-        "glslify-bundle": "5.1.1",
-        "glslify-deps": "1.3.1",
-        "minimist": "1.2.0",
-        "resolve": "1.4.0",
+        "glsl-token-whitespace-trim": "^1.0.0",
+        "glslify-bundle": "^5.0.0",
+        "glslify-deps": "^1.2.5",
+        "minimist": "^1.2.0",
+        "resolve": "^1.1.5",
         "stack-trace": "0.0.9",
-        "static-eval": "2.0.2",
-        "through2": "2.0.5",
-        "xtend": "4.0.1"
+        "static-eval": "^2.0.0",
+        "through2": "^2.0.1",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -3765,13 +3765,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -3779,7 +3779,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "through2": {
@@ -3787,8 +3787,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -3798,15 +3798,15 @@
       "resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-5.1.1.tgz",
       "integrity": "sha512-plaAOQPv62M1r3OsWf2UbjN0hUYAB7Aph5bfH58VxJZJhloRNbxOL9tl/7H71K7OLJoSJ2ZqWOKk3ttQ6wy24A==",
       "requires": {
-        "glsl-inject-defines": "1.0.3",
-        "glsl-token-defines": "1.0.0",
-        "glsl-token-depth": "1.1.2",
-        "glsl-token-descope": "1.0.2",
-        "glsl-token-scope": "1.1.2",
-        "glsl-token-string": "1.0.1",
-        "glsl-token-whitespace-trim": "1.0.0",
-        "glsl-tokenizer": "2.1.5",
-        "murmurhash-js": "1.0.0",
+        "glsl-inject-defines": "^1.0.1",
+        "glsl-token-defines": "^1.0.0",
+        "glsl-token-depth": "^1.1.1",
+        "glsl-token-descope": "^1.0.2",
+        "glsl-token-scope": "^1.1.1",
+        "glsl-token-string": "^1.0.1",
+        "glsl-token-whitespace-trim": "^1.0.0",
+        "glsl-tokenizer": "^2.0.2",
+        "murmurhash-js": "^1.0.0",
         "shallow-copy": "0.0.1"
       }
     },
@@ -3815,14 +3815,14 @@
       "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.1.tgz",
       "integrity": "sha512-Ogm179MCazwIRyEqs3g3EOY4Y3XIAa0yl8J5RE9rJC6QH1w8weVOp2RZu0mvnYy/2xIas1w166YR2eZdDkWQxg==",
       "requires": {
-        "@choojs/findup": "0.2.1",
-        "events": "1.1.1",
+        "@choojs/findup": "^0.2.0",
+        "events": "^1.0.2",
         "glsl-resolve": "0.0.1",
-        "glsl-tokenizer": "2.1.5",
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
+        "glsl-tokenizer": "^2.0.0",
+        "graceful-fs": "^4.1.2",
+        "inherits": "^2.0.1",
         "map-limit": "0.0.1",
-        "resolve": "1.4.0"
+        "resolve": "^1.0.0"
       },
       "dependencies": {
         "@choojs/findup": {
@@ -3830,7 +3830,7 @@
           "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
           "integrity": "sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==",
           "requires": {
-            "commander": "2.20.3"
+            "commander": "^2.15.1"
           }
         },
         "commander": {
@@ -3855,7 +3855,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-flag": {
@@ -3868,7 +3868,7 @@
       "resolved": "https://registry.npmjs.org/has-hover/-/has-hover-1.0.1.tgz",
       "integrity": "sha1-PZdDeusZnGK4rAisvcU9O8UsF/c=",
       "requires": {
-        "is-browser": "2.1.0"
+        "is-browser": "^2.0.1"
       }
     },
     "has-passive-events": {
@@ -3876,7 +3876,7 @@
       "resolved": "https://registry.npmjs.org/has-passive-events/-/has-passive-events-1.0.0.tgz",
       "integrity": "sha512-2vSj6IeIsgvsRMyeQ0JaCX5Q3lX4zMn5HpoVc7MEhQ6pv8Iq9rsXjsp+E5ZwaT7T0xhMT0KmU8gtt1EFVdbJiw==",
       "requires": {
-        "is-browser": "2.1.0"
+        "is-browser": "^2.0.1"
       }
     },
     "has-symbols": {
@@ -3890,7 +3890,7 @@
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "hash.js": {
@@ -3899,8 +3899,8 @@
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "hmac-drbg": {
@@ -3909,9 +3909,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -3943,13 +3943,13 @@
       "integrity": "sha512-EiyC45FRIs+z4g98+jBzuYCfoM6TKG9p7Ek5YZUeM7rucNucaMZIseRj/5Q3I4ypkZXyC2wnU1RcYrVmshe2xw==",
       "dev": true,
       "requires": {
-        "bl": "1.2.1",
-        "findup": "0.1.5",
+        "bl": "^1.0.0",
+        "findup": "^0.1.5",
         "from2-array": "0.0.4",
         "map-limit": "0.0.1",
-        "multipipe": "0.3.1",
-        "read-package-json": "2.0.13",
-        "resolve": "1.4.0"
+        "multipipe": "^0.3.0",
+        "read-package-json": "^2.0.2",
+        "resolve": "^1.1.6"
       }
     },
     "image-palette": {
@@ -3957,9 +3957,9 @@
       "resolved": "https://registry.npmjs.org/image-palette/-/image-palette-2.1.0.tgz",
       "integrity": "sha512-3ImSEWD26+xuQFdP0RWR4WSXadZwvgrFhjGNpMEapTG1tf2XrBFS2dlKK5hNgH4UIaSQlSUFRn1NeA+zULIWbQ==",
       "requires": {
-        "color-id": "1.1.0",
-        "pxls": "2.3.2",
-        "quantize": "1.0.2"
+        "color-id": "^1.1.0",
+        "pxls": "^2.0.0",
+        "quantize": "^1.0.2"
       }
     },
     "incremental-convex-hull": {
@@ -3967,8 +3967,8 @@
       "resolved": "https://registry.npmjs.org/incremental-convex-hull/-/incremental-convex-hull-1.0.1.tgz",
       "integrity": "sha1-UUKMFMudmmFEv+abKFH7N3M0vh4=",
       "requires": {
-        "robust-orientation": "1.1.3",
-        "simplicial-complex": "1.0.0"
+        "robust-orientation": "^1.1.2",
+        "simplicial-complex": "^1.0.0"
       }
     },
     "indexof": {
@@ -3982,8 +3982,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -4002,7 +4002,7 @@
       "resolved": "https://registry.npmjs.org/interval-tree-1d/-/interval-tree-1d-1.0.3.tgz",
       "integrity": "sha1-j9veArayx9verWNry+2OCHENhcE=",
       "requires": {
-        "binary-search-bounds": "1.0.0"
+        "binary-search-bounds": "^1.0.0"
       },
       "dependencies": {
         "binary-search-bounds": {
@@ -4045,7 +4045,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.11.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-blob": {
@@ -4069,7 +4069,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -4094,7 +4094,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -4114,7 +4114,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-firefox": {
@@ -4133,7 +4133,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-glob": {
@@ -4142,7 +4142,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-iexplorer": {
@@ -4161,7 +4161,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-obj": {
@@ -4191,7 +4191,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.1"
       }
     },
     "is-stream": {
@@ -4215,7 +4215,7 @@
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "requires": {
-        "has-symbols": "1.0.0"
+        "has-symbols": "^1.0.0"
       }
     },
     "isarray": {
@@ -4290,7 +4290,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -4304,7 +4304,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "left-pad": {
@@ -4322,8 +4322,8 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -4332,10 +4332,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "loader-runner": {
@@ -4350,9 +4350,9 @@
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "dev": true,
       "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1"
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
       }
     },
     "locate-path": {
@@ -4361,8 +4361,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -4381,8 +4381,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "magic-string": {
@@ -4390,7 +4390,7 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.4.tgz",
       "integrity": "sha512-oycWO9nEVAP2RVPbIoDoA4Y7LFIJ3xRYov93gAyJhZkET1tNuB0u7uWkZS2LpBWTJUWnmau/To8ECWRC+jKNfw==",
       "requires": {
-        "sourcemap-codec": "1.4.6"
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "map-limit": {
@@ -4398,7 +4398,7 @@
       "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
       "integrity": "sha1-63lhAxwPDo0AG/LVb6toXViCLzg=",
       "requires": {
-        "once": "1.3.3"
+        "once": "~1.3.0"
       },
       "dependencies": {
         "once": {
@@ -4406,7 +4406,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         }
       }
@@ -4416,29 +4416,29 @@
       "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.3.2.tgz",
       "integrity": "sha512-6Ro7GbTMWxcbc836m6rbBNkesgTncbE1yXWeuHlr89esSqaItKr0+ntOu8rZie3fv+GtitkbODysXzIGCA7G+w==",
       "requires": {
-        "@mapbox/geojson-rewind": "0.4.0",
-        "@mapbox/geojson-types": "1.0.2",
-        "@mapbox/jsonlint-lines-primitives": "2.0.2",
-        "@mapbox/mapbox-gl-supported": "1.4.1",
-        "@mapbox/point-geometry": "0.1.0",
-        "@mapbox/tiny-sdf": "1.1.1",
-        "@mapbox/unitbezier": "0.0.0",
-        "@mapbox/vector-tile": "1.3.1",
-        "@mapbox/whoots-js": "3.1.0",
-        "csscolorparser": "1.0.3",
-        "earcut": "2.2.1",
-        "geojson-vt": "3.2.1",
-        "gl-matrix": "3.1.0",
-        "grid-index": "1.1.0",
+        "@mapbox/geojson-rewind": "^0.4.0",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.4.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.0",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.2",
+        "earcut": "^2.1.5",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.0.0",
+        "grid-index": "^1.1.0",
         "minimist": "0.0.8",
-        "murmurhash-js": "1.0.0",
-        "pbf": "3.2.1",
-        "potpack": "1.0.1",
-        "quickselect": "2.0.0",
-        "rw": "1.3.3",
-        "supercluster": "6.0.2",
-        "tinyqueue": "2.0.3",
-        "vt-pbf": "3.1.1"
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.0.5",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^6.0.1",
+        "tinyqueue": "^2.0.0",
+        "vt-pbf": "^3.1.1"
       },
       "dependencies": {
         "minimist": {
@@ -4453,7 +4453,7 @@
       "resolved": "https://registry.npmjs.org/marching-simplex-table/-/marching-simplex-table-1.0.0.tgz",
       "integrity": "sha1-vBYlbg+Pm1WKqbKHL4gy2UM/Uuo=",
       "requires": {
-        "convex-hull": "1.0.3"
+        "convex-hull": "^1.0.3"
       }
     },
     "mat4-decompose": {
@@ -4461,8 +4461,8 @@
       "resolved": "https://registry.npmjs.org/mat4-decompose/-/mat4-decompose-1.0.4.tgz",
       "integrity": "sha1-ZetP451wh496RE60Yk1S9+frL68=",
       "requires": {
-        "gl-mat4": "1.2.0",
-        "gl-vec3": "1.1.3"
+        "gl-mat4": "^1.0.1",
+        "gl-vec3": "^1.0.2"
       }
     },
     "mat4-interpolate": {
@@ -4470,11 +4470,11 @@
       "resolved": "https://registry.npmjs.org/mat4-interpolate/-/mat4-interpolate-1.0.4.tgz",
       "integrity": "sha1-Vf/p6zw1KV4sDVqfdyXZBoqJ/3Q=",
       "requires": {
-        "gl-mat4": "1.2.0",
-        "gl-vec3": "1.1.3",
-        "mat4-decompose": "1.0.4",
-        "mat4-recompose": "1.0.4",
-        "quat-slerp": "1.0.1"
+        "gl-mat4": "^1.0.1",
+        "gl-vec3": "^1.0.2",
+        "mat4-decompose": "^1.0.3",
+        "mat4-recompose": "^1.0.3",
+        "quat-slerp": "^1.0.0"
       }
     },
     "mat4-recompose": {
@@ -4482,7 +4482,7 @@
       "resolved": "https://registry.npmjs.org/mat4-recompose/-/mat4-recompose-1.0.4.tgz",
       "integrity": "sha1-OVPCMP8kc9x3LuAUpSySXPgbDk0=",
       "requires": {
-        "gl-mat4": "1.2.0"
+        "gl-mat4": "^1.0.1"
       }
     },
     "math-log2": {
@@ -4495,10 +4495,10 @@
       "resolved": "https://registry.npmjs.org/matrix-camera-controller/-/matrix-camera-controller-2.1.3.tgz",
       "integrity": "sha1-NeUmDMHNVQliunmfLY1OlLGjk3A=",
       "requires": {
-        "binary-search-bounds": "1.0.0",
-        "gl-mat4": "1.2.0",
-        "gl-vec3": "1.1.3",
-        "mat4-interpolate": "1.0.4"
+        "binary-search-bounds": "^1.0.0",
+        "gl-mat4": "^1.1.2",
+        "gl-vec3": "^1.0.3",
+        "mat4-interpolate": "^1.0.3"
       },
       "dependencies": {
         "binary-search-bounds": {
@@ -4514,8 +4514,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       },
       "dependencies": {
         "hash-base": {
@@ -4524,8 +4524,8 @@
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         }
       }
@@ -4536,7 +4536,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "memory-fs": {
@@ -4545,8 +4545,8 @@
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
       "requires": {
-        "errno": "0.1.7",
-        "readable-stream": "2.3.4"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -4561,13 +4561,13 @@
           "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -4576,7 +4576,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -4587,19 +4587,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "miller-rabin": {
@@ -4608,8 +4608,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mimic-fn": {
@@ -4635,7 +4635,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -4670,7 +4670,7 @@
       "resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
       "integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
       "requires": {
-        "robust-orientation": "1.1.3"
+        "robust-orientation": "^1.1.3"
       }
     },
     "mouse-change": {
@@ -4678,7 +4678,7 @@
       "resolved": "https://registry.npmjs.org/mouse-change/-/mouse-change-1.4.0.tgz",
       "integrity": "sha1-wrd+W/o0pDzhRFyBV6Tk3JiVwU8=",
       "requires": {
-        "mouse-event": "1.0.5"
+        "mouse-event": "^1.0.0"
       }
     },
     "mouse-event": {
@@ -4696,9 +4696,9 @@
       "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
       "integrity": "sha1-bSkDseqPtI5h8bU7kDZ3PwQs21w=",
       "requires": {
-        "right-now": "1.0.0",
-        "signum": "1.0.0",
-        "to-px": "1.1.0"
+        "right-now": "^1.0.0",
+        "signum": "^1.0.0",
+        "to-px": "^1.0.1"
       },
       "dependencies": {
         "signum": {
@@ -4714,7 +4714,7 @@
       "integrity": "sha1-kmJVJXYboE/qoJYFtjgrziyR8R8=",
       "dev": true,
       "requires": {
-        "duplexer2": "0.1.4"
+        "duplexer2": "^0.1.2"
       },
       "dependencies": {
         "duplexer2": {
@@ -4723,7 +4723,7 @@
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6"
+            "readable-stream": "^2.0.2"
           }
         },
         "isarray": {
@@ -4738,13 +4738,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -4753,7 +4753,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -4763,7 +4763,7 @@
       "resolved": "https://registry.npmjs.org/mumath/-/mumath-3.3.4.tgz",
       "integrity": "sha1-SNSg8P2MrU57Mglu6JsWGmPTC78=",
       "requires": {
-        "almost-equal": "1.1.0"
+        "almost-equal": "^1.1.0"
       }
     },
     "murmurhash-js": {
@@ -4783,8 +4783,8 @@
       "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.18.tgz",
       "integrity": "sha1-tg06cyJOxVXQ+qeXEeUCRI/T95M=",
       "requires": {
-        "iota-array": "1.0.0",
-        "is-buffer": "1.1.6"
+        "iota-array": "^1.0.0",
+        "is-buffer": "^1.0.2"
       }
     },
     "ndarray-extract-contour": {
@@ -4792,7 +4792,7 @@
       "resolved": "https://registry.npmjs.org/ndarray-extract-contour/-/ndarray-extract-contour-1.0.1.tgz",
       "integrity": "sha1-Cu4ROjozsia5DEiIz4d79HUTBeQ=",
       "requires": {
-        "typedarray-pool": "1.1.0"
+        "typedarray-pool": "^1.0.0"
       }
     },
     "ndarray-fill": {
@@ -4800,7 +4800,7 @@
       "resolved": "https://registry.npmjs.org/ndarray-fill/-/ndarray-fill-1.0.2.tgz",
       "integrity": "sha1-owpg9xiODJWC/N1YiWrNy1IqHtY=",
       "requires": {
-        "cwise": "1.0.10"
+        "cwise": "^1.0.10"
       }
     },
     "ndarray-gradient": {
@@ -4808,8 +4808,8 @@
       "resolved": "https://registry.npmjs.org/ndarray-gradient/-/ndarray-gradient-1.0.0.tgz",
       "integrity": "sha1-t0kaUVxqZJ8ZpiMk//byf8jCU5M=",
       "requires": {
-        "cwise-compiler": "1.1.3",
-        "dup": "1.0.0"
+        "cwise-compiler": "^1.0.0",
+        "dup": "^1.0.0"
       }
     },
     "ndarray-homography": {
@@ -4817,8 +4817,8 @@
       "resolved": "https://registry.npmjs.org/ndarray-homography/-/ndarray-homography-1.0.0.tgz",
       "integrity": "sha1-w1UW6oa8KGK06ASiNqJwcwn+KWs=",
       "requires": {
-        "gl-matrix-invert": "1.0.0",
-        "ndarray-warp": "1.0.1"
+        "gl-matrix-invert": "^1.0.0",
+        "ndarray-warp": "^1.0.0"
       }
     },
     "ndarray-linear-interpolate": {
@@ -4831,7 +4831,7 @@
       "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
       "integrity": "sha1-WeiNLDKn7ryxvGkPrhQVeVV6YU4=",
       "requires": {
-        "cwise-compiler": "1.1.3"
+        "cwise-compiler": "^1.0.0"
       }
     },
     "ndarray-pack": {
@@ -4839,8 +4839,8 @@
       "resolved": "https://registry.npmjs.org/ndarray-pack/-/ndarray-pack-1.2.1.tgz",
       "integrity": "sha1-jK6+qqJNXs9w/4YCBjeXfajuWFo=",
       "requires": {
-        "cwise-compiler": "1.1.3",
-        "ndarray": "1.0.18"
+        "cwise-compiler": "^1.1.2",
+        "ndarray": "^1.0.13"
       }
     },
     "ndarray-scratch": {
@@ -4848,9 +4848,9 @@
       "resolved": "https://registry.npmjs.org/ndarray-scratch/-/ndarray-scratch-1.2.0.tgz",
       "integrity": "sha1-YwRjbWLrqT20cnrBPGkzQdulDgE=",
       "requires": {
-        "ndarray": "1.0.18",
-        "ndarray-ops": "1.2.2",
-        "typedarray-pool": "1.1.0"
+        "ndarray": "^1.0.14",
+        "ndarray-ops": "^1.2.1",
+        "typedarray-pool": "^1.0.2"
       }
     },
     "ndarray-sort": {
@@ -4858,7 +4858,7 @@
       "resolved": "https://registry.npmjs.org/ndarray-sort/-/ndarray-sort-1.0.1.tgz",
       "integrity": "sha1-/qBbTLg0x/TgIWo1TzynUTAN/Wo=",
       "requires": {
-        "typedarray-pool": "1.1.0"
+        "typedarray-pool": "^1.0.0"
       }
     },
     "ndarray-warp": {
@@ -4866,8 +4866,8 @@
       "resolved": "https://registry.npmjs.org/ndarray-warp/-/ndarray-warp-1.0.1.tgz",
       "integrity": "sha1-qKElqqu6C+v5O9bKg+ar1oIqNOA=",
       "requires": {
-        "cwise": "1.0.10",
-        "ndarray-linear-interpolate": "1.0.0"
+        "cwise": "^1.0.4",
+        "ndarray-linear-interpolate": "^1.0.0"
       }
     },
     "next-tick": {
@@ -4880,7 +4880,7 @@
       "resolved": "https://registry.npmjs.org/nextafter/-/nextafter-1.0.0.tgz",
       "integrity": "sha1-t9d7U1MQ4+CX5gJauwqQNHfsGjo=",
       "requires": {
-        "double-bits": "1.1.1"
+        "double-bits": "^1.1.0"
       }
     },
     "node-fetch": {
@@ -4894,28 +4894,28 @@
       "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "dev": true,
       "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.2.0",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.2.0",
-        "events": "1.1.1",
-        "https-browserify": "1.0.0",
-        "os-browserify": "0.3.0",
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
         "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.4",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.8.0",
-        "string_decoder": "1.0.3",
-        "timers-browserify": "2.0.6",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
         "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -4931,13 +4931,13 @@
           "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -4946,7 +4946,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -4957,10 +4957,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -4969,7 +4969,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-svg-path": {
@@ -4988,7 +4988,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "number-is-integer": {
@@ -4996,7 +4996,7 @@
       "resolved": "https://registry.npmjs.org/number-is-integer/-/number-is-integer-1.0.1.tgz",
       "integrity": "sha1-5ZvKFy/+0nMY55x862y3LAlbIVI=",
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.1"
       }
     },
     "number-is-nan": {
@@ -5030,8 +5030,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "once": {
@@ -5039,7 +5039,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optionator": {
@@ -5047,12 +5047,12 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "orbit-camera-controller": {
@@ -5060,8 +5060,8 @@
       "resolved": "https://registry.npmjs.org/orbit-camera-controller/-/orbit-camera-controller-4.0.0.tgz",
       "integrity": "sha1-bis28OeHhmPDMPUNqbfOaGwncAU=",
       "requires": {
-        "filtered-vector": "1.2.4",
-        "gl-mat4": "1.2.0"
+        "filtered-vector": "^1.2.1",
+        "gl-mat4": "^1.0.3"
       }
     },
     "os-browserify": {
@@ -5081,9 +5081,9 @@
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "p-finally": {
@@ -5098,7 +5098,7 @@
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -5107,7 +5107,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.2.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-try": {
@@ -5121,7 +5121,7 @@
       "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-1.0.2.tgz",
       "integrity": "sha1-GeVzXqmDlaJs7carkm6tEPMQDUw=",
       "requires": {
-        "repeat-string": "1.6.1"
+        "repeat-string": "^1.3.0"
       }
     },
     "pako": {
@@ -5141,11 +5141,11 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true,
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.1.1",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.14"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "parse-glob": {
@@ -5154,10 +5154,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-json": {
@@ -5166,7 +5166,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-rect": {
@@ -5174,7 +5174,7 @@
       "resolved": "https://registry.npmjs.org/parse-rect/-/parse-rect-1.2.0.tgz",
       "integrity": "sha512-4QZ6KYbnE6RTwg9E0HpLchUM9EZt6DnDxajFZZDSV4p/12ZJEvPO702DZpGvRYEPo00yKDys7jASi+/w7aO8LA==",
       "requires": {
-        "pick-by-alias": "1.2.0"
+        "pick-by-alias": "^1.2.0"
       }
     },
     "parse-svg-path": {
@@ -5226,7 +5226,7 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.0.0"
       }
     },
     "pbf": {
@@ -5234,8 +5234,8 @@
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
       "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
       "requires": {
-        "ieee754": "1.1.13",
-        "resolve-protobuf-schema": "2.1.0"
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
       },
       "dependencies": {
         "ieee754": {
@@ -5251,11 +5251,11 @@
       "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "performance-now": {
@@ -5268,7 +5268,7 @@
       "resolved": "https://registry.npmjs.org/permutation-parity/-/permutation-parity-1.0.0.tgz",
       "integrity": "sha1-AXTVH8pwSxG5pLFSsj1Tf9xrXvQ=",
       "requires": {
-        "typedarray-pool": "1.1.0"
+        "typedarray-pool": "^1.0.0"
       }
     },
     "permutation-rank": {
@@ -5276,8 +5276,8 @@
       "resolved": "https://registry.npmjs.org/permutation-rank/-/permutation-rank-1.0.0.tgz",
       "integrity": "sha1-n9mLvOzwj79ZlLXq3JSmLmeUg7U=",
       "requires": {
-        "invert-permutation": "1.0.0",
-        "typedarray-pool": "1.1.0"
+        "invert-permutation": "^1.0.0",
+        "typedarray-pool": "^1.0.0"
       }
     },
     "pick-by-alias": {
@@ -5296,8 +5296,8 @@
       "resolved": "https://registry.npmjs.org/planar-dual/-/planar-dual-1.0.2.tgz",
       "integrity": "sha1-tqQjVSOxsMt55fkm+OozXdmC1WM=",
       "requires": {
-        "compare-angle": "1.0.1",
-        "dup": "1.0.0"
+        "compare-angle": "^1.0.0",
+        "dup": "^1.0.0"
       }
     },
     "planar-graph-to-polyline": {
@@ -5305,13 +5305,13 @@
       "resolved": "https://registry.npmjs.org/planar-graph-to-polyline/-/planar-graph-to-polyline-1.0.5.tgz",
       "integrity": "sha1-iCuGBRmbqIv9RkyVUzA1VsUrmIo=",
       "requires": {
-        "edges-to-adjacency-list": "1.0.0",
-        "planar-dual": "1.0.2",
-        "point-in-big-polygon": "2.0.0",
-        "robust-orientation": "1.1.3",
-        "robust-sum": "1.0.0",
-        "two-product": "1.0.2",
-        "uniq": "1.0.1"
+        "edges-to-adjacency-list": "^1.0.0",
+        "planar-dual": "^1.0.0",
+        "point-in-big-polygon": "^2.0.0",
+        "robust-orientation": "^1.0.1",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0",
+        "uniq": "^1.0.0"
       }
     },
     "plotly.js": {
@@ -5321,65 +5321,65 @@
       "requires": {
         "@plotly/d3-sankey": "0.7.2",
         "@plotly/d3-sankey-circular": "0.33.1",
-        "@turf/area": "6.0.1",
-        "@turf/centroid": "6.0.2",
-        "alpha-shape": "1.0.0",
-        "canvas-fit": "1.5.0",
-        "color-normalize": "1.5.0",
-        "color-rgba": "2.1.1",
-        "convex-hull": "1.0.3",
-        "country-regex": "1.1.0",
-        "d3": "3.5.17",
-        "d3-force": "1.2.1",
-        "d3-hierarchy": "1.1.8",
-        "d3-interpolate": "1.3.2",
-        "delaunay-triangulate": "1.1.6",
-        "es6-promise": "3.3.1",
-        "fast-isnumeric": "1.1.3",
-        "gl-cone3d": "1.5.1",
-        "gl-contour2d": "1.1.6",
-        "gl-error3d": "1.0.15",
-        "gl-heatmap2d": "1.0.5",
-        "gl-line3d": "1.1.11",
-        "gl-mat4": "1.2.0",
-        "gl-mesh3d": "2.1.1",
-        "gl-plot2d": "1.4.2",
-        "gl-plot3d": "2.3.0",
-        "gl-pointcloud2d": "1.0.2",
-        "gl-scatter3d": "1.2.2",
-        "gl-select-box": "1.0.3",
-        "gl-spikes2d": "1.0.2",
-        "gl-streamtube3d": "1.4.0",
-        "gl-surface3d": "1.4.6",
-        "gl-text": "1.1.8",
-        "glslify": "7.0.0",
-        "has-hover": "1.0.1",
-        "has-passive-events": "1.0.0",
+        "@turf/area": "^6.0.1",
+        "@turf/centroid": "^6.0.2",
+        "alpha-shape": "^1.0.0",
+        "canvas-fit": "^1.5.0",
+        "color-normalize": "^1.5.0",
+        "color-rgba": "^2.1.1",
+        "convex-hull": "^1.0.3",
+        "country-regex": "^1.1.0",
+        "d3": "^3.5.12",
+        "d3-force": "^1.0.6",
+        "d3-hierarchy": "^1.1.8",
+        "d3-interpolate": "1",
+        "delaunay-triangulate": "^1.1.6",
+        "es6-promise": "^3.0.2",
+        "fast-isnumeric": "^1.1.3",
+        "gl-cone3d": "^1.5.1",
+        "gl-contour2d": "^1.1.6",
+        "gl-error3d": "^1.0.15",
+        "gl-heatmap2d": "^1.0.5",
+        "gl-line3d": "^1.1.11",
+        "gl-mat4": "^1.2.0",
+        "gl-mesh3d": "^2.1.1",
+        "gl-plot2d": "^1.4.2",
+        "gl-plot3d": "^2.3.0",
+        "gl-pointcloud2d": "^1.0.2",
+        "gl-scatter3d": "^1.2.2",
+        "gl-select-box": "^1.0.3",
+        "gl-spikes2d": "^1.0.2",
+        "gl-streamtube3d": "^1.4.0",
+        "gl-surface3d": "^1.4.6",
+        "gl-text": "^1.1.8",
+        "glslify": "^7.0.0",
+        "has-hover": "^1.0.1",
+        "has-passive-events": "^1.0.0",
         "mapbox-gl": "1.3.2",
-        "matrix-camera-controller": "2.1.3",
-        "mouse-change": "1.4.0",
-        "mouse-event-offset": "3.0.2",
-        "mouse-wheel": "1.2.0",
-        "ndarray": "1.0.18",
-        "ndarray-fill": "1.0.2",
-        "ndarray-homography": "1.0.0",
-        "point-cluster": "3.1.8",
-        "polybooljs": "1.2.0",
-        "regl": "1.3.13",
-        "regl-error2d": "2.0.8",
-        "regl-line2d": "3.0.15",
-        "regl-scatter2d": "3.1.7",
-        "regl-splom": "1.0.8",
-        "right-now": "1.0.0",
-        "robust-orientation": "1.1.3",
-        "sane-topojson": "4.0.0",
-        "strongly-connected-components": "1.0.1",
-        "superscript-text": "1.0.0",
-        "svg-path-sdf": "1.1.3",
-        "tinycolor2": "1.4.1",
-        "topojson-client": "2.1.0",
-        "webgl-context": "2.2.0",
-        "world-calendars": "1.0.3"
+        "matrix-camera-controller": "^2.1.3",
+        "mouse-change": "^1.4.0",
+        "mouse-event-offset": "^3.0.2",
+        "mouse-wheel": "^1.2.0",
+        "ndarray": "^1.0.18",
+        "ndarray-fill": "^1.0.2",
+        "ndarray-homography": "^1.0.0",
+        "point-cluster": "^3.1.8",
+        "polybooljs": "^1.2.0",
+        "regl": "^1.3.11",
+        "regl-error2d": "^2.0.8",
+        "regl-line2d": "^3.0.15",
+        "regl-scatter2d": "^3.1.7",
+        "regl-splom": "^1.0.8",
+        "right-now": "^1.0.0",
+        "robust-orientation": "^1.1.3",
+        "sane-topojson": "^4.0.0",
+        "strongly-connected-components": "^1.0.1",
+        "superscript-text": "^1.0.0",
+        "svg-path-sdf": "^1.1.3",
+        "tinycolor2": "^1.4.1",
+        "topojson-client": "^2.1.0",
+        "webgl-context": "^2.2.0",
+        "world-calendars": "^1.0.3"
       }
     },
     "point-cluster": {
@@ -5387,18 +5387,18 @@
       "resolved": "https://registry.npmjs.org/point-cluster/-/point-cluster-3.1.8.tgz",
       "integrity": "sha512-7klIr45dpMeZuqjIK9+qBg3m2IhyZJNJkdqjJFw0Olq75FM8ojrTMjClVUrMjNYRVqtwztxCHH71Fyjhg+YwyQ==",
       "requires": {
-        "array-bounds": "1.0.1",
-        "array-normalize": "1.1.4",
-        "binary-search-bounds": "2.0.4",
-        "bubleify": "1.2.1",
-        "clamp": "1.0.1",
-        "defined": "1.0.0",
-        "dtype": "2.0.0",
-        "flatten-vertex-data": "1.0.2",
-        "is-obj": "1.0.1",
-        "math-log2": "1.0.1",
-        "parse-rect": "1.2.0",
-        "pick-by-alias": "1.2.0"
+        "array-bounds": "^1.0.1",
+        "array-normalize": "^1.1.4",
+        "binary-search-bounds": "^2.0.4",
+        "bubleify": "^1.1.0",
+        "clamp": "^1.0.1",
+        "defined": "^1.0.0",
+        "dtype": "^2.0.0",
+        "flatten-vertex-data": "^1.0.2",
+        "is-obj": "^1.0.1",
+        "math-log2": "^1.0.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0"
       }
     },
     "point-in-big-polygon": {
@@ -5406,10 +5406,10 @@
       "resolved": "https://registry.npmjs.org/point-in-big-polygon/-/point-in-big-polygon-2.0.0.tgz",
       "integrity": "sha1-ObYT6mzxfWtD4Yj3fzTETGszulU=",
       "requires": {
-        "binary-search-bounds": "1.0.0",
-        "interval-tree-1d": "1.0.3",
-        "robust-orientation": "1.1.3",
-        "slab-decomposition": "1.0.2"
+        "binary-search-bounds": "^1.0.0",
+        "interval-tree-1d": "^1.0.1",
+        "robust-orientation": "^1.1.3",
+        "slab-decomposition": "^1.0.1"
       },
       "dependencies": {
         "binary-search-bounds": {
@@ -5429,7 +5429,7 @@
       "resolved": "https://registry.npmjs.org/polytope-closest-point/-/polytope-closest-point-1.0.0.tgz",
       "integrity": "sha1-5uV/QIGrXox3i4Ee8G4sSK4zjD8=",
       "requires": {
-        "numeric": "1.2.6"
+        "numeric": "^1.2.6"
       }
     },
     "potpack": {
@@ -5482,11 +5482,11 @@
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "parse-asn1": "5.1.0",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "punycode": {
@@ -5500,12 +5500,12 @@
       "resolved": "https://registry.npmjs.org/pxls/-/pxls-2.3.2.tgz",
       "integrity": "sha512-pQkwgbLqWPcuES5iEmGa10OlCf5xG0blkIF3dg7PpRZShbTYcvAdfFfGL03SMrkaSUaa/V0UpN9HWg40O2AIIw==",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "compute-dims": "1.1.0",
-        "flip-pixels": "1.0.2",
-        "is-browser": "2.1.0",
-        "is-buffer": "2.0.4",
-        "to-uint8": "1.4.1"
+        "arr-flatten": "^1.1.0",
+        "compute-dims": "^1.1.0",
+        "flip-pixels": "^1.0.2",
+        "is-browser": "^2.1.0",
+        "is-buffer": "^2.0.3",
+        "to-uint8": "^1.4.1"
       },
       "dependencies": {
         "is-buffer": {
@@ -5525,7 +5525,7 @@
       "resolved": "https://registry.npmjs.org/quat-slerp/-/quat-slerp-1.0.1.tgz",
       "integrity": "sha1-K6oVzjprvcMkHZcusXKDE57Wnyk=",
       "requires": {
-        "gl-quat": "1.0.0"
+        "gl-quat": "^1.0.0"
       }
     },
     "querystring": {
@@ -5556,7 +5556,7 @@
       "integrity": "sha1-zeKelMQJsW4Z3HCYuJtmWPlyHTs=",
       "requires": {
         "minimist": "0.0.8",
-        "through2": "0.4.2"
+        "through2": "~0.4.1"
       },
       "dependencies": {
         "minimist": {
@@ -5574,8 +5574,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "2.1.2"
+            "readable-stream": "~1.0.17",
+            "xtend": "~2.1.1"
           }
         },
         "xtend": {
@@ -5583,7 +5583,7 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "requires": {
-            "object-keys": "0.4.0"
+            "object-keys": "~0.4.0"
           }
         }
       }
@@ -5593,7 +5593,7 @@
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
       "requires": {
-        "performance-now": "2.1.0"
+        "performance-now": "^2.1.0"
       }
     },
     "randomatic": {
@@ -5602,8 +5602,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -5612,7 +5612,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -5621,7 +5621,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -5632,7 +5632,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.6"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -5643,7 +5643,7 @@
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -5652,8 +5652,8 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "rat-vec": {
@@ -5661,7 +5661,7 @@
       "resolved": "https://registry.npmjs.org/rat-vec/-/rat-vec-1.1.1.tgz",
       "integrity": "sha1-Dd4rZrezS7G80qI4BerIBth/0X8=",
       "requires": {
-        "big-rat": "1.0.4"
+        "big-rat": "^1.0.3"
       }
     },
     "read-package-json": {
@@ -5670,11 +5670,11 @@
       "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "json-parse-better-errors": "1.0.2",
-        "normalize-package-data": "2.4.0",
-        "slash": "1.0.0"
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.2",
+        "json-parse-better-errors": "^1.0.1",
+        "normalize-package-data": "^2.0.0",
+        "slash": "^1.0.0"
       }
     },
     "read-pkg": {
@@ -5683,9 +5683,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
       }
     },
     "read-pkg-up": {
@@ -5694,8 +5694,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
       }
     },
     "readable-stream": {
@@ -5703,10 +5703,10 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
         "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
+        "string_decoder": "~0.10.x"
       }
     },
     "readdirp": {
@@ -5715,10 +5715,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.4",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -5733,13 +5733,13 @@
           "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -5748,7 +5748,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -5758,7 +5758,7 @@
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
       "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
       "requires": {
-        "esprima": "1.0.4"
+        "esprima": "~1.0.4"
       },
       "dependencies": {
         "esprima": {
@@ -5773,9 +5773,9 @@
       "resolved": "https://registry.npmjs.org/reduce-simplicial-complex/-/reduce-simplicial-complex-1.0.0.tgz",
       "integrity": "sha1-dNaWovg196bc2SBl/YxRgfLt+Lw=",
       "requires": {
-        "cell-orientation": "1.0.1",
-        "compare-cell": "1.0.0",
-        "compare-oriented-cell": "1.0.1"
+        "cell-orientation": "^1.0.1",
+        "compare-cell": "^1.0.0",
+        "compare-oriented-cell": "^1.0.1"
       }
     },
     "regenerate": {
@@ -5788,7 +5788,7 @@
       "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
       "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
       "requires": {
-        "regenerate": "1.4.0"
+        "regenerate": "^1.4.0"
       }
     },
     "regex-cache": {
@@ -5797,7 +5797,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regex-regex": {
@@ -5810,12 +5810,12 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
       "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
       "requires": {
-        "regenerate": "1.4.0",
-        "regenerate-unicode-properties": "8.1.0",
-        "regjsgen": "0.5.1",
-        "regjsparser": "0.6.0",
-        "unicode-match-property-ecmascript": "1.0.4",
-        "unicode-match-property-value-ecmascript": "1.1.0"
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.1.0",
+        "regjsgen": "^0.5.0",
+        "regjsparser": "^0.6.0",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.1.0"
       }
     },
     "regjsgen": {
@@ -5828,7 +5828,7 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
       "integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       }
     },
     "regl": {
@@ -5841,14 +5841,14 @@
       "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.8.tgz",
       "integrity": "sha512-5nszdicXbimRUnYB42i+O7KPcla7PzI62nZLCP6qVRKlQCf3rSrWbikMNd1S84LE8+deWHWcb8rZ/v7rZ9qmmw==",
       "requires": {
-        "array-bounds": "1.0.1",
-        "bubleify": "1.2.1",
-        "color-normalize": "1.5.0",
-        "flatten-vertex-data": "1.0.2",
-        "object-assign": "4.1.1",
-        "pick-by-alias": "1.2.0",
-        "to-float32": "1.0.1",
-        "update-diff": "1.1.0"
+        "array-bounds": "^1.0.1",
+        "bubleify": "^1.2.0",
+        "color-normalize": "^1.5.0",
+        "flatten-vertex-data": "^1.0.2",
+        "object-assign": "^4.1.1",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.0.1",
+        "update-diff": "^1.1.0"
       }
     },
     "regl-line2d": {
@@ -5856,18 +5856,18 @@
       "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.0.15.tgz",
       "integrity": "sha512-RuQbg9iZ6MyuInG8izF6zjQ/2g4qL6sg1egiuFalWzaGSvuve/IWBsIcqKTlwpiEsRt9b4cHu9NYs2fLt1gYJw==",
       "requires": {
-        "array-bounds": "1.0.1",
-        "array-normalize": "1.1.4",
-        "bubleify": "1.2.1",
-        "color-normalize": "1.5.0",
-        "earcut": "2.2.1",
-        "es6-weak-map": "2.0.3",
-        "flatten-vertex-data": "1.0.2",
-        "glslify": "7.0.0",
-        "object-assign": "4.1.1",
-        "parse-rect": "1.2.0",
-        "pick-by-alias": "1.2.0",
-        "to-float32": "1.0.1"
+        "array-bounds": "^1.0.1",
+        "array-normalize": "^1.1.4",
+        "bubleify": "^1.2.0",
+        "color-normalize": "^1.5.0",
+        "earcut": "^2.1.5",
+        "es6-weak-map": "^2.0.3",
+        "flatten-vertex-data": "^1.0.2",
+        "glslify": "^7.0.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.0.1"
       },
       "dependencies": {
         "es5-ext": {
@@ -5875,9 +5875,9 @@
           "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.52.tgz",
           "integrity": "sha512-bWCbE9fbpYQY4CU6hJbJ1vSz70EClMlDgJ7BmwI+zEJhxrwjesZRPglGJlsZhu0334U3hI+gaspwksH9IGD6ag==",
           "requires": {
-            "es6-iterator": "2.0.3",
-            "es6-symbol": "3.1.3",
-            "next-tick": "1.0.0"
+            "es6-iterator": "~2.0.3",
+            "es6-symbol": "~3.1.2",
+            "next-tick": "~1.0.0"
           },
           "dependencies": {
             "d": {
@@ -5885,8 +5885,8 @@
               "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
               "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
               "requires": {
-                "es5-ext": "0.10.52",
-                "type": "1.2.0"
+                "es5-ext": "^0.10.50",
+                "type": "^1.0.1"
               }
             },
             "es6-symbol": {
@@ -5894,8 +5894,8 @@
               "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
               "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
               "requires": {
-                "d": "1.0.1",
-                "ext": "1.1.2"
+                "d": "^1.0.1",
+                "ext": "^1.1.2"
               }
             }
           }
@@ -5905,10 +5905,10 @@
           "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
           "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.52",
-            "es6-iterator": "2.0.3",
-            "es6-symbol": "3.1.1"
+            "d": "1",
+            "es5-ext": "^0.10.46",
+            "es6-iterator": "^2.0.3",
+            "es6-symbol": "^3.1.1"
           }
         }
       }
@@ -5918,22 +5918,22 @@
       "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.1.7.tgz",
       "integrity": "sha512-FWw1hMsQrV3Y0zMU8YOytGjwSBuV3V58t8GR/mhlSL2S04jXLK1m2eAa/rDP3SpvMDkdVEr744PPDeHwsZVUhA==",
       "requires": {
-        "array-range": "1.0.1",
-        "array-rearrange": "2.2.2",
-        "clamp": "1.0.1",
-        "color-id": "1.1.0",
+        "array-range": "^1.0.1",
+        "array-rearrange": "^2.2.2",
+        "clamp": "^1.0.1",
+        "color-id": "^1.1.0",
         "color-normalize": "1.5.0",
-        "color-rgba": "2.1.1",
-        "flatten-vertex-data": "1.0.2",
-        "glslify": "7.0.0",
-        "image-palette": "2.1.0",
-        "is-iexplorer": "1.0.0",
-        "object-assign": "4.1.1",
-        "parse-rect": "1.2.0",
-        "pick-by-alias": "1.2.0",
-        "point-cluster": "3.1.8",
-        "to-float32": "1.0.1",
-        "update-diff": "1.1.0"
+        "color-rgba": "^2.1.1",
+        "flatten-vertex-data": "^1.0.2",
+        "glslify": "^7.0.0",
+        "image-palette": "^2.1.0",
+        "is-iexplorer": "^1.0.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "point-cluster": "^3.1.8",
+        "to-float32": "^1.0.1",
+        "update-diff": "^1.1.0"
       }
     },
     "regl-splom": {
@@ -5941,18 +5941,18 @@
       "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.8.tgz",
       "integrity": "sha512-4GQTgcArCbGLsXhgalWVBxeW7OXllnu+Gvil/4SbQQmtiqLCl+xgF79pISKY9mLXTlobxiX7cVKdjGjp25559A==",
       "requires": {
-        "array-bounds": "1.0.1",
-        "array-range": "1.0.1",
-        "bubleify": "1.2.1",
-        "color-alpha": "1.0.4",
-        "defined": "1.0.0",
-        "flatten-vertex-data": "1.0.2",
-        "left-pad": "1.3.0",
-        "parse-rect": "1.2.0",
-        "pick-by-alias": "1.2.0",
-        "point-cluster": "3.1.8",
-        "raf": "3.4.1",
-        "regl-scatter2d": "3.1.7"
+        "array-bounds": "^1.0.1",
+        "array-range": "^1.0.1",
+        "bubleify": "^1.2.0",
+        "color-alpha": "^1.0.4",
+        "defined": "^1.0.0",
+        "flatten-vertex-data": "^1.0.2",
+        "left-pad": "^1.3.0",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "point-cluster": "^3.1.8",
+        "raf": "^3.4.1",
+        "regl-scatter2d": "^3.1.2"
       }
     },
     "remove-trailing-separator": {
@@ -5994,7 +5994,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-protobuf-schema": {
@@ -6002,7 +6002,7 @@
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
       "requires": {
-        "protocol-buffers-schema": "3.3.2"
+        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "resumer": {
@@ -6010,7 +6010,7 @@
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3.4"
       }
     },
     "right-align": {
@@ -6018,7 +6018,7 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "right-now": {
@@ -6032,7 +6032,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "ripemd160": {
@@ -6041,8 +6041,8 @@
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "dev": true,
       "requires": {
-        "hash-base": "2.0.2",
-        "inherits": "2.0.3"
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "robust-compress": {
@@ -6055,10 +6055,10 @@
       "resolved": "https://registry.npmjs.org/robust-determinant/-/robust-determinant-1.1.0.tgz",
       "integrity": "sha1-jsrnm3nKqz509t6+IjflORon6cc=",
       "requires": {
-        "robust-compress": "1.0.0",
-        "robust-scale": "1.0.2",
-        "robust-sum": "1.0.0",
-        "two-product": "1.0.2"
+        "robust-compress": "^1.0.0",
+        "robust-scale": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0"
       }
     },
     "robust-dot-product": {
@@ -6066,8 +6066,8 @@
       "resolved": "https://registry.npmjs.org/robust-dot-product/-/robust-dot-product-1.0.0.tgz",
       "integrity": "sha1-yboBeL0sMEv9cl9Y6Inx2UYARVM=",
       "requires": {
-        "robust-sum": "1.0.0",
-        "two-product": "1.0.2"
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0"
       }
     },
     "robust-in-sphere": {
@@ -6075,10 +6075,10 @@
       "resolved": "https://registry.npmjs.org/robust-in-sphere/-/robust-in-sphere-1.1.3.tgz",
       "integrity": "sha1-HFiD0WpOkjkpR27zSBmFe/Kpz3U=",
       "requires": {
-        "robust-scale": "1.0.2",
-        "robust-subtract": "1.0.0",
-        "robust-sum": "1.0.0",
-        "two-product": "1.0.2"
+        "robust-scale": "^1.0.0",
+        "robust-subtract": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0"
       }
     },
     "robust-linear-solve": {
@@ -6086,7 +6086,7 @@
       "resolved": "https://registry.npmjs.org/robust-linear-solve/-/robust-linear-solve-1.0.0.tgz",
       "integrity": "sha1-DNasUEBpGm8qo81jEdcokFyjofE=",
       "requires": {
-        "robust-determinant": "1.1.0"
+        "robust-determinant": "^1.1.0"
       }
     },
     "robust-orientation": {
@@ -6094,10 +6094,10 @@
       "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.1.3.tgz",
       "integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
       "requires": {
-        "robust-scale": "1.0.2",
-        "robust-subtract": "1.0.0",
-        "robust-sum": "1.0.0",
-        "two-product": "1.0.2"
+        "robust-scale": "^1.0.2",
+        "robust-subtract": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.2"
       }
     },
     "robust-product": {
@@ -6105,8 +6105,8 @@
       "resolved": "https://registry.npmjs.org/robust-product/-/robust-product-1.0.0.tgz",
       "integrity": "sha1-aFJQAHzbunzx3nW/9tKScBEJir4=",
       "requires": {
-        "robust-scale": "1.0.2",
-        "robust-sum": "1.0.0"
+        "robust-scale": "^1.0.0",
+        "robust-sum": "^1.0.0"
       }
     },
     "robust-scale": {
@@ -6114,8 +6114,8 @@
       "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
       "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
       "requires": {
-        "two-product": "1.0.2",
-        "two-sum": "1.0.0"
+        "two-product": "^1.0.2",
+        "two-sum": "^1.0.0"
       }
     },
     "robust-segment-intersect": {
@@ -6123,7 +6123,7 @@
       "resolved": "https://registry.npmjs.org/robust-segment-intersect/-/robust-segment-intersect-1.0.1.tgz",
       "integrity": "sha1-MlK2oPwboUreaRXMvgnLzpqrHBw=",
       "requires": {
-        "robust-orientation": "1.1.3"
+        "robust-orientation": "^1.1.3"
       }
     },
     "robust-subtract": {
@@ -6181,8 +6181,8 @@
       "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shallow-copy": {
@@ -6195,9 +6195,9 @@
       "resolved": "https://registry.npmjs.org/sharkdown/-/sharkdown-0.1.1.tgz",
       "integrity": "sha512-exwooSpmo5s45lrexgz6Q0rFQM574wYIX3iDZ7RLLqOb7IAoQZu9nxlZODU972g19sR69OIpKP2cpHTzU+PHIg==",
       "requires": {
-        "cardinal": "0.4.4",
+        "cardinal": "~0.4.2",
         "minimist": "0.0.5",
-        "split": "0.2.10"
+        "split": "~0.2.10"
       },
       "dependencies": {
         "minimist": {
@@ -6213,7 +6213,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -6238,8 +6238,8 @@
       "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-1.0.0.tgz",
       "integrity": "sha1-bDOk7Wn81Nkbe8rdOzC2NoPq4kE=",
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "union-find": "1.0.2"
+        "bit-twiddle": "^1.0.0",
+        "union-find": "^1.0.0"
       }
     },
     "simplicial-complex-boundary": {
@@ -6247,8 +6247,8 @@
       "resolved": "https://registry.npmjs.org/simplicial-complex-boundary/-/simplicial-complex-boundary-1.0.1.tgz",
       "integrity": "sha1-csn/HiTeqjdMm7L6DL8MCB6++BU=",
       "requires": {
-        "boundary-cells": "2.0.1",
-        "reduce-simplicial-complex": "1.0.0"
+        "boundary-cells": "^2.0.0",
+        "reduce-simplicial-complex": "^1.0.0"
       }
     },
     "simplicial-complex-contour": {
@@ -6256,10 +6256,10 @@
       "resolved": "https://registry.npmjs.org/simplicial-complex-contour/-/simplicial-complex-contour-1.0.2.tgz",
       "integrity": "sha1-iQqsrChDZTQBEFRc8mKaJuBL+dE=",
       "requires": {
-        "marching-simplex-table": "1.0.0",
-        "ndarray": "1.0.18",
-        "ndarray-sort": "1.0.1",
-        "typedarray-pool": "1.1.0"
+        "marching-simplex-table": "^1.0.0",
+        "ndarray": "^1.0.15",
+        "ndarray-sort": "^1.0.0",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "simplify-planar-graph": {
@@ -6267,8 +6267,8 @@
       "resolved": "https://registry.npmjs.org/simplify-planar-graph/-/simplify-planar-graph-2.0.1.tgz",
       "integrity": "sha1-vIWJNyXzLo+oriVoE5hEbSy892Y=",
       "requires": {
-        "robust-orientation": "1.1.3",
-        "simplicial-complex": "0.3.3"
+        "robust-orientation": "^1.0.1",
+        "simplicial-complex": "^0.3.3"
       },
       "dependencies": {
         "bit-twiddle": {
@@ -6281,8 +6281,8 @@
           "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-0.3.3.tgz",
           "integrity": "sha1-TDDK1X+eRXKd2PMGyHU1efRr6Z4=",
           "requires": {
-            "bit-twiddle": "0.0.2",
-            "union-find": "0.0.4"
+            "bit-twiddle": "~0.0.1",
+            "union-find": "~0.0.3"
           }
         },
         "union-find": {
@@ -6297,9 +6297,9 @@
       "resolved": "https://registry.npmjs.org/slab-decomposition/-/slab-decomposition-1.0.2.tgz",
       "integrity": "sha1-He1WdU1AixBznxRRA9/GGAf2UTQ=",
       "requires": {
-        "binary-search-bounds": "1.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "robust-orientation": "1.1.3"
+        "binary-search-bounds": "^1.0.0",
+        "functional-red-black-tree": "^1.0.0",
+        "robust-orientation": "^1.1.3"
       },
       "dependencies": {
         "binary-search-bounds": {
@@ -6337,7 +6337,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -6357,7 +6357,7 @@
       "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
       "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split-polygon": {
@@ -6365,8 +6365,8 @@
       "resolved": "https://registry.npmjs.org/split-polygon/-/split-polygon-1.0.0.tgz",
       "integrity": "sha1-DqzIoTanaxKj2VJW6n2kXbDC0kc=",
       "requires": {
-        "robust-dot-product": "1.0.0",
-        "robust-sum": "1.0.0"
+        "robust-dot-product": "^1.0.0",
+        "robust-sum": "^1.0.0"
       }
     },
     "sprintf-js": {
@@ -6384,7 +6384,7 @@
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
       "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
       "requires": {
-        "escodegen": "1.12.0"
+        "escodegen": "^1.8.1"
       }
     },
     "static-module": {
@@ -6392,17 +6392,17 @@
       "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.5.0.tgz",
       "integrity": "sha1-J9qYg8QajNCSNvhC8MHrxu32PYY=",
       "requires": {
-        "concat-stream": "1.6.2",
-        "duplexer2": "0.0.2",
-        "escodegen": "1.3.3",
-        "falafel": "2.1.0",
-        "has": "1.0.3",
-        "object-inspect": "0.4.0",
-        "quote-stream": "0.0.0",
-        "readable-stream": "1.0.34",
-        "shallow-copy": "0.0.1",
-        "static-eval": "0.2.4",
-        "through2": "0.4.2"
+        "concat-stream": "~1.6.0",
+        "duplexer2": "~0.0.2",
+        "escodegen": "~1.3.2",
+        "falafel": "^2.1.0",
+        "has": "^1.0.0",
+        "object-inspect": "~0.4.0",
+        "quote-stream": "~0.0.0",
+        "readable-stream": "~1.0.27-1",
+        "shallow-copy": "~0.0.1",
+        "static-eval": "~0.2.0",
+        "through2": "~0.4.1"
       },
       "dependencies": {
         "escodegen": {
@@ -6410,10 +6410,10 @@
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
           "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
           "requires": {
-            "esprima": "1.1.1",
-            "estraverse": "1.5.1",
-            "esutils": "1.0.0",
-            "source-map": "0.1.43"
+            "esprima": "~1.1.1",
+            "estraverse": "~1.5.0",
+            "esutils": "~1.0.0",
+            "source-map": "~0.1.33"
           }
         },
         "esprima": {
@@ -6447,7 +6447,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "static-eval": {
@@ -6455,7 +6455,7 @@
           "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
           "integrity": "sha1-t9NNg4k3uWn5ZBygfUj47eJj6ns=",
           "requires": {
-            "escodegen": "0.0.28"
+            "escodegen": "~0.0.24"
           },
           "dependencies": {
             "escodegen": {
@@ -6463,9 +6463,9 @@
               "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
               "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
               "requires": {
-                "esprima": "1.0.4",
-                "estraverse": "1.3.2",
-                "source-map": "0.1.43"
+                "esprima": "~1.0.2",
+                "estraverse": "~1.3.0",
+                "source-map": ">= 0.1.2"
               }
             },
             "esprima": {
@@ -6485,8 +6485,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "2.1.2"
+            "readable-stream": "~1.0.17",
+            "xtend": "~2.1.1"
           }
         },
         "xtend": {
@@ -6494,7 +6494,7 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "requires": {
-            "object-keys": "0.4.0"
+            "object-keys": "~0.4.0"
           }
         }
       }
@@ -6505,8 +6505,8 @@
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       },
       "dependencies": {
         "isarray": {
@@ -6521,13 +6521,13 @@
           "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -6536,7 +6536,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -6547,11 +6547,11 @@
       "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.3",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -6566,13 +6566,13 @@
           "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -6581,7 +6581,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -6596,7 +6596,7 @@
       "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
       "integrity": "sha512-KaJKY+hfpzNyet/emP81PJA9hTVSfxNLS9SFTWxdCnnW1/zOOwiV248+EfoX7IQFcBaOp4G5YE6xTJMF+pLg6A==",
       "requires": {
-        "parenthesis": "3.1.7"
+        "parenthesis": "^3.1.5"
       }
     },
     "string-to-arraybuffer": {
@@ -6604,8 +6604,8 @@
       "resolved": "https://registry.npmjs.org/string-to-arraybuffer/-/string-to-arraybuffer-1.0.2.tgz",
       "integrity": "sha512-DaGZidzi93dwjQen5I2osxR9ERS/R7B1PFyufNMnzhj+fmlDQAc1DSDIJVJhgI8Oq221efIMbABUBdPHDRt43Q==",
       "requires": {
-        "atob-lite": "2.0.0",
-        "is-base64": "0.1.0"
+        "atob-lite": "^2.0.0",
+        "is-base64": "^0.1.0"
       },
       "dependencies": {
         "atob-lite": {
@@ -6621,8 +6621,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6643,7 +6643,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -6653,9 +6653,9 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
       "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.16.0",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.0",
+        "function-bind": "^1.0.2"
       }
     },
     "string.prototype.trimleft": {
@@ -6663,8 +6663,8 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
       "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
       "requires": {
-        "define-properties": "1.1.3",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string.prototype.trimright": {
@@ -6672,8 +6672,8 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
       "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
       "requires": {
-        "define-properties": "1.1.3",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {
@@ -6687,7 +6687,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -6712,7 +6712,7 @@
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.2.tgz",
       "integrity": "sha512-aa0v2HURjBTOpbcknilcfxGDuArM8khklKSmZ/T8ZXL0BuRwb5aRw95lz+2bmWpFvCXDX/+FzqHxmg0TIaJErw==",
       "requires": {
-        "kdbush": "3.0.0"
+        "kdbush": "^3.0.0"
       }
     },
     "superscript-text": {
@@ -6725,7 +6725,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "surface-nets": {
@@ -6733,9 +6733,9 @@
       "resolved": "https://registry.npmjs.org/surface-nets/-/surface-nets-1.0.2.tgz",
       "integrity": "sha1-5DPIy7qUpydMb0yZVStGG/H8eks=",
       "requires": {
-        "ndarray-extract-contour": "1.0.1",
-        "triangulate-hypercube": "1.0.1",
-        "zero-crossings": "1.0.1"
+        "ndarray-extract-contour": "^1.0.0",
+        "triangulate-hypercube": "^1.0.0",
+        "zero-crossings": "^1.0.0"
       }
     },
     "svg-arc-to-cubic-bezier": {
@@ -6748,10 +6748,10 @@
       "resolved": "https://registry.npmjs.org/svg-path-bounds/-/svg-path-bounds-1.0.1.tgz",
       "integrity": "sha1-v0WLeDcmv1NDG0Yz8nkvYHSNn3Q=",
       "requires": {
-        "abs-svg-path": "0.1.1",
-        "is-svg-path": "1.0.2",
-        "normalize-svg-path": "1.0.1",
-        "parse-svg-path": "0.1.2"
+        "abs-svg-path": "^0.1.1",
+        "is-svg-path": "^1.0.1",
+        "normalize-svg-path": "^1.0.0",
+        "parse-svg-path": "^0.1.2"
       },
       "dependencies": {
         "normalize-svg-path": {
@@ -6759,7 +6759,7 @@
           "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.0.1.tgz",
           "integrity": "sha1-b3Ka1rcLtMpO/y/ksQdInv4dVv4=",
           "requires": {
-            "svg-arc-to-cubic-bezier": "3.2.0"
+            "svg-arc-to-cubic-bezier": "^3.0.0"
           }
         }
       }
@@ -6769,11 +6769,11 @@
       "resolved": "https://registry.npmjs.org/svg-path-sdf/-/svg-path-sdf-1.1.3.tgz",
       "integrity": "sha512-vJJjVq/R5lSr2KLfVXVAStktfcfa1pNFjFOgyJnzZFXlO/fDZ5DmM8FpnSKKzLPfEYTVeXuVBTHF296TpxuJVg==",
       "requires": {
-        "bitmap-sdf": "1.0.3",
-        "draw-svg-path": "1.0.0",
-        "is-svg-path": "1.0.2",
-        "parse-svg-path": "0.1.2",
-        "svg-path-bounds": "1.0.1"
+        "bitmap-sdf": "^1.0.0",
+        "draw-svg-path": "^1.0.0",
+        "is-svg-path": "^1.0.1",
+        "parse-svg-path": "^0.1.2",
+        "svg-path-bounds": "^1.0.1"
       }
     },
     "tapable": {
@@ -6787,19 +6787,19 @@
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.11.0.tgz",
       "integrity": "sha512-yixvDMX7q7JIs/omJSzSZrqulOV51EC9dK8dM0TzImTIkHWfe2/kFyL5v+d9C+SrCMaICk59ujsqFAVidDqDaA==",
       "requires": {
-        "deep-equal": "1.0.1",
-        "defined": "1.0.0",
-        "for-each": "0.3.3",
-        "function-bind": "1.1.1",
-        "glob": "7.1.5",
-        "has": "1.0.3",
-        "inherits": "2.0.4",
-        "minimist": "1.2.0",
-        "object-inspect": "1.6.0",
-        "resolve": "1.11.1",
-        "resumer": "0.0.0",
-        "string.prototype.trim": "1.1.2",
-        "through": "2.3.8"
+        "deep-equal": "~1.0.1",
+        "defined": "~1.0.0",
+        "for-each": "~0.3.3",
+        "function-bind": "~1.1.1",
+        "glob": "~7.1.4",
+        "has": "~1.0.3",
+        "inherits": "~2.0.4",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.6.0",
+        "resolve": "~1.11.1",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.1.2",
+        "through": "~2.3.8"
       },
       "dependencies": {
         "glob": {
@@ -6807,12 +6807,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
           "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.4",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "inherits": {
@@ -6830,7 +6830,7 @@
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
           "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
           "requires": {
-            "path-parse": "1.0.6"
+            "path-parse": "^1.0.6"
           }
         }
       }
@@ -6840,7 +6840,7 @@
       "resolved": "https://registry.npmjs.org/text-cache/-/text-cache-4.2.1.tgz",
       "integrity": "sha512-G52NFRYXEW9BL4E3kBPquefXql9OT3sNT4J16gcpl3/a8y/YioDOR2Iwga5rNs9tY7rH2xv6rF8fAYrbINn6Kg==",
       "requires": {
-        "vectorize-text": "3.2.1"
+        "vectorize-text": "^3.2.1"
       }
     },
     "through": {
@@ -6853,8 +6853,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
       "requires": {
-        "readable-stream": "1.0.34",
-        "xtend": "4.0.1"
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
       }
     },
     "timers-browserify": {
@@ -6863,7 +6863,7 @@
       "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
       "dev": true,
       "requires": {
-        "setimmediate": "1.0.5"
+        "setimmediate": "^1.0.4"
       }
     },
     "tinycolor2": {
@@ -6881,9 +6881,9 @@
       "resolved": "https://registry.npmjs.org/to-array-buffer/-/to-array-buffer-3.2.0.tgz",
       "integrity": "sha512-zN33mwi0gpL+7xW1ITLfJ48CEj6ZQW0ZAP0MU+2W3kEY0PAIncyuxmD4OqkUVhPAbTP7amq9j/iwvZKYS+lzSQ==",
       "requires": {
-        "flatten-vertex-data": "1.0.2",
-        "is-blob": "2.0.1",
-        "string-to-arraybuffer": "1.0.2"
+        "flatten-vertex-data": "^1.0.2",
+        "is-blob": "^2.0.1",
+        "string-to-arraybuffer": "^1.0.0"
       }
     },
     "to-arraybuffer": {
@@ -6902,7 +6902,7 @@
       "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.1.0.tgz",
       "integrity": "sha512-bfg3GLYrGoEzrGoE05TAL/Uw+H/qrf2ptr9V3W7U0lkjjyYnIfgxmVLUfhQ1hZpIQwin81uxhDjvUkDYsC0xWw==",
       "requires": {
-        "parse-unit": "1.0.1"
+        "parse-unit": "^1.0.1"
       }
     },
     "to-uint8": {
@@ -6910,11 +6910,11 @@
       "resolved": "https://registry.npmjs.org/to-uint8/-/to-uint8-1.4.1.tgz",
       "integrity": "sha512-o+ochsMlTZyucbww8It401FC2Rx+OP2RpDeYbA6h+y9HgedDl1UjdsJ9CmzKEG7AFP9es5PmJ4eDWeeeXihESg==",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "clamp": "1.0.1",
-        "is-base64": "0.1.0",
-        "is-float-array": "1.0.0",
-        "to-array-buffer": "3.2.0"
+        "arr-flatten": "^1.1.0",
+        "clamp": "^1.0.1",
+        "is-base64": "^0.1.0",
+        "is-float-array": "^1.0.0",
+        "to-array-buffer": "^3.0.0"
       }
     },
     "topojson-client": {
@@ -6922,7 +6922,7 @@
       "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-2.1.0.tgz",
       "integrity": "sha1-/59784mRGF4LQoTCsGroNPDqxsg=",
       "requires": {
-        "commander": "2.1.0"
+        "commander": "2"
       }
     },
     "triangulate-hypercube": {
@@ -6930,9 +6930,9 @@
       "resolved": "https://registry.npmjs.org/triangulate-hypercube/-/triangulate-hypercube-1.0.1.tgz",
       "integrity": "sha1-2Acdsuv8/VHzCNC88qXEils20Tc=",
       "requires": {
-        "gamma": "0.1.0",
-        "permutation-parity": "1.0.0",
-        "permutation-rank": "1.0.0"
+        "gamma": "^0.1.0",
+        "permutation-parity": "^1.0.0",
+        "permutation-rank": "^1.0.0"
       }
     },
     "triangulate-polyline": {
@@ -6940,7 +6940,7 @@
       "resolved": "https://registry.npmjs.org/triangulate-polyline/-/triangulate-polyline-1.0.3.tgz",
       "integrity": "sha1-v4uod6hQVBA/65+lphtOjXAXgU0=",
       "requires": {
-        "cdt2d": "1.0.0"
+        "cdt2d": "^1.0.0"
       }
     },
     "tty-browserify": {
@@ -6954,9 +6954,9 @@
       "resolved": "https://registry.npmjs.org/turntable-camera-controller/-/turntable-camera-controller-3.0.1.tgz",
       "integrity": "sha1-jb0/4AVQGRxlFky4iJcQSVeK/Zk=",
       "requires": {
-        "filtered-vector": "1.2.4",
-        "gl-mat4": "1.2.0",
-        "gl-vec3": "1.1.3"
+        "filtered-vector": "^1.2.1",
+        "gl-mat4": "^1.0.2",
+        "gl-vec3": "^1.0.2"
       }
     },
     "two-product": {
@@ -6979,7 +6979,7 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-name": {
@@ -6997,8 +6997,8 @@
       "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.1.0.tgz",
       "integrity": "sha1-0RT0hIAUifU+yrXoCIqiMET0mNk=",
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "dup": "1.0.0"
+        "bit-twiddle": "^1.0.0",
+        "dup": "^1.0.0"
       }
     },
     "typescript": {
@@ -7012,9 +7012,9 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       }
     },
     "uglify-to-browserify": {
@@ -7029,9 +7029,9 @@
       "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-js": "2.8.29",
-        "webpack-sources": "1.1.0"
+        "source-map": "^0.5.6",
+        "uglify-js": "^2.8.29",
+        "webpack-sources": "^1.0.1"
       }
     },
     "underscore": {
@@ -7049,8 +7049,8 @@
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "1.0.4",
-        "unicode-property-aliases-ecmascript": "1.0.5"
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
       }
     },
     "unicode-match-property-value-ecmascript": {
@@ -7088,7 +7088,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -7121,8 +7121,8 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
       "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
       "requires": {
-        "querystringify": "2.1.1",
-        "requires-port": "1.0.0"
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "util": {
@@ -7152,15 +7152,15 @@
       "resolved": "https://registry.npmjs.org/utils-copy/-/utils-copy-1.1.1.tgz",
       "integrity": "sha1-biuXmCqozXPhGCo+b4vsPA9AWKc=",
       "requires": {
-        "const-pinf-float64": "1.0.0",
-        "object-keys": "1.1.1",
-        "type-name": "2.0.2",
-        "utils-copy-error": "1.0.1",
-        "utils-indexof": "1.0.0",
-        "utils-regex-from-string": "1.0.0",
-        "validate.io-array": "1.0.6",
-        "validate.io-buffer": "1.0.2",
-        "validate.io-nonnegative-integer": "1.0.0"
+        "const-pinf-float64": "^1.0.0",
+        "object-keys": "^1.0.9",
+        "type-name": "^2.0.0",
+        "utils-copy-error": "^1.0.0",
+        "utils-indexof": "^1.0.0",
+        "utils-regex-from-string": "^1.0.0",
+        "validate.io-array": "^1.0.3",
+        "validate.io-buffer": "^1.0.1",
+        "validate.io-nonnegative-integer": "^1.0.0"
       }
     },
     "utils-copy-error": {
@@ -7168,8 +7168,8 @@
       "resolved": "https://registry.npmjs.org/utils-copy-error/-/utils-copy-error-1.0.1.tgz",
       "integrity": "sha1-eR3jk8DwmJCv1Z88vqY18HmpT6U=",
       "requires": {
-        "object-keys": "1.1.1",
-        "utils-copy": "1.1.1"
+        "object-keys": "^1.0.9",
+        "utils-copy": "^1.1.0"
       }
     },
     "utils-indexof": {
@@ -7177,8 +7177,8 @@
       "resolved": "https://registry.npmjs.org/utils-indexof/-/utils-indexof-1.0.0.tgz",
       "integrity": "sha1-IP6r8J7xAYtSNkPoOA57yD7GG1w=",
       "requires": {
-        "validate.io-array-like": "1.0.2",
-        "validate.io-integer-primitive": "1.0.0"
+        "validate.io-array-like": "^1.0.1",
+        "validate.io-integer-primitive": "^1.0.0"
       }
     },
     "utils-regex-from-string": {
@@ -7186,8 +7186,8 @@
       "resolved": "https://registry.npmjs.org/utils-regex-from-string/-/utils-regex-from-string-1.0.0.tgz",
       "integrity": "sha1-/hopCfjeD/DVGCyA+8ZU1qaH0Yk=",
       "requires": {
-        "regex-regex": "1.0.0",
-        "validate.io-string-primitive": "1.0.1"
+        "regex-regex": "^1.0.0",
+        "validate.io-string-primitive": "^1.0.0"
       }
     },
     "validate-npm-package-license": {
@@ -7196,8 +7196,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "validate.io-array": {
@@ -7210,8 +7210,8 @@
       "resolved": "https://registry.npmjs.org/validate.io-array-like/-/validate.io-array-like-1.0.2.tgz",
       "integrity": "sha1-evn363tRcVvrIhVmjsXM5U+t21o=",
       "requires": {
-        "const-max-uint32": "1.0.2",
-        "validate.io-integer-primitive": "1.0.0"
+        "const-max-uint32": "^1.0.2",
+        "validate.io-integer-primitive": "^1.0.0"
       }
     },
     "validate.io-buffer": {
@@ -7224,7 +7224,7 @@
       "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
       "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
       "requires": {
-        "validate.io-number": "1.0.3"
+        "validate.io-number": "^1.0.3"
       }
     },
     "validate.io-integer-primitive": {
@@ -7232,7 +7232,7 @@
       "resolved": "https://registry.npmjs.org/validate.io-integer-primitive/-/validate.io-integer-primitive-1.0.0.tgz",
       "integrity": "sha1-qaoBA1X+hoHA/qbBp0rSQZyt3cY=",
       "requires": {
-        "validate.io-number-primitive": "1.0.0"
+        "validate.io-number-primitive": "^1.0.0"
       }
     },
     "validate.io-matrix-like": {
@@ -7250,7 +7250,7 @@
       "resolved": "https://registry.npmjs.org/validate.io-nonnegative-integer/-/validate.io-nonnegative-integer-1.0.0.tgz",
       "integrity": "sha1-gGkkOgjF+Y6VQTySnf17GPP28p8=",
       "requires": {
-        "validate.io-integer": "1.0.5"
+        "validate.io-integer": "^1.0.5"
       }
     },
     "validate.io-number": {
@@ -7268,7 +7268,7 @@
       "resolved": "https://registry.npmjs.org/validate.io-positive-integer/-/validate.io-positive-integer-1.0.0.tgz",
       "integrity": "sha1-ftLQO0wnVYzGagCqsPDpIYFKZYI=",
       "requires": {
-        "validate.io-integer": "1.0.5"
+        "validate.io-integer": "^1.0.5"
       }
     },
     "validate.io-string-primitive": {
@@ -7281,13 +7281,13 @@
       "resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.2.1.tgz",
       "integrity": "sha512-rGojF+D9BB96iPZPUitfq5kaiS6eCJmfEel0NXOK/MzZSuXGiwhoop80PtaDas9/Hg/oaox1tI9g3h93qpuspg==",
       "requires": {
-        "cdt2d": "1.0.0",
-        "clean-pslg": "1.1.2",
-        "ndarray": "1.0.18",
-        "planar-graph-to-polyline": "1.0.5",
-        "simplify-planar-graph": "2.0.1",
-        "surface-nets": "1.0.2",
-        "triangulate-polyline": "1.0.3"
+        "cdt2d": "^1.0.0",
+        "clean-pslg": "^1.1.0",
+        "ndarray": "^1.0.11",
+        "planar-graph-to-polyline": "^1.0.0",
+        "simplify-planar-graph": "^2.0.1",
+        "surface-nets": "^1.0.0",
+        "triangulate-polyline": "^1.0.0"
       }
     },
     "vm-browserify": {
@@ -7305,8 +7305,8 @@
       "integrity": "sha512-pHjWdrIoxurpmTcbfBWXaPwSmtPAHS105253P1qyEfSTV2HJddqjM+kIHquaT/L6lVJIk9ltTGc0IxR/G47hYA==",
       "requires": {
         "@mapbox/point-geometry": "0.1.0",
-        "@mapbox/vector-tile": "1.3.1",
-        "pbf": "3.2.1"
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.0.5"
       }
     },
     "watchpack": {
@@ -7315,9 +7315,9 @@
       "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "chokidar": "1.7.0",
-        "graceful-fs": "4.1.11"
+        "async": "^2.1.2",
+        "chokidar": "^1.7.0",
+        "graceful-fs": "^4.1.2"
       }
     },
     "weak-map": {
@@ -7335,7 +7335,7 @@
       "resolved": "https://registry.npmjs.org/webgl-context/-/webgl-context-2.2.0.tgz",
       "integrity": "sha1-jzfXJXz23xzQpJ5qextyG5TMhqA=",
       "requires": {
-        "get-canvas-context": "1.0.2"
+        "get-canvas-context": "^1.0.1"
       }
     },
     "webpack": {
@@ -7344,28 +7344,28 @@
       "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
       "dev": true,
       "requires": {
-        "acorn": "5.4.1",
-        "acorn-dynamic-import": "2.0.2",
-        "ajv": "6.1.1",
-        "ajv-keywords": "3.1.0",
-        "async": "2.6.0",
-        "enhanced-resolve": "3.4.1",
-        "escope": "3.6.0",
-        "interpret": "1.1.0",
-        "json-loader": "0.5.7",
-        "json5": "0.5.1",
-        "loader-runner": "2.3.0",
-        "loader-utils": "1.1.0",
-        "memory-fs": "0.4.1",
-        "mkdirp": "0.5.1",
-        "node-libs-browser": "2.1.0",
-        "source-map": "0.5.7",
-        "supports-color": "4.5.0",
-        "tapable": "0.2.8",
-        "uglifyjs-webpack-plugin": "0.4.6",
-        "watchpack": "1.4.0",
-        "webpack-sources": "1.1.0",
-        "yargs": "8.0.2"
+        "acorn": "^5.0.0",
+        "acorn-dynamic-import": "^2.0.0",
+        "ajv": "^6.1.0",
+        "ajv-keywords": "^3.1.0",
+        "async": "^2.1.2",
+        "enhanced-resolve": "^3.4.0",
+        "escope": "^3.6.0",
+        "interpret": "^1.0.0",
+        "json-loader": "^0.5.4",
+        "json5": "^0.5.1",
+        "loader-runner": "^2.3.0",
+        "loader-utils": "^1.1.0",
+        "memory-fs": "~0.4.1",
+        "mkdirp": "~0.5.0",
+        "node-libs-browser": "^2.0.0",
+        "source-map": "^0.5.3",
+        "supports-color": "^4.2.1",
+        "tapable": "^0.2.7",
+        "uglifyjs-webpack-plugin": "^0.4.6",
+        "watchpack": "^1.4.0",
+        "webpack-sources": "^1.0.1",
+        "yargs": "^8.0.2"
       },
       "dependencies": {
         "ajv": {
@@ -7374,9 +7374,9 @@
           "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         },
         "camelcase": {
@@ -7391,9 +7391,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "string-width": {
@@ -7402,9 +7402,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -7421,7 +7421,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         },
         "yargs": {
@@ -7430,19 +7430,19 @@
           "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
           }
         }
       }
@@ -7453,8 +7453,8 @@
       "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
       "dev": true,
       "requires": {
-        "source-list-map": "2.0.0",
-        "source-map": "0.6.1"
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.6.1"
       },
       "dependencies": {
         "source-map": {
@@ -7476,7 +7476,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -7500,7 +7500,7 @@
       "resolved": "https://registry.npmjs.org/world-calendars/-/world-calendars-1.0.3.tgz",
       "integrity": "sha1-slxQMrokEo/8QdCfr0pewbnBQzU=",
       "requires": {
-        "object-assign": "4.1.1"
+        "object-assign": "^4.1.0"
       }
     },
     "wrap-ansi": {
@@ -7509,8 +7509,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
         "string-width": {
@@ -7519,9 +7519,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -7536,7 +7536,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.1.tgz",
       "integrity": "sha512-ILHfMbuqLJvnSgYXLgy4kMntroJpe8hT41dOVWM8bxRuw6TK4mgMp9VJUNsZTEc5Bh+Mbs0DJT4M0N+wBG9l9A==",
       "requires": {
-        "async-limiter": "1.0.0"
+        "async-limiter": "^1.0.0"
       }
     },
     "xtend": {
@@ -7561,9 +7561,9 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     },
@@ -7573,7 +7573,7 @@
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       },
       "dependencies": {
         "camelcase": {
@@ -7589,7 +7589,7 @@
       "resolved": "https://registry.npmjs.org/zero-crossings/-/zero-crossings-1.0.1.tgz",
       "integrity": "sha1-xWK9MRNkPzRDokXRJAa4i2m5qf8=",
       "requires": {
-        "cwise-compiler": "1.1.3"
+        "cwise-compiler": "^1.0.0"
       }
     }
   }

--- a/packages/javascript/plotlywidget/src/Figure.js
+++ b/packages/javascript/plotlywidget/src/Figure.js
@@ -2,8 +2,7 @@ var widgets = require("@jupyter-widgets/base");
 var _ = require("lodash");
 
 window.PlotlyConfig = {MathJaxConfig: 'local'};
-var Plotly = require("plotly.js/dist/plotly.min");
-var PlotlyIndex = require("plotly.js/src/lib/index");
+var Plotly = require("plotly.js/dist/plotly");
 var semver_range = "^" + require("../package.json").version;
 
 // Model
@@ -700,7 +699,7 @@ var FigureView = widgets.DOMWidgetView.extend({
 
         // Set view UID
         // ------------
-        this.viewID = PlotlyIndex.randstr();
+        this.viewID = randstr();
 
         // Initialize Plotly.js figure
         // ---------------------------
@@ -1084,7 +1083,7 @@ var FigureView = widgets.DOMWidgetView.extend({
     handle_plotly_selected: function (data) {
         this._send_points_callback_message(data, "plotly_selected");
     },
-    
+
     /**
      * Handle plotly_deselect events emitted by the Plotly.js library
      * @param data
@@ -1094,7 +1093,7 @@ var FigureView = widgets.DOMWidgetView.extend({
             points : []
         }
         this._send_points_callback_message(data, "plotly_deselect");
-    },    
+    },
 
     /**
      * Build and send a points callback message to the Python side
@@ -1810,6 +1809,43 @@ function createDeltaObject(fullObj, removeObj) {
         }
     }
     return res
+}
+
+function randstr(existing, bits, base, _recursion) {
+    if(!base) base = 16;
+    if(bits === undefined) bits = 24;
+    if(bits <= 0) return '0';
+
+    var digits = Math.log(Math.pow(2, bits)) / Math.log(base);
+    var res = '';
+    var i, b, x;
+
+    for(i = 2; digits === Infinity; i *= 2) {
+        digits = Math.log(Math.pow(2, bits / i)) / Math.log(base) * i;
+    }
+
+    var rem = digits - Math.floor(digits);
+
+    for(i = 0; i < Math.floor(digits); i++) {
+        x = Math.floor(Math.random() * base).toString(base);
+        res = x + res;
+    }
+
+    if(rem) {
+        b = Math.pow(base, rem);
+        x = Math.floor(Math.random() * b).toString(base);
+        res = x + res;
+    }
+
+    var parsed = parseInt(res, base);
+    if((existing && existing[res]) ||
+        (parsed !== Infinity && parsed >= Math.pow(2, bits))) {
+        if(_recursion > 10) {
+            lib.warn('randstr failed uniqueness');
+            return res;
+        }
+        return randstr(existing, bits, base, (_recursion || 0) + 1);
+    } else return res;
 }
 
 module.exports = {


### PR DESCRIPTION
With this PR, both `jupyterlab-plotly` and `plotlywidget` now load plotly.js from the unminified dist bundle, so jupyterlab should be able to de-duplicate plotly.js when both extensions are installed.

Closes https://github.com/plotly/plotly.py/issues/1873

cc @vidartf