### PR TITLE
Fix for Python 3.10: don't compare to sys.version string

### DIFF
--- a/packages/python/plotly/_plotly_utils/utils.py
+++ b/packages/python/plotly/_plotly_utils/utils.py
@@ -227,7 +227,7 @@ def iso_to_plotly_time_string(iso_string):
 
 def template_doc(**names):
     def _decorator(func):
-        if sys.version[:3] != "3.2":
+        if not sys.version_info[:2] == (3, 2):
             if func.__doc__ is not None:
                 func.__doc__ = func.__doc__.format(**names)
         return func


### PR DESCRIPTION
When dealing with version numbers, it's generally safer to use the `sys.version_info` tuple that the `sys.version` string.

```pycon
>>> sys.version
'3.7.5 (default, Nov  1 2019, 02:16:32) \n[Clang 11.0.0 (clang-1100.0.33.8)]'
>>> sys.version[:3]
'3.7'
>>> fake_version310_info = '3.10.5 (default, Nov  1 2019, 02:16:32) \n[Clang 11.0.0 (clang-1100.0.33.8)]'
>>> fake_version310_info[:3]
'3.1'
```

When Python 3.10 comes around (probably in [May 2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule)), it will claim to be on Python 3.1!

In this case, Python 3.2 is no longer supported, so this check can be removed. (And in fact, it wouldn't have failed until Python 3.20, but it's good to clean up.)

---

Found with https://github.com/asottile/flake8-2020
