### PR TITLE
Fix for Python 4

### DIFF
--- a/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_api/__init__.py
+++ b/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_api/__init__.py
@@ -8,7 +8,7 @@ from chart_studio.tests.utils import PlotlyTestCase
 import sys
 
 # import from mock
-if sys.version_info.major == 3 and sys.version_info.minor >= 3:
+if sys.version_info >= (3, 3):
     from unittest.mock import patch
 else:
     from mock import patch

--- a/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_get_figure/test_get_figure.py
+++ b/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_get_figure/test_get_figure.py
@@ -99,7 +99,7 @@ class GetFigureTest(PlotlyTestCase):
 
 
 class TestBytesVStrings(PlotlyTestCase):
-    @skipIf(not six.PY3, "Decoding and missing escapes only seen in PY3")
+    @skipIf(six.PY2, "Decoding and missing escapes only seen in PY3")
     def test_proper_escaping(self):
         un = "PlotlyImageTest"
         ak = "786r5mecv0"

--- a/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_get_requests/test_get_requests.py
+++ b/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_get_requests/test_get_requests.py
@@ -36,10 +36,10 @@ class GetRequestsTest(PlotlyTestCase):
         hd["plotly-apikey"] = api_key
         resource = "/apigetfile/{0}/{1}/".format(file_owner, file_id)
         response = requests.get(server + resource, headers=hd)
-        if six.PY3:
-            content = _json.loads(response.content.decode("unicode_escape"))
-        else:
+        if six.PY2:
             content = _json.loads(response.content)
