### PR TITLE
Propagate empty templates

### DIFF
--- a/packages/python/plotly/_plotly_utils/basevalidators.py
+++ b/packages/python/plotly/_plotly_utils/basevalidators.py
@@ -2712,6 +2712,13 @@ class BaseTemplateValidator(CompoundValidator):
             # v is un-hashable
             pass
 
+        # Check for empty template
+        if v == {} or isinstance(v, self.data_class) and v.to_plotly_json() == {}:
+            # Replace empty template with {'data': {'scatter': [{}]}} so that we can
+            # tell the difference between an un-initialized template and a template
+            # explicitly set to empty.
+            return self.data_class(data_scatter=[{}])
+
         return super(BaseTemplateValidator, self).validate_coerce(
             v, skip_invalid=skip_invalid
         )

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -1945,7 +1945,7 @@ Please use the add_trace method with the row and col parameters.
             if pio.templates.default is not None:
                 self._layout_obj.template = pio.templates.default
             else:
-                self._layout_obj.template = {}
+                self._layout_obj.template = None
 
     @property
     def layout(self):

--- a/packages/python/plotly/plotly/io/_templates.py
+++ b/packages/python/plotly/plotly/io/_templates.py
@@ -79,7 +79,7 @@ class TemplatesConfig(object):
 
                 if template_name == "none":
                     # "none" is a special built-in named template that applied no defaults
-                    template = Template()
+                    template = Template(data_scatter=[{}])
                     self._templates[template_name] = template
                 else:
                     # Load template from package data

--- a/packages/python/plotly/plotly/tests/test_core/test_graph_objs/test_template.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_graph_objs/test_template.py
@@ -154,7 +154,7 @@ class TemplateTest(TestCase):
     def test_template_default_override_empty(self):
         pio.templates.default = "test_template"
         fig = go.Figure(layout={"template": {}})
-        self.assertEqual(fig.layout.template, go.layout.Template())
+        self.assertEqual(fig.layout.template, go.layout.Template(data_scatter=[{}]))
 
     def test_delete_default_template(self):
         pio.templates.default = "test_template"

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px.py
@@ -80,7 +80,7 @@ def test_px_templates():
 
     # accept objects in args
     fig = px.scatter(template={})
-    assert fig.layout.template == go.layout.Template()
+    assert fig.layout.template == go.layout.Template(data_scatter=[{}])
 
     # read colorway from the template
     fig = px.scatter(


### PR DESCRIPTION
When a template is explicitly set to `{}`, it is now replaced by `{"data": {"scatter": [{}]}}` so that it will not get overridden by a default template when a figure is passed along to other functions/libraries.

cc @nicolaskruchten 