### PR TITLE
More flexible parallel_categories magic

### DIFF
--- a/doc/python/parallel-categories-diagram.md
+++ b/doc/python/parallel-categories-diagram.md
@@ -39,7 +39,7 @@ The parallel categories diagram (also known as parallel sets or alluvial diagram
 
 Combinations of category rectangles across dimensions are connected by ribbons, where the height of the ribbon corresponds to the relative frequency of occurrence of the combination of categories in the data set.
 
-For other representations of multivariate data, also see [parallel coordinates](/python/parallel-coordinates-plot/), [radar charts](/python/radar-chart/) and [scatterplot matrix (SPLOM)](/python/splom/). A visually-similar but more generic type of visualization is the [sankey diagrams](https://plot.ly/python/sankey-diagram/).
+For other representations of multivariate data, also see [parallel coordinates](/python/parallel-coordinates-plot/), [radar charts](/python/radar-chart/) and [scatterplot matrix (SPLOM)](/python/splom/). A visually-similar but more generic type of visualization is the [sankey diagrams](/python/sankey-diagram/).
 
 #### Basic Parallel Category Diagram with plotly.express
 

--- a/doc/python/parallel-categories-diagram.md
+++ b/doc/python/parallel-categories-diagram.md
@@ -5,8 +5,8 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: "1.1"
-      jupytext_version: 1.1.1
+      format_version: '1.2'
+      jupytext_version: 1.3.1
   kernelspec:
     display_name: Python 3
     language: python
@@ -20,7 +20,7 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.7.3
+    version: 3.6.8
   plotly:
     description: How to make parallel categories diagrams in Python with Plotly.
     display_as: statistical
@@ -35,15 +35,17 @@ jupyter:
 
 #### Parallel Categories Diagram
 
-The parallel categories diagram is a visualization of multi-dimensional categorical data sets. Each variable in the data set is represented by a column of rectangles, where each rectangle corresponds to a discrete value taken on by that variable. The relative heights of the rectangles reflect the relative frequency of occurrence of the corresponding value.
+The parallel categories diagram (also known as parallel sets or alluvial diagram) is a visualization of multi-dimensional categorical data sets. Each variable in the data set is represented by a column of rectangles, where each rectangle corresponds to a discrete value taken on by that variable. The relative heights of the rectangles reflect the relative frequency of occurrence of the corresponding value.
 
 Combinations of category rectangles across dimensions are connected by ribbons, where the height of the ribbon corresponds to the relative frequency of occurrence of the combination of categories in the data set.
 
-For other representations of multivariate data, also see [parallel coordinates](/python/parallel-coordinates-plot/), [radar charts](/python/radar-chart/) and [scatterplot matrix (SPLOM)](/python/splom/).
+For other representations of multivariate data, also see [parallel coordinates](/python/parallel-coordinates-plot/), [radar charts](/python/radar-chart/) and [scatterplot matrix (SPLOM)](/python/splom/). A visually-similar but more generic type of visualization is the [sankey diagrams](https://plot.ly/python/sankey-diagram/).
 
 #### Basic Parallel Category Diagram with plotly.express
 
 This example visualizes the resturant bills of a sample of 244 people. Hovering over a category rectangle (sex, smoker, etc) displays a tooltip with the number of people with that single trait. Hovering over a ribbon in the diagram displays a tooltip with the number of people with a particular combination of the five traits connected by the ribbon.
+
+By default, `px.parallel_categories` will display any column in the `data_frame` that has a cardinality (or number of unique values) of less than 50. This can be overridden either by passing in a specific list of columns to `dimensions` or by setting `dimensions_max_cardinality` to something other than 50. 
 
 ```python
 import plotly.express as px
@@ -68,7 +70,7 @@ fig = px.parallel_categories(df, dimensions=['sex', 'smoker', 'day'],
 fig.show()
 ```
 
-#### Basic Parallel Categories Diagram
+### Basic Parallel Categories Diagram with `graph_objects`
 
 This example illustartes the hair color, eye color, and sex of a sample of 8 people. The dimension labels can be dragged horizontally to reorder the dimensions and the category rectangles can be dragged vertically to reorder the categories within a dimension.
 

--- a/packages/python/plotly/plotly/express/_chart_types.py
+++ b/packages/python/plotly/plotly/express/_chart_types.py
@@ -1205,6 +1205,7 @@ def parallel_categories(
     template=None,
     width=None,
     height=None,
+    dimensions_max_cardinality=50,
 ):
     """
     In a parallel categories (or parallel sets) plot, each row of

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -181,7 +181,9 @@ def make_trace_kwargs(args, trace_spec, g, mapping_labels, sizeref):
                 )
                 and (
                     trace_spec.constructor != go.Parcats
-                    or len(args["data_frame"][name].unique()) <= 20
+                    or (v is not None and name in v)
+                    or len(args["data_frame"][name].unique())
+                    <= args["dimensions_max_cardinality"]
                 )
             ]
             result["dimensions"] = [

--- a/packages/python/plotly/plotly/express/_doc.py
+++ b/packages/python/plotly/plotly/express/_doc.py
@@ -110,6 +110,7 @@ docs = dict(
         "int (default 50)",
         "When `dimensions` is `None` and `data_frame` is provided, "
         "columns with more than this number of unique values are excluded from the output.",
+        "Not used when `dimensions` is passed.",
     ],
     error_x=[
         colref_type,

--- a/packages/python/plotly/plotly/express/_doc.py
+++ b/packages/python/plotly/plotly/express/_doc.py
@@ -106,6 +106,11 @@ docs = dict(
         colref_list_desc,
         "Values from these columns are used for multidimensional visualization.",
     ],
+    dimensions_max_cardinality=[
+        "int (default 50)",
+        "When `dimensions` is `None` and `data_frame` is provided, "
+        "columns with more than this number of unique values are excluded from the output.",
+    ],
     error_x=[
         colref_type,
         colref_desc,

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_functions.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_functions.py
@@ -139,3 +139,36 @@ def test_funnel():
         color=["0", "0", "0", "1", "1", "1"],
     )
     assert len(fig.data) == 2
+
+
+def test_parcats_dimensions_max():
+    df = px.data.tips()
+
+    # default behaviour
+    fig = px.parallel_categories(df)
+    assert [d.label for d in fig.data[0].dimensions] == [
+        "sex",
+        "smoker",
+        "day",
+        "time",
+        "size",
+    ]
+
+    # explicit subset of default
+    fig = px.parallel_categories(df, dimensions=["sex", "smoker", "day"])
+    assert [d.label for d in fig.data[0].dimensions] == ["sex", "smoker", "day"]
+
+    # shrinking max
+    fig = px.parallel_categories(df, dimensions_max_cardinality=4)
+    assert [d.label for d in fig.data[0].dimensions] == [
+        "sex",
+        "smoker",
+        "day",
+        "time",
+    ]
+
+    # explicit superset of default, violating the max
+    fig = px.parallel_categories(
+        df, dimensions=["sex", "smoker", "day", "size"], dimensions_max_cardinality=4
+    )
+    assert [d.label for d in fig.data[0].dimensions] == ["sex", "smoker", "day", "size"]


### PR DESCRIPTION
Closes #2008 by:

* Exposing the `dimensions_max_cardinality` cutoff in kwargs
* Bumping the default from 20 to 50
* Exempting the columns in `dimensions` from the cutoff

This means that a user can now do `px.parallel_categories(tips, dimensions=["smoker", "total_bill"])` if they like and get both columns in the output even though `total_bill` has more than 50 unique values. The user can also now do `px.parallel_categories(tips, dimensions_max_cardinality=1000)` to get similar output to parallel coordinates although less readable/useful.

@emmanuelle if you like this approach to solving the problem I'll add some tests and docs.