### PR TITLE
python: fix python 3.8 Syntax Warning

### DIFF
--- a/packages/python/plotly/_plotly_utils/utils.py
+++ b/packages/python/plotly/_plotly_utils/utils.py
@@ -211,7 +211,7 @@ class NotEncodable(Exception):
 def iso_to_plotly_time_string(iso_string):
     """Remove timezone info and replace 'T' delimeter with ' ' (ws)."""
     # make sure we don't send timezone info to plotly
-    if (iso_string.split("-")[:3] is "00:00") or (iso_string.split("+")[0] is "00:00"):
+    if (iso_string.split("-")[:3] == "00:00") or (iso_string.split("+")[0] == "00:00"):
         raise Exception(
             "Plotly won't accept timestrings with timezone info.\n"
             "All timestrings are assumed to be in UTC."

--- a/packages/python/plotly/plotly/figure_factory/_candlestick.py
+++ b/packages/python/plotly/plotly/figure_factory/_candlestick.py
@@ -191,12 +191,12 @@ def create_candlestick(open, high, low, close, dates=None, direction="both", **k
         utils.validate_equal_length(open, high, low, close)
     validate_ohlc(open, high, low, close, direction, **kwargs)
 
-    if direction is "increasing":
+    if direction == "increasing":
         candle_incr_data = make_increasing_candle(
             open, high, low, close, dates, **kwargs
         )
         data = candle_incr_data
-    elif direction is "decreasing":
+    elif direction == "decreasing":
         candle_decr_data = make_decreasing_candle(
             open, high, low, close, dates, **kwargs
         )

--- a/packages/python/plotly/plotly/figure_factory/_ohlc.py
+++ b/packages/python/plotly/plotly/figure_factory/_ohlc.py
@@ -173,10 +173,10 @@ def create_ohlc(open, high, low, close, dates=None, direction="both", **kwargs):
         utils.validate_equal_length(open, high, low, close)
     validate_ohlc(open, high, low, close, direction, **kwargs)
 
-    if direction is "increasing":
+    if direction == "increasing":
         ohlc_incr = make_increasing_ohlc(open, high, low, close, dates, **kwargs)
         data = [ohlc_incr]
-    elif direction is "decreasing":
+    elif direction == "decreasing":
         ohlc_decr = make_decreasing_ohlc(open, high, low, close, dates, **kwargs)
         data = [ohlc_decr]
     else:

--- a/packages/python/plotly/plotly/matplotlylib/renderer.py
+++ b/packages/python/plotly/plotly/matplotlylib/renderer.py
@@ -457,7 +457,7 @@ class PlotlyRenderer(Renderer):
 
         """
         self.msg += "    Attempting to draw a path collection\n"
-        if props["offset_coordinates"] is "data":
+        if props["offset_coordinates"] == "data":
             markerstyle = mpltools.get_markerstyle_from_collection(props)
             scatter_props = {
                 "coordinates": "data",
@@ -569,7 +569,7 @@ class PlotlyRenderer(Renderer):
             self.draw_title(**props)
         else:  # just a regular text annotation...
             self.msg += "      Text object is a normal annotation\n"
-            if props["coordinates"] is not "data":
+            if props["coordinates"] != "data":
                 self.msg += (
                     "        Text object isn't linked to 'data' " "coordinates\n"
                 )


### PR DESCRIPTION
Closes #2230 