### PR TITLE
document usage of an externally hosted Orca instance

### DIFF
--- a/doc/python/static-image-export.md
+++ b/doc/python/static-image-export.md
@@ -64,6 +64,19 @@ If you are unable to install conda or npm, you can install orca as a precompiled
 ```
 $ pip install psutil requests
 ```
+
+##### Externally Hosted Orca + pip
+If you already run an instance of [orca](https://github.com/plotly/orca) on your network, there's no need to install it.
+You can simply point to it in your Python code.
+
+```python
+import plotly
+# specify URL to Orca's endpoint
+plotly.io.orca.config.server_url = "http://localhost:9091"
+```
+
+Note that for this to work, you still need to first `requests` and `psutil`.
+
 <!-- #endregion -->
 
 ### Create a Figure


### PR DESCRIPTION
This PR adds documentation for the new feature introduced in https://github.com/plotly/plotly.py/pull/1850 and https://github.com/plotly/plotly.py/pull/1915 that enables using an externally running Orca to produce static images.

Please feel free to rephrase/modify the text!

cc @nicolaskruchten 