### PR TITLE
Fix improper JSON encoding exception when pillow module not installed

### DIFF
--- a/packages/python/plotly/_plotly_utils/utils.py
+++ b/packages/python/plotly/_plotly_utils/utils.py
@@ -197,8 +197,8 @@ class PlotlyJSONEncoder(_json.JSONEncoder):
     @staticmethod
     def encode_as_pil(obj):
         """Attempt to convert PIL.Image.Image to base64 data uri"""
-        pil = get_module("PIL")
-        if isinstance(obj, pil.Image.Image):
+        image = get_module("PIL.Image")
+        if image is not None and isinstance(obj, image.Image):
             return ImageUriValidator.pil_image_to_uri(obj)
         else:
             raise NotEncodable

--- a/packages/python/plotly/plotly/tests/test_core/test_utils/test_utils.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_utils/test_utils.py
@@ -15,6 +15,10 @@ class TestJSONEncoder(TestCase):
         expected_result = '[1, null, null, null, "platypus"]'
         self.assertEqual(result, expected_result)
 
+    def test_invalid_encode_exception(self):
+        with self.assertRaises(TypeError):
+            _json.dumps({"a": {1}}, cls=PlotlyJSONEncoder)
+
 
 class TestGetByPath(TestCase):
     def test_get_by_path(self):


### PR DESCRIPTION
4.4.0 regression.  When the `pillow` module is not installed, and an attempt is made to JSON serialize a figure that includes unsupported object types, an `AttributeError: 'NoneType' object has no attribute 'Image'` exception was raised.

With this fix, the proper `TypeError` exception is raised once more.