### PR TITLE
Support JupyterLab 2.0.0

### DIFF
--- a/packages/javascript/jupyterlab-plotly/package-lock.json
+++ b/packages/javascript/jupyterlab-plotly/package-lock.json
@@ -9,9 +9,9 @@
       "resolved": "https://registry.npmjs.org/3d-view/-/3d-view-2.0.0.tgz",
       "integrity": "sha1-gxrpQtdQjFCAHj4G+v4ejFdOF74=",
       "requires": {
-        "matrix-camera-controller": "2.1.3",
-        "orbit-camera-controller": "4.0.0",
-        "turntable-camera-controller": "3.0.1"
+        "matrix-camera-controller": "^2.1.1",
+        "orbit-camera-controller": "^4.0.0",
+        "turntable-camera-controller": "^3.0.0"
       }
     },
     "@choojs/findup": {
@@ -19,7 +19,7 @@
       "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
       "integrity": "sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==",
       "requires": {
-        "commander": "2.20.3"
+        "commander": "^2.15.1"
       },
       "dependencies": {
         "commander": {
@@ -30,12 +30,120 @@
       }
     },
     "@jupyterlab/rendermime-interfaces": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.3.0.tgz",
-      "integrity": "sha512-04ohT/xdTcdp/TKuNMqY1MLwh7IWyjbMrQXiuwanE8xo52fIe6OIK0DENwc6VDMej1+8NVSU7rX42urLCex0sA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-2.0.0.tgz",
+      "integrity": "sha512-1BRpxIppycFmJtV5kq+BVcQT80k3PflMmDsSITXFUspX20SiEktjZcSfzUplTwkp6pSXlr2QCLTV2rQE00dGNA==",
       "requires": {
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/widgets": "1.8.1"
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/widgets": "^1.11.1"
+      }
+    },
+    "@lumino/algorithm": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lumino/algorithm/-/algorithm-1.2.3.tgz",
+      "integrity": "sha512-XBJ/homcm7o8Y9G6MzYvf0FF7SVqUCzvkIO01G2mZhCOnkZZhZ9c4uNOcE2VjSHNxHv2WU0l7d8rdhyKhmet+A=="
+    },
+    "@lumino/collections": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lumino/collections/-/collections-1.2.3.tgz",
+      "integrity": "sha512-lrSTb7kru/w8xww8qWqHHhHO3GkoQeXST2oNkOEbWNEO4wuBIHoKPSOmXpUwu58UykBUfd5hL5wbkeTzyNMONg==",
+      "requires": {
+        "@lumino/algorithm": "^1.2.3"
+      }
+    },
+    "@lumino/commands": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-1.10.1.tgz",
+      "integrity": "sha512-HGtXtqKD1WZJszJ42u2DyM3sgxrLal66IoHSJjbn2ygcEVCKDK73NSzoaQtXFtiissMedzKl8aIRXB3uyeEOlw==",
+      "requires": {
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/domutils": "^1.1.7",
+        "@lumino/keyboard": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/virtualdom": "^1.6.1"
+      }
+    },
+    "@lumino/coreutils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-1.4.2.tgz",
+      "integrity": "sha512-SmQ4YDANe25rZd0bLoW7LVAHmgySjkrJmyNPnPW0GrpBt2u4/6D+EQJ8PCCMNWuJvrljBCdlmgOFsT38qYhfcw=="
+    },
+    "@lumino/disposable": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@lumino/disposable/-/disposable-1.3.5.tgz",
+      "integrity": "sha512-IWDAd+nysBnwLhEtW7M62PVk84OEex9OEktZsS6V+19n/o8/Rw4ccL0pt0GFby01CsVK0YcELDoDaMUZsMiAmA==",
+      "requires": {
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/signaling": "^1.3.5"
+      }
+    },
+    "@lumino/domutils": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@lumino/domutils/-/domutils-1.1.7.tgz",
+      "integrity": "sha512-NPysY8XfpCvLNvDe+z1caIUPxOLXWRPQMUAjOj/EhggRyXadan6Lm/5uO6M9S5gW/v9QUXT4+1Sxe3WXz0nRCA=="
+    },
+    "@lumino/dragdrop": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lumino/dragdrop/-/dragdrop-1.5.1.tgz",
+      "integrity": "sha512-MFg/hy6hHdPwBZypBue5mlrBzjoNrtBQzzJW+kbM5ftAOvS99ZRgyMMlMQcbsHd+6yib9NOQ64Hd8P8uZEWTdw==",
+      "requires": {
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5"
+      }
+    },
+    "@lumino/keyboard": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-1.1.6.tgz",
+      "integrity": "sha512-W6pqe0TXRfGOoz1ZK1PRmuGZUWpmdoJArrzwmduUf0t2r06yl56S7w76gxrB7ExTidNPPaOWydGIosPgdgZf5A=="
+    },
+    "@lumino/messaging": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@lumino/messaging/-/messaging-1.3.3.tgz",
+      "integrity": "sha512-J+0m1aywl64I9/dr9fzE9IwC+eq90T5gUi1hCXP1MFnZh4aLUymmRV5zFw1CNh/vYlNnEu72xxEuhfCfuhiy8g==",
+      "requires": {
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/collections": "^1.2.3"
+      }
+    },
+    "@lumino/properties": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lumino/properties/-/properties-1.1.6.tgz",
+      "integrity": "sha512-QnZa1IB7sr4Tawf0OKvwgZAptxDRK7DUAMJ71zijXNXH4FlxyThzOWXef51HHFsISKYa8Rn3rysOwtc62XkmXw=="
+    },
+    "@lumino/signaling": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-1.3.5.tgz",
+      "integrity": "sha512-6jniKrLrJOXKJmaJyU7hr6PBzE4GJ5Wms5hc/yzNKKDBxGSEPdtNJlW3wTNUuSTTtF/9ItN8A8ZC/G0yIu53Tw==",
+      "requires": {
+        "@lumino/algorithm": "^1.2.3"
+      }
+    },
+    "@lumino/virtualdom": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-1.6.1.tgz",
+      "integrity": "sha512-+KdzSw8TCPwvK6qhZr4xTyp6HymvEb2Da0xPdi4RsVUNhYf2gBI03uidXHx76Vx5OIbEgCn1B+0srxvm2ZbWsQ==",
+      "requires": {
+        "@lumino/algorithm": "^1.2.3"
+      }
+    },
+    "@lumino/widgets": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@lumino/widgets/-/widgets-1.11.1.tgz",
+      "integrity": "sha512-f4QDe6lVNPcjL8Vb20BiP0gzbT1rx0/1Hc719u5oW9c0Z/xrXMWwNhnb/zYM/kBBVBe3omLmCfJOiNuE0oZl0A==",
+      "requires": {
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/domutils": "^1.1.7",
+        "@lumino/dragdrop": "^1.5.1",
+        "@lumino/keyboard": "^1.1.6",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/virtualdom": "^1.6.1"
       }
     },
     "@mapbox/geojson-area": {
@@ -52,9 +160,9 @@
       "integrity": "sha512-b+1uPWBERW4Pet/969BNu61ZPDyH2ilIxBjJDFzxyS9TyszF9UrTQyYIl/G38clux3rtpAGGFSGTCSF/qR6UjA==",
       "requires": {
         "@mapbox/geojson-area": "0.2.2",
-        "concat-stream": "1.6.2",
+        "concat-stream": "~1.6.0",
         "minimist": "1.2.0",
-        "sharkdown": "0.1.1"
+        "sharkdown": "^0.1.0"
       }
     },
     "@mapbox/geojson-types": {
@@ -92,7 +200,7 @@
       "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
       "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
       "requires": {
-        "@mapbox/point-geometry": "0.1.0"
+        "@mapbox/point-geometry": "~0.1.0"
       }
     },
     "@mapbox/whoots-js": {
@@ -100,121 +208,14 @@
       "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
     },
