### PR TITLE
add the word background to bgcolor description so it will get indexed by algolia

### DIFF
--- a/packages/python/plotly/codegen/resources/plot-schema.json
+++ b/packages/python/plotly/codegen/resources/plot-schema.json
@@ -57324,14 +57324,14 @@
                 "role": "style",
                 "dflt": "#fff",
                 "editType": "plot",
-                "description": "Sets the color of paper where the graph is drawn."
+                "description": "Sets the background color of the paper where the graph is drawn."
             },
             "plot_bgcolor": {
                 "valType": "color",
                 "role": "style",
                 "dflt": "#fff",
                 "editType": "layoutstyle",
-                "description": "Sets the color of plotting area in-between x and y axes."
+                "description": "Sets the background color of the plotting area in-between x and y axes."
             },
             "separators": {
                 "valType": "string",

--- a/packages/python/plotly/plotly/graph_objs/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/__init__.py
@@ -96070,7 +96070,7 @@ class Layout(_BaseLayoutType):
     @property
     def paper_bgcolor(self):
         """
-        Sets the color of paper where the graph is drawn.
+        Sets the background color of the paper where the graph is drawn.
     
         The 'paper_bgcolor' property is a color and may be specified as:
           - A hex string (e.g. '#ff0000')
@@ -96153,7 +96153,7 @@ class Layout(_BaseLayoutType):
     @property
     def plot_bgcolor(self):
         """
-        Sets the color of plotting area in-between x and y axes.
+        Sets the background color of the plotting area in-between x and y axes.
     
         The 'plot_bgcolor' property is a color and may be specified as:
           - A hex string (e.g. '#ff0000')
@@ -98684,14 +98684,14 @@ class Layout(_BaseLayoutType):
             "polar" subplots. Rotates the entire polar by the given
             angle in legacy polar charts.
         paper_bgcolor
-            Sets the color of paper where the graph is drawn.
+            Sets the background color of the paper where the graph is drawn.
         piecolorway
             Sets the default pie slice colors. Defaults to the main
             `colorway` used for trace colors. If you specify a new
             list here it can still be extended with lighter and
             darker colors, see `extendpiecolors`.
         plot_bgcolor
-            Sets the color of plotting area in-between x and y
+            Sets the background color of the plotting area in-between x and y
             axes.
         polar
             plotly.graph_objects.layout.Polar instance or dict with
@@ -99198,14 +99198,14 @@ class Layout(_BaseLayoutType):
             "polar" subplots. Rotates the entire polar by the given
             angle in legacy polar charts.
         paper_bgcolor
-            Sets the color of paper where the graph is drawn.
+            Sets the background color of the paper where the graph is drawn.
         piecolorway
             Sets the default pie slice colors. Defaults to the main
             `colorway` used for trace colors. If you specify a new
             list here it can still be extended with lighter and
             darker colors, see `extendpiecolors`.
         plot_bgcolor
-            Sets the color of plotting area in-between x and y
+            Sets the background color of the plotting area in-between x and y
             axes.
         polar
             plotly.graph_objects.layout.Polar instance or dict with

--- a/packages/python/plotly/plotly/graph_objs/_figure.py
+++ b/packages/python/plotly/plotly/graph_objs/_figure.py
@@ -370,7 +370,7 @@ class Figure(BaseFigure):
                         polar by the given angle in legacy polar
                         charts.
                     paper_bgcolor
-                        Sets the color of paper where the graph is
+                        Sets the background color of the paper where the graph is
                         drawn.
                     piecolorway
                         Sets the default pie slice colors. Defaults to
@@ -379,7 +379,7 @@ class Figure(BaseFigure):
                         extended with lighter and darker colors, see
                         `extendpiecolors`.
                     plot_bgcolor
-                        Sets the color of plotting area in-between x
+                        Sets the background color of the plotting area in-between x
                         and y axes.
                     polar
                         plotly.graph_objects.layout.Polar instance or

--- a/packages/python/plotly/plotly/graph_objs/_figurewidget.py
+++ b/packages/python/plotly/plotly/graph_objs/_figurewidget.py
@@ -370,7 +370,7 @@ class FigureWidget(BaseFigureWidget):
                         polar by the given angle in legacy polar
                         charts.
                     paper_bgcolor
-                        Sets the color of paper where the graph is
+                        Sets the background color of the paper where the graph is
                         drawn.
                     piecolorway
                         Sets the default pie slice colors. Defaults to
@@ -379,7 +379,7 @@ class FigureWidget(BaseFigureWidget):
                         extended with lighter and darker colors, see
                         `extendpiecolors`.
                     plot_bgcolor
-                        Sets the color of plotting area in-between x
+                        Sets the background color of the plotting area in-between x
                         and y axes.
                     polar
                         plotly.graph_objects.layout.Polar instance or

--- a/packages/python/plotly/plotly/validators/__init__.py
+++ b/packages/python/plotly/plotly/validators/__init__.py
@@ -281,7 +281,7 @@ class LayoutValidator(_plotly_utils.basevalidators.CompoundValidator):
                 polar by the given angle in legacy polar
                 charts.
             paper_bgcolor
-                Sets the color of paper where the graph is
+                Sets the background color of the paper where the graph is
                 drawn.
             piecolorway
                 Sets the default pie slice colors. Defaults to
@@ -290,7 +290,7 @@ class LayoutValidator(_plotly_utils.basevalidators.CompoundValidator):
                 extended with lighter and darker colors, see
                 `extendpiecolors`.
             plot_bgcolor
-                Sets the color of plotting area in-between x
+                Sets the background color of the plotting area in-between x
                 and y axes.
             polar
                 plotly.graph_objects.layout.Polar instance or


### PR DESCRIPTION
The purpose of this PR is to make sure that `plot_bgcolor` and `paper_bgcolor` show up in algolia search results for `background`. 

Related to https://github.com/plotly/plotly.js/pull/4536