### PR TITLE
Add an example with `constrain='domain'`

### DIFF
--- a/doc/python/axes.md
+++ b/doc/python/axes.md
@@ -481,6 +481,37 @@ fig.update_layout(
 fig.show()
 ```
 
+### Fixed Ratio Axes with Compressed domain
+
+If an axis needs to be compressed (either due to its own `scaleanchor` and `scaleratio` or those of the other axis), `constrain` determines how that happens: by increasing the "range" (default), or by decreasing the "domain".
+
+```python
+import plotly.graph_objects as go
+
+fig = go.Figure()
+
+fig.add_trace(go.Scatter(
+    x = [0,1,1,0,0,1,1,2,2,3,3,2,2,3],
+    y = [0,0,1,1,3,3,2,2,3,3,1,1,0,0]
+))
+
+fig.update_layout(
+    width = 800,
+    height = 500,
+    title = "fixed-ratio axes with compressed axes",
+    xaxis = dict(
+      range=[-1,4],  # sets the range of xaxis
+      constrain="domain",  # meanwhile compresses the xaxis by decreasing its "domain"
+    ),
+    yaxis = dict(
+      scaleanchor = "x",
+      scaleratio = 1,
+    ),
+)
+
+fig.show()
+```
+
 #### Reversed Axes
 
 You can tell plotly's automatic axis range calculation logic to reverse the direction of an axis by setting the `autorange` axis property to `"reversed"`.


### PR DESCRIPTION
Add a following example demonstrating Fixed Ratio Axes with Compressed domain to [axes tutorial](https://plot.ly/python/axes/).