### PR TITLE
Update sliders.md

### DIFF
--- a/doc/python/sliders.md
+++ b/doc/python/sliders.md
@@ -33,8 +33,8 @@ jupyter:
     thumbnail: thumbnail/slider2017.gif
 ---
 
-#### Simple Slider Control
-Sliders can now be used in Plotly to change the data displayed or style of a plot!
+### Simple Slider Control
+Sliders can be used in Plotly to change the data displayed or style of a plot. 
 
 ```python
 import plotly.graph_objects as go
@@ -60,10 +60,11 @@ fig.data[10].visible = True
 steps = []
 for i in range(len(fig.data)):
     step = dict(
-        method="restyle",
-        args=["visible", [False] * len(fig.data)],
+        method="update",
+        args=[{"visible": [False] * len(fig.data)},
+              {"title": "Slider switched to step: " + str(i)}],  # layout attribute
     )
-    step["args"][1][i] = True  # Toggle i'th trace to "visible"
+    step["args"][0]["visible"][i] = True  # Toggle i'th trace to "visible"
     steps.append(step)
 
 sliders = [dict(
@@ -77,6 +78,28 @@ fig.update_layout(
     sliders=sliders
 )
 
+fig.show()
+```
+
+#### Methods
+The method determines which [plotly.js function](https://plot.ly/javascript/plotlyjs-function-reference/) will be used to update the chart. Plotly can use several [updatemenu](https://plot.ly/python/reference/#layout-updatemenus-items-updatemenu-buttons-items-button-method) methods to add the slider:
+- `"restyle"`: modify **data** attributes
+- `"relayout"`: modify **layout** attributes
+- `"update"`: modify **data and layout** attributes
+- `"animate"`: start or pause an animation
+
+### Sliders in Plotly Express
+Plotly Express provide sliders, but with implicit animation. The animation can be ommited by removing `updatemenus` in the `layout`:
+
+```python
+import plotly.express as px
+
+df = px.data.gapminder()
+fig = px.scatter(df, x="gdpPercap", y="lifeExp", animation_frame="year", animation_group="country",
+           size="pop", color="continent", hover_name="country",
+           log_x=True, size_max=55, range_x=[100,100000], range_y=[25,90])
+
+fig["layout"].pop("updatemenus") # optional, drop animation buttons
 fig.show()
 ```
 


### PR DESCRIPTION
'Simple Slider Control' section: change method to 'update', add title. 
Add 'Sliders in Plotly Express', 'Methods' sections.
Issue #1965 

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [x] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [x] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [x] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [x] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [x] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [x] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [x] `fig.show()` is at the end of each new/modified example
- [x] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)