### PR TITLE
Add support for MultiIndex levels in px

### DIFF
--- a/doc/python/px-arguments.md
+++ b/doc/python/px-arguments.md
@@ -87,6 +87,17 @@ fig = px.scatter(iris, x='sepal_length', y='sepal_width', color='species', size=
 fig.show()
 ```
 
+If the `data_frame` has a MultiIndex with named levels, it is possible to pass the name of the level as well.
+In such case its values are extracted with `get_level_values()`.
+If a column and an index level have the same name, the column is preferred.
+
+```python
+iris = px.data.iris()
+mi_iris = iris.set_index('species', append=True, drop=False)
+# Use level name for color. This is the same chart as above.
+fig = px.scatter(mi_iris, x='sepal_length', y='sepal_width', color='species', size='petal_length')
+fig.show()
+```
 #### Using the index of a DataFrame
 
 In addition to columns, it is also possible to pass the index of a DataFrame as argument. In the example below the index is displayed in the hover data.

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1,18 +1,19 @@
+import math
+from collections import OrderedDict, namedtuple
+
+import numpy as np
+import pandas as pd
+
 import plotly.graph_objs as go
 import plotly.io as pio
-from collections import namedtuple, OrderedDict
-
 from _plotly_utils.basevalidators import ColorscaleValidator
-from .colors import qualitative, sequential
-import math
-import pandas as pd
-import numpy as np
-
 from plotly.subplots import (
-    make_subplots,
     _set_trace_grid_reference,
     _subplot_type_for_trace_type,
+    make_subplots,
 )
+
+from .colors import qualitative, sequential
 
 
 class PxDefaults(object):
@@ -355,10 +356,7 @@ def make_trace_kwargs(args, trace_spec, g, mapping_labels, sizeref):
                 if v:
                     result[k] = g[v]
                 mapping_labels[v_label] = "%%{%s}" % k
-    if trace_spec.constructor not in [
-        go.Parcoords,
-        go.Parcats,
-    ]:
+    if trace_spec.constructor not in [go.Parcoords, go.Parcats]:
         hover_lines = [k + "=" + v for k, v in mapping_labels.items()]
         result["hovertemplate"] = hover_header + "<br>".join(hover_lines)
     return result, fit_results
@@ -885,7 +883,8 @@ def build_dataframe(args, attrables, array_attrables):
     if "dimensions" in args and args["dimensions"] is None:
         if not df_provided:
             raise ValueError(
-                "No data were provided. Please provide data either with the `data_frame` or with the `dimensions` argument."
+                "No data were provided. Please provide data either with the `data_frame`"
+                "or with the `dimensions` argument."
             )
         else:
             df_output[df_input.columns] = df_input[df_input.columns]

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -918,7 +918,7 @@ def build_dataframe(args, attrables, array_attrables):
                 raise TypeError(
                     "Argument '%s' is a pandas MultiIndex. "
                     "pandas MultiIndex is not supported by plotly express "
-                    "at the moment." % field
+                    "at the moment. You can pass a level name instead." % field
                 )
             # ----------------- argument is a col name ----------------------
             if isinstance(argument, (str, int)):
@@ -956,7 +956,7 @@ def build_dataframe(args, attrables, array_attrables):
                 col_name = str(argument)
                 if argument in df_input.columns:  # string or int
                     vals = df_input[argument]
-                else:  # string only at this stage
+                else:  # pick MultiIndex level with that name
                     vals = pd.Series(
                         df_input.index.get_level_values(level=argument),
                         index=df_input.index,
@@ -970,6 +970,10 @@ def build_dataframe(args, attrables, array_attrables):
                         % (field, len(vals), str(list(df_output.columns)), length)
                     )
                 df_output[col_name] = vals
+                # avoid df_output.groupby ambiguity errors
+                if argument in df_output.index.names:
+                    df_output.reset_index(level=argument, inplace=True, drop=True)
+
             # ----------------- argument is a column / array / list.... -------
             else:
                 is_index = isinstance(argument, pd.RangeIndex)

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -959,7 +959,9 @@ def build_dataframe(args, attrables, array_attrables):
                 else:  # pick MultiIndex level with that name
                     vals = pd.Series(
                         df_input.index.get_level_values(level=argument),
-                        index=df_input.index,
+                        index=df_output.index
+                        if len(df_output.index)
+                        else df_input.index,
                     )
 
                 if length and len(vals) != length:
@@ -972,7 +974,8 @@ def build_dataframe(args, attrables, array_attrables):
                 df_output[col_name] = vals
                 # avoid df_output.groupby ambiguity errors
                 if argument in df_output.index.names:
-                    df_output.reset_index(level=argument, inplace=True, drop=True)
+                    df_output = df_output.reset_index(level=argument, drop=True)
+                    df_input = df_input.reset_index(level=argument, drop=True)
 
             # ----------------- argument is a column / array / list.... -------
             else:

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -955,23 +955,18 @@ def build_dataframe(args, attrables, array_attrables):
 
                 col_name = str(argument)
                 if argument in df_input.columns:  # string or int
-                    vals = df_input[argument]
+                    series = df_input[argument]
                 else:  # pick MultiIndex level with that name
-                    vals = pd.Series(
-                        df_input.index.get_level_values(level=argument),
-                        index=df_output.index
-                        if len(df_output.index)
-                        else df_input.index,
-                    )
+                    series = df_input.index.get_level_values(level=argument)
 
-                if length and len(vals) != length:
+                if length and len(series) != length:
                     raise ValueError(
                         "All arguments should have the same length. "
                         "The length of column (or index level) argument `df[%s]` is %d,"
                         " whereas the length of previous arguments %s is %d"
-                        % (field, len(vals), str(list(df_output.columns)), length)
+                        % (field, len(series), str(list(df_output.columns)), length)
                     )
-                df_output[col_name] = vals
+                df_output[col_name] = series.values
                 # avoid df_output.groupby ambiguity errors
                 if argument in df_output.index.names:
                     df_output = df_output.reset_index(level=argument, drop=True)

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -222,7 +222,9 @@ def test_build_df_from_lists():
     df = pd.DataFrame(args)
     args["data_frame"] = None
     out = build_dataframe(args, all_attrables, array_attrables)
-    assert_frame_equal(df.sort_index(axis=1), out["data_frame"].sort_index(axis=1))
+    assert_frame_equal(
+        df.sort_index(axis=1), out["data_frame"].sort_index(axis=1), check_dtype=False
+    )
     out.pop("data_frame")
     assert out == output
 
@@ -232,7 +234,9 @@ def test_build_df_from_lists():
     df = pd.DataFrame(args)
     args["data_frame"] = None
     out = build_dataframe(args, all_attrables, array_attrables)
-    assert_frame_equal(df.sort_index(axis=1), out["data_frame"].sort_index(axis=1))
+    assert_frame_equal(
+        df.sort_index(axis=1), out["data_frame"].sort_index(axis=1), check_dtype=False
+    )
     out.pop("data_frame")
     assert out == output
 
@@ -319,3 +323,7 @@ def test_size_column():
     df = px.data.tips()
     fig = px.scatter(df, x=df["size"], y=df.tip)
     assert fig.data[0].hovertemplate == "size=%{x}<br>tip=%{y}"
+
+
+if __name__ == "__main__":
+    test_build_df_from_lists()

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -1,9 +1,10 @@
-import plotly.express as px
 import numpy as np
 import pandas as pd
 import pytest
-from plotly.express._core import build_dataframe
 from pandas.util.testing import assert_frame_equal
+
+import plotly.express as px
+from plotly.express._core import build_dataframe
 
 attrables = (
     ["x", "y", "z", "a", "b", "c", "r", "theta", "size", "dimensions"]

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -203,6 +203,17 @@ def test_multiindex_raise_error():
         )
 
 
+def test_build_df_multiindex_level():
+    tips = px.data.tips()
+    mi_tips = tips.set_index("sex", append=True)  # two-level index
+    args = dict(data_frame=mi_tips, x="sex", y="total_bill")
+    mi_out = build_dataframe(args, all_attrables, array_attrables)
+    args["data_frame"] = tips
+    out = build_dataframe(args, all_attrables, array_attrables)
+    assert "sex" in mi_out["data_frame"].columns
+    assert_frame_equal(mi_out["data_frame"].reset_index(drop=True), out["data_frame"])
+
+
 def test_build_df_from_lists():
     # Just lists
     args = dict(x=[1, 2, 3], y=[2, 3, 4], color=[1, 3, 9])


### PR DESCRIPTION
This is one feature I'm missing in my standard workflow where I often end up with a nice MultiIndex but need to drop its levels (or use horribly verbose `index.get_level_values()`) every time I try to plot something.

Here I provide an implementation which in a situation like `px(df, x='x')` searches for 'x' in the levels of `df.index` if its not found in `df.columns`.

I also provided a test function and updated suitable docstring. I hope to see this extension in future versions of Plotly :)