### PR TITLE
Remove unsupported opacity kwarg from pie-like functions

### DIFF
--- a/packages/python/plotly/plotly/express/_chart_types.py
+++ b/packages/python/plotly/plotly/express/_chart_types.py
@@ -1234,7 +1234,6 @@ def pie(
     template=None,
     width=None,
     height=None,
-    opacity=None,
     hole=None,
 ):
     """
@@ -1423,7 +1422,6 @@ def funnel_area(
     template=None,
     width=None,
     height=None,
-    opacity=None,
 ):
     """
     In a funnel area plot, each row of `data_frame` is represented as a


### PR DESCRIPTION
Whoops, `marker_opacity` isn't supported in `pie`-like traces! See https://community.plot.ly/t/possible-bug-color-discrete-map-and-opacity-in-px-pie-plotly-io-as-pio/36386/2