-    "@phosphor/algorithm": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.1.3.tgz",
-      "integrity": "sha512-+dkdYTBglR+qGnLVQdCvYojNZMGxf+xSl1Jeksha3pm7niQktSFz2aR5gEPu/nI5LM8T8slTpqE4Pjvq8P+IVA=="
-    },
-    "@phosphor/collections": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.1.3.tgz",
-      "integrity": "sha512-J2U1xd2e5LtqoOJt4kynrjDNeHhVpJjuY2/zA0InS5kyOuWmvy79pt/KJ22n0LBNcU/fjkImqtQmbrC2Z4q2xQ==",
-      "requires": {
-        "@phosphor/algorithm": "1.1.3"
-      }
-    },
-    "@phosphor/commands": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/commands/-/commands-1.6.3.tgz",
-      "integrity": "sha512-PYNHWv6tbXAfAtKiqXuT0OBJvwbJ+RRTV60MBykMF7Vqz9UaZ9n2e/eB2EAGEFccF0PnjTCvBEZgarwwMVi8Hg==",
-      "requires": {
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/domutils": "1.1.3",
-        "@phosphor/keyboard": "1.1.3",
-        "@phosphor/signaling": "1.2.3"
-      }
-    },
-    "@phosphor/coreutils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@phosphor/coreutils/-/coreutils-1.3.1.tgz",
-      "integrity": "sha512-9OHCn8LYRcPU/sbHm5v7viCA16Uev3gbdkwqoQqlV+EiauDHl70jmeL7XVDXdigl66Dz0LI11C99XOxp+s3zOA=="
-    },
-    "@phosphor/disposable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@phosphor/disposable/-/disposable-1.2.0.tgz",
-      "integrity": "sha512-4PoWoffdrLyWOW5Qv7I8//owvZmv57YhaxetAMWeJl13ThXc901RprL0Gxhtue2ZxL2PtUjM1207HndKo2FVjA==",
-      "requires": {
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/signaling": "1.2.3"
-      }
-    },
-    "@phosphor/domutils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/domutils/-/domutils-1.1.3.tgz",
-      "integrity": "sha512-5CtLAhURQXXHhNXfQydDk/luG1cDVnhlu/qw7gz8/9pht0KXIAmNg/M0LKxx2oJ9+YMNCLVWxAnHAU0yrDpWSA=="
-    },
-    "@phosphor/dragdrop": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/dragdrop/-/dragdrop-1.3.3.tgz",
-      "integrity": "sha512-+SrlGsVQwY8OHCWxE/Zvihpk6Rc6bytJDqOUUTZqdL8hvM9QZeopAFioPDxuo1pTj87Um6cR4ekvbTU4KZ/90w==",
-      "requires": {
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0"
-      }
-    },
-    "@phosphor/keyboard": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/keyboard/-/keyboard-1.1.3.tgz",
-      "integrity": "sha512-dzxC/PyHiD6mXaESRy6PZTd9JeK+diwG1pyngkyUf127IXOEzubTIbu52VSdpGBklszu33ws05BAGDa4oBE4mQ=="
-    },
-    "@phosphor/messaging": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.2.3.tgz",
-      "integrity": "sha512-89Ps4uSRNOEQoepB/0SDoyPpNUWd6VZnmbMetmeXZJHsuJ1GLxtnq3WBdl7UCVNsw3W9NC610pWaDCy/BafRlg==",
-      "requires": {
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/collections": "1.1.3"
-      }
-    },
-    "@phosphor/properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/properties/-/properties-1.1.3.tgz",
-      "integrity": "sha512-GiglqzU77s6+tFVt6zPq9uuyu/PLQPFcqZt914ZhJ4cN/7yNI/SLyMzpYZ56IRMXvzK9TUgbRna6URE3XAwFUg=="
-    },
-    "@phosphor/signaling": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.2.3.tgz",
-      "integrity": "sha512-DMwS0m9OgfY5ljpTsklRQPUQpTyg4obz85FyImRDacUVxUVbas95djIDEbU4s1TMzdHBBO+gfki3V4giXUvXzw==",
-      "requires": {
-        "@phosphor/algorithm": "1.1.3"
-      }
-    },
-    "@phosphor/virtualdom": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/virtualdom/-/virtualdom-1.1.3.tgz",
-      "integrity": "sha512-V8PHhhnZCRa5esrC4q5VthqlLtxTo9ZV1mZ6b4YEloapca1S1nggZSQhrSlltXQjtYNUaWJZUZ/BlFD8wFtIEQ==",
-      "requires": {
-        "@phosphor/algorithm": "1.1.3"
-      }
-    },
-    "@phosphor/widgets": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@phosphor/widgets/-/widgets-1.8.1.tgz",
-      "integrity": "sha512-OY5T0nAioYTitPks/lCHm7a6QpjRB/XviIT2j6WtYm5J1U8MluIPpClqZ/NQbZfm23BYpmJeiQQyZA+5YphsDA==",
-      "requires": {
-        "@phosphor/algorithm": "1.1.3",
-        "@phosphor/commands": "1.6.3",
-        "@phosphor/coreutils": "1.3.1",
-        "@phosphor/disposable": "1.2.0",
-        "@phosphor/domutils": "1.1.3",
-        "@phosphor/dragdrop": "1.3.3",
-        "@phosphor/keyboard": "1.1.3",
-        "@phosphor/messaging": "1.2.3",
-        "@phosphor/properties": "1.1.3",
-        "@phosphor/signaling": "1.2.3",
-        "@phosphor/virtualdom": "1.1.3"
-      }
-    },
     "@plotly/d3-sankey": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
       "integrity": "sha512-2jdVos1N3mMp3QW0k2q1ph7Gd6j5PY1YihBrwpkFnKqO+cqtZq3AdEYUeSGXMeLsBDQYiqTVcihYfk8vr5tqhw==",
       "requires": {
-        "d3-array": "1.2.4",
-        "d3-collection": "1.0.7",
-        "d3-shape": "1.3.7"
+        "d3-array": "1",
+        "d3-collection": "1",
+        "d3-shape": "^1.2.0"
       }
     },
     "@plotly/d3-sankey-circular": {
@@ -222,10 +223,10 @@
       "resolved": "https://registry.npmjs.org/@plotly/d3-sankey-circular/-/d3-sankey-circular-0.33.1.tgz",
       "integrity": "sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==",
       "requires": {
-        "d3-array": "1.2.4",
-        "d3-collection": "1.0.7",
-        "d3-shape": "1.3.7",
-        "elementary-circuits-directed-graph": "1.0.4"
+        "d3-array": "^1.2.1",
+        "d3-collection": "^1.0.4",
+        "d3-shape": "^1.2.0",
+        "elementary-circuits-directed-graph": "^1.0.4"
       }
     },
     "@turf/area": {
@@ -233,8 +234,8 @@
       "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.0.1.tgz",
       "integrity": "sha512-Zv+3N1ep9P5JvR0YOYagLANyapGWQBh8atdeR3bKpWcigVXFsEKNUw03U/5xnh+cKzm7yozHD6MFJkqQv55y0g==",
       "requires": {
-        "@turf/helpers": "6.1.4",
-        "@turf/meta": "6.0.2"
+        "@turf/helpers": "6.x",
+        "@turf/meta": "6.x"
       }
     },
     "@turf/bbox": {
@@ -242,8 +243,8 @@
       "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.0.1.tgz",
       "integrity": "sha512-EGgaRLettBG25Iyx7VyUINsPpVj1x3nFQFiGS3ER8KCI1MximzNLsam3eXRabqQDjyAKyAE1bJ4EZEpGvspQxw==",
       "requires": {
-        "@turf/helpers": "6.1.4",
-        "@turf/meta": "6.0.2"
+        "@turf/helpers": "6.x",
+        "@turf/meta": "6.x"
       }
     },
     "@turf/centroid": {
@@ -251,8 +252,8 @@
       "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.0.2.tgz",
       "integrity": "sha512-auyDauOtC4eddH7GC3CHFTDu2PKhpSeKCRhwhHhXtJqn2dWCJQNIoCeJRmfXRIbzCWhWvgvQafvvhq8HNvmvWw==",
       "requires": {
-        "@turf/helpers": "6.1.4",
-        "@turf/meta": "6.0.2"
+        "@turf/helpers": "6.x",
+        "@turf/meta": "6.x"
       }
     },
     "@turf/helpers": {
@@ -265,7 +266,7 @@
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
       "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
       "requires": {
-        "@turf/helpers": "6.1.4"
+        "@turf/helpers": "6.x"
       }
     },
     "@types/d3": {
@@ -278,7 +279,7 @@
       "resolved": "https://registry.npmjs.org/@types/plotly.js/-/plotly.js-1.44.28.tgz",
       "integrity": "sha512-Ajvtn6QHjLMZfRySd0L7f17ONKxiYpZSzW29sx/bU9KL/pzbu+pXdfNika9n+W0G1ScLEJEtI2yBsZXT1UXDKA==",
       "requires": {
-        "@types/d3": "3.5.43"
+        "@types/d3": "^3"
       }
     },
     "a-big-triangle": {
@@ -286,9 +287,9 @@
       "resolved": "https://registry.npmjs.org/a-big-triangle/-/a-big-triangle-1.0.3.tgz",
       "integrity": "sha1-7v0wsCqPUl6LH3K7a7GwwWdRx5Q=",
       "requires": {
-        "gl-buffer": "2.1.2",
-        "gl-vao": "1.3.0",
-        "weak-map": "1.0.5"
+        "gl-buffer": "^2.1.1",
+        "gl-vao": "^1.2.0",
+        "weak-map": "^1.0.5"
       }
     },
     "abs-svg-path": {
@@ -316,7 +317,7 @@
       "resolved": "https://registry.npmjs.org/add-line-numbers/-/add-line-numbers-1.0.1.tgz",
       "integrity": "sha1-SNu96kfb0jTer+rGyTzqb3C0t+M=",
       "requires": {
-        "pad-left": "1.0.2"
+        "pad-left": "^1.0.2"
       }
     },
     "affine-hull": {
@@ -324,7 +325,7 @@
       "resolved": "https://registry.npmjs.org/affine-hull/-/affine-hull-1.0.0.tgz",
       "integrity": "sha1-dj/x040GPOt+Jy8X7k17vK+QXF0=",
       "requires": {
-        "robust-orientation": "1.1.3"
+        "robust-orientation": "^1.1.3"
       }
     },
     "align-text": {
@@ -332,9 +333,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "almost-equal": {
@@ -347,8 +348,8 @@
       "resolved": "https://registry.npmjs.org/alpha-complex/-/alpha-complex-1.0.0.tgz",
       "integrity": "sha1-kIZYcNawVCrnPAwTHU75iWabctI=",
       "requires": {
-        "circumradius": "1.0.0",
-        "delaunay-triangulate": "1.1.6"
+        "circumradius": "^1.0.0",
+        "delaunay-triangulate": "^1.1.6"
       }
     },
     "alpha-shape": {
@@ -356,8 +357,8 @@
       "resolved": "https://registry.npmjs.org/alpha-shape/-/alpha-shape-1.0.0.tgz",
       "integrity": "sha1-yDEJkj7P2mZ9IWP+Tyb+JHJvZKk=",
       "requires": {
-        "alpha-complex": "1.0.0",
-        "simplicial-complex-boundary": "1.0.1"
+        "alpha-complex": "^1.0.0",
+        "simplicial-complex-boundary": "^1.0.0"
       }
     },
     "amdefine": {
@@ -371,7 +372,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "ansicolors": {
@@ -394,7 +395,7 @@
       "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.4.tgz",
       "integrity": "sha512-fCp0wKFLjvSPmCn4F5Tiw4M3lpMZoHlCjfcs7nNzuj3vqQQ1/a8cgB9DXcpDSn18c+coLnaW7rqfcYCvKbyJXg==",
       "requires": {
-        "array-bounds": "1.0.1"
+        "array-bounds": "^1.0.0"
       }
     },
     "array-range": {
@@ -422,7 +423,7 @@
       "resolved": "https://registry.npmjs.org/barycentric/-/barycentric-1.0.1.tgz",
       "integrity": "sha1-8VYruJGyb0/sRjqC7to2V4AOxog=",
       "requires": {
-        "robust-linear-solve": "1.0.0"
+        "robust-linear-solve": "^1.0.0"
       }
     },
     "big-rat": {
@@ -430,9 +431,9 @@
       "resolved": "https://registry.npmjs.org/big-rat/-/big-rat-1.0.4.tgz",
       "integrity": "sha1-do0JO7V5MN0Y7Vdcf8on3FORreo=",
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "bn.js": "4.11.8",
-        "double-bits": "1.1.1"
+        "bit-twiddle": "^1.0.2",
+        "bn.js": "^4.11.6",
+        "double-bits": "^1.1.1"
       }
     },
     "binary-search-bounds": {
@@ -450,7 +451,7 @@
       "resolved": "https://registry.npmjs.org/bitmap-sdf/-/bitmap-sdf-1.0.3.tgz",
       "integrity": "sha512-ojYySSvWTx21cbgntR942zgEgqj38wHctN64vr4vYRFf3GKVmI23YlA94meWGkFslidwLwGCsMy2laJ3g/94Sg==",
       "requires": {
-        "clamp": "1.0.1"
+        "clamp": "^1.0.1"
       }
     },
     "bl": {
@@ -458,7 +459,7 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
       "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
       "requires": {
-        "readable-stream": "2.3.4"
+        "readable-stream": "^2.0.5"
       },
       "dependencies": {
         "isarray": {
@@ -471,13 +472,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
           "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -485,7 +486,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -500,7 +501,7 @@
       "resolved": "https://registry.npmjs.org/boundary-cells/-/boundary-cells-2.0.1.tgz",
       "integrity": "sha1-6QWo0UGc9Hyza+Pb9SXbXiTeAEI=",
       "requires": {
-        "tape": "4.13.0"
+        "tape": "^4.0.0"
       }
     },
     "box-intersect": {
@@ -508,8 +509,8 @@
       "resolved": "https://registry.npmjs.org/box-intersect/-/box-intersect-1.0.2.tgz",
       "integrity": "sha512-yJeMwlmFPG1gIa7Rs/cGXeI6iOj6Qz5MG5PE61xLKpElUGzmJ4abm+qsLpzxKJFpsSDq742BQEocr8dI2t8Nxw==",
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "typedarray-pool": "1.2.0"
+        "bit-twiddle": "^1.0.2",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "brace-expansion": {
@@ -517,7 +518,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -526,14 +527,14 @@
       "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.8.tgz",
       "integrity": "sha512-IoGZzrUTY5fKXVkgGHw3QeXFMUNBFv+9l8a4QJKG1JhG3nCMHTdEX1DCOg8568E2Q9qvAQIiSokv6Jsgx8p2cA==",
       "requires": {
-        "acorn": "6.4.0",
-        "acorn-dynamic-import": "4.0.0",
-        "acorn-jsx": "5.1.0",
-        "chalk": "2.4.2",
-        "magic-string": "0.25.6",
-        "minimist": "1.2.0",
-        "os-homedir": "2.0.0",
-        "regexpu-core": "4.6.0"
+        "acorn": "^6.1.1",
+        "acorn-dynamic-import": "^4.0.0",
+        "acorn-jsx": "^5.0.1",
+        "chalk": "^2.4.2",
+        "magic-string": "^0.25.3",
+        "minimist": "^1.2.0",
+        "os-homedir": "^2.0.0",
+        "regexpu-core": "^4.5.4"
       },
       "dependencies": {
         "acorn": {
@@ -548,7 +549,7 @@
       "resolved": "https://registry.npmjs.org/bubleify/-/bubleify-1.2.1.tgz",
       "integrity": "sha512-vp3NHmaQVoKaKWvi15FTMinPNjfp+47+/kFJ9ifezdMF/CBLArCxDVUh+FQE3qRxCRj1qyjJqilTBHHqlM8MaQ==",
       "requires": {
-        "buble": "0.19.8"
+        "buble": "^0.19.3"
       }
     },
     "buffer-from": {
@@ -572,7 +573,7 @@
       "resolved": "https://registry.npmjs.org/canvas-fit/-/canvas-fit-1.5.0.tgz",
       "integrity": "sha1-rhO+Zq3kL1vg5IfjRfzjCl5bXl8=",
       "requires": {
-        "element-size": "1.1.1"
+        "element-size": "^1.1.1"
       }
     },
     "cardinal": {
@@ -580,8 +581,8 @@
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
       "integrity": "sha1-ylu2iltRG5D+k7ms6km97lwyv+I=",
       "requires": {
-        "ansicolors": "0.2.1",
-        "redeyed": "0.4.4"
+        "ansicolors": "~0.2.1",
+        "redeyed": "~0.4.0"
       }
     },
     "cdt2d": {
@@ -589,9 +590,9 @@
       "resolved": "https://registry.npmjs.org/cdt2d/-/cdt2d-1.0.0.tgz",
       "integrity": "sha1-TyEkNLzWe9s9aLj+9KzcLFRBUUE=",
       "requires": {
-        "binary-search-bounds": "2.0.4",
-        "robust-in-sphere": "1.1.3",
-        "robust-orientation": "1.1.3"
+        "binary-search-bounds": "^2.0.3",
+        "robust-in-sphere": "^1.1.3",
+        "robust-orientation": "^1.1.3"
       }
     },
     "cell-orientation": {
@@ -604,8 +605,8 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -613,9 +614,9 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "circumcenter": {
@@ -623,8 +624,8 @@
       "resolved": "https://registry.npmjs.org/circumcenter/-/circumcenter-1.0.0.tgz",
       "integrity": "sha1-INeqE7F/usUvUtpPVMasi5Bu5Sk=",
       "requires": {
-        "dup": "1.0.0",
-        "robust-linear-solve": "1.0.0"
+        "dup": "^1.0.0",
+        "robust-linear-solve": "^1.0.0"
       }
     },
     "circumradius": {
@@ -632,7 +633,7 @@
       "resolved": "https://registry.npmjs.org/circumradius/-/circumradius-1.0.0.tgz",
       "integrity": "sha1-cGxEfj5VzR7T0RvRM+N8JSzDBbU=",
       "requires": {
-        "circumcenter": "1.0.0"
+        "circumcenter": "^1.0.0"
       }
     },
     "clamp": {
@@ -645,13 +646,13 @@
       "resolved": "https://registry.npmjs.org/clean-pslg/-/clean-pslg-1.1.2.tgz",
       "integrity": "sha1-vTXHRgt+irWp92Gl7VF5aqPIbBE=",
       "requires": {
-        "big-rat": "1.0.4",
-        "box-intersect": "1.0.2",
-        "nextafter": "1.0.0",
-        "rat-vec": "1.1.1",
-        "robust-segment-intersect": "1.0.1",
-        "union-find": "1.0.2",
-        "uniq": "1.0.1"
+        "big-rat": "^1.0.3",
+        "box-intersect": "^1.0.1",
+        "nextafter": "^1.0.0",
+        "rat-vec": "^1.1.1",
+        "robust-segment-intersect": "^1.0.1",
+        "union-find": "^1.0.2",
+        "uniq": "^1.0.1"
       }
     },
     "cliui": {
@@ -659,8 +660,8 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       }
     },
@@ -669,7 +670,7 @@
       "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.4.tgz",
       "integrity": "sha512-lr8/t5NPozTSqli+duAN+x+no/2WaKTeWvxhHGN+aXT6AJ8vPlzLa7UriyjWak0pSC2jHol9JgjBYnnHsGha9A==",
       "requires": {
-        "color-parse": "1.3.8"
+        "color-parse": "^1.3.8"
       }
     },
     "color-convert": {
@@ -692,7 +693,7 @@
       "resolved": "https://registry.npmjs.org/color-id/-/color-id-1.1.0.tgz",
       "integrity": "sha512-2iRtAn6dC/6/G7bBIo0uupVrIne1NsQJvJxZOBCzQOfk7jRq97feaDZ3RdzuHakRXXnHGNwglto3pqtRx1sX0g==",
       "requires": {
-        "clamp": "1.0.1"
+        "clamp": "^1.0.1"
       }
     },
     "color-name": {
@@ -705,9 +706,9 @@
       "resolved": "https://registry.npmjs.org/color-normalize/-/color-normalize-1.5.0.tgz",
       "integrity": "sha512-rUT/HDXMr6RFffrR53oX3HGWkDOP9goSAQGBkUaAYKjOE2JxozccdGyufageWDlInRAjm/jYPrf/Y38oa+7obw==",
       "requires": {
-        "clamp": "1.0.1",
-        "color-rgba": "2.1.1",
-        "dtype": "2.0.0"
+        "clamp": "^1.0.1",
+        "color-rgba": "^2.1.1",
+        "dtype": "^2.0.0"
       }
     },
     "color-parse": {
@@ -715,9 +716,9 @@
       "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.8.tgz",
       "integrity": "sha512-1Y79qFv0n1xair3lNMTNeoFvmc3nirMVBij24zbs1f13+7fPpQClMg5b4AuKXLt3szj7BRlHMCXHplkce6XlmA==",
       "requires": {
-        "color-name": "1.1.4",
-        "defined": "1.0.0",
-        "is-plain-obj": "1.1.0"
+        "color-name": "^1.0.0",
+        "defined": "^1.0.0",
+        "is-plain-obj": "^1.1.0"
       }
     },
     "color-rgba": {
@@ -725,9 +726,9 @@
       "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.1.1.tgz",
       "integrity": "sha512-VaX97wsqrMwLSOR6H7rU1Doa2zyVdmShabKrPEIFywLlHoibgD3QW9Dw6fSqM4+H/LfjprDNAUUW31qEQcGzNw==",
       "requires": {
-        "clamp": "1.0.1",
-        "color-parse": "1.3.8",
-        "color-space": "1.16.0"
+        "clamp": "^1.0.1",
+        "color-parse": "^1.3.8",
+        "color-space": "^1.14.6"
       }
     },
     "color-space": {
@@ -735,8 +736,8 @@
       "resolved": "https://registry.npmjs.org/color-space/-/color-space-1.16.0.tgz",
       "integrity": "sha512-A6WMiFzunQ8KEPFmj02OnnoUnqhmSaHaZ/0LVFcPTdlvm8+3aMJ5x1HRHy3bDHPkovkf4sS0f4wsVvwk71fKkg==",
       "requires": {
-        "hsluv": "0.0.3",
-        "mumath": "3.3.4"
+        "hsluv": "^0.0.3",
+        "mumath": "^3.3.4"
       }
     },
     "colormap": {
@@ -744,7 +745,7 @@
       "resolved": "https://registry.npmjs.org/colormap/-/colormap-2.3.1.tgz",
       "integrity": "sha512-TEzNlo/qYp6pBoR2SK9JiV+DG1cmUcVO/+DEJqVPSHIKNlWh5L5L4FYog7b/h0bAnhKhpOAvx/c1dFp2QE9sFw==",
       "requires": {
-        "lerp": "1.0.3"
+        "lerp": "^1.0.3"
       }
     },
     "colors": {
@@ -763,11 +764,11 @@
       "resolved": "https://registry.npmjs.org/compare-angle/-/compare-angle-1.0.1.tgz",
       "integrity": "sha1-pOtjQW6jx0f8a9bItjZotN5PoSk=",
       "requires": {
-        "robust-orientation": "1.1.3",
-        "robust-product": "1.0.0",
-        "robust-sum": "1.0.0",
-        "signum": "0.0.0",
-        "two-sum": "1.0.0"
+        "robust-orientation": "^1.0.2",
+        "robust-product": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "signum": "^0.0.0",
+        "two-sum": "^1.0.0"
       }
     },
     "compare-cell": {
@@ -780,8 +781,8 @@
       "resolved": "https://registry.npmjs.org/compare-oriented-cell/-/compare-oriented-cell-1.0.1.tgz",
       "integrity": "sha1-ahSf7vnfxPj8YjWOUd1C7/u9w54=",
       "requires": {
-        "cell-orientation": "1.0.1",
-        "compare-cell": "1.0.0"
+        "cell-orientation": "^1.0.1",
+        "compare-cell": "^1.0.0"
       }
     },
     "compute-dims": {
@@ -789,11 +790,11 @@
       "resolved": "https://registry.npmjs.org/compute-dims/-/compute-dims-1.1.0.tgz",
       "integrity": "sha512-YHMiIKjH/8Eom8zATk3g8/lH3HxGCZcVQyEfEoVrfWI7od/WRpTgRGShnei3jArYSx77mQqPxZNokjGHCdLfxg==",
       "requires": {
-        "utils-copy": "1.1.1",
-        "validate.io-array": "1.0.6",
-        "validate.io-matrix-like": "1.0.2",
-        "validate.io-ndarray-like": "1.0.0",
-        "validate.io-positive-integer": "1.0.0"
+        "utils-copy": "^1.0.0",
+        "validate.io-array": "^1.0.6",
+        "validate.io-matrix-like": "^1.0.2",
+        "validate.io-ndarray-like": "^1.0.0",
+        "validate.io-positive-integer": "^1.0.0"
       }
     },
     "concat-map": {
@@ -806,10 +807,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.7",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       },
       "dependencies": {
         "isarray": {
@@ -822,13 +823,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -836,7 +837,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -856,9 +857,9 @@
       "resolved": "https://registry.npmjs.org/convex-hull/-/convex-hull-1.0.3.tgz",
       "integrity": "sha1-IKOqbOh/St6i/30XlxyfwcZ+H/8=",
       "requires": {
-        "affine-hull": "1.0.0",
-        "incremental-convex-hull": "1.0.1",
-        "monotone-convex-hull-2d": "1.0.1"
+        "affine-hull": "^1.0.0",
+        "incremental-convex-hull": "^1.0.1",
+        "monotone-convex-hull-2d": "^1.0.1"
       }
     },
     "core-util-is": {
@@ -876,15 +877,15 @@
       "resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
       "integrity": "sha512-V4U4Wps4dPDACJ4WpgofJ2RT5Yqwe1lEH6wlOOaIxMi0gTjdIijsc5FmxQlZ7ZZyKQkkutqqvULOp07l9c7ssA==",
       "requires": {
-        "css-font-size-keywords": "1.0.0",
-        "css-font-stretch-keywords": "1.0.1",
-        "css-font-style-keywords": "1.0.1",
-        "css-font-weight-keywords": "1.0.0",
-        "css-global-keywords": "1.0.1",
-        "css-system-font-keywords": "1.0.0",
-        "pick-by-alias": "1.2.0",
-        "string-split-by": "1.0.0",
-        "unquote": "1.1.1"
+        "css-font-size-keywords": "^1.0.0",
+        "css-font-stretch-keywords": "^1.0.1",
+        "css-font-style-keywords": "^1.0.1",
+        "css-font-weight-keywords": "^1.0.0",
+        "css-global-keywords": "^1.0.1",
+        "css-system-font-keywords": "^1.0.0",
+        "pick-by-alias": "^1.2.0",
+        "string-split-by": "^1.0.0",
+        "unquote": "^1.1.0"
       }
     },
     "css-font-size-keywords": {
@@ -932,10 +933,10 @@
       "resolved": "https://registry.npmjs.org/cwise/-/cwise-1.0.10.tgz",
       "integrity": "sha1-JO7mBy69/WuMb12tsXCQtkmxK+8=",
       "requires": {
-        "cwise-compiler": "1.1.3",
-        "cwise-parser": "1.0.3",
-        "static-module": "1.5.0",
-        "uglify-js": "2.8.29"
+        "cwise-compiler": "^1.1.1",
+        "cwise-parser": "^1.0.0",
+        "static-module": "^1.0.0",
+        "uglify-js": "^2.6.0"
       }
     },
     "cwise-compiler": {
@@ -943,7 +944,7 @@
       "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
       "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
       "requires": {
-        "uniq": "1.0.1"
+        "uniq": "^1.0.0"
       }
     },
     "cwise-parser": {
@@ -951,8 +952,8 @@
       "resolved": "https://registry.npmjs.org/cwise-parser/-/cwise-parser-1.0.3.tgz",
       "integrity": "sha1-jkk8F9VPl8sDCp6YVLyGyd+zVP4=",
       "requires": {
-        "esprima": "1.2.5",
-        "uniq": "1.0.1"
+        "esprima": "^1.0.3",
+        "uniq": "^1.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -967,8 +968,8 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
       "requires": {
-        "es5-ext": "0.10.53",
-        "type": "1.2.0"
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
       }
     },
     "d3": {
@@ -1001,10 +1002,10 @@
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
       "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
       "requires": {
-        "d3-collection": "1.0.7",
-        "d3-dispatch": "1.0.6",
-        "d3-quadtree": "1.0.7",
-        "d3-timer": "1.0.10"
+        "d3-collection": "1",
+        "d3-dispatch": "1",
+        "d3-quadtree": "1",
+        "d3-timer": "1"
       }
     },
     "d3-hierarchy": {
@@ -1017,7 +1018,7 @@
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
       "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
       "requires": {
-        "d3-color": "1.4.0"
+        "d3-color": "1"
       }
     },
     "d3-path": {
@@ -1035,7 +1036,7 @@
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
       "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
       "requires": {
-        "d3-path": "1.0.9"
+        "d3-path": "1"
       }
     },
     "d3-timer": {
@@ -1053,12 +1054,12 @@
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
       "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
       "requires": {
-        "is-arguments": "1.0.4",
-        "is-date-object": "1.0.2",
-        "is-regex": "1.0.5",
-        "object-is": "1.0.2",
-        "object-keys": "1.1.1",
-        "regexp.prototype.flags": "1.3.0"
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
       }
     },
     "deep-is": {
@@ -1071,7 +1072,7 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "requires": {
-        "object-keys": "1.1.1"
+        "object-keys": "^1.0.12"
       }
     },
     "defined": {
@@ -1084,8 +1085,8 @@
       "resolved": "https://registry.npmjs.org/delaunay-triangulate/-/delaunay-triangulate-1.1.6.tgz",
       "integrity": "sha1-W7yiGweBmNS8PHV5ajXLuYwllUw=",
       "requires": {
-        "incremental-convex-hull": "1.0.1",
-        "uniq": "1.0.1"
+        "incremental-convex-hull": "^1.0.1",
+        "uniq": "^1.0.1"
       }
     },
     "detect-kerning": {
@@ -1098,7 +1099,7 @@
       "resolved": "https://registry.npmjs.org/dotignore/-/dotignore-0.1.2.tgz",
       "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
       "requires": {
-        "minimatch": "3.0.4"
+        "minimatch": "^3.0.4"
       }
     },
     "double-bits": {
@@ -1111,8 +1112,8 @@
       "resolved": "https://registry.npmjs.org/draw-svg-path/-/draw-svg-path-1.0.0.tgz",
       "integrity": "sha1-bxFtli3TFLmepTTW9Y3WbNvWk3k=",
       "requires": {
-        "abs-svg-path": "0.1.1",
-        "normalize-svg-path": "0.1.0"
+        "abs-svg-path": "~0.1.1",
+        "normalize-svg-path": "~0.1.0"
       }
     },
     "dtype": {
@@ -1130,7 +1131,7 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "~1.1.9"
       },
       "dependencies": {
         "readable-stream": {
@@ -1138,10 +1139,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         }
       }
@@ -1151,10 +1152,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "requires": {
-        "end-of-stream": "1.4.4",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.7",
-        "stream-shift": "1.0.1"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -1167,13 +1168,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -1181,7 +1182,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -1196,7 +1197,7 @@
       "resolved": "https://registry.npmjs.org/edges-to-adjacency-list/-/edges-to-adjacency-list-1.0.0.tgz",
       "integrity": "sha1-wUbS4ISt37p0pRKTxuAZmkn3V/E=",
       "requires": {
-        "uniq": "1.0.1"
+        "uniq": "^1.0.0"
       }
     },
     "element-size": {
@@ -1209,7 +1210,7 @@
       "resolved": "https://registry.npmjs.org/elementary-circuits-directed-graph/-/elementary-circuits-directed-graph-1.0.4.tgz",
       "integrity": "sha512-+xpVxSimU+fcHiTRPWrRN1IFOKaygwotCtZGSBle/rnFaFAoI+4Y8/pimAY1cKiDIHTek2Zox1R7SEQAB/AQ1g==",
       "requires": {
-        "strongly-connected-components": "1.0.1"
+        "strongly-connected-components": "^1.0.1"
       }
     },
     "end-of-stream": {
@@ -1217,7 +1218,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "es-abstract": {
@@ -1225,17 +1226,17 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.3.tgz",
       "integrity": "sha512-AwiVPKf3sKGMoWtFw0J7Y4MTZ4Iek67k4COWOwHqS8B9TOZ71DCfcoBmdamy8Y6mj4MDz0+VNUpC2HKHFHA3pg==",
       "requires": {
-        "es-to-primitive": "1.2.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "has-symbols": "1.0.1",
-        "is-callable": "1.1.5",
-        "is-regex": "1.0.5",
-        "object-inspect": "1.7.0",
-        "object-keys": "1.1.1",
-        "object.assign": "4.1.0",
-        "string.prototype.trimleft": "2.1.1",
-        "string.prototype.trimright": "2.1.1"
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
       }
     },
     "es-to-primitive": {
@@ -1243,9 +1244,9 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "requires": {
-        "is-callable": "1.1.5",
-        "is-date-object": "1.0.2",
-        "is-symbol": "1.0.3"
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "es5-ext": {
@@ -1253,9 +1254,9 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
       "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.3",
-        "next-tick": "1.0.0"
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.3",
+        "next-tick": "~1.0.0"
       }
     },
     "es6-iterator": {
@@ -1263,9 +1264,9 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
-        "d": "1.0.1",
-        "es5-ext": "0.10.53",
-        "es6-symbol": "3.1.3"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-promise": {
@@ -1278,8 +1279,8 @@
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
       "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
       "requires": {
-        "d": "1.0.1",
-        "ext": "1.4.0"
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
       }
     },
     "es6-weak-map": {
@@ -1287,10 +1288,10 @@
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
       "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
       "requires": {
-        "d": "1.0.1",
-        "es5-ext": "0.10.53",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.3"
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -1303,11 +1304,11 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.13.0.tgz",
       "integrity": "sha512-eYk2dCkxR07DsHA/X2hRBj0CFAZeri/LyDMc0C8JT1Hqi6JnVpMhJ7XFITbb0+yZS3lVkaPL2oCkZ3AVmeVbMw==",
       "requires": {
-        "esprima": "4.0.1",
-        "estraverse": "4.3.0",
-        "esutils": "2.0.3",
-        "optionator": "0.8.3",
-        "source-map": "0.6.1"
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       }
     },
     "esprima": {
@@ -1335,7 +1336,7 @@
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
       "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
       "requires": {
-        "type": "2.0.0"
+        "type": "^2.0.0"
       },
       "dependencies": {
         "type": {
@@ -1355,10 +1356,10 @@
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
       "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
       "requires": {
-        "acorn": "5.7.3",
-        "foreach": "2.0.5",
+        "acorn": "^5.0.0",
+        "foreach": "^2.0.5",
         "isarray": "0.0.1",
-        "object-keys": "1.1.1"
+        "object-keys": "^1.0.6"
       }
     },
     "fast-isnumeric": {
@@ -1366,7 +1367,7 @@
       "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.3.tgz",
       "integrity": "sha512-MdojHkfLx8pjRNZyGjOhX4HxNPaf0l5R/v5rGZ1bGXCnRPyQIUAe4I1H7QtrlUwuuiDHKdpQTjT3lmueVH2otw==",
       "requires": {
-        "is-string-blank": "1.0.1"
+        "is-string-blank": "^1.0.1"
       }
     },
     "fast-levenshtein": {
@@ -1379,8 +1380,8 @@
       "resolved": "https://registry.npmjs.org/filtered-vector/-/filtered-vector-1.2.4.tgz",
       "integrity": "sha1-VkU8A030MC0pPKjs3qw/kKvGeNM=",
       "requires": {
-        "binary-search-bounds": "1.0.0",
-        "cubic-hermite": "1.0.0"
+        "binary-search-bounds": "^1.0.0",
+        "cubic-hermite": "^1.0.0"
       },
       "dependencies": {
         "binary-search-bounds": {
@@ -1396,8 +1397,8 @@
       "integrity": "sha1-itkpozk7rGJ5V6fl3kYjsGsOLOs=",
       "dev": true,
       "requires": {
-        "colors": "0.6.2",
-        "commander": "2.1.0"
+        "colors": "~0.6.0-1",
+        "commander": "~2.1.0"
       }
     },
     "flatten-vertex-data": {
@@ -1405,7 +1406,7 @@
       "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.2.tgz",
       "integrity": "sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==",
       "requires": {
-        "dtype": "2.0.0"
+        "dtype": "^2.0.0"
       }
     },
     "flip-pixels": {
@@ -1418,7 +1419,7 @@
       "resolved": "https://registry.npmjs.org/font-atlas/-/font-atlas-2.1.0.tgz",
       "integrity": "sha512-kP3AmvX+HJpW4w3d+PiPR2X6E1yvsBXt2yhuCw+yReO9F1WYhvZwx3c95DGZGwg9xYzDGrgJYa885xmVA+28Cg==",
       "requires": {
-        "css-font": "1.2.0"
+        "css-font": "^1.0.0"
       }
     },
     "font-measure": {
@@ -1426,7 +1427,7 @@
       "resolved": "https://registry.npmjs.org/font-measure/-/font-measure-1.2.2.tgz",
       "integrity": "sha512-mRLEpdrWzKe9hbfaF3Qpr06TAjquuBVP5cHy4b3hyeNdjc9i0PO6HniGsX5vjL5OWv7+Bd++NiooNpT/s8BvIA==",
       "requires": {
-        "css-font": "1.2.0"
+        "css-font": "^1.2.0"
       }
     },
     "for-each": {
@@ -1434,7 +1435,7 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "requires": {
-        "is-callable": "1.1.5"
+        "is-callable": "^1.1.3"
       }
     },
     "foreach": {
@@ -1447,8 +1448,8 @@
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -1461,13 +1462,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
           "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -1475,7 +1476,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -1486,7 +1487,7 @@
       "integrity": "sha1-6vwWtl9uJxm81X/cGGkAWsEzLNY=",
       "dev": true,
       "requires": {
-        "from2": "2.3.0"
+        "from2": "^2.0.3"
       }
     },
     "fs.realpath": {
@@ -1524,19 +1525,19 @@
       "resolved": "https://registry.npmjs.org/gl-axes3d/-/gl-axes3d-1.5.2.tgz",
       "integrity": "sha512-47Cfh5KhUVRFtYXgufR4lGY5cyXH7SPgAlS1FlvTGK84spIYFCBMlOGUN3AdavGLGUOcXS4ml+tMM61cY6M3gg==",
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "dup": "1.0.0",
-        "extract-frustum-planes": "1.0.0",
-        "gl-buffer": "2.1.2",
-        "gl-mat4": "1.2.0",
-        "gl-shader": "4.2.1",
-        "gl-state": "1.0.0",
-        "gl-vao": "1.3.0",
-        "gl-vec4": "1.0.1",
-        "glslify": "7.0.0",
-        "robust-orientation": "1.1.3",
-        "split-polygon": "1.0.0",
-        "vectorize-text": "3.2.1"
+        "bit-twiddle": "^1.0.2",
+        "dup": "^1.0.0",
+        "extract-frustum-planes": "^1.0.0",
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
+        "gl-state": "^1.0.0",
+        "gl-vao": "^1.3.0",
+        "gl-vec4": "^1.0.1",
+        "glslify": "^7.0.0",
+        "robust-orientation": "^1.1.3",
+        "split-polygon": "^1.0.0",
+        "vectorize-text": "^3.2.1"
       }
     },
     "gl-buffer": {
@@ -1544,9 +1545,9 @@
       "resolved": "https://registry.npmjs.org/gl-buffer/-/gl-buffer-2.1.2.tgz",
       "integrity": "sha1-LbjZwaVSf7oM25EonCBuiCuInNs=",
       "requires": {
-        "ndarray": "1.0.19",
-        "ndarray-ops": "1.2.2",
-        "typedarray-pool": "1.2.0"
+        "ndarray": "^1.0.15",
+        "ndarray-ops": "^1.1.0",
+        "typedarray-pool": "^1.0.0"
       }
     },
     "gl-cone3d": {
@@ -1554,18 +1555,18 @@
       "resolved": "https://registry.npmjs.org/gl-cone3d/-/gl-cone3d-1.5.1.tgz",
       "integrity": "sha512-R8m2lPfVN5ip/IPzykvMNgUUGWTkp9rMuCrVknKIkhjH+gaQeGfwF3+WrB0kwq3FRWvlYWcfdvabv37sZ2rKYA==",
       "requires": {
-        "colormap": "2.3.1",
-        "gl-buffer": "2.1.2",
-        "gl-mat4": "1.2.0",
-        "gl-shader": "4.2.1",
-        "gl-texture2d": "2.1.0",
-        "gl-vao": "1.3.0",
-        "gl-vec3": "1.1.3",
-        "glsl-inverse": "1.0.0",
-        "glsl-out-of-range": "1.0.4",
-        "glsl-specular-cook-torrance": "2.0.1",
-        "glslify": "7.0.0",
-        "ndarray": "1.0.19"
+        "colormap": "^2.3.1",
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
+        "gl-texture2d": "^2.1.0",
+        "gl-vao": "^1.3.0",
+        "gl-vec3": "^1.1.3",
+        "glsl-inverse": "^1.0.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-cook-torrance": "^2.0.1",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.18"
       }
     },
     "gl-constants": {
@@ -1578,15 +1579,15 @@
       "resolved": "https://registry.npmjs.org/gl-contour2d/-/gl-contour2d-1.1.6.tgz",
       "integrity": "sha512-n8nEFb4VRYooBo3+hbAgiXGELVn7PtYyVbj/hWmTNtrkxFK39Yr8LUczcT2uOOyzqq7sO3FH8+J8PSMFh+z+5A==",
       "requires": {
-        "binary-search-bounds": "2.0.4",
-        "cdt2d": "1.0.0",
-        "clean-pslg": "1.1.2",
-        "gl-buffer": "2.1.2",
-        "gl-shader": "4.2.1",
-        "glslify": "7.0.0",
-        "iota-array": "1.0.0",
-        "ndarray": "1.0.19",
-        "surface-nets": "1.0.2"
+        "binary-search-bounds": "^2.0.4",
+        "cdt2d": "^1.0.0",
+        "clean-pslg": "^1.1.2",
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "glslify": "^7.0.0",
+        "iota-array": "^1.0.0",
+        "ndarray": "^1.0.18",
+        "surface-nets": "^1.0.2"
       }
     },
     "gl-error3d": {
@@ -1594,11 +1595,11 @@
       "resolved": "https://registry.npmjs.org/gl-error3d/-/gl-error3d-1.0.15.tgz",
       "integrity": "sha512-7mB1zU22Vzdvq0KzzYRzE0xvCRF9nHd1+9ElUqkvt0GMH0gVIpxKk+m3hNPM/iQHmNupcXaE1cBcOQE2agN3uA==",
       "requires": {
-        "gl-buffer": "2.1.2",
-        "gl-shader": "4.2.1",
-        "gl-vao": "1.3.0",
-        "glsl-out-of-range": "1.0.4",
-        "glslify": "7.0.0"
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "gl-vao": "^1.3.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glslify": "^7.0.0"
       }
     },
     "gl-fbo": {
@@ -1606,7 +1607,7 @@
       "resolved": "https://registry.npmjs.org/gl-fbo/-/gl-fbo-2.0.5.tgz",
       "integrity": "sha1-D6daSXz3h2lVMGkcjwSrtvtV+iI=",
       "requires": {
-        "gl-texture2d": "2.1.0"
+        "gl-texture2d": "^2.0.0"
       }
     },
     "gl-format-compiler-error": {
@@ -1614,10 +1615,10 @@
       "resolved": "https://registry.npmjs.org/gl-format-compiler-error/-/gl-format-compiler-error-1.0.3.tgz",
       "integrity": "sha1-DHmxdRiZzpcy6GJA8JCqQemEcag=",
       "requires": {
-        "add-line-numbers": "1.0.1",
-        "gl-constants": "1.0.0",
-        "glsl-shader-name": "1.0.0",
-        "sprintf-js": "1.1.2"
+        "add-line-numbers": "^1.0.1",
+        "gl-constants": "^1.0.0",
+        "glsl-shader-name": "^1.0.0",
+        "sprintf-js": "^1.0.3"
       }
     },
     "gl-heatmap2d": {
@@ -1625,12 +1626,12 @@
       "resolved": "https://registry.npmjs.org/gl-heatmap2d/-/gl-heatmap2d-1.0.5.tgz",
       "integrity": "sha512-nki9GIh0g4OXKNIrlnAT/gy/uXxkwrFKgI+XwRcUO6nLBM1WbI2hl8EPykNFXCqsyd08HJQbXKiqaHPW7cNpJg==",
       "requires": {
-        "binary-search-bounds": "2.0.4",
-        "gl-buffer": "2.1.2",
-        "gl-shader": "4.2.1",
-        "glslify": "7.0.0",
-        "iota-array": "1.0.0",
-        "typedarray-pool": "1.2.0"
+        "binary-search-bounds": "^2.0.3",
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.0.5",
+        "glslify": "^7.0.0",
+        "iota-array": "^1.0.0",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-line3d": {
@@ -1638,15 +1639,15 @@
       "resolved": "https://registry.npmjs.org/gl-line3d/-/gl-line3d-1.1.11.tgz",
       "integrity": "sha512-EitFKPEEYdn/ivFOxJ8khSi0BzNum4sXZFLq6SQq21MX5YPCYb0o+XzjpWNuU32BoXORBC78B1JTiQqnTaWhWQ==",
       "requires": {
-        "binary-search-bounds": "2.0.4",
-        "gl-buffer": "2.1.2",
-        "gl-shader": "4.2.1",
-        "gl-texture2d": "2.1.0",
-        "gl-vao": "1.3.0",
-        "glsl-out-of-range": "1.0.4",
-        "glsl-read-float": "1.1.0",
-        "glslify": "7.0.0",
-        "ndarray": "1.0.19"
+        "binary-search-bounds": "^2.0.4",
+        "gl-buffer": "^2.0.8",
+        "gl-shader": "^4.2.1",
+        "gl-texture2d": "^2.0.2",
+        "gl-vao": "^1.1.3",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-read-float": "^1.0.0",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.16"
       }
     },
     "gl-mat2": {
@@ -1674,9 +1675,9 @@
       "resolved": "https://registry.npmjs.org/gl-matrix-invert/-/gl-matrix-invert-1.0.0.tgz",
       "integrity": "sha1-o2173jZUxFkKEn7nxo9uE/6oxj0=",
       "requires": {
-        "gl-mat2": "1.0.1",
-        "gl-mat3": "1.0.0",
-        "gl-mat4": "1.2.0"
+        "gl-mat2": "^1.0.0",
+        "gl-mat3": "^1.0.0",
+        "gl-mat4": "^1.0.0"
       }
     },
     "gl-mesh3d": {
@@ -1684,21 +1685,21 @@
       "resolved": "https://registry.npmjs.org/gl-mesh3d/-/gl-mesh3d-2.2.0.tgz",
       "integrity": "sha512-wO6EKjBUo/k7ZLGsMACWGETjmjfsGwwoDWEKjDbjyjo1qPvgkTQQB9Y8p+OKGjE6GeihsfQuoqGBUTu9tiAOmg==",
       "requires": {
-        "barycentric": "1.0.1",
-        "colormap": "2.3.1",
-        "gl-buffer": "2.1.2",
-        "gl-mat4": "1.2.0",
-        "gl-shader": "4.2.1",
-        "gl-texture2d": "2.1.0",
-        "gl-vao": "1.3.0",
-        "glsl-out-of-range": "1.0.4",
-        "glsl-specular-cook-torrance": "2.0.1",
-        "glslify": "7.0.0",
-        "ndarray": "1.0.19",
-        "normals": "1.1.0",
-        "polytope-closest-point": "1.0.0",
-        "simplicial-complex-contour": "1.0.2",
-        "typedarray-pool": "1.2.0"
+        "barycentric": "^1.0.1",
+        "colormap": "^2.3.1",
+        "gl-buffer": "^2.0.8",
+        "gl-mat4": "^1.0.0",
+        "gl-shader": "^4.2.1",
+        "gl-texture2d": "^2.0.8",
+        "gl-vao": "^1.1.3",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-cook-torrance": "^2.0.1",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.15",
+        "normals": "^1.0.1",
+        "polytope-closest-point": "^1.0.0",
+        "simplicial-complex-contour": "^1.0.0",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-plot2d": {
@@ -1706,13 +1707,13 @@
       "resolved": "https://registry.npmjs.org/gl-plot2d/-/gl-plot2d-1.4.2.tgz",
       "integrity": "sha512-YLFiu/vgDCYZ/Qnz0wn0gV60IYCtImSnx0OTMsZ5fP1XZAhFztrRb2fJfnjfEVe15yZ+G+9zJ36RlWmJsNQYjQ==",
       "requires": {
-        "binary-search-bounds": "2.0.4",
-        "gl-buffer": "2.1.2",
-        "gl-select-static": "2.0.4",
-        "gl-shader": "4.2.1",
-        "glsl-inverse": "1.0.0",
-        "glslify": "7.0.0",
-        "text-cache": "4.2.1"
+        "binary-search-bounds": "^2.0.4",
+        "gl-buffer": "^2.1.2",
+        "gl-select-static": "^2.0.4",
+        "gl-shader": "^4.2.1",
+        "glsl-inverse": "^1.0.0",
+        "glslify": "^7.0.0",
+        "text-cache": "^4.2.1"
       }
     },
     "gl-plot3d": {
@@ -1720,22 +1721,22 @@
       "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-2.4.0.tgz",
       "integrity": "sha512-ZPs7gvWaCqK99GXoB0XJTMTLpChB/CiDUt3MthIawVlFhknSJLNPAJSbUU3f4pWzKCbbGtVARQr/i6XdM3MnKA==",
       "requires": {
-        "3d-view": "2.0.0",
-        "a-big-triangle": "1.0.3",
-        "gl-axes3d": "1.5.2",
-        "gl-fbo": "2.0.5",
-        "gl-mat4": "1.2.0",
-        "gl-select-static": "2.0.4",
-        "gl-shader": "4.2.1",
-        "gl-spikes3d": "1.0.9",
-        "glslify": "7.0.0",
-        "has-passive-events": "1.0.0",
-        "is-mobile": "2.1.0",
-        "mouse-change": "1.4.0",
-        "mouse-event-offset": "3.0.2",
-        "mouse-wheel": "1.2.0",
-        "ndarray": "1.0.19",
-        "right-now": "1.0.0"
+        "3d-view": "^2.0.0",
+        "a-big-triangle": "^1.0.3",
+        "gl-axes3d": "^1.5.2",
+        "gl-fbo": "^2.0.5",
+        "gl-mat4": "^1.2.0",
+        "gl-select-static": "^2.0.4",
+        "gl-shader": "^4.2.1",
+        "gl-spikes3d": "^1.0.9",
+        "glslify": "^7.0.0",
+        "has-passive-events": "^1.0.0",
+        "is-mobile": "^2.1.0",
+        "mouse-change": "^1.4.0",
+        "mouse-event-offset": "^3.0.2",
+        "mouse-wheel": "^1.2.0",
+        "ndarray": "^1.0.18",
+        "right-now": "^1.0.0"
       }
     },
     "gl-pointcloud2d": {
@@ -1743,10 +1744,10 @@
       "resolved": "https://registry.npmjs.org/gl-pointcloud2d/-/gl-pointcloud2d-1.0.2.tgz",
       "integrity": "sha512-KDfuJLg1dFWNPo6eJYgwUpNdVcIdK5y29ZiYpzzP0qh3eg0bSLMq8ZkaqvPmSJsFksUryT73IRunsuxJtTJkvA==",
       "requires": {
-        "gl-buffer": "2.1.2",
-        "gl-shader": "4.2.1",
-        "glslify": "7.0.0",
-        "typedarray-pool": "1.2.0"
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "glslify": "^7.0.0",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-quat": {
@@ -1754,9 +1755,9 @@
       "resolved": "https://registry.npmjs.org/gl-quat/-/gl-quat-1.0.0.tgz",
       "integrity": "sha1-CUXskjOG9FMpvl3DV7HIwtR1hsU=",
       "requires": {
-        "gl-mat3": "1.0.0",
-        "gl-vec3": "1.1.3",
-        "gl-vec4": "1.0.1"
+        "gl-mat3": "^1.0.0",
+        "gl-vec3": "^1.0.3",
+        "gl-vec4": "^1.0.0"
       }
     },
     "gl-scatter3d": {
@@ -1764,15 +1765,15 @@
       "resolved": "https://registry.npmjs.org/gl-scatter3d/-/gl-scatter3d-1.2.2.tgz",
       "integrity": "sha512-oZh3WQ0bVXnpASpZmYmiEp7eUiD0oU6J4G5C9KUOhUo5d2gucvZEILAtfWmzCT3zsOltoROn4jGuuP2tlLN88Q==",
       "requires": {
-        "gl-buffer": "2.1.2",
-        "gl-mat4": "1.2.0",
-        "gl-shader": "4.2.1",
-        "gl-vao": "1.3.0",
-        "glsl-out-of-range": "1.0.4",
-        "glslify": "7.0.0",
-        "is-string-blank": "1.0.1",
-        "typedarray-pool": "1.2.0",
-        "vectorize-text": "3.2.1"
+        "gl-buffer": "^2.0.6",
+        "gl-mat4": "^1.0.0",
+        "gl-shader": "^4.2.0",
+        "gl-vao": "^1.1.2",
+        "glsl-out-of-range": "^1.0.4",
+        "glslify": "^7.0.0",
+        "is-string-blank": "^1.0.1",
+        "typedarray-pool": "^1.0.2",
+        "vectorize-text": "^3.2.1"
       }
     },
     "gl-select-box": {
@@ -1780,9 +1781,9 @@
       "resolved": "https://registry.npmjs.org/gl-select-box/-/gl-select-box-1.0.3.tgz",
       "integrity": "sha512-sQb18g1aZ6PJAsvsC8nNYhuhc2TYXNbzVbI0bP9AH9770NjrDnd7TC8HHcfu8nJXGPG69HjqR6EzS+QSqiXPSA==",
       "requires": {
-        "gl-buffer": "2.1.2",
-        "gl-shader": "4.2.1",
-        "glslify": "7.0.0"
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.0.5",
+        "glslify": "^7.0.0"
       }
     },
     "gl-select-static": {
@@ -1790,11 +1791,11 @@
       "resolved": "https://registry.npmjs.org/gl-select-static/-/gl-select-static-2.0.4.tgz",
       "integrity": "sha512-4Kqx5VjeT8nmV+j6fry3UBFNL2B7ktQU4o508QGVPKWCILlV44rTDq3mnBFThup8rMIH9kJQx6xWsg9jTmfeMw==",
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "cwise": "1.0.10",
-        "gl-fbo": "2.0.5",
-        "ndarray": "1.0.19",
-        "typedarray-pool": "1.2.0"
+        "bit-twiddle": "^1.0.2",
+        "cwise": "^1.0.3",
+        "gl-fbo": "^2.0.3",
+        "ndarray": "^1.0.15",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-shader": {
@@ -1802,8 +1803,8 @@
       "resolved": "https://registry.npmjs.org/gl-shader/-/gl-shader-4.2.1.tgz",
       "integrity": "sha1-vJuAjpKTxRtmjojeYVsMETcI3C8=",
       "requires": {
-        "gl-format-compiler-error": "1.0.3",
-        "weakmap-shim": "1.1.1"
+        "gl-format-compiler-error": "^1.0.2",
+        "weakmap-shim": "^1.1.0"
       }
     },
     "gl-spikes2d": {
@@ -1816,10 +1817,10 @@
       "resolved": "https://registry.npmjs.org/gl-spikes3d/-/gl-spikes3d-1.0.9.tgz",
       "integrity": "sha512-laMxydgGdnE8kvd1YD9cNWrx0uSmrPj1Oi02cHhnxWIklut97w3F7mZKnmLMEyUkxpRLkEeQ7YkYy7Y+aUEblw==",
       "requires": {
-        "gl-buffer": "2.1.2",
-        "gl-shader": "4.2.1",
-        "gl-vao": "1.3.0",
-        "glslify": "7.0.0"
+        "gl-buffer": "^2.1.2",
+        "gl-shader": "^4.2.1",
+        "gl-vao": "^1.3.0",
+        "glslify": "^7.0.0"
       }
     },
     "gl-state": {
@@ -1827,7 +1828,7 @@
       "resolved": "https://registry.npmjs.org/gl-state/-/gl-state-1.0.0.tgz",
       "integrity": "sha1-Ji+qdYNbC5xTLBLzitxCXR0wzRc=",
       "requires": {
-        "uniq": "1.0.1"
+        "uniq": "^1.0.0"
       }
     },
     "gl-streamtube3d": {
@@ -1835,13 +1836,13 @@
       "resolved": "https://registry.npmjs.org/gl-streamtube3d/-/gl-streamtube3d-1.4.0.tgz",
       "integrity": "sha512-WgRtdB77uFCN1lBZ6ogz7VTK4J8WwW5DGHvyB3LaBSZF3t5lf/KWeXPgm+xnNINlOy4JqJIgny+CtzwTHAk3Ew==",
       "requires": {
-        "gl-cone3d": "1.5.1",
-        "gl-vec3": "1.1.3",
-        "gl-vec4": "1.0.1",
-        "glsl-inverse": "1.0.0",
-        "glsl-out-of-range": "1.0.4",
-        "glsl-specular-cook-torrance": "2.0.1",
-        "glslify": "7.0.0"
+        "gl-cone3d": "^1.5.0",
+        "gl-vec3": "^1.1.3",
+        "gl-vec4": "^1.0.1",
+        "glsl-inverse": "^1.0.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-cook-torrance": "^2.0.1",
+        "glslify": "^7.0.0"
       }
     },
     "gl-surface3d": {
@@ -1849,25 +1850,25 @@
       "resolved": "https://registry.npmjs.org/gl-surface3d/-/gl-surface3d-1.4.6.tgz",
       "integrity": "sha512-aItWQTNUX3JJc6i2FbXX82ljPZgDV3kXzkzANcBGoAnKwRpJw12WcMKKTL4sOCs9BW+3sx6BhR0P5+2zh5Scfw==",
       "requires": {
-        "binary-search-bounds": "2.0.4",
-        "bit-twiddle": "1.0.2",
-        "colormap": "2.3.1",
-        "dup": "1.0.0",
-        "gl-buffer": "2.1.2",
-        "gl-mat4": "1.2.0",
-        "gl-shader": "4.2.1",
-        "gl-texture2d": "2.1.0",
-        "gl-vao": "1.3.0",
-        "glsl-out-of-range": "1.0.4",
-        "glsl-specular-beckmann": "1.1.2",
-        "glslify": "7.0.0",
-        "ndarray": "1.0.19",
-        "ndarray-gradient": "1.0.0",
-        "ndarray-ops": "1.2.2",
-        "ndarray-pack": "1.2.1",
-        "ndarray-scratch": "1.2.0",
-        "surface-nets": "1.0.2",
-        "typedarray-pool": "1.2.0"
+        "binary-search-bounds": "^2.0.4",
+        "bit-twiddle": "^1.0.2",
+        "colormap": "^2.3.1",
+        "dup": "^1.0.0",
+        "gl-buffer": "^2.0.3",
+        "gl-mat4": "^1.0.0",
+        "gl-shader": "^4.2.0",
+        "gl-texture2d": "^2.0.0",
+        "gl-vao": "^1.1.1",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-beckmann": "^1.1.2",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.16",
+        "ndarray-gradient": "^1.0.0",
+        "ndarray-ops": "^1.2.1",
+        "ndarray-pack": "^1.0.1",
+        "ndarray-scratch": "^1.1.1",
+        "surface-nets": "^1.0.2",
+        "typedarray-pool": "^1.0.0"
       }
     },
     "gl-text": {
@@ -1875,23 +1876,23 @@
       "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.1.8.tgz",
       "integrity": "sha512-whnq9DEFYbW92C4ONwk2eT0YkzmVPHoADnEtuzMOmit87XhgAhBrNs3lK9EgGjU/MoWYvlF6RkI8Kl7Yuo1hUw==",
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "color-normalize": "1.5.0",
-        "css-font": "1.2.0",
-        "detect-kerning": "2.1.2",
-        "es6-weak-map": "2.0.3",
-        "flatten-vertex-data": "1.0.2",
-        "font-atlas": "2.1.0",
-        "font-measure": "1.2.2",
-        "gl-util": "3.1.2",
-        "is-plain-obj": "1.1.0",
-        "object-assign": "4.1.1",
-        "parse-rect": "1.2.0",
-        "parse-unit": "1.0.1",
-        "pick-by-alias": "1.2.0",
-        "regl": "1.3.13",
-        "to-px": "1.1.0",
-        "typedarray-pool": "1.2.0"
+        "bit-twiddle": "^1.0.2",
+        "color-normalize": "^1.5.0",
+        "css-font": "^1.2.0",
+        "detect-kerning": "^2.1.2",
+        "es6-weak-map": "^2.0.3",
+        "flatten-vertex-data": "^1.0.2",
+        "font-atlas": "^2.1.0",
+        "font-measure": "^1.2.2",
+        "gl-util": "^3.1.2",
+        "is-plain-obj": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "parse-unit": "^1.0.1",
+        "pick-by-alias": "^1.2.0",
+        "regl": "^1.3.11",
+        "to-px": "^1.0.1",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-texture2d": {
@@ -1899,9 +1900,9 @@
       "resolved": "https://registry.npmjs.org/gl-texture2d/-/gl-texture2d-2.1.0.tgz",
       "integrity": "sha1-/2gk5+fDGoum/c2+nlxpXX4hh8c=",
       "requires": {
-        "ndarray": "1.0.19",
-        "ndarray-ops": "1.2.2",
-        "typedarray-pool": "1.2.0"
+        "ndarray": "^1.0.15",
+        "ndarray-ops": "^1.2.2",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "gl-util": {
@@ -1909,13 +1910,13 @@
       "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.2.tgz",
       "integrity": "sha512-8czWhGTGp/H4S35X1UxGbFlJ1hjtTFhm2mc85GcymEi1CDf633WJgtkCddEiSjIa4BnNxBrqOIhj6jlF6naPqw==",
       "requires": {
-        "is-browser": "2.1.0",
-        "is-firefox": "1.0.3",
-        "is-plain-obj": "1.1.0",
-        "number-is-integer": "1.0.1",
-        "object-assign": "4.1.1",
-        "pick-by-alias": "1.2.0",
-        "weak-map": "1.0.5"
+        "is-browser": "^2.0.1",
+        "is-firefox": "^1.0.3",
+        "is-plain-obj": "^1.1.0",
+        "number-is-integer": "^1.0.1",
+        "object-assign": "^4.1.0",
+        "pick-by-alias": "^1.2.0",
+        "weak-map": "^1.0.5"
       }
     },
     "gl-vao": {
@@ -1939,12 +1940,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glsl-inject-defines": {
@@ -1952,9 +1953,9 @@
       "resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
       "integrity": "sha1-3RqswsF/yyvT/DJBHGYz0Ne2D9Q=",
       "requires": {
-        "glsl-token-inject-block": "1.1.0",
-        "glsl-token-string": "1.0.1",
-        "glsl-tokenizer": "2.1.5"
+        "glsl-token-inject-block": "^1.0.0",
+        "glsl-token-string": "^1.0.1",
+        "glsl-tokenizer": "^2.0.2"
       }
     },
     "glsl-inverse": {
@@ -1977,8 +1978,8 @@
       "resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",
       "integrity": "sha1-iUvvc5ENeSyBtRQxgANdCnivdtM=",
       "requires": {
-        "resolve": "0.6.3",
-        "xtend": "2.2.0"
+        "resolve": "^0.6.1",
+        "xtend": "^2.1.2"
       },
       "dependencies": {
         "resolve": {
@@ -1998,8 +1999,8 @@
       "resolved": "https://registry.npmjs.org/glsl-shader-name/-/glsl-shader-name-1.0.0.tgz",
       "integrity": "sha1-osMLO6c0mb77DMcYTXx3M91LSH0=",
       "requires": {
-        "atob-lite": "1.0.0",
-        "glsl-tokenizer": "2.1.5"
+        "atob-lite": "^1.0.0",
+        "glsl-tokenizer": "^2.0.2"
       }
     },
     "glsl-specular-beckmann": {
@@ -2012,7 +2013,7 @@
       "resolved": "https://registry.npmjs.org/glsl-specular-cook-torrance/-/glsl-specular-cook-torrance-2.0.1.tgz",
       "integrity": "sha1-qJHMBsjHtPRyhwK0gk/ay7ln148=",
       "requires": {
-        "glsl-specular-beckmann": "1.1.2"
+        "glsl-specular-beckmann": "^1.1.1"
       }
     },
     "glsl-token-assignments": {
@@ -2025,7 +2026,7 @@
       "resolved": "https://registry.npmjs.org/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz",
       "integrity": "sha1-y4kqqVmTYjFyhHDU90AySJaX+p0=",
       "requires": {
-        "glsl-tokenizer": "2.1.5"
+        "glsl-tokenizer": "^2.0.0"
       }
     },
     "glsl-token-depth": {
@@ -2038,10 +2039,10 @@
       "resolved": "https://registry.npmjs.org/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz",
       "integrity": "sha1-D8kKsyYYa4L1l7LnfcniHvzTIHY=",
       "requires": {
-        "glsl-token-assignments": "2.0.2",
-        "glsl-token-depth": "1.1.2",
-        "glsl-token-properties": "1.0.1",
-        "glsl-token-scope": "1.1.2"
+        "glsl-token-assignments": "^2.0.0",
+        "glsl-token-depth": "^1.1.0",
+        "glsl-token-properties": "^1.0.0",
+        "glsl-token-scope": "^1.1.0"
       }
     },
     "glsl-token-inject-block": {
@@ -2074,7 +2075,7 @@
       "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz",
       "integrity": "sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==",
       "requires": {
-        "through2": "0.6.5"
+        "through2": "^0.6.3"
       }
     },
     "glslify": {
@@ -2082,21 +2083,21 @@
       "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
       "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
       "requires": {
-        "bl": "1.2.1",
-        "concat-stream": "1.6.2",
-        "duplexify": "3.7.1",
-        "falafel": "2.1.0",
-        "from2": "2.3.0",
+        "bl": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "duplexify": "^3.4.5",
+        "falafel": "^2.1.0",
+        "from2": "^2.3.0",
         "glsl-resolve": "0.0.1",
-        "glsl-token-whitespace-trim": "1.0.0",
-        "glslify-bundle": "5.1.1",
-        "glslify-deps": "1.3.1",
-        "minimist": "1.2.0",
-        "resolve": "1.4.0",
+        "glsl-token-whitespace-trim": "^1.0.0",
+        "glslify-bundle": "^5.0.0",
+        "glslify-deps": "^1.2.5",
+        "minimist": "^1.2.0",
+        "resolve": "^1.1.5",
         "stack-trace": "0.0.9",
-        "static-eval": "2.0.3",
-        "through2": "2.0.5",
-        "xtend": "4.0.2"
+        "static-eval": "^2.0.0",
+        "through2": "^2.0.1",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -2109,13 +2110,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -2123,7 +2124,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "through2": {
@@ -2131,8 +2132,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "requires": {
-            "readable-stream": "2.3.7",
-            "xtend": "4.0.2"
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -2142,15 +2143,15 @@
       "resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-5.1.1.tgz",
       "integrity": "sha512-plaAOQPv62M1r3OsWf2UbjN0hUYAB7Aph5bfH58VxJZJhloRNbxOL9tl/7H71K7OLJoSJ2ZqWOKk3ttQ6wy24A==",
       "requires": {
-        "glsl-inject-defines": "1.0.3",
-        "glsl-token-defines": "1.0.0",
-        "glsl-token-depth": "1.1.2",
-        "glsl-token-descope": "1.0.2",
-        "glsl-token-scope": "1.1.2",
-        "glsl-token-string": "1.0.1",
-        "glsl-token-whitespace-trim": "1.0.0",
-        "glsl-tokenizer": "2.1.5",
-        "murmurhash-js": "1.0.0",
+        "glsl-inject-defines": "^1.0.1",
+        "glsl-token-defines": "^1.0.0",
+        "glsl-token-depth": "^1.1.1",
+        "glsl-token-descope": "^1.0.2",
+        "glsl-token-scope": "^1.1.1",
+        "glsl-token-string": "^1.0.1",
+        "glsl-token-whitespace-trim": "^1.0.0",
+        "glsl-tokenizer": "^2.0.2",
+        "murmurhash-js": "^1.0.0",
         "shallow-copy": "0.0.1"
       }
     },
@@ -2159,14 +2160,14 @@
       "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.1.tgz",
       "integrity": "sha512-Ogm179MCazwIRyEqs3g3EOY4Y3XIAa0yl8J5RE9rJC6QH1w8weVOp2RZu0mvnYy/2xIas1w166YR2eZdDkWQxg==",
       "requires": {
-        "@choojs/findup": "0.2.1",
-        "events": "1.1.1",
+        "@choojs/findup": "^0.2.0",
+        "events": "^1.0.2",
         "glsl-resolve": "0.0.1",
-        "glsl-tokenizer": "2.1.5",
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
+        "glsl-tokenizer": "^2.0.0",
+        "graceful-fs": "^4.1.2",
+        "inherits": "^2.0.1",
         "map-limit": "0.0.1",
-        "resolve": "1.4.0"
+        "resolve": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -2184,7 +2185,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-flag": {
@@ -2197,7 +2198,7 @@
       "resolved": "https://registry.npmjs.org/has-hover/-/has-hover-1.0.1.tgz",
       "integrity": "sha1-PZdDeusZnGK4rAisvcU9O8UsF/c=",
       "requires": {
-        "is-browser": "2.1.0"
+        "is-browser": "^2.0.1"
       }
     },
     "has-passive-events": {
@@ -2205,7 +2206,7 @@
       "resolved": "https://registry.npmjs.org/has-passive-events/-/has-passive-events-1.0.0.tgz",
       "integrity": "sha512-2vSj6IeIsgvsRMyeQ0JaCX5Q3lX4zMn5HpoVc7MEhQ6pv8Iq9rsXjsp+E5ZwaT7T0xhMT0KmU8gtt1EFVdbJiw==",
       "requires": {
-        "is-browser": "2.1.0"
+        "is-browser": "^2.0.1"
       }
     },
     "has-symbols": {
@@ -2235,13 +2236,13 @@
       "integrity": "sha512-EiyC45FRIs+z4g98+jBzuYCfoM6TKG9p7Ek5YZUeM7rucNucaMZIseRj/5Q3I4ypkZXyC2wnU1RcYrVmshe2xw==",
       "dev": true,
       "requires": {
-        "bl": "1.2.1",
-        "findup": "0.1.5",
+        "bl": "^1.0.0",
+        "findup": "^0.1.5",
         "from2-array": "0.0.4",
         "map-limit": "0.0.1",
-        "multipipe": "0.3.1",
-        "read-package-json": "2.0.13",
-        "resolve": "1.4.0"
+        "multipipe": "^0.3.0",
+        "read-package-json": "^2.0.2",
+        "resolve": "^1.1.6"
       }
     },
     "image-palette": {
@@ -2249,9 +2250,9 @@
       "resolved": "https://registry.npmjs.org/image-palette/-/image-palette-2.1.0.tgz",
       "integrity": "sha512-3ImSEWD26+xuQFdP0RWR4WSXadZwvgrFhjGNpMEapTG1tf2XrBFS2dlKK5hNgH4UIaSQlSUFRn1NeA+zULIWbQ==",
       "requires": {
-        "color-id": "1.1.0",
-        "pxls": "2.3.2",
-        "quantize": "1.0.2"
+        "color-id": "^1.1.0",
+        "pxls": "^2.0.0",
+        "quantize": "^1.0.2"
       }
     },
     "incremental-convex-hull": {
@@ -2259,8 +2260,8 @@
       "resolved": "https://registry.npmjs.org/incremental-convex-hull/-/incremental-convex-hull-1.0.1.tgz",
       "integrity": "sha1-UUKMFMudmmFEv+abKFH7N3M0vh4=",
       "requires": {
-        "robust-orientation": "1.1.3",
-        "simplicial-complex": "1.0.0"
+        "robust-orientation": "^1.1.2",
+        "simplicial-complex": "^1.0.0"
       }
     },
     "inflight": {
@@ -2268,8 +2269,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -2282,7 +2283,7 @@
       "resolved": "https://registry.npmjs.org/interval-tree-1d/-/interval-tree-1d-1.0.3.tgz",
       "integrity": "sha1-j9veArayx9verWNry+2OCHENhcE=",
       "requires": {
-        "binary-search-bounds": "1.0.0"
+        "binary-search-bounds": "^1.0.0"
       },
       "dependencies": {
         "binary-search-bounds": {
@@ -2333,7 +2334,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -2351,7 +2352,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-firefox": {
@@ -2389,7 +2390,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
       "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
       "requires": {
-        "has": "1.0.3"
+        "has": "^1.0.3"
       }
     },
     "is-string-blank": {
@@ -2407,7 +2408,7 @@
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "requires": {
-        "has-symbols": "1.0.1"
+        "has-symbols": "^1.0.1"
       }
     },
     "isarray": {
@@ -2436,7 +2437,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -2459,8 +2460,8 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lodash": {
@@ -2478,7 +2479,7 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.6.tgz",
       "integrity": "sha512-3a5LOMSGoCTH5rbqobC2HuDNRtE2glHZ8J7pK+QZYppyWA36yuNpsX994rIY2nCuyP7CZYy7lQq/X2jygiZ89g==",
       "requires": {
-        "sourcemap-codec": "1.4.8"
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "map-limit": {
@@ -2486,7 +2487,7 @@
       "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
       "integrity": "sha1-63lhAxwPDo0AG/LVb6toXViCLzg=",
       "requires": {
-        "once": "1.3.3"
+        "once": "~1.3.0"
       },
       "dependencies": {
         "once": {
@@ -2494,7 +2495,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         }
       }
@@ -2504,29 +2505,29 @@
       "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.3.2.tgz",
       "integrity": "sha512-6Ro7GbTMWxcbc836m6rbBNkesgTncbE1yXWeuHlr89esSqaItKr0+ntOu8rZie3fv+GtitkbODysXzIGCA7G+w==",
       "requires": {
-        "@mapbox/geojson-rewind": "0.4.0",
-        "@mapbox/geojson-types": "1.0.2",
-        "@mapbox/jsonlint-lines-primitives": "2.0.2",
-        "@mapbox/mapbox-gl-supported": "1.4.1",
-        "@mapbox/point-geometry": "0.1.0",
-        "@mapbox/tiny-sdf": "1.1.1",
-        "@mapbox/unitbezier": "0.0.0",
-        "@mapbox/vector-tile": "1.3.1",
-        "@mapbox/whoots-js": "3.1.0",
-        "csscolorparser": "1.0.3",
-        "earcut": "2.2.1",
-        "geojson-vt": "3.2.1",
-        "gl-matrix": "3.1.0",
-        "grid-index": "1.1.0",
+        "@mapbox/geojson-rewind": "^0.4.0",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.4.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.0",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.2",
+        "earcut": "^2.1.5",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.0.0",
+        "grid-index": "^1.1.0",
         "minimist": "0.0.8",
-        "murmurhash-js": "1.0.0",
-        "pbf": "3.2.1",
-        "potpack": "1.0.1",
-        "quickselect": "2.0.0",
-        "rw": "1.3.3",
-        "supercluster": "6.0.2",
-        "tinyqueue": "2.0.3",
-        "vt-pbf": "3.1.1"
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.0.5",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^6.0.1",
+        "tinyqueue": "^2.0.0",
+        "vt-pbf": "^3.1.1"
       },
       "dependencies": {
         "minimist": {
@@ -2541,7 +2542,7 @@
       "resolved": "https://registry.npmjs.org/marching-simplex-table/-/marching-simplex-table-1.0.0.tgz",
       "integrity": "sha1-vBYlbg+Pm1WKqbKHL4gy2UM/Uuo=",
       "requires": {
-        "convex-hull": "1.0.3"
+        "convex-hull": "^1.0.3"
       }
     },
     "mat4-decompose": {
@@ -2549,8 +2550,8 @@
       "resolved": "https://registry.npmjs.org/mat4-decompose/-/mat4-decompose-1.0.4.tgz",
       "integrity": "sha1-ZetP451wh496RE60Yk1S9+frL68=",
       "requires": {
-        "gl-mat4": "1.2.0",
-        "gl-vec3": "1.1.3"
+        "gl-mat4": "^1.0.1",
+        "gl-vec3": "^1.0.2"
       }
     },
     "mat4-interpolate": {
@@ -2558,11 +2559,11 @@
       "resolved": "https://registry.npmjs.org/mat4-interpolate/-/mat4-interpolate-1.0.4.tgz",
       "integrity": "sha1-Vf/p6zw1KV4sDVqfdyXZBoqJ/3Q=",
       "requires": {
-        "gl-mat4": "1.2.0",
-        "gl-vec3": "1.1.3",
-        "mat4-decompose": "1.0.4",
-        "mat4-recompose": "1.0.4",
-        "quat-slerp": "1.0.1"
+        "gl-mat4": "^1.0.1",
+        "gl-vec3": "^1.0.2",
+        "mat4-decompose": "^1.0.3",
+        "mat4-recompose": "^1.0.3",
+        "quat-slerp": "^1.0.0"
       }
     },
     "mat4-recompose": {
@@ -2570,7 +2571,7 @@
       "resolved": "https://registry.npmjs.org/mat4-recompose/-/mat4-recompose-1.0.4.tgz",
       "integrity": "sha1-OVPCMP8kc9x3LuAUpSySXPgbDk0=",
       "requires": {
-        "gl-mat4": "1.2.0"
+        "gl-mat4": "^1.0.1"
       }
     },
     "math-log2": {
@@ -2583,10 +2584,10 @@
       "resolved": "https://registry.npmjs.org/matrix-camera-controller/-/matrix-camera-controller-2.1.3.tgz",
       "integrity": "sha1-NeUmDMHNVQliunmfLY1OlLGjk3A=",
       "requires": {
-        "binary-search-bounds": "1.0.0",
-        "gl-mat4": "1.2.0",
-        "gl-vec3": "1.1.3",
-        "mat4-interpolate": "1.0.4"
+        "binary-search-bounds": "^1.0.0",
+        "gl-mat4": "^1.1.2",
+        "gl-vec3": "^1.0.3",
+        "mat4-interpolate": "^1.0.3"
       },
       "dependencies": {
         "binary-search-bounds": {
@@ -2601,7 +2602,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -2614,7 +2615,7 @@
       "resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
       "integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
       "requires": {
-        "robust-orientation": "1.1.3"
+        "robust-orientation": "^1.1.3"
       }
     },
     "mouse-change": {
@@ -2622,7 +2623,7 @@
       "resolved": "https://registry.npmjs.org/mouse-change/-/mouse-change-1.4.0.tgz",
       "integrity": "sha1-wrd+W/o0pDzhRFyBV6Tk3JiVwU8=",
       "requires": {
-        "mouse-event": "1.0.5"
+        "mouse-event": "^1.0.0"
       }
     },
     "mouse-event": {
@@ -2640,9 +2641,9 @@
       "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
       "integrity": "sha1-bSkDseqPtI5h8bU7kDZ3PwQs21w=",
       "requires": {
-        "right-now": "1.0.0",
-        "signum": "1.0.0",
-        "to-px": "1.1.0"
+        "right-now": "^1.0.0",
+        "signum": "^1.0.0",
+        "to-px": "^1.0.1"
       },
       "dependencies": {
         "signum": {
@@ -2658,7 +2659,7 @@
       "integrity": "sha1-kmJVJXYboE/qoJYFtjgrziyR8R8=",
       "dev": true,
       "requires": {
-        "duplexer2": "0.1.4"
+        "duplexer2": "^0.1.2"
       },
       "dependencies": {
         "duplexer2": {
@@ -2667,7 +2668,7 @@
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
           "requires": {
-            "readable-stream": "2.3.6"
+            "readable-stream": "^2.0.2"
           }
         },
         "isarray": {
@@ -2682,13 +2683,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -2697,7 +2698,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -2707,7 +2708,7 @@
       "resolved": "https://registry.npmjs.org/mumath/-/mumath-3.3.4.tgz",
       "integrity": "sha1-SNSg8P2MrU57Mglu6JsWGmPTC78=",
       "requires": {
-        "almost-equal": "1.1.0"
+        "almost-equal": "^1.1.0"
       }
     },
     "murmurhash-js": {
@@ -2720,8 +2721,8 @@
       "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
       "integrity": "sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==",
       "requires": {
-        "iota-array": "1.0.0",
-        "is-buffer": "1.1.6"
+        "iota-array": "^1.0.0",
+        "is-buffer": "^1.0.2"
       }
     },
     "ndarray-extract-contour": {
@@ -2729,7 +2730,7 @@
       "resolved": "https://registry.npmjs.org/ndarray-extract-contour/-/ndarray-extract-contour-1.0.1.tgz",
       "integrity": "sha1-Cu4ROjozsia5DEiIz4d79HUTBeQ=",
       "requires": {
-        "typedarray-pool": "1.2.0"
+        "typedarray-pool": "^1.0.0"
       }
     },
     "ndarray-fill": {
@@ -2737,7 +2738,7 @@
       "resolved": "https://registry.npmjs.org/ndarray-fill/-/ndarray-fill-1.0.2.tgz",
       "integrity": "sha1-owpg9xiODJWC/N1YiWrNy1IqHtY=",
       "requires": {
-        "cwise": "1.0.10"
+        "cwise": "^1.0.10"
       }
     },
     "ndarray-gradient": {
@@ -2745,8 +2746,8 @@
       "resolved": "https://registry.npmjs.org/ndarray-gradient/-/ndarray-gradient-1.0.0.tgz",
       "integrity": "sha1-t0kaUVxqZJ8ZpiMk//byf8jCU5M=",
       "requires": {
-        "cwise-compiler": "1.1.3",
-        "dup": "1.0.0"
+        "cwise-compiler": "^1.0.0",
+        "dup": "^1.0.0"
       }
     },
     "ndarray-homography": {
@@ -2754,8 +2755,8 @@
       "resolved": "https://registry.npmjs.org/ndarray-homography/-/ndarray-homography-1.0.0.tgz",
       "integrity": "sha1-w1UW6oa8KGK06ASiNqJwcwn+KWs=",
       "requires": {
-        "gl-matrix-invert": "1.0.0",
-        "ndarray-warp": "1.0.1"
+        "gl-matrix-invert": "^1.0.0",
+        "ndarray-warp": "^1.0.0"
       }
     },
     "ndarray-linear-interpolate": {
@@ -2768,7 +2769,7 @@
       "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
       "integrity": "sha1-WeiNLDKn7ryxvGkPrhQVeVV6YU4=",
       "requires": {
-        "cwise-compiler": "1.1.3"
+        "cwise-compiler": "^1.0.0"
       }
     },
     "ndarray-pack": {
@@ -2776,8 +2777,8 @@
       "resolved": "https://registry.npmjs.org/ndarray-pack/-/ndarray-pack-1.2.1.tgz",
       "integrity": "sha1-jK6+qqJNXs9w/4YCBjeXfajuWFo=",
       "requires": {
-        "cwise-compiler": "1.1.3",
-        "ndarray": "1.0.19"
+        "cwise-compiler": "^1.1.2",
+        "ndarray": "^1.0.13"
       }
     },
     "ndarray-scratch": {
@@ -2785,9 +2786,9 @@
       "resolved": "https://registry.npmjs.org/ndarray-scratch/-/ndarray-scratch-1.2.0.tgz",
       "integrity": "sha1-YwRjbWLrqT20cnrBPGkzQdulDgE=",
       "requires": {
-        "ndarray": "1.0.19",
-        "ndarray-ops": "1.2.2",
-        "typedarray-pool": "1.2.0"
+        "ndarray": "^1.0.14",
+        "ndarray-ops": "^1.2.1",
+        "typedarray-pool": "^1.0.2"
       }
     },
     "ndarray-sort": {
@@ -2795,7 +2796,7 @@
       "resolved": "https://registry.npmjs.org/ndarray-sort/-/ndarray-sort-1.0.1.tgz",
       "integrity": "sha1-/qBbTLg0x/TgIWo1TzynUTAN/Wo=",
       "requires": {
-        "typedarray-pool": "1.2.0"
+        "typedarray-pool": "^1.0.0"
       }
     },
     "ndarray-warp": {
@@ -2803,8 +2804,8 @@
       "resolved": "https://registry.npmjs.org/ndarray-warp/-/ndarray-warp-1.0.1.tgz",
       "integrity": "sha1-qKElqqu6C+v5O9bKg+ar1oIqNOA=",
       "requires": {
-        "cwise": "1.0.10",
-        "ndarray-linear-interpolate": "1.0.0"
+        "cwise": "^1.0.4",
+        "ndarray-linear-interpolate": "^1.0.0"
       }
     },
     "next-tick": {
@@ -2817,7 +2818,7 @@
       "resolved": "https://registry.npmjs.org/nextafter/-/nextafter-1.0.0.tgz",
       "integrity": "sha1-t9d7U1MQ4+CX5gJauwqQNHfsGjo=",
       "requires": {
-        "double-bits": "1.1.1"
+        "double-bits": "^1.1.0"
       }
     },
     "normalize-package-data": {
@@ -2826,10 +2827,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-svg-path": {
@@ -2847,7 +2848,7 @@
       "resolved": "https://registry.npmjs.org/number-is-integer/-/number-is-integer-1.0.1.tgz",
       "integrity": "sha1-5ZvKFy/+0nMY55x862y3LAlbIVI=",
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.1"
       }
     },
     "number-is-nan": {
@@ -2885,10 +2886,10 @@
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "requires": {
-        "define-properties": "1.1.3",
-        "function-bind": "1.1.1",
-        "has-symbols": "1.0.1",
-        "object-keys": "1.1.1"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
       }
     },
     "once": {
@@ -2896,7 +2897,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optionator": {
@@ -2904,12 +2905,12 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
       "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "word-wrap": "1.2.3"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
       }
     },
     "orbit-camera-controller": {
@@ -2917,8 +2918,8 @@
       "resolved": "https://registry.npmjs.org/orbit-camera-controller/-/orbit-camera-controller-4.0.0.tgz",
       "integrity": "sha1-bis28OeHhmPDMPUNqbfOaGwncAU=",
       "requires": {
-        "filtered-vector": "1.2.4",
-        "gl-mat4": "1.2.0"
+        "filtered-vector": "^1.2.1",
+        "gl-mat4": "^1.0.3"
       }
     },
     "os-homedir": {
@@ -2931,7 +2932,7 @@
       "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-1.0.2.tgz",
       "integrity": "sha1-GeVzXqmDlaJs7carkm6tEPMQDUw=",
       "requires": {
-        "repeat-string": "1.6.1"
+        "repeat-string": "^1.3.0"
       }
     },
     "parenthesis": {
@@ -2944,7 +2945,7 @@
       "resolved": "https://registry.npmjs.org/parse-rect/-/parse-rect-1.2.0.tgz",
       "integrity": "sha512-4QZ6KYbnE6RTwg9E0HpLchUM9EZt6DnDxajFZZDSV4p/12ZJEvPO702DZpGvRYEPo00yKDys7jASi+/w7aO8LA==",
       "requires": {
-        "pick-by-alias": "1.2.0"
+        "pick-by-alias": "^1.2.0"
       }
     },
     "parse-svg-path": {
@@ -2972,8 +2973,8 @@
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
       "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
       "requires": {
-        "ieee754": "1.1.13",
-        "resolve-protobuf-schema": "2.1.0"
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
       }
     },
     "performance-now": {
@@ -2986,7 +2987,7 @@
       "resolved": "https://registry.npmjs.org/permutation-parity/-/permutation-parity-1.0.0.tgz",
       "integrity": "sha1-AXTVH8pwSxG5pLFSsj1Tf9xrXvQ=",
       "requires": {
-        "typedarray-pool": "1.2.0"
+        "typedarray-pool": "^1.0.0"
       }
     },
     "permutation-rank": {
@@ -2994,8 +2995,8 @@
       "resolved": "https://registry.npmjs.org/permutation-rank/-/permutation-rank-1.0.0.tgz",
       "integrity": "sha1-n9mLvOzwj79ZlLXq3JSmLmeUg7U=",
       "requires": {
-        "invert-permutation": "1.0.0",
-        "typedarray-pool": "1.2.0"
+        "invert-permutation": "^1.0.0",
+        "typedarray-pool": "^1.0.0"
       }
     },
     "pick-by-alias": {
@@ -3008,8 +3009,8 @@
       "resolved": "https://registry.npmjs.org/planar-dual/-/planar-dual-1.0.2.tgz",
       "integrity": "sha1-tqQjVSOxsMt55fkm+OozXdmC1WM=",
       "requires": {
-        "compare-angle": "1.0.1",
-        "dup": "1.0.0"
+        "compare-angle": "^1.0.0",
+        "dup": "^1.0.0"
       }
     },
     "planar-graph-to-polyline": {
@@ -3017,13 +3018,13 @@
       "resolved": "https://registry.npmjs.org/planar-graph-to-polyline/-/planar-graph-to-polyline-1.0.5.tgz",
       "integrity": "sha1-iCuGBRmbqIv9RkyVUzA1VsUrmIo=",
       "requires": {
-        "edges-to-adjacency-list": "1.0.0",
-        "planar-dual": "1.0.2",
-        "point-in-big-polygon": "2.0.0",
-        "robust-orientation": "1.1.3",
-        "robust-sum": "1.0.0",
-        "two-product": "1.0.2",
-        "uniq": "1.0.1"
+        "edges-to-adjacency-list": "^1.0.0",
+        "planar-dual": "^1.0.0",
+        "point-in-big-polygon": "^2.0.0",
+        "robust-orientation": "^1.0.1",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0",
+        "uniq": "^1.0.0"
       }
     },
     "plotly.js": {
@@ -3033,66 +3034,66 @@
       "requires": {
         "@plotly/d3-sankey": "0.7.2",
         "@plotly/d3-sankey-circular": "0.33.1",
-        "@turf/area": "6.0.1",
-        "@turf/bbox": "6.0.1",
-        "@turf/centroid": "6.0.2",
-        "alpha-shape": "1.0.0",
-        "canvas-fit": "1.5.0",
-        "color-normalize": "1.5.0",
-        "color-rgba": "2.1.1",
-        "convex-hull": "1.0.3",
-        "country-regex": "1.1.0",
-        "d3": "3.5.17",
-        "d3-force": "1.2.1",
-        "d3-hierarchy": "1.1.9",
-        "d3-interpolate": "1.4.0",
-        "delaunay-triangulate": "1.1.6",
-        "es6-promise": "3.3.1",
-        "fast-isnumeric": "1.1.3",
-        "gl-cone3d": "1.5.1",
-        "gl-contour2d": "1.1.6",
-        "gl-error3d": "1.0.15",
-        "gl-heatmap2d": "1.0.5",
-        "gl-line3d": "1.1.11",
-        "gl-mat4": "1.2.0",
-        "gl-mesh3d": "2.2.0",
-        "gl-plot2d": "1.4.2",
-        "gl-plot3d": "2.4.0",
-        "gl-pointcloud2d": "1.0.2",
-        "gl-scatter3d": "1.2.2",
-        "gl-select-box": "1.0.3",
-        "gl-spikes2d": "1.0.2",
-        "gl-streamtube3d": "1.4.0",
-        "gl-surface3d": "1.4.6",
-        "gl-text": "1.1.8",
-        "glslify": "7.0.0",
-        "has-hover": "1.0.1",
-        "has-passive-events": "1.0.0",
+        "@turf/area": "^6.0.1",
+        "@turf/bbox": "^6.0.1",
+        "@turf/centroid": "^6.0.2",
+        "alpha-shape": "^1.0.0",
+        "canvas-fit": "^1.5.0",
+        "color-normalize": "^1.5.0",
+        "color-rgba": "^2.1.1",
+        "convex-hull": "^1.0.3",
+        "country-regex": "^1.1.0",
+        "d3": "^3.5.12",
+        "d3-force": "^1.0.6",
+        "d3-hierarchy": "^1.1.8",
+        "d3-interpolate": "1",
+        "delaunay-triangulate": "^1.1.6",
+        "es6-promise": "^3.0.2",
+        "fast-isnumeric": "^1.1.3",
+        "gl-cone3d": "^1.5.1",
+        "gl-contour2d": "^1.1.6",
+        "gl-error3d": "^1.0.15",
+        "gl-heatmap2d": "^1.0.5",
+        "gl-line3d": "^1.1.11",
+        "gl-mat4": "^1.2.0",
+        "gl-mesh3d": "^2.2.0",
+        "gl-plot2d": "^1.4.2",
+        "gl-plot3d": "^2.3.0",
+        "gl-pointcloud2d": "^1.0.2",
+        "gl-scatter3d": "^1.2.2",
+        "gl-select-box": "^1.0.3",
+        "gl-spikes2d": "^1.0.2",
+        "gl-streamtube3d": "^1.4.0",
+        "gl-surface3d": "^1.4.6",
+        "gl-text": "^1.1.8",
+        "glslify": "^7.0.0",
+        "has-hover": "^1.0.1",
+        "has-passive-events": "^1.0.0",
         "mapbox-gl": "1.3.2",
-        "matrix-camera-controller": "2.1.3",
-        "mouse-change": "1.4.0",
-        "mouse-event-offset": "3.0.2",
-        "mouse-wheel": "1.2.0",
-        "ndarray": "1.0.19",
-        "ndarray-fill": "1.0.2",
-        "ndarray-homography": "1.0.0",
-        "point-cluster": "3.1.8",
-        "polybooljs": "1.2.0",
-        "regl": "1.3.13",
-        "regl-error2d": "2.0.8",
-        "regl-line2d": "3.0.15",
-        "regl-scatter2d": "3.1.7",
-        "regl-splom": "1.0.8",
-        "right-now": "1.0.0",
-        "robust-orientation": "1.1.3",
-        "sane-topojson": "4.0.0",
-        "strongly-connected-components": "1.0.1",
-        "superscript-text": "1.0.0",
-        "svg-path-sdf": "1.1.3",
-        "tinycolor2": "1.4.1",
-        "topojson-client": "2.1.0",
-        "webgl-context": "2.2.0",
-        "world-calendars": "1.0.3"
+        "matrix-camera-controller": "^2.1.3",
+        "mouse-change": "^1.4.0",
+        "mouse-event-offset": "^3.0.2",
+        "mouse-wheel": "^1.2.0",
+        "ndarray": "^1.0.18",
+        "ndarray-fill": "^1.0.2",
+        "ndarray-homography": "^1.0.0",
+        "point-cluster": "^3.1.8",
+        "polybooljs": "^1.2.0",
+        "regl": "^1.3.11",
+        "regl-error2d": "^2.0.8",
+        "regl-line2d": "^3.0.15",
+        "regl-scatter2d": "^3.1.7",
+        "regl-splom": "^1.0.8",
+        "right-now": "^1.0.0",
+        "robust-orientation": "^1.1.3",
+        "sane-topojson": "^4.0.0",
+        "strongly-connected-components": "^1.0.1",
+        "superscript-text": "^1.0.0",
+        "svg-path-sdf": "^1.1.3",
+        "tinycolor2": "^1.4.1",
+        "topojson-client": "^2.1.0",
+        "webgl-context": "^2.2.0",
+        "world-calendars": "^1.0.3"
       }
     },
     "point-cluster": {
@@ -3100,18 +3101,18 @@
       "resolved": "https://registry.npmjs.org/point-cluster/-/point-cluster-3.1.8.tgz",
       "integrity": "sha512-7klIr45dpMeZuqjIK9+qBg3m2IhyZJNJkdqjJFw0Olq75FM8ojrTMjClVUrMjNYRVqtwztxCHH71Fyjhg+YwyQ==",
       "requires": {
-        "array-bounds": "1.0.1",
-        "array-normalize": "1.1.4",
-        "binary-search-bounds": "2.0.4",
-        "bubleify": "1.2.1",
-        "clamp": "1.0.1",
-        "defined": "1.0.0",
-        "dtype": "2.0.0",
-        "flatten-vertex-data": "1.0.2",
-        "is-obj": "1.0.1",
-        "math-log2": "1.0.1",
-        "parse-rect": "1.2.0",
-        "pick-by-alias": "1.2.0"
+        "array-bounds": "^1.0.1",
+        "array-normalize": "^1.1.4",
+        "binary-search-bounds": "^2.0.4",
+        "bubleify": "^1.1.0",
+        "clamp": "^1.0.1",
+        "defined": "^1.0.0",
+        "dtype": "^2.0.0",
+        "flatten-vertex-data": "^1.0.2",
+        "is-obj": "^1.0.1",
+        "math-log2": "^1.0.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0"
       }
     },
     "point-in-big-polygon": {
@@ -3119,10 +3120,10 @@
       "resolved": "https://registry.npmjs.org/point-in-big-polygon/-/point-in-big-polygon-2.0.0.tgz",
       "integrity": "sha1-ObYT6mzxfWtD4Yj3fzTETGszulU=",
       "requires": {
-        "binary-search-bounds": "1.0.0",
-        "interval-tree-1d": "1.0.3",
-        "robust-orientation": "1.1.3",
-        "slab-decomposition": "1.0.2"
+        "binary-search-bounds": "^1.0.0",
+        "interval-tree-1d": "^1.0.1",
+        "robust-orientation": "^1.1.3",
+        "slab-decomposition": "^1.0.1"
       },
       "dependencies": {
         "binary-search-bounds": {
@@ -3142,7 +3143,7 @@
       "resolved": "https://registry.npmjs.org/polytope-closest-point/-/polytope-closest-point-1.0.0.tgz",
       "integrity": "sha1-5uV/QIGrXox3i4Ee8G4sSK4zjD8=",
       "requires": {
-        "numeric": "1.2.6"
+        "numeric": "^1.2.6"
       }
     },
     "potpack": {
@@ -3170,12 +3171,12 @@
       "resolved": "https://registry.npmjs.org/pxls/-/pxls-2.3.2.tgz",
       "integrity": "sha512-pQkwgbLqWPcuES5iEmGa10OlCf5xG0blkIF3dg7PpRZShbTYcvAdfFfGL03SMrkaSUaa/V0UpN9HWg40O2AIIw==",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "compute-dims": "1.1.0",
-        "flip-pixels": "1.0.2",
-        "is-browser": "2.1.0",
-        "is-buffer": "2.0.4",
-        "to-uint8": "1.4.1"
+        "arr-flatten": "^1.1.0",
+        "compute-dims": "^1.1.0",
+        "flip-pixels": "^1.0.2",
+        "is-browser": "^2.1.0",
+        "is-buffer": "^2.0.3",
+        "to-uint8": "^1.4.1"
       },
       "dependencies": {
         "is-buffer": {
@@ -3195,7 +3196,7 @@
       "resolved": "https://registry.npmjs.org/quat-slerp/-/quat-slerp-1.0.1.tgz",
       "integrity": "sha1-K6oVzjprvcMkHZcusXKDE57Wnyk=",
       "requires": {
-        "gl-quat": "1.0.0"
+        "gl-quat": "^1.0.0"
       }
     },
     "quickselect": {
@@ -3209,7 +3210,7 @@
       "integrity": "sha1-zeKelMQJsW4Z3HCYuJtmWPlyHTs=",
       "requires": {
         "minimist": "0.0.8",
-        "through2": "0.4.2"
+        "through2": "~0.4.1"
       },
       "dependencies": {
         "minimist": {
@@ -3227,8 +3228,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "2.1.2"
+            "readable-stream": "~1.0.17",
+            "xtend": "~2.1.1"
           }
         },
         "xtend": {
@@ -3236,7 +3237,7 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "requires": {
-            "object-keys": "0.4.0"
+            "object-keys": "~0.4.0"
           }
         }
       }
@@ -3246,7 +3247,7 @@
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
       "requires": {
-        "performance-now": "2.1.0"
+        "performance-now": "^2.1.0"
       }
     },
     "rat-vec": {
@@ -3254,7 +3255,7 @@
       "resolved": "https://registry.npmjs.org/rat-vec/-/rat-vec-1.1.1.tgz",
       "integrity": "sha1-Dd4rZrezS7G80qI4BerIBth/0X8=",
       "requires": {
-        "big-rat": "1.0.4"
+        "big-rat": "^1.0.3"
       }
     },
     "read-package-json": {
@@ -3263,11 +3264,11 @@
       "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "json-parse-better-errors": "1.0.2",
-        "normalize-package-data": "2.4.0",
-        "slash": "1.0.0"
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.1.2",
+        "json-parse-better-errors": "^1.0.1",
+        "normalize-package-data": "^2.0.0",
+        "slash": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -3275,10 +3276,10 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
         "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
+        "string_decoder": "~0.10.x"
       }
     },
     "redeyed": {
@@ -3286,7 +3287,7 @@
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
       "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
       "requires": {
-        "esprima": "1.0.4"
+        "esprima": "~1.0.4"
       },
       "dependencies": {
         "esprima": {
@@ -3301,9 +3302,9 @@
       "resolved": "https://registry.npmjs.org/reduce-simplicial-complex/-/reduce-simplicial-complex-1.0.0.tgz",
       "integrity": "sha1-dNaWovg196bc2SBl/YxRgfLt+Lw=",
       "requires": {
-        "cell-orientation": "1.0.1",
-        "compare-cell": "1.0.0",
-        "compare-oriented-cell": "1.0.1"
+        "cell-orientation": "^1.0.1",
+        "compare-cell": "^1.0.0",
+        "compare-oriented-cell": "^1.0.1"
       }
     },
     "regenerate": {
@@ -3316,7 +3317,7 @@
       "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
       "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
       "requires": {
-        "regenerate": "1.4.0"
+        "regenerate": "^1.4.0"
       }
     },
     "regex-regex": {
@@ -3329,8 +3330,8 @@
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
       "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.3"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "regexpu-core": {
@@ -3338,12 +3339,12 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
       "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
       "requires": {
-        "regenerate": "1.4.0",
-        "regenerate-unicode-properties": "8.1.0",
-        "regjsgen": "0.5.1",
-        "regjsparser": "0.6.2",
-        "unicode-match-property-ecmascript": "1.0.4",
-        "unicode-match-property-value-ecmascript": "1.1.0"
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.1.0",
+        "regjsgen": "^0.5.0",
+        "regjsparser": "^0.6.0",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.1.0"
       }
     },
     "regjsgen": {
@@ -3356,7 +3357,7 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.2.tgz",
       "integrity": "sha512-E9ghzUtoLwDekPT0DYCp+c4h+bvuUpe6rRHCTYn6eGoqj1LgKXxT6I0Il4WbjhQkOghzi/V+y03bPKvbllL93Q==",
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       }
     },
     "regl": {
@@ -3369,14 +3370,14 @@
       "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.8.tgz",
       "integrity": "sha512-5nszdicXbimRUnYB42i+O7KPcla7PzI62nZLCP6qVRKlQCf3rSrWbikMNd1S84LE8+deWHWcb8rZ/v7rZ9qmmw==",
       "requires": {
-        "array-bounds": "1.0.1",
-        "bubleify": "1.2.1",
-        "color-normalize": "1.5.0",
-        "flatten-vertex-data": "1.0.2",
-        "object-assign": "4.1.1",
-        "pick-by-alias": "1.2.0",
-        "to-float32": "1.0.1",
-        "update-diff": "1.1.0"
+        "array-bounds": "^1.0.1",
+        "bubleify": "^1.2.0",
+        "color-normalize": "^1.5.0",
+        "flatten-vertex-data": "^1.0.2",
+        "object-assign": "^4.1.1",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.0.1",
+        "update-diff": "^1.1.0"
       }
     },
     "regl-line2d": {
@@ -3384,18 +3385,18 @@
       "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.0.15.tgz",
       "integrity": "sha512-RuQbg9iZ6MyuInG8izF6zjQ/2g4qL6sg1egiuFalWzaGSvuve/IWBsIcqKTlwpiEsRt9b4cHu9NYs2fLt1gYJw==",
       "requires": {
-        "array-bounds": "1.0.1",
-        "array-normalize": "1.1.4",
-        "bubleify": "1.2.1",
-        "color-normalize": "1.5.0",
-        "earcut": "2.2.1",
-        "es6-weak-map": "2.0.3",
-        "flatten-vertex-data": "1.0.2",
-        "glslify": "7.0.0",
-        "object-assign": "4.1.1",
-        "parse-rect": "1.2.0",
-        "pick-by-alias": "1.2.0",
-        "to-float32": "1.0.1"
+        "array-bounds": "^1.0.1",
+        "array-normalize": "^1.1.4",
+        "bubleify": "^1.2.0",
+        "color-normalize": "^1.5.0",
+        "earcut": "^2.1.5",
+        "es6-weak-map": "^2.0.3",
+        "flatten-vertex-data": "^1.0.2",
+        "glslify": "^7.0.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.0.1"
       }
     },
     "regl-scatter2d": {
@@ -3403,22 +3404,22 @@
       "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.1.7.tgz",
       "integrity": "sha512-FWw1hMsQrV3Y0zMU8YOytGjwSBuV3V58t8GR/mhlSL2S04jXLK1m2eAa/rDP3SpvMDkdVEr744PPDeHwsZVUhA==",
       "requires": {
-        "array-range": "1.0.1",
-        "array-rearrange": "2.2.2",
-        "clamp": "1.0.1",
-        "color-id": "1.1.0",
+        "array-range": "^1.0.1",
+        "array-rearrange": "^2.2.2",
+        "clamp": "^1.0.1",
+        "color-id": "^1.1.0",
         "color-normalize": "1.5.0",
-        "color-rgba": "2.1.1",
-        "flatten-vertex-data": "1.0.2",
-        "glslify": "7.0.0",
-        "image-palette": "2.1.0",
-        "is-iexplorer": "1.0.0",
-        "object-assign": "4.1.1",
-        "parse-rect": "1.2.0",
-        "pick-by-alias": "1.2.0",
-        "point-cluster": "3.1.8",
-        "to-float32": "1.0.1",
-        "update-diff": "1.1.0"
+        "color-rgba": "^2.1.1",
+        "flatten-vertex-data": "^1.0.2",
+        "glslify": "^7.0.0",
+        "image-palette": "^2.1.0",
+        "is-iexplorer": "^1.0.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "point-cluster": "^3.1.8",
+        "to-float32": "^1.0.1",
+        "update-diff": "^1.1.0"
       }
     },
     "regl-splom": {
@@ -3426,18 +3427,18 @@
       "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.8.tgz",
       "integrity": "sha512-4GQTgcArCbGLsXhgalWVBxeW7OXllnu+Gvil/4SbQQmtiqLCl+xgF79pISKY9mLXTlobxiX7cVKdjGjp25559A==",
       "requires": {
-        "array-bounds": "1.0.1",
-        "array-range": "1.0.1",
-        "bubleify": "1.2.1",
-        "color-alpha": "1.0.4",
-        "defined": "1.0.0",
-        "flatten-vertex-data": "1.0.2",
-        "left-pad": "1.3.0",
-        "parse-rect": "1.2.0",
-        "pick-by-alias": "1.2.0",
-        "point-cluster": "3.1.8",
-        "raf": "3.4.1",
-        "regl-scatter2d": "3.1.7"
+        "array-bounds": "^1.0.1",
+        "array-range": "^1.0.1",
+        "bubleify": "^1.2.0",
+        "color-alpha": "^1.0.4",
+        "defined": "^1.0.0",
+        "flatten-vertex-data": "^1.0.2",
+        "left-pad": "^1.3.0",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "point-cluster": "^3.1.8",
+        "raf": "^3.4.1",
+        "regl-scatter2d": "^3.1.2"
       }
     },
     "repeat-string": {
@@ -3450,7 +3451,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-protobuf-schema": {
@@ -3458,7 +3459,7 @@
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
       "requires": {
-        "protocol-buffers-schema": "3.3.3"
+        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "resumer": {
@@ -3466,7 +3467,7 @@
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "requires": {
-        "through": "2.3.8"
+        "through": "~2.3.4"
       }
     },
     "right-align": {
@@ -3474,7 +3475,7 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "right-now": {
@@ -3488,7 +3489,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "robust-compress": {
@@ -3501,10 +3502,10 @@
       "resolved": "https://registry.npmjs.org/robust-determinant/-/robust-determinant-1.1.0.tgz",
       "integrity": "sha1-jsrnm3nKqz509t6+IjflORon6cc=",
       "requires": {
-        "robust-compress": "1.0.0",
-        "robust-scale": "1.0.2",
-        "robust-sum": "1.0.0",
-        "two-product": "1.0.2"
+        "robust-compress": "^1.0.0",
+        "robust-scale": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0"
       }
     },
     "robust-dot-product": {
@@ -3512,8 +3513,8 @@
       "resolved": "https://registry.npmjs.org/robust-dot-product/-/robust-dot-product-1.0.0.tgz",
       "integrity": "sha1-yboBeL0sMEv9cl9Y6Inx2UYARVM=",
       "requires": {
-        "robust-sum": "1.0.0",
-        "two-product": "1.0.2"
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0"
       }
     },
     "robust-in-sphere": {
@@ -3521,10 +3522,10 @@
       "resolved": "https://registry.npmjs.org/robust-in-sphere/-/robust-in-sphere-1.1.3.tgz",
       "integrity": "sha1-HFiD0WpOkjkpR27zSBmFe/Kpz3U=",
       "requires": {
-        "robust-scale": "1.0.2",
-        "robust-subtract": "1.0.0",
-        "robust-sum": "1.0.0",
-        "two-product": "1.0.2"
+        "robust-scale": "^1.0.0",
+        "robust-subtract": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.0"
       }
     },
     "robust-linear-solve": {
@@ -3532,7 +3533,7 @@
       "resolved": "https://registry.npmjs.org/robust-linear-solve/-/robust-linear-solve-1.0.0.tgz",
       "integrity": "sha1-DNasUEBpGm8qo81jEdcokFyjofE=",
       "requires": {
-        "robust-determinant": "1.1.0"
+        "robust-determinant": "^1.1.0"
       }
     },
     "robust-orientation": {
@@ -3540,10 +3541,10 @@
       "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.1.3.tgz",
       "integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
       "requires": {
-        "robust-scale": "1.0.2",
-        "robust-subtract": "1.0.0",
-        "robust-sum": "1.0.0",
-        "two-product": "1.0.2"
+        "robust-scale": "^1.0.2",
+        "robust-subtract": "^1.0.0",
+        "robust-sum": "^1.0.0",
+        "two-product": "^1.0.2"
       }
     },
     "robust-product": {
@@ -3551,8 +3552,8 @@
       "resolved": "https://registry.npmjs.org/robust-product/-/robust-product-1.0.0.tgz",
       "integrity": "sha1-aFJQAHzbunzx3nW/9tKScBEJir4=",
       "requires": {
-        "robust-scale": "1.0.2",
-        "robust-sum": "1.0.0"
+        "robust-scale": "^1.0.0",
+        "robust-sum": "^1.0.0"
       }
     },
     "robust-scale": {
@@ -3560,8 +3561,8 @@
       "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
       "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
       "requires": {
-        "two-product": "1.0.2",
-        "two-sum": "1.0.0"
+        "two-product": "^1.0.2",
+        "two-sum": "^1.0.0"
       }
     },
     "robust-segment-intersect": {
@@ -3569,7 +3570,7 @@
       "resolved": "https://registry.npmjs.org/robust-segment-intersect/-/robust-segment-intersect-1.0.1.tgz",
       "integrity": "sha1-MlK2oPwboUreaRXMvgnLzpqrHBw=",
       "requires": {
-        "robust-orientation": "1.1.3"
+        "robust-orientation": "^1.1.3"
       }
     },
     "robust-subtract": {
@@ -3613,9 +3614,9 @@
       "resolved": "https://registry.npmjs.org/sharkdown/-/sharkdown-0.1.1.tgz",
       "integrity": "sha512-exwooSpmo5s45lrexgz6Q0rFQM574wYIX3iDZ7RLLqOb7IAoQZu9nxlZODU972g19sR69OIpKP2cpHTzU+PHIg==",
       "requires": {
-        "cardinal": "0.4.4",
+        "cardinal": "~0.4.2",
         "minimist": "0.0.5",
-        "split": "0.2.10"
+        "split": "~0.2.10"
       },
       "dependencies": {
         "minimist": {
@@ -3635,8 +3636,8 @@
       "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-1.0.0.tgz",
       "integrity": "sha1-bDOk7Wn81Nkbe8rdOzC2NoPq4kE=",
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "union-find": "1.0.2"
+        "bit-twiddle": "^1.0.0",
+        "union-find": "^1.0.0"
       }
     },
     "simplicial-complex-boundary": {
@@ -3644,8 +3645,8 @@
       "resolved": "https://registry.npmjs.org/simplicial-complex-boundary/-/simplicial-complex-boundary-1.0.1.tgz",
       "integrity": "sha1-csn/HiTeqjdMm7L6DL8MCB6++BU=",
       "requires": {
-        "boundary-cells": "2.0.1",
-        "reduce-simplicial-complex": "1.0.0"
+        "boundary-cells": "^2.0.0",
+        "reduce-simplicial-complex": "^1.0.0"
       }
     },
     "simplicial-complex-contour": {
@@ -3653,10 +3654,10 @@
       "resolved": "https://registry.npmjs.org/simplicial-complex-contour/-/simplicial-complex-contour-1.0.2.tgz",
       "integrity": "sha1-iQqsrChDZTQBEFRc8mKaJuBL+dE=",
       "requires": {
-        "marching-simplex-table": "1.0.0",
-        "ndarray": "1.0.19",
-        "ndarray-sort": "1.0.1",
-        "typedarray-pool": "1.2.0"
+        "marching-simplex-table": "^1.0.0",
+        "ndarray": "^1.0.15",
+        "ndarray-sort": "^1.0.0",
+        "typedarray-pool": "^1.1.0"
       }
     },
     "simplify-planar-graph": {
@@ -3664,8 +3665,8 @@
       "resolved": "https://registry.npmjs.org/simplify-planar-graph/-/simplify-planar-graph-2.0.1.tgz",
       "integrity": "sha1-vIWJNyXzLo+oriVoE5hEbSy892Y=",
       "requires": {
-        "robust-orientation": "1.1.3",
-        "simplicial-complex": "0.3.3"
+        "robust-orientation": "^1.0.1",
+        "simplicial-complex": "^0.3.3"
       },
       "dependencies": {
         "bit-twiddle": {
@@ -3678,8 +3679,8 @@
           "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-0.3.3.tgz",
           "integrity": "sha1-TDDK1X+eRXKd2PMGyHU1efRr6Z4=",
           "requires": {
-            "bit-twiddle": "0.0.2",
-            "union-find": "0.0.4"
+            "bit-twiddle": "~0.0.1",
+            "union-find": "~0.0.3"
           }
         },
         "union-find": {
@@ -3694,9 +3695,9 @@
       "resolved": "https://registry.npmjs.org/slab-decomposition/-/slab-decomposition-1.0.2.tgz",
       "integrity": "sha1-He1WdU1AixBznxRRA9/GGAf2UTQ=",
       "requires": {
-        "binary-search-bounds": "1.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "robust-orientation": "1.1.3"
+        "binary-search-bounds": "^1.0.0",
+        "functional-red-black-tree": "^1.0.0",
+        "robust-orientation": "^1.1.3"
       },
       "dependencies": {
         "binary-search-bounds": {
@@ -3729,7 +3730,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -3749,7 +3750,7 @@
       "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
       "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split-polygon": {
@@ -3757,8 +3758,8 @@
       "resolved": "https://registry.npmjs.org/split-polygon/-/split-polygon-1.0.0.tgz",
       "integrity": "sha1-DqzIoTanaxKj2VJW6n2kXbDC0kc=",
       "requires": {
-        "robust-dot-product": "1.0.0",
-        "robust-sum": "1.0.0"
+        "robust-dot-product": "^1.0.0",
+        "robust-sum": "^1.0.0"
       }
     },
     "sprintf-js": {
@@ -3776,7 +3777,7 @@
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.3.tgz",
       "integrity": "sha512-zsxDGucfAh8T339sSKgpFbvg15Fms2IVaJGC+jqp0bVsxhcpM+iMeAI8weNo8dmf4OblgifTBUoyk1vGVtYw2w==",
       "requires": {
-        "escodegen": "1.13.0"
+        "escodegen": "^1.11.1"
       }
     },
     "static-module": {
@@ -3784,17 +3785,17 @@
       "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.5.0.tgz",
       "integrity": "sha1-J9qYg8QajNCSNvhC8MHrxu32PYY=",
       "requires": {
-        "concat-stream": "1.6.2",
-        "duplexer2": "0.0.2",
-        "escodegen": "1.3.3",
-        "falafel": "2.1.0",
-        "has": "1.0.3",
-        "object-inspect": "0.4.0",
-        "quote-stream": "0.0.0",
-        "readable-stream": "1.0.34",
-        "shallow-copy": "0.0.1",
-        "static-eval": "0.2.4",
-        "through2": "0.4.2"
+        "concat-stream": "~1.6.0",
+        "duplexer2": "~0.0.2",
+        "escodegen": "~1.3.2",
+        "falafel": "^2.1.0",
+        "has": "^1.0.0",
+        "object-inspect": "~0.4.0",
+        "quote-stream": "~0.0.0",
+        "readable-stream": "~1.0.27-1",
+        "shallow-copy": "~0.0.1",
+        "static-eval": "~0.2.0",
+        "through2": "~0.4.1"
       },
       "dependencies": {
         "escodegen": {
@@ -3802,10 +3803,10 @@
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
           "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
           "requires": {
-            "esprima": "1.1.1",
-            "estraverse": "1.5.1",
-            "esutils": "1.0.0",
-            "source-map": "0.1.43"
+            "esprima": "~1.1.1",
+            "estraverse": "~1.5.0",
+            "esutils": "~1.0.0",
+            "source-map": "~0.1.33"
           }
         },
         "esprima": {
@@ -3839,7 +3840,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "optional": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "static-eval": {
@@ -3847,7 +3848,7 @@
           "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
           "integrity": "sha1-t9NNg4k3uWn5ZBygfUj47eJj6ns=",
           "requires": {
-            "escodegen": "0.0.28"
+            "escodegen": "~0.0.24"
           },
           "dependencies": {
             "escodegen": {
@@ -3855,9 +3856,9 @@
               "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
               "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
               "requires": {
-                "esprima": "1.0.4",
-                "estraverse": "1.3.2",
-                "source-map": "0.1.43"
+                "esprima": "~1.0.2",
+                "estraverse": "~1.3.0",
+                "source-map": ">= 0.1.2"
               }
             },
             "esprima": {
@@ -3877,8 +3878,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "2.1.2"
+            "readable-stream": "~1.0.17",
+            "xtend": "~2.1.1"
           }
         },
         "xtend": {
@@ -3886,7 +3887,7 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "requires": {
-            "object-keys": "0.4.0"
+            "object-keys": "~0.4.0"
           }
         }
       }
@@ -3901,7 +3902,7 @@
       "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
       "integrity": "sha512-KaJKY+hfpzNyet/emP81PJA9hTVSfxNLS9SFTWxdCnnW1/zOOwiV248+EfoX7IQFcBaOp4G5YE6xTJMF+pLg6A==",
       "requires": {
-        "parenthesis": "3.1.7"
+        "parenthesis": "^3.1.5"
       }
     },
     "string-to-arraybuffer": {
@@ -3909,8 +3910,8 @@
       "resolved": "https://registry.npmjs.org/string-to-arraybuffer/-/string-to-arraybuffer-1.0.2.tgz",
       "integrity": "sha512-DaGZidzi93dwjQen5I2osxR9ERS/R7B1PFyufNMnzhj+fmlDQAc1DSDIJVJhgI8Oq221efIMbABUBdPHDRt43Q==",
       "requires": {
-        "atob-lite": "2.0.0",
-        "is-base64": "0.1.0"
+        "atob-lite": "^2.0.0",
+        "is-base64": "^0.1.0"
       },
       "dependencies": {
         "atob-lite": {
@@ -3925,9 +3926,9 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
       "integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
       "requires": {
-        "define-properties": "1.1.3",
-        "es-abstract": "1.17.3",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1"
       }
     },
     "string.prototype.trimleft": {
@@ -3935,8 +3936,8 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
       "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
       "requires": {
-        "define-properties": "1.1.3",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string.prototype.trimright": {
@@ -3944,8 +3945,8 @@
       "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
       "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
       "requires": {
-        "define-properties": "1.1.3",
-        "function-bind": "1.1.1"
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {
@@ -3963,7 +3964,7 @@
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.2.tgz",
       "integrity": "sha512-aa0v2HURjBTOpbcknilcfxGDuArM8khklKSmZ/T8ZXL0BuRwb5aRw95lz+2bmWpFvCXDX/+FzqHxmg0TIaJErw==",
       "requires": {
-        "kdbush": "3.0.0"
+        "kdbush": "^3.0.0"
       }
     },
     "superscript-text": {
@@ -3976,7 +3977,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "surface-nets": {
@@ -3984,9 +3985,9 @@
       "resolved": "https://registry.npmjs.org/surface-nets/-/surface-nets-1.0.2.tgz",
       "integrity": "sha1-5DPIy7qUpydMb0yZVStGG/H8eks=",
       "requires": {
-        "ndarray-extract-contour": "1.0.1",
-        "triangulate-hypercube": "1.0.1",
-        "zero-crossings": "1.0.1"
+        "ndarray-extract-contour": "^1.0.0",
+        "triangulate-hypercube": "^1.0.0",
+        "zero-crossings": "^1.0.0"
       }
     },
     "svg-arc-to-cubic-bezier": {
@@ -3999,10 +4000,10 @@
       "resolved": "https://registry.npmjs.org/svg-path-bounds/-/svg-path-bounds-1.0.1.tgz",
       "integrity": "sha1-v0WLeDcmv1NDG0Yz8nkvYHSNn3Q=",
       "requires": {
-        "abs-svg-path": "0.1.1",
-        "is-svg-path": "1.0.2",
-        "normalize-svg-path": "1.0.1",
-        "parse-svg-path": "0.1.2"
+        "abs-svg-path": "^0.1.1",
+        "is-svg-path": "^1.0.1",
+        "normalize-svg-path": "^1.0.0",
+        "parse-svg-path": "^0.1.2"
       },
       "dependencies": {
         "normalize-svg-path": {
@@ -4010,7 +4011,7 @@
           "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.0.1.tgz",
           "integrity": "sha1-b3Ka1rcLtMpO/y/ksQdInv4dVv4=",
           "requires": {
-            "svg-arc-to-cubic-bezier": "3.2.0"
+            "svg-arc-to-cubic-bezier": "^3.0.0"
           }
         }
       }
@@ -4020,11 +4021,11 @@
       "resolved": "https://registry.npmjs.org/svg-path-sdf/-/svg-path-sdf-1.1.3.tgz",
       "integrity": "sha512-vJJjVq/R5lSr2KLfVXVAStktfcfa1pNFjFOgyJnzZFXlO/fDZ5DmM8FpnSKKzLPfEYTVeXuVBTHF296TpxuJVg==",
       "requires": {
-        "bitmap-sdf": "1.0.3",
-        "draw-svg-path": "1.0.0",
-        "is-svg-path": "1.0.2",
-        "parse-svg-path": "0.1.2",
-        "svg-path-bounds": "1.0.1"
+        "bitmap-sdf": "^1.0.0",
+        "draw-svg-path": "^1.0.0",
+        "is-svg-path": "^1.0.1",
+        "parse-svg-path": "^0.1.2",
+        "svg-path-bounds": "^1.0.1"
       }
     },
     "tape": {
@@ -4032,21 +4033,21 @@
       "resolved": "https://registry.npmjs.org/tape/-/tape-4.13.0.tgz",
       "integrity": "sha512-J/hvA+GJnuWJ0Sj8Z0dmu3JgMNU+MmusvkCT7+SN4/2TklW18FNCp/UuHIEhPZwHfy4sXfKYgC7kypKg4umbOw==",
       "requires": {
-        "deep-equal": "1.1.1",
-        "defined": "1.0.0",
-        "dotignore": "0.1.2",
-        "for-each": "0.3.3",
-        "function-bind": "1.1.1",
-        "glob": "7.1.6",
-        "has": "1.0.3",
-        "inherits": "2.0.4",
-        "is-regex": "1.0.5",
-        "minimist": "1.2.0",
-        "object-inspect": "1.7.0",
-        "resolve": "1.14.2",
-        "resumer": "0.0.0",
-        "string.prototype.trim": "1.2.1",
-        "through": "2.3.8"
+        "deep-equal": "~1.1.1",
+        "defined": "~1.0.0",
+        "dotignore": "~0.1.2",
+        "for-each": "~0.3.3",
+        "function-bind": "~1.1.1",
+        "glob": "~7.1.6",
+        "has": "~1.0.3",
+        "inherits": "~2.0.4",
+        "is-regex": "~1.0.5",
+        "minimist": "~1.2.0",
+        "object-inspect": "~1.7.0",
+        "resolve": "~1.14.2",
+        "resumer": "~0.0.0",
+        "string.prototype.trim": "~1.2.1",
+        "through": "~2.3.8"
       },
       "dependencies": {
         "glob": {
@@ -4054,12 +4055,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
           "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.4",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "inherits": {
@@ -4077,7 +4078,7 @@
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
           "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
           "requires": {
-            "path-parse": "1.0.6"
+            "path-parse": "^1.0.6"
           }
         }
       }
@@ -4087,7 +4088,7 @@
       "resolved": "https://registry.npmjs.org/text-cache/-/text-cache-4.2.1.tgz",
       "integrity": "sha512-G52NFRYXEW9BL4E3kBPquefXql9OT3sNT4J16gcpl3/a8y/YioDOR2Iwga5rNs9tY7rH2xv6rF8fAYrbINn6Kg==",
       "requires": {
-        "vectorize-text": "3.2.1"
+        "vectorize-text": "^3.2.1"
       }
     },
     "through": {
@@ -4100,8 +4101,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
       "requires": {
-        "readable-stream": "1.0.34",
-        "xtend": "4.0.2"
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
       }
     },
     "tinycolor2": {
@@ -4119,9 +4120,9 @@
       "resolved": "https://registry.npmjs.org/to-array-buffer/-/to-array-buffer-3.2.0.tgz",
       "integrity": "sha512-zN33mwi0gpL+7xW1ITLfJ48CEj6ZQW0ZAP0MU+2W3kEY0PAIncyuxmD4OqkUVhPAbTP7amq9j/iwvZKYS+lzSQ==",
       "requires": {
-        "flatten-vertex-data": "1.0.2",
-        "is-blob": "2.1.0",
-        "string-to-arraybuffer": "1.0.2"
+        "flatten-vertex-data": "^1.0.2",
+        "is-blob": "^2.0.1",
+        "string-to-arraybuffer": "^1.0.0"
       }
     },
     "to-float32": {
@@ -4134,7 +4135,7 @@
       "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.1.0.tgz",
       "integrity": "sha512-bfg3GLYrGoEzrGoE05TAL/Uw+H/qrf2ptr9V3W7U0lkjjyYnIfgxmVLUfhQ1hZpIQwin81uxhDjvUkDYsC0xWw==",
       "requires": {
-        "parse-unit": "1.0.1"
+        "parse-unit": "^1.0.1"
       }
     },
     "to-uint8": {
@@ -4142,11 +4143,11 @@
       "resolved": "https://registry.npmjs.org/to-uint8/-/to-uint8-1.4.1.tgz",
       "integrity": "sha512-o+ochsMlTZyucbww8It401FC2Rx+OP2RpDeYbA6h+y9HgedDl1UjdsJ9CmzKEG7AFP9es5PmJ4eDWeeeXihESg==",
       "requires": {
-        "arr-flatten": "1.1.0",
-        "clamp": "1.0.1",
-        "is-base64": "0.1.0",
-        "is-float-array": "1.0.0",
-        "to-array-buffer": "3.2.0"
+        "arr-flatten": "^1.1.0",
+        "clamp": "^1.0.1",
+        "is-base64": "^0.1.0",
+        "is-float-array": "^1.0.0",
+        "to-array-buffer": "^3.0.0"
       }
     },
     "topojson-client": {
@@ -4154,7 +4155,7 @@
       "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-2.1.0.tgz",
       "integrity": "sha1-/59784mRGF4LQoTCsGroNPDqxsg=",
       "requires": {
-        "commander": "2.1.0"
+        "commander": "2"
       }
     },
     "triangulate-hypercube": {
@@ -4162,9 +4163,9 @@
       "resolved": "https://registry.npmjs.org/triangulate-hypercube/-/triangulate-hypercube-1.0.1.tgz",
       "integrity": "sha1-2Acdsuv8/VHzCNC88qXEils20Tc=",
       "requires": {
-        "gamma": "0.1.0",
-        "permutation-parity": "1.0.0",
-        "permutation-rank": "1.0.0"
+        "gamma": "^0.1.0",
+        "permutation-parity": "^1.0.0",
+        "permutation-rank": "^1.0.0"
       }
     },
     "triangulate-polyline": {
@@ -4172,7 +4173,7 @@
       "resolved": "https://registry.npmjs.org/triangulate-polyline/-/triangulate-polyline-1.0.3.tgz",
       "integrity": "sha1-v4uod6hQVBA/65+lphtOjXAXgU0=",
       "requires": {
-        "cdt2d": "1.0.0"
+        "cdt2d": "^1.0.0"
       }
     },
     "turntable-camera-controller": {
@@ -4180,9 +4181,9 @@
       "resolved": "https://registry.npmjs.org/turntable-camera-controller/-/turntable-camera-controller-3.0.1.tgz",
       "integrity": "sha1-jb0/4AVQGRxlFky4iJcQSVeK/Zk=",
       "requires": {
-        "filtered-vector": "1.2.4",
-        "gl-mat4": "1.2.0",
-        "gl-vec3": "1.1.3"
+        "filtered-vector": "^1.2.1",
+        "gl-mat4": "^1.0.2",
+        "gl-vec3": "^1.0.2"
       }
     },
     "two-product": {
@@ -4205,7 +4206,7 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-name": {
@@ -4223,14 +4224,14 @@
       "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
       "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
       "requires": {
-        "bit-twiddle": "1.0.2",
-        "dup": "1.0.0"
+        "bit-twiddle": "^1.0.0",
+        "dup": "^1.0.0"
       }
     },
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
     "uglify-js": {
@@ -4238,9 +4239,9 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "source-map": {
@@ -4266,8 +4267,8 @@
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
       "requires": {
-        "unicode-canonical-property-names-ecmascript": "1.0.4",
-        "unicode-property-aliases-ecmascript": "1.0.5"
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
       }
     },
     "unicode-match-property-value-ecmascript": {
@@ -4310,15 +4311,15 @@
       "resolved": "https://registry.npmjs.org/utils-copy/-/utils-copy-1.1.1.tgz",
       "integrity": "sha1-biuXmCqozXPhGCo+b4vsPA9AWKc=",
       "requires": {
-        "const-pinf-float64": "1.0.0",
-        "object-keys": "1.1.1",
-        "type-name": "2.0.2",
-        "utils-copy-error": "1.0.1",
-        "utils-indexof": "1.0.0",
-        "utils-regex-from-string": "1.0.0",
-        "validate.io-array": "1.0.6",
-        "validate.io-buffer": "1.0.2",
-        "validate.io-nonnegative-integer": "1.0.0"
+        "const-pinf-float64": "^1.0.0",
+        "object-keys": "^1.0.9",
+        "type-name": "^2.0.0",
+        "utils-copy-error": "^1.0.0",
+        "utils-indexof": "^1.0.0",
+        "utils-regex-from-string": "^1.0.0",
+        "validate.io-array": "^1.0.3",
+        "validate.io-buffer": "^1.0.1",
+        "validate.io-nonnegative-integer": "^1.0.0"
       }
     },
     "utils-copy-error": {
@@ -4326,8 +4327,8 @@
       "resolved": "https://registry.npmjs.org/utils-copy-error/-/utils-copy-error-1.0.1.tgz",
       "integrity": "sha1-eR3jk8DwmJCv1Z88vqY18HmpT6U=",
       "requires": {
-        "object-keys": "1.1.1",
-        "utils-copy": "1.1.1"
+        "object-keys": "^1.0.9",
+        "utils-copy": "^1.1.0"
       }
     },
     "utils-indexof": {
@@ -4335,8 +4336,8 @@
       "resolved": "https://registry.npmjs.org/utils-indexof/-/utils-indexof-1.0.0.tgz",
       "integrity": "sha1-IP6r8J7xAYtSNkPoOA57yD7GG1w=",
       "requires": {
-        "validate.io-array-like": "1.0.2",
-        "validate.io-integer-primitive": "1.0.0"
+        "validate.io-array-like": "^1.0.1",
+        "validate.io-integer-primitive": "^1.0.0"
       }
     },
     "utils-regex-from-string": {
@@ -4344,8 +4345,8 @@
       "resolved": "https://registry.npmjs.org/utils-regex-from-string/-/utils-regex-from-string-1.0.0.tgz",
       "integrity": "sha1-/hopCfjeD/DVGCyA+8ZU1qaH0Yk=",
       "requires": {
-        "regex-regex": "1.0.0",
-        "validate.io-string-primitive": "1.0.1"
+        "regex-regex": "^1.0.0",
+        "validate.io-string-primitive": "^1.0.0"
       }
     },
     "validate-npm-package-license": {
@@ -4354,8 +4355,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "validate.io-array": {
@@ -4368,8 +4369,8 @@
       "resolved": "https://registry.npmjs.org/validate.io-array-like/-/validate.io-array-like-1.0.2.tgz",
       "integrity": "sha1-evn363tRcVvrIhVmjsXM5U+t21o=",
       "requires": {
-        "const-max-uint32": "1.0.2",
-        "validate.io-integer-primitive": "1.0.0"
+        "const-max-uint32": "^1.0.2",
+        "validate.io-integer-primitive": "^1.0.0"
       }
     },
     "validate.io-buffer": {
@@ -4382,7 +4383,7 @@
       "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
       "integrity": "sha1-FoSWSAuVviJH7EQ/IjPeT4mHgGg=",
       "requires": {
-        "validate.io-number": "1.0.3"
+        "validate.io-number": "^1.0.3"
       }
     },
     "validate.io-integer-primitive": {
@@ -4390,7 +4391,7 @@
       "resolved": "https://registry.npmjs.org/validate.io-integer-primitive/-/validate.io-integer-primitive-1.0.0.tgz",
       "integrity": "sha1-qaoBA1X+hoHA/qbBp0rSQZyt3cY=",
       "requires": {
-        "validate.io-number-primitive": "1.0.0"
+        "validate.io-number-primitive": "^1.0.0"
       }
     },
     "validate.io-matrix-like": {
@@ -4408,7 +4409,7 @@
       "resolved": "https://registry.npmjs.org/validate.io-nonnegative-integer/-/validate.io-nonnegative-integer-1.0.0.tgz",
       "integrity": "sha1-gGkkOgjF+Y6VQTySnf17GPP28p8=",
       "requires": {
-        "validate.io-integer": "1.0.5"
+        "validate.io-integer": "^1.0.5"
       }
     },
     "validate.io-number": {
@@ -4426,7 +4427,7 @@
       "resolved": "https://registry.npmjs.org/validate.io-positive-integer/-/validate.io-positive-integer-1.0.0.tgz",
       "integrity": "sha1-ftLQO0wnVYzGagCqsPDpIYFKZYI=",
       "requires": {
-        "validate.io-integer": "1.0.5"
+        "validate.io-integer": "^1.0.5"
       }
     },
     "validate.io-string-primitive": {
@@ -4439,13 +4440,13 @@
       "resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.2.1.tgz",
       "integrity": "sha512-rGojF+D9BB96iPZPUitfq5kaiS6eCJmfEel0NXOK/MzZSuXGiwhoop80PtaDas9/Hg/oaox1tI9g3h93qpuspg==",
       "requires": {
-        "cdt2d": "1.0.0",
-        "clean-pslg": "1.1.2",
-        "ndarray": "1.0.19",
-        "planar-graph-to-polyline": "1.0.5",
-        "simplify-planar-graph": "2.0.1",
-        "surface-nets": "1.0.2",
-        "triangulate-polyline": "1.0.3"
+        "cdt2d": "^1.0.0",
+        "clean-pslg": "^1.1.0",
+        "ndarray": "^1.0.11",
+        "planar-graph-to-polyline": "^1.0.0",
+        "simplify-planar-graph": "^2.0.1",
+        "surface-nets": "^1.0.0",
+        "triangulate-polyline": "^1.0.0"
       }
     },
     "vt-pbf": {
@@ -4454,8 +4455,8 @@
       "integrity": "sha512-pHjWdrIoxurpmTcbfBWXaPwSmtPAHS105253P1qyEfSTV2HJddqjM+kIHquaT/L6lVJIk9ltTGc0IxR/G47hYA==",
       "requires": {
         "@mapbox/point-geometry": "0.1.0",
-        "@mapbox/vector-tile": "1.3.1",
-        "pbf": "3.2.1"
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.0.5"
       }
     },
     "weak-map": {
@@ -4473,7 +4474,7 @@
       "resolved": "https://registry.npmjs.org/webgl-context/-/webgl-context-2.2.0.tgz",
       "integrity": "sha1-jzfXJXz23xzQpJ5qextyG5TMhqA=",
       "requires": {
-        "get-canvas-context": "1.0.2"
+        "get-canvas-context": "^1.0.1"
       }
     },
     "wgs84": {
@@ -4501,7 +4502,7 @@
       "resolved": "https://registry.npmjs.org/world-calendars/-/world-calendars-1.0.3.tgz",
       "integrity": "sha1-slxQMrokEo/8QdCfr0pewbnBQzU=",
       "requires": {
-        "object-assign": "4.1.1"
+        "object-assign": "^4.1.0"
       }
     },
     "wrappy": {
@@ -4519,9 +4520,9 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     },
@@ -4530,7 +4531,7 @@
       "resolved": "https://registry.npmjs.org/zero-crossings/-/zero-crossings-1.0.1.tgz",
       "integrity": "sha1-xWK9MRNkPzRDokXRJAa4i2m5qf8=",
       "requires": {
-        "cwise-compiler": "1.1.3"
+        "cwise-compiler": "^1.0.0"
       }
     }
   }

--- a/packages/javascript/jupyterlab-plotly/package.json
+++ b/packages/javascript/jupyterlab-plotly/package.json
@@ -28,14 +28,14 @@
   "devDependencies": {
     "rimraf": "^2.6.1",
     "ify-loader": "^1.1.0",
-    "typescript": "~3.1.1"
+    "typescript": "~3.7.0"
   },
   "dependencies": {
     "plotly.js": "^1.52.1",
     "@types/plotly.js": "1.44.28",
-    "@jupyterlab/rendermime-interfaces": "^1.3.0",
-    "@phosphor/messaging": "^1.2.3",
-    "@phosphor/widgets": "^1.8.1",
+    "@jupyterlab/rendermime-interfaces": "^1.3.0 || ^2.0.0",
+    "@lumino/messaging": "^1.2.3",
+    "@lumino/widgets": "^1.8.1",
     "lodash": "^4.17.4"
   },
   "jupyterlab": {

--- a/packages/javascript/jupyterlab-plotly/package.json
+++ b/packages/javascript/jupyterlab-plotly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-plotly",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "The plotly JupyterLab extension",
   "author": "The plotly.py team",
   "license": "MIT",

--- a/packages/javascript/jupyterlab-plotly/src/javascript-renderer-extension.ts
+++ b/packages/javascript/jupyterlab-plotly/src/javascript-renderer-extension.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { Widget } from '@phosphor/widgets';
+import { Widget } from '@lumino/widgets';
 
-import { Message } from '@phosphor/messaging';
+import { Message } from '@lumino/messaging';
 
 import { IRenderMime } from '@jupyterlab/rendermime-interfaces';
 


### PR DESCRIPTION
I think this is a backward compatible change that makes the jupyterlab extension `jupyterlab-plotly` support JupyterLab 2.0.0 by accepting also JupyterLab 2.0.0 required dependencies.

Fixes #2244

## JupyterLab 2.0.0 references
- [Change log for developers](https://jupyterlab.readthedocs.io/en/stable/getting_started/changelog.html#for-developers)
- [A migration guide](https://jupyterlab.readthedocs.io/en/stable/developer/extension_migration.html#extension-migration)