### PR TITLE
Update sankey-diagram.md

### DIFF
--- a/doc/python/sankey-diagram.md
+++ b/doc/python/sankey-diagram.md
@@ -62,9 +62,9 @@ fig.update_layout(title_text="Basic Sankey Diagram", font_size=10)
 fig.show()
 ```
 
-### More complex Sankey diagram
+### More complex Sankey diagram with colored links
 
-```python inputHidden=false outputHidden=false
+```python
 import plotly.graph_objects as go
 import urllib, json
 
@@ -76,7 +76,7 @@ data = json.loads(response.read())
 opacity = 0.4
 # change 'magenta' to its 'rgba' value to add opacity
 data['data'][0]['node']['color'] = ['rgba(255,0,255, 0.8)' if color == "magenta" else color for color in data['data'][0]['node']['color']]
-data['data'][0]['link']['color'] = [data['data'][0]['node']['color'][src].replace("0.8", str(opacity)) 
+data['data'][0]['link']['color'] = [data['data'][0]['node']['color'][src].replace("0.8", str(opacity))
                                     for src in data['data'][0]['link']['source']]
 
 fig = go.Figure(data=[go.Sankey(

--- a/doc/python/sankey-diagram.md
+++ b/doc/python/sankey-diagram.md
@@ -71,6 +71,13 @@ import urllib, json
 url = 'https://raw.githubusercontent.com/plotly/plotly.js/master/test/image/mocks/sankey_energy.json'
 response = urllib.request.urlopen(url)
 data = json.loads(response.read())
+
+# override gray link colors with 'source' colors
+opacity = 0.4
+data['data'][0]['node']['color'] = ['rgba(255,0,255, 0.8)' if color == "magenta" else color for color in data['data'][0]['node']['color']]
+data['data'][0]['link']['color'] = [data['data'][0]['node']['color'][src] for src in data['data'][0]['link']['source']]
+data['data'][0]['link']['color'] = [color.replace("0.8", str(opacity)) for color in data['data'][0]['link']['color']]
+
 fig = go.Figure(data=[go.Sankey(
     valueformat = ".0f",
     valuesuffix = "TWh",
@@ -87,8 +94,9 @@ fig = go.Figure(data=[go.Sankey(
       source =  data['data'][0]['link']['source'],
       target =  data['data'][0]['link']['target'],
       value =  data['data'][0]['link']['value'],
-      label =  data['data'][0]['link']['label']
-  ))])
+      label =  data['data'][0]['link']['label'],
+      color =  data['data'][0]['link']['color']
+))])
 
 fig.update_layout(title_text="Energy forecast for 2050<br>Source: Department of Energy & Climate Change, Tom Counsell via <a href='https://bost.ocks.org/mike/sankey/'>Mike Bostock</a>",
                   font_size=10)

--- a/doc/python/sankey-diagram.md
+++ b/doc/python/sankey-diagram.md
@@ -74,9 +74,10 @@ data = json.loads(response.read())
 
 # override gray link colors with 'source' colors
 opacity = 0.4
+# change 'magenta' to its 'rgba' value to add opacity
 data['data'][0]['node']['color'] = ['rgba(255,0,255, 0.8)' if color == "magenta" else color for color in data['data'][0]['node']['color']]
-data['data'][0]['link']['color'] = [data['data'][0]['node']['color'][src] for src in data['data'][0]['link']['source']]
-data['data'][0]['link']['color'] = [color.replace("0.8", str(opacity)) for color in data['data'][0]['link']['color']]
+data['data'][0]['link']['color'] = [data['data'][0]['node']['color'][src].replace("0.8", str(opacity)) 
+                                    for src in data['data'][0]['link']['source']]
 
 fig = go.Figure(data=[go.Sankey(
     valueformat = ".0f",


### PR DESCRIPTION
Add colorful links to the Sankey diagram.
#1965 

Please uncomment this block and take a look at this checklist if your PR is making substantial changes to documentation/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [x] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [x] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [x] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [x] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [x] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [x] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [x] `fig.show()` is at the end of each new/modified example
- [x] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)
