### PR TITLE
removing dash-example section

### DIFF
--- a/doc/python/3d-surface-plots.md
+++ b/doc/python/3d-surface-plots.md
@@ -163,21 +163,6 @@ fig = go.Figure(data=[
 fig.show()
 ```
 
-### Dash Example
-
-
-[Dash](https://plot.ly/products/dash/) is an Open Source Python library which can help you convert plotly figures into a reactive, web-based application. Below is a simple example of a dashboard created using Dash. Its [source code](https://github.com/plotly/simple-example-chart-apps/tree/master/dash-3dsurfaceplot) can easily be deployed to a PaaS.
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-3dsurfaceplot/", width="100%", height=950 ,frameBorder="0")
-```
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-3dsurfaceplot/code", width="100%", height=500 ,frameBorder="0")
-```
-
 #### Reference
 
 

--- a/doc/python/bar-charts.md
+++ b/doc/python/bar-charts.md
@@ -370,21 +370,6 @@ fig.show()
 
 See examples of horizontal bar charts [here](https://plot.ly/python/horizontal-bar-charts/).
 
-### Dash Example
-
-[Dash](https://plot.ly/products/dash/) is an Open Source Python library which can help you convert plotly figures into a reactive, web-based application. Below is a simple example of a dashboard created using Dash. Its [source code](https://github.com/plotly/simple-example-chart-apps/tree/master/dash-barplot) is also show below and can easily be deployed to a PaaS (platform as a service).
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-barplot/", width="100%", height="650px", frameBorder="0")
-
-```
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-barplot/code", width="80%", height=500, frameBorder="0")
-```
-
 ### Reference
 
 See https://plot.ly/python/reference/#bar for more information and chart attribute options!

--- a/doc/python/box-plots.md
+++ b/doc/python/box-plots.md
@@ -487,20 +487,6 @@ fig.update_layout(
 fig.show()
 ```
 
-### Dash Example
-
-[Dash](https://plot.ly/products/dash/) is an Open Source Python library which can help you convert plotly figures into a reactive, web-based application. Below is a simple example of a dashboard created using Dash. Its [source code](https://github.com/plotly/simple-example-chart-apps/tree/master/dash-boxplot) can easily be deployed to a PaaS.
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-boxplot/", width="100%", height="650px", frameBorder="0")
-```
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-boxplot/code", width="100%", height=500, frameBorder="0")
-```
-
 #### Reference
 
 See https://plot.ly/python/reference/#box for more information and chart attribute options!

--- a/doc/python/candlestick-charts.md
+++ b/doc/python/candlestick-charts.md
@@ -143,20 +143,5 @@ fig = go.Figure(data=[go.Candlestick(x=dates,
 fig.show()
 ```
 
-### Dash Example
-
-
-[Dash](https://plot.ly/products/dash/) is an Open Source Python library which can help you convert plotly figures into a reactive, web-based application. Below is a simple example of a dashboard created using Dash. Its [source code](https://github.com/plotly/simple-example-chart-apps/tree/master/dash-candlestickplot) can easily be deployed to a PaaS.
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-candlestickplot/", width="100%", height="750px", frameBorder="0")
-```
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-candlestickplot/code", width="100%", height=500, frameBorder="0")
-```
-
 #### Reference
 For more information on candlestick attributes, see: https://plot.ly/python/reference/#candlestick

--- a/doc/python/choropleth-maps.md
+++ b/doc/python/choropleth-maps.md
@@ -275,20 +275,6 @@ fig.layout.template = None
 fig.show()
 ```
 
-### Dash Example
-
-[Dash](https://plot.ly/products/dash/) is an Open Source Python library which can help you convert plotly figures into a reactive, web-based application. Below is a simple example of a dashboard created using Dash. Its [source code](https://github.com/plotly/simple-example-chart-apps/tree/master/dash-choroplethplot) can easily be deployed to a PaaS.
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-choroplethplot/", width="100%", height="950px", frameBorder="0")
-```
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-choroplethplot/code", width="100%", height=500, frameBorder="0")
-```
-
 #### Reference
 
 See https://plot.ly/python/reference/#choropleth for more information and chart attribute options!

--- a/doc/python/heatmaps.md
+++ b/doc/python/heatmaps.md
@@ -162,20 +162,5 @@ fig.update_layout(
 fig.show()
 ```
 
-### Dash Example
-
-
-[Dash](https://plot.ly/products/dash/) is an Open Source Python library which can help you convert plotly figures into a reactive, web-based application. Below is a simple example of a dashboard created using Dash. Its source code can be found [here](https://github.com/plotly/simple-example-chart-apps/tree/master/dash-heatmapplot) and can easily be deployed to a PaaS.
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-heatmapplot/", width="120%", height="650px", frameBorder="0")
-```
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-heatmapplot/code", width="120%", height=500, frameBorder="0")
-```
-
 #### Reference
 See https://plot.ly/python/reference/#heatmap for more information and chart attribute options!

--- a/doc/python/histograms.md
+++ b/doc/python/histograms.md
@@ -373,22 +373,6 @@ fig.update_layout(
 fig.show()
 ```
 
-### Dash Example
-
-[Dash](https://plot.ly/products/dash/) is an Open Source Python library which can help you convert plotly figures into a reactive, web-based application. Below is a simple example of a dashboard created using Dash. Its [source code](https://github.com/plotly/simple-example-chart-apps/tree/master/dash-histogramplot) can easily be deployed to a PaaS.
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-histogramplot/", width="100%", height="650px", frameBorder="0")
-
-```
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-histogramplot/code", width="100%", height=500, frameBorder="0")
-
-```
-
 #### Reference
 
 See https://plot.ly/python/reference/#histogram for more information and chart attribute options!

--- a/doc/python/line-and-scatter.md
+++ b/doc/python/line-and-scatter.md
@@ -274,21 +274,6 @@ fig = go.Figure(data=go.Scattergl(
 fig.show()
 ```
 
-### Dash Example
-
-[Dash](https://plot.ly/products/dash/) is an Open Source Python library which can help you convert plotly figures into a reactive, web-based application. Below is a simple example of a dashboard created using Dash. Its [source code](https://github.com/plotly/simple-example-chart-apps/tree/master/dash-linescatterplot) can easily be deployed to a PaaS.
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-linescatterplot/", width="100%",height="750px", frameBorder="0")
-
-```
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-linescatterplot/code", width="100%",height=500, frameBorder="0")
-```
-
 ### Reference
 
 See https://plot.ly/python/reference/#scatter or https://plot.ly/python/reference/#scattergl for more information and chart attribute options!

--- a/doc/python/line-charts.md
+++ b/doc/python/line-charts.md
@@ -406,22 +406,6 @@ fig.update_traces(mode='lines')
 fig.show()
 ```
 
-### Dash Example
-
-[Dash](https://plot.ly/products/dash/) is an Open Source Python library which can help you convert plotly figures into a reactive, web-based application. Below is a simple example of a dashboard created using Dash. Its [source code](https://github.com/plotly/simple-example-chart-apps/tree/master/dash-lineplot) can easily be deployed to a PaaS.
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-lineplot/", width="100%", height="650px", frameBorder="0")
-
-```
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-lineplot/code", width="100%", height=500, frameBorder="0")
-
-```
-
 #### Reference
 
 See https://plot.ly/python/reference/#scatter for more information and chart attribute options!

--- a/doc/python/pie-charts.md
+++ b/doc/python/pie-charts.md
@@ -276,20 +276,5 @@ fig.show()
 
 ```
 
-### Dash Example
-
-
-[Dash](https://plot.ly/products/dash/) is an Open Source Python library which can help you convert plotly figures into a reactive, web-based application. Below is a simple example of a dashboard created using Dash. Its [source code](https://github.com/plotly/simple-example-chart-apps/tree/master/dash-pieplot) can easily be deployed to a PaaS.
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-pieplot", width="100%", height="650px" ,frameBorder="0")
-```
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-pieplot/code", width="100%", height=500 ,frameBorder="0")
-```
-
 #### Reference
 See https://plot.ly/python/reference/#pie for more information and chart attribute options!

--- a/doc/python/table.md
+++ b/doc/python/table.md
@@ -210,20 +210,5 @@ fig = go.Figure(data=[go.Table(
 fig.show()
 ```
 
-### Dash Example
-
-
-[Dash](https://plot.ly/products/dash/) is an Open Source Python library which can help you convert plotly figures into a reactive, web-based application. Below is a simple example of a dashboard created using Dash. Its [source code](https://github.com/plotly/simple-example-chart-apps/tree/master/dash-tableplot) can easily be deployed to a PaaS.
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-tableplot/", width="100%", height="850px", frameBorder="0")
-```
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-tableplot/code", width="100%", height=500, frameBorder="0")
-```
-
 #### Reference
 For more information on tables and table attributes see: https://plot.ly/python/reference/#table.

--- a/doc/python/time-series.md
+++ b/doc/python/time-series.md
@@ -127,20 +127,5 @@ fig.update_layout(title_text='Time Series with Rangeslider',
 fig.show()
 ```
 
-### Dash Example
-
-
-[Dash](https://plot.ly/products/dash/) is an Open Source Python library which can help you convert plotly figures into a reactive, web-based application. Below is a simple example of a dashboard created using Dash. Its [source code](https://github.com/plotly/simple-example-chart-apps/tree/master/dash-timeseriesplot) can easily be deployed to a PaaS.
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-timeseriesplot/", width="100%", height="750px", frameBorder="0")
-```
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-timeseriesplot/code", width="100%", height=500, frameBorder="0")
-```
-
 #### Reference
 See https://plot.ly/python/reference/#layout-xaxis-rangeslider and<br> https://plot.ly/python/reference/#layout-xaxis-rangeselector for more information and chart attribute options!


### PR DESCRIPTION
The purpose of this PR is to remove the `dash example` section from these docs per https://github.com/plotly/documentation/issues/1654