+        else:
+            content = _json.loads(response.content.decode("unicode_escape"))
         error_message = (
             "Aw, snap! We don't have an account for {0}. Want to "
             "try again? Sign in is not case sensitive.".format(username)
@@ -58,10 +58,10 @@ class GetRequestsTest(PlotlyTestCase):
         hd["plotly-apikey"] = api_key
         resource = "/apigetfile/{0}/{1}/".format(file_owner, file_id)
         response = requests.get(server + resource, headers=hd)
-        if six.PY3:
-            content = _json.loads(response.content.decode("unicode_escape"))
-        else:
+        if six.PY2:
             content = _json.loads(response.content)
+        else:
+            content = _json.loads(response.content.decode("unicode_escape"))
         error_message = (
             "Aw, snap! It looks like this file does " "not exist. Want to try again?"
         )
@@ -96,10 +96,10 @@ class GetRequestsTest(PlotlyTestCase):
         hd["plotly-apikey"] = api_key
         resource = "/apigetfile/{0}/{1}/".format(file_owner, file_id)
         response = requests.get(server + resource, headers=hd)
-        if six.PY3:
-            content = _json.loads(response.content.decode("unicode_escape"))
-        else:
+        if six.PY2:
             content = _json.loads(response.content)
+        else:
+            content = _json.loads(response.content.decode("unicode_escape"))
         self.assertEqual(response.status_code, 403)
 
     # Private File that is shared
@@ -115,10 +115,10 @@ class GetRequestsTest(PlotlyTestCase):
             hd = copy.copy(default_headers)
             del hd[header]
             response = requests.get(server + resource, headers=hd)
-            if six.PY3:
-                content = _json.loads(response.content.decode("unicode_escape"))
-            else:
+            if six.PY2:
                 content = _json.loads(response.content)
+            else:
+                content = _json.loads(response.content.decode("unicode_escape"))
             self.assertEqual(response.status_code, 422)
 
     @attr("slow")
@@ -132,10 +132,10 @@ class GetRequestsTest(PlotlyTestCase):
         hd["plotly-apikey"] = api_key
         resource = "/apigetfile/{0}/{1}/".format(file_owner, file_id)
         response = requests.get(server + resource, headers=hd)
-        if six.PY3:
-            content = _json.loads(response.content.decode("unicode_escape"))
-        else:
+        if six.PY2:
             content = _json.loads(response.content)
+        else:
+            content = _json.loads(response.content.decode("unicode_escape"))
         self.assertEqual(response.status_code, 200)
         # content = _json.loads(res.content)
         # response_payload = content['payload']

--- a/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_plotly/test_credentials.py
+++ b/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_plotly/test_credentials.py
@@ -9,7 +9,7 @@ from chart_studio.tests.utils import PlotlyTestCase
 import sys
 
 # import from mock
-if sys.version_info.major == 3 and sys.version_info.minor >= 3:
+if sys.version_info >= (3, 3):
     from unittest.mock import patch
 else:
     from mock import patch

--- a/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_plotly/test_plot.py
+++ b/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_plotly/test_plot.py
@@ -25,7 +25,7 @@ from chart_studio.files import CONFIG_FILE
 
 
 # import from mock
-if sys.version_info.major == 3 and sys.version_info.minor >= 3:
+if sys.version_info >= (3, 3):
     from unittest.mock import patch
 else:
     from mock import patch

--- a/packages/python/plotly/_plotly_utils/utils.py
+++ b/packages/python/plotly/_plotly_utils/utils.py
@@ -7,7 +7,7 @@ from _plotly_utils.optional_imports import get_module
 from _plotly_utils.basevalidators import ImageUriValidator
 
 
-PY36_OR_LATER = sys.version_info.major == 3 and sys.version_info.minor >= 6
+PY36_OR_LATER = sys.version_info >= (3, 6)
 
 
 class PlotlyJSONEncoder(_json.JSONEncoder):

--- a/packages/python/plotly/_plotly_utils/utils.py
+++ b/packages/python/plotly/_plotly_utils/utils.py
@@ -227,7 +227,7 @@ def iso_to_plotly_time_string(iso_string):
 
 def template_doc(**names):
     def _decorator(func):
-        if sys.version[:3] != "3.2":
+        if not sys.version_info[:2] == (3, 2):
             if func.__doc__ is not None:
                 func.__doc__ = func.__doc__.format(**names)
         return func

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -4458,11 +4458,7 @@ class BaseLayoutType(BaseLayoutHierarchyType):
         Custom __dir__ that handles dynamic subplot properties
         """
         # Include any active subplot values
-        if six.PY3:
-            return list(super(BaseLayoutHierarchyType, self).__dir__()) + sorted(
-                self._subplotid_props
-            )
-        else:
+        if six.PY2:
 
             def get_attrs(obj):
                 import types
@@ -4493,6 +4489,11 @@ class BaseLayoutType(BaseLayoutHierarchyType):
                 return list(attrs)
 
             return dir2(self) + sorted(self._subplotid_props)
+        else:
+
+            return list(super(BaseLayoutHierarchyType, self).__dir__()) + sorted(
+                self._subplotid_props
+            )
 
 
 class BaseTraceHierarchyType(BasePlotlyType):

--- a/packages/python/plotly/plotly/tests/test_core/test_figure_messages/test_add_traces.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_figure_messages/test_add_traces.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 import plotly.graph_objs as go
 
-if sys.version_info.major == 3 and sys.version_info.minor >= 3:
+if sys.version_info >= (3, 3):
     from unittest.mock import MagicMock
 else:
     from mock import MagicMock

--- a/packages/python/plotly/plotly/tests/test_core/test_figure_messages/test_batch_animate.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_figure_messages/test_batch_animate.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 import plotly.graph_objs as go
 
-if sys.version_info.major == 3 and sys.version_info.minor >= 3:
+if sys.version_info >= (3, 3):
     from unittest.mock import MagicMock
 else:
     from mock import MagicMock

--- a/packages/python/plotly/plotly/tests/test_core/test_figure_messages/test_move_delete_traces.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_figure_messages/test_move_delete_traces.py
@@ -4,7 +4,7 @@ from nose.tools import raises
 
 import plotly.graph_objs as go
 
-if sys.version_info.major == 3 and sys.version_info.minor >= 3:
+if sys.version_info >= (3, 3):
     from unittest.mock import MagicMock
 else:
     from mock import MagicMock

--- a/packages/python/plotly/plotly/tests/test_core/test_figure_messages/test_on_change.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_figure_messages/test_on_change.py
@@ -4,7 +4,7 @@ from nose.tools import raises
 
 import plotly.graph_objs as go
 
-if sys.version_info.major == 3 and sys.version_info.minor >= 3:
+if sys.version_info >= (3, 3):
     from unittest.mock import MagicMock
 else:
     from mock import MagicMock

--- a/packages/python/plotly/plotly/tests/test_core/test_figure_messages/test_plotly_relayout.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_figure_messages/test_plotly_relayout.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 import plotly.graph_objs as go
 
-if sys.version_info.major == 3 and sys.version_info.minor >= 3:
+if sys.version_info >= (3, 3):
     from unittest.mock import MagicMock
 else:
     from mock import MagicMock

--- a/packages/python/plotly/plotly/tests/test_core/test_figure_messages/test_plotly_restyle.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_figure_messages/test_plotly_restyle.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 import plotly.graph_objs as go
 
-if sys.version_info.major == 3 and sys.version_info.minor >= 3:
+if sys.version_info >= (3, 3):
     from unittest.mock import MagicMock
 else:
     from mock import MagicMock

--- a/packages/python/plotly/plotly/tests/test_core/test_figure_messages/test_plotly_update.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_figure_messages/test_plotly_update.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 import plotly.graph_objs as go
 from plotly.basedatatypes import Undefined
 
-if sys.version_info.major == 3 and sys.version_info.minor >= 3:
+if sys.version_info >= (3, 3):
     from unittest.mock import MagicMock
 else:
     from mock import MagicMock

--- a/packages/python/plotly/plotly/tests/test_core/test_optional_imports/test_optional_imports.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_optional_imports/test_optional_imports.py
@@ -27,7 +27,7 @@ class OptionalImportsTest(TestCase):
         # Get module that raises an exception on import
         module_str = "plotly.tests.test_core." "test_optional_imports.exploding_module"
 
-        if sys.version_info.major == 3 and sys.version_info.minor >= 4:
+        if sys.version_info >= (3, 4):
             with self.assertLogs("_plotly_utils.optional_imports", level="ERROR") as cm:
                 module = get_module(module_str)
 

--- a/packages/python/plotly/plotly/tests/test_io/test_renderers.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_renderers.py
@@ -12,7 +12,7 @@ import plotly.graph_objs as go
 import plotly.io as pio
 from plotly.offline import get_plotlyjs
 
-if sys.version_info.major == 3 and sys.version_info.minor >= 3:
+if sys.version_info >= (3, 3):
     import unittest.mock as mock
     from unittest.mock import MagicMock
 else:

--- a/packages/python/plotly/plotly/tests/test_io/test_to_from_json.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_to_from_json.py
@@ -6,7 +6,7 @@ import json
 import sys
 import os
 
-if sys.version_info.major == 3 and sys.version_info.minor >= 3:
+if sys.version_info >= (3, 3):
     from unittest.mock import MagicMock
     import tempfile
 else:

--- a/packages/python/plotly/plotly/tests/test_orca/test_image_renderers.py
+++ b/packages/python/plotly/plotly/tests/test_orca/test_image_renderers.py
@@ -10,7 +10,7 @@ import plotly.graph_objs as go
 
 from plotly.offline.offline import _get_jconfig
 
-if sys.version_info.major == 3 and sys.version_info.minor >= 3:
+if sys.version_info >= (3, 3):
     import unittest.mock as mock
 else:
     import mock

--- a/packages/python/plotly/plotly/tests/test_orca/test_to_image.py
+++ b/packages/python/plotly/plotly/tests/test_orca/test_to_image.py
@@ -7,7 +7,7 @@ import pytest
 import sys
 import pandas as pd
 
-if sys.version_info.major == 3 and sys.version_info.minor >= 3:
+if sys.version_info >= (3, 3):
     from unittest.mock import MagicMock
 else:
     from mock import MagicMock

--- a/packages/python/plotly/setup.py
+++ b/packages/python/plotly/setup.py
@@ -161,7 +161,7 @@ class CodegenCommand(Command):
         pass
 
     def run(self):
-        if sys.version_info.major != 3 or sys.version_info.minor < 6:
+        if sys.version_info < (3, 6):
             raise ImportError("Code generation must be executed with Python >= 3.6")
 
         from codegen import perform_codegen


### PR DESCRIPTION
Python 4 is some way off, but it may be a good idea to clean some of these up, similar to #2076.

---

This comparison is `True` for Python 3.3 - 3.99, but is `False` for Python 4 and would run the Python 2 - 3.2 code:

```python
if sys.version_info.major == 3 and sys.version_info.minor >= 3:	
    from unittest.mock import patch
else:
    from mock import patch	
```

Because Python 3.3 is the minimum Python 3.x supported, it can be simplified:

```diff
-if sys.version_info.major == 3 and sys.version_info.minor >= 3:	
+if sys.version_info.major >= 3:	
```

---

Another couple of cases which fail on Python 4.0, here we need to compare the `version_info` tuple and avoid comparing the `sys.version_info.minor` integer:

```diff
-if sys.version_info.major == 3 and sys.version_info.minor >= 4:
+if sys.version_info >= (3, 4):
```

```diff
-if sys.version_info.major != 3 or sys.version_info.minor < 6:
+if sys.version_info < (3, 6):
```

---

Finally, there's some code which uses `six.PY3`, a bit like:

```python
if six.PY3:
    print("Python 3+ code")
else:
    print "Python 2 code"
```

Where in six.py:

```python
PY3 = sys.version_info[0] == 3
```

When run on Python 4, this will run the Python 2 code!

Instead, use `six.PY2`.

---


Found with https://github.com/asottile/flake8-2020.
