### PR TITLE
switch ternary scatter and ternary contour doc order

### DIFF
--- a/doc/python/ternary-contour.md
+++ b/doc/python/ternary-contour.md
@@ -28,7 +28,7 @@ jupyter:
     layout: base
     name: Ternary contours
     order: 4
-    page_type: u-guide
+    page_type: example_index
     permalink: python/ternary-contour/
     thumbnail: thumbnail/ternary-contour.jpg
 ---

--- a/doc/python/ternary-contour.md
+++ b/doc/python/ternary-contour.md
@@ -27,7 +27,7 @@ jupyter:
     language: python
     layout: base
     name: Ternary contours
-    order: 19
+    order: 4
     page_type: u-guide
     permalink: python/ternary-contour/
     thumbnail: thumbnail/ternary-contour.jpg

--- a/doc/python/ternary-plots.md
+++ b/doc/python/ternary-plots.md
@@ -27,7 +27,7 @@ jupyter:
     language: python
     layout: base
     name: Ternary Plots
-    order: 4
+    order: 19
     page_type: example_index
     permalink: python/ternary-plots/
     thumbnail: thumbnail/ternary.jpg

--- a/doc/python/ternary-plots.md
+++ b/doc/python/ternary-plots.md
@@ -28,7 +28,7 @@ jupyter:
     layout: base
     name: Ternary Plots
     order: 19
-    page_type: example_index
+    page_type: u-guide
     permalink: python/ternary-plots/
     thumbnail: thumbnail/ternary.jpg
 ---


### PR DESCRIPTION
closes https://github.com/plotly/documentation/issues/1553

The purpose of this PR is to swap the order of the ternary contour and scatter plot examples so that the countour example shows up on the index page. 