### PR TITLE
modified trendline formatting

### DIFF
--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -236,7 +236,7 @@ def make_trace_kwargs(args, trace_spec, g, mapping_labels, sizeref):
                         fit_results = sm.OLS(y.values, sm.add_constant(x.values)).fit()
                         result["y"] = fit_results.predict()
                         hover_header = "<b>OLS trendline</b><br>"
-                        hover_header += "%s = %f * %s + %f<br>" % (
+                        hover_header += "%s = %g * %s + %g<br>" % (
                             args["y"],
                             fit_results.params[1],
                             args["x"],


### PR DESCRIPTION
Closes #1984. 
For example 
```
import plotly.express as px

df = px.data.tips()
fig = px.scatter(df, x="total_bill", y=1.e-6 * df.tip, trendline="ols")
fig.show()
```
Master:
![image](https://user-images.githubusercontent.com/263366/72555260-3aa80480-386a-11ea-8ea2-5ca1fe081e71.png)

Now:
![image](https://user-images.githubusercontent.com/263366/72555183-1ba97280-386a-11ea-8359-211e8551e175.png)

Existing examples should not be modified, I checked with the doc example of `trendline`.
