### PR TITLE
change .ly to .com

### DIFF
--- a/doc/python/2D-Histogram.md
+++ b/doc/python/2D-Histogram.md
@@ -71,7 +71,7 @@ fig = go.Figure(go.Histogram2d(x=x, y=y, histnorm='probability',
 fig.show()
 ```
 ### Sharing bin settings between 2D Histograms
-This example shows how to use [bingroup](https://plot.ly/python/reference/#histogram-bingroup) attribute to have a compatible bin settings for both histograms. To define `start`, `end` and `size` value of x-axis and y-axis seperatly, set [ybins](https://plot.ly/python/reference/#histogram2dcontour-ybins) and `xbins`.
+This example shows how to use [bingroup](https://plotly.com/python/reference/#histogram-bingroup) attribute to have a compatible bin settings for both histograms. To define `start`, `end` and `size` value of x-axis and y-axis seperatly, set [ybins](https://plotly.com/python/reference/#histogram2dcontour-ybins) and `xbins`.
 
 ```python
 import plotly.graph_objects as go
@@ -170,4 +170,4 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#histogram2d for more information and chart attribute options!
+See https://plotly.com/python/reference/#histogram2d for more information and chart attribute options!

--- a/doc/python/2d-histogram-contour.md
+++ b/doc/python/2d-histogram-contour.md
@@ -185,4 +185,4 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#histogram2dcontour for more information and chart attribute options!
+See https://plotly.com/python/reference/#histogram2dcontour for more information and chart attribute options!

--- a/doc/python/3d-axes.md
+++ b/doc/python/3d-axes.md
@@ -39,7 +39,7 @@ jupyter:
 attributes such as `xaxis`, `yaxis` and `zaxis` parameters, in order to
 set the range, title, ticks, color etc. of the axes.
 
-For creating 3D charts, see [this page](https://plot.ly/python/3d-charts/).
+For creating 3D charts, see [this page](https://plotly.com/python/3d-charts/).
 
 ```python
 import plotly.graph_objects as go

--- a/doc/python/3d-bubble-charts.md
+++ b/doc/python/3d-bubble-charts.md
@@ -108,7 +108,7 @@ fig = go.Figure(data=go.Scatter3d(
     mode = 'markers',
     marker = dict(
         sizemode = 'diameter',
-        sizeref = 750, # info on sizeref: https://plot.ly/python/reference/#scatter-marker-sizeref
+        sizeref = 750, # info on sizeref: https://plotly.com/python/reference/#scatter-marker-sizeref
         size = planet_diameter,
         color = planet_colors,
         )
@@ -147,7 +147,7 @@ fig = go.Figure(go.Scatter3d(
     mode = 'markers',
     marker = dict(
         sizemode = 'diameter',
-        sizeref = 750, # info on sizeref: https://plot.ly/python/reference/#scatter-marker-sizeref
+        sizeref = 750, # info on sizeref: https://plotly.com/python/reference/#scatter-marker-sizeref
         size = planet_diameter,
         color = temperatures,
         colorbar_title = 'Mean<br>Temperature',
@@ -167,4 +167,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#scatter3d and https://plot.ly/python/reference/#scatter-marker-sizeref <br>for more information and chart attribute options!
+See https://plotly.com/python/reference/#scatter3d and https://plotly.com/python/reference/#scatter-marker-sizeref <br>for more information and chart attribute options!

--- a/doc/python/3d-camera-controls.md
+++ b/doc/python/3d-camera-controls.md
@@ -290,4 +290,4 @@ fig.show()
 #### Reference
 
 
-See https://plot.ly/python/reference/#layout-scene-camera for more information and chart attribute options!
+See https://plotly.com/python/reference/#layout-scene-camera for more information and chart attribute options!

--- a/doc/python/3d-isosurface-plots.md
+++ b/doc/python/3d-isosurface-plots.md
@@ -235,5 +235,5 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#isosurface for more information and chart attribute options!
+See https://plotly.com/python/reference/#isosurface for more information and chart attribute options!
 

--- a/doc/python/3d-line-plots.md
+++ b/doc/python/3d-line-plots.md
@@ -120,4 +120,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#scatter3d-marker-line for more information and chart attribute options!
+See https://plotly.com/python/reference/#scatter3d-marker-line for more information and chart attribute options!

--- a/doc/python/3d-mesh.md
+++ b/doc/python/3d-mesh.md
@@ -163,4 +163,4 @@ fig.show()
 ```
 
 ## Reference
-See https://plot.ly/python/reference/#mesh3d for more information and chart attribute options!
+See https://plotly.com/python/reference/#mesh3d for more information and chart attribute options!

--- a/doc/python/3d-scatter-plots.md
+++ b/doc/python/3d-scatter-plots.md
@@ -37,7 +37,7 @@ jupyter:
 
 [Plotly Express](/python/plotly-express/) is the easy-to-use, high-level interface to Plotly, which [operates on "tidy" data](/python/px-arguments/) and produces [easy-to-style figures](/python/styling-plotly-express/).
 
-Like the [2D scatter plot](https://plot.ly/python/line-and-scatter/) `px.scatter`, the 3D function `px.scatter_3d` plots individual data in three-dimensional space.
+Like the [2D scatter plot](https://plotly.com/python/line-and-scatter/) `px.scatter`, the 3D function `px.scatter_3d` plots individual data in three-dimensional space.
 
 ```python
 import plotly.express as px
@@ -77,7 +77,7 @@ fig.update_layout(margin=dict(l=0, r=0, b=0, t=0))
 #### Basic 3D Scatter Plot
 
 If Plotly Express does not provide a good starting point, it is also possible to use the more generic `go.Scatter3D` from `plotly.graph_objs`.
-Like the [2D scatter plot](https://plot.ly/python/line-and-scatter/) `go.Scatter`, `go.Scatter3d` plots individual data in three-dimensional space.
+Like the [2D scatter plot](https://plotly.com/python/line-and-scatter/) `go.Scatter`, `go.Scatter3d` plots individual data in three-dimensional space.
 
 ```python
 import plotly.graph_objects as go
@@ -122,7 +122,7 @@ fig.show()
 
 ### Dash App
 
-[Dash](https://plot.ly/products/dash/) is an Open Source Python library which can help you convert plotly figures into a reactive, web-based application. Below is a simple example of a dashboard created using Dash. Its [source code](https://github.com/plotly/simple-example-chart-apps/tree/master/dash-3dscatterplot) can easily be deployed to a PaaS.
+[Dash](https://plotly.com/products/dash/) is an Open Source Python library which can help you convert plotly figures into a reactive, web-based application. Below is a simple example of a dashboard created using Dash. Its [source code](https://github.com/plotly/simple-example-chart-apps/tree/master/dash-3dscatterplot) can easily be deployed to a PaaS.
 
 ```python
 from IPython.display import IFrame
@@ -136,4 +136,4 @@ IFrame(src= "https://dash-simple-apps.plotly.host/dash-3dscatterplot/code", widt
 
 #### Reference
 
-See https://plot.ly/python/reference/#scatter3d for more information and chart attribute options!
+See https://plotly.com/python/reference/#scatter3d for more information and chart attribute options!

--- a/doc/python/3d-subplots.md
+++ b/doc/python/3d-subplots.md
@@ -82,4 +82,4 @@ fig.show()
 #### Reference
 
 
-See https://plot.ly/python/subplots/ for more information regarding subplots!
+See https://plotly.com/python/subplots/ for more information regarding subplots!

--- a/doc/python/3d-surface-coloring.md
+++ b/doc/python/3d-surface-coloring.md
@@ -60,5 +60,5 @@ fig.show()
 #### Reference
 
 
-See https://plot.ly/python/reference/#surface-surfacecolor for more information!
+See https://plotly.com/python/reference/#surface-surfacecolor for more information!
 

--- a/doc/python/3d-surface-plots.md
+++ b/doc/python/3d-surface-plots.md
@@ -76,7 +76,7 @@ fig.show()
 #### Surface Plot With Contours
 
 
-Display and customize contour data for each axis using the `contours` attribute ([reference](plot.ly/python/reference/#surface-contours)).
+Display and customize contour data for each axis using the `contours` attribute ([reference](plotly.com/python/reference/#surface-contours)).
 
 ```python
 import plotly.graph_objects as go
@@ -98,7 +98,7 @@ fig.update_layout(title='Mt Bruno Elevation', autosize=False,
 fig.show()
 ```
 #### Configure Surface Contour Levels
-This example shows how to slice the surface graph on the desired position for each of x, y and z axis. [contours.x.start](https://plot.ly/python/reference/#surface-contours-x-start) sets the starting contour level value, `end` sets the end of it, and `size` sets the step between each contour level. 
+This example shows how to slice the surface graph on the desired position for each of x, y and z axis. [contours.x.start](https://plotly.com/python/reference/#surface-contours-x-start) sets the starting contour level value, `end` sets the end of it, and `size` sets the step between each contour level. 
 
 ```python
 import plotly.graph_objects as go
@@ -166,4 +166,4 @@ fig.show()
 #### Reference
 
 
-See https://plot.ly/python/reference/#surface for more information!
+See https://plotly.com/python/reference/#surface for more information!

--- a/doc/python/3d-volume.md
+++ b/doc/python/3d-volume.md
@@ -190,7 +190,7 @@ fig = go.Figure(data=go.Volume(
     ))
 
 # Change camera view for a better view of the sides, XZ plane
-# (see https://plot.ly/python/v3/3d-camera-controls/)
+# (see https://plotly.com/python/v3/3d-camera-controls/)
 fig.update_layout(scene_camera = dict(
     up=dict(x=0, y=0, z=1),
     center=dict(x=0, y=0, z=0),
@@ -254,7 +254,7 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#volume for more information and chart attribute options!
+See https://plotly.com/python/reference/#volume for more information and chart attribute options!
 
 #### See also
 [3D isosurface documentation](/python/3d-isosurface-plots/)

--- a/doc/python/aggregations.md
+++ b/doc/python/aggregations.md
@@ -142,7 +142,7 @@ import plotly.io as pio
 
 import pandas as pd
 
-df = pd.read_csv("https://plot.ly/~public.health/17.csv")
+df = pd.read_csv("https://plotly.com/~public.health/17.csv")
 
 data = [dict(
   x = df['date'],
@@ -270,4 +270,4 @@ pio.show(fig_dict, validate=False)
 ```
 
 #### Reference
-See https://plot.ly/python/reference/ for more information and chart attribute options!
+See https://plotly.com/python/reference/ for more information and chart attribute options!

--- a/doc/python/animations.md
+++ b/doc/python/animations.md
@@ -63,7 +63,7 @@ Along with `data` and `layout`, `frames` can be added as a key in a figure objec
 
 #### Adding Control Buttons to Animations
 
-You can add play and pause buttons to control your animated charts by adding an `updatemenus` array to the `layout` of your `figure`. More information on style and placement of the buttons is available in Plotly's [`updatemenus` reference](https://plot.ly/python/reference/#layout-updatemenus).
+You can add play and pause buttons to control your animated charts by adding an `updatemenus` array to the `layout` of your `figure`. More information on style and placement of the buttons is available in Plotly's [`updatemenus` reference](https://plotly.com/python/reference/#layout-updatemenus).
 <br>
 The buttons are defined as follows:
 
@@ -389,5 +389,5 @@ fig.show()
 
 #### Reference
 
-For additional information and attributes for creating bubble charts in Plotly see: https://plot.ly/python/bubble-charts/.
-For more documentation on creating animations with Plotly, see https://plot.ly/python/#animations.
+For additional information and attributes for creating bubble charts in Plotly see: https://plotly.com/python/bubble-charts/.
+For more documentation on creating animations with Plotly, see https://plotly.com/python/#animations.

--- a/doc/python/annotated-heatmap.md
+++ b/doc/python/annotated-heatmap.md
@@ -202,7 +202,7 @@ fig.show()
 ```
 
 #### Reference
-For more info on Plotly heatmaps, see: https://plot.ly/python/reference/#heatmap.<br> For more info on using colorscales with Plotly see: https://plot.ly/python/heatmap-and-contour-colorscales/ <br>For more info on annotated_heatmaps, see:
+For more info on Plotly heatmaps, see: https://plotly.com/python/reference/#heatmap.<br> For more info on using colorscales with Plotly see: https://plotly.com/python/heatmap-and-contour-colorscales/ <br>For more info on annotated_heatmaps, see:
 
 ```python
 help(ff.create_annotated_heatmap)

--- a/doc/python/axes.md
+++ b/doc/python/axes.md
@@ -477,7 +477,7 @@ fig.show()
 
 ### Set axis title position
 
-This example sets `standoff` attribute to cartesian axes to determine the distance between the tick labels and the axis title. Note that the axis title position is always constrained within the margins, so the actual standoff distance is always less than the set or default value. By default [automargin](https://plot.ly/python/setting-graph-size/#automatically-adjust-margins) is `True` in Plotly template for the cartesian axis, so the margins will be pushed to fit the axis title at given standoff distance.
+This example sets `standoff` attribute to cartesian axes to determine the distance between the tick labels and the axis title. Note that the axis title position is always constrained within the margins, so the actual standoff distance is always less than the set or default value. By default [automargin](https://plotly.com/python/setting-graph-size/#automatically-adjust-margins) is `True` in Plotly template for the cartesian axis, so the margins will be pushed to fit the axis title at given standoff distance.
 
 ```python
 import plotly.graph_objects as go
@@ -743,7 +743,7 @@ fig.show()
 
 #### Synchronizing axes in subplots with `matches`
 
-Using `facet_col` from `plotly.express` let [zoom](https://help.plot.ly/zoom-pan-hover-controls/#step-3-zoom-in-and-zoom-out-autoscale-the-plot) and [pan](https://help.plot.ly/zoom-pan-hover-controls/#step-6-pan-along-axes) each facet to the same range implicitly. However, if the subplots are created with `make_subplots`, the axis needs to be updated with `matches` parameter to update all the subplots accordingly. 
+Using `facet_col` from `plotly.express` let [zoom](https://help.plotly.com/zoom-pan-hover-controls/#step-3-zoom-in-and-zoom-out-autoscale-the-plot) and [pan](https://help.plotly.com/zoom-pan-hover-controls/#step-6-pan-along-axes) each facet to the same range implicitly. However, if the subplots are created with `make_subplots`, the axis needs to be updated with `matches` parameter to update all the subplots accordingly. 
 
 Zoom in one trace below, to see the other subplots zoomed to the same x-axis range. To pan all the subplots, click and drag from the center of x-axis to the side:
 
@@ -764,4 +764,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#layout-xaxis and https://plot.ly/python/reference/#layout-yaxis for more information and chart attribute options!
+See https://plotly.com/python/reference/#layout-xaxis and https://plotly.com/python/reference/#layout-yaxis for more information and chart attribute options!

--- a/doc/python/bar-charts.md
+++ b/doc/python/bar-charts.md
@@ -336,7 +336,7 @@ fig.show()
 
 ### Bar Chart with Sorted or Ordered Categories
 
-Set `categoryorder` to `"category ascending"` or `"category descending"` for the alphanumerical order of the category names or `"total ascending"` or `"total descending"` for numerical order of values. [categoryorder](https://plot.ly/python/reference/#layout-xaxis-categoryorder) for more information. Note that sorting the bars by a particular trace isn't possible right now - it's only possible to sort by the total values. Of course, you can always sort your data _before_ plotting it if you need more customization.
+Set `categoryorder` to `"category ascending"` or `"category descending"` for the alphanumerical order of the category names or `"total ascending"` or `"total descending"` for numerical order of values. [categoryorder](https://plotly.com/python/reference/#layout-xaxis-categoryorder) for more information. Note that sorting the bars by a particular trace isn't possible right now - it's only possible to sort by the total values. Of course, you can always sort your data _before_ plotting it if you need more customization.
 
 This example orders the bar chart alphabetically with `categoryorder: 'category ascending'`
 
@@ -382,8 +382,8 @@ fig.show()
 
 ### Horizontal Bar Charts
 
-See examples of horizontal bar charts [here](https://plot.ly/python/horizontal-bar-charts/).
+See examples of horizontal bar charts [here](https://plotly.com/python/horizontal-bar-charts/).
 
 ### Reference
 
-See https://plot.ly/python/reference/#bar for more information and chart attribute options!
+See https://plotly.com/python/reference/#bar for more information and chart attribute options!

--- a/doc/python/box-plots.md
+++ b/doc/python/box-plots.md
@@ -36,7 +36,7 @@ jupyter:
     thumbnail: thumbnail/box.jpg
 ---
 
-A [box plot](https://en.wikipedia.org/wiki/Box_plot) is a statistical representation of numerical data through their quartiles. The ends of the box represent the lower and upper quartiles, while the median (second quartile) is marked by a line inside the box. For other statistical representations of numerical data, see [other statistical charts](https://plot.ly/python/statistical-charts/).
+A [box plot](https://en.wikipedia.org/wiki/Box_plot) is a statistical representation of numerical data through their quartiles. The ends of the box represent the lower and upper quartiles, while the median (second quartile) is marked by a line inside the box. For other statistical representations of numerical data, see [other statistical charts](https://plotly.com/python/statistical-charts/).
 
 ## Box Plot with `plotly.express`
 
@@ -134,7 +134,7 @@ fig.show()
 
 ## Box plot with go.Box
 
-If Plotly Express does not provide a good starting point, it is also possible to use the more generic `go.Box` function from `plotly.graph_objects`. All available options for `go.Box` are described in the reference page https://plot.ly/python/reference/#box.
+If Plotly Express does not provide a good starting point, it is also possible to use the more generic `go.Box` function from `plotly.graph_objects`. All available options for `go.Box` are described in the reference page https://plotly.com/python/reference/#box.
 
 ### Basic Box Plot
 
@@ -491,4 +491,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#box for more information and chart attribute options!
+See https://plotly.com/python/reference/#box for more information and chart attribute options!

--- a/doc/python/bubble-charts.md
+++ b/doc/python/bubble-charts.md
@@ -36,7 +36,7 @@ jupyter:
 
 ## Bubble chart with plotly.express
 
-A [bubble chart](https://en.wikipedia.org/wiki/Bubble_chart) is a scatter plot in which a third dimension of the data is shown through the size of markers. For other types of scatter plot, see the [line and scatter page](https://plot.ly/python/line-and-scatter/).
+A [bubble chart](https://en.wikipedia.org/wiki/Bubble_chart) is a scatter plot in which a third dimension of the data is shown through the size of markers. For other types of scatter plot, see the [line and scatter page](https://plotly.com/python/line-and-scatter/).
 
 We first show a bubble chart example using Plotly Express. [Plotly Express](/python/plotly-express/) is the easy-to-use, high-level interface to Plotly, which [operates on "tidy" data](/python/px-arguments/) and produces [easy-to-style figures](/python/styling-plotly-express/). The size of markers is set from the dataframe column given as the `size` parameter.
 
@@ -52,7 +52,7 @@ fig.show()
 
 ## Bubble Chart with plotly.graph_objects
 
-If Plotly Express does not provide a good starting point, it is also possible to use the more generic `go.Scatter` from `plotly.graph_objects`, and define the size of markers to create a bubble chart. All of the available options are described in the scatter section of the reference page: https://plot.ly/python/reference#scatter.
+If Plotly Express does not provide a good starting point, it is also possible to use the more generic `go.Scatter` from `plotly.graph_objects`, and define the size of markers to create a bubble chart. All of the available options are described in the scatter section of the reference page: https://plotly.com/python/reference#scatter.
 
 ### Simple Bubble Chart
 
@@ -91,8 +91,8 @@ fig.show()
 
 To scale the bubble size, use the attribute `sizeref`. We recommend using the following formula to calculate a `sizeref` value:<br>
 `sizeref = 2. * max(array of size values) / (desired maximum marker size ** 2)`<br>
-Note that setting 'sizeref' to a value greater than 1, decreases the rendered marker sizes, while setting 'sizeref' to less than 1, increases the rendered marker sizes. See https://plot.ly/python/reference/#scatter-marker-sizeref for more information.
-Additionally, we recommend setting the sizemode attribute: https://plot.ly/python/reference/#scatter-marker-sizemode to area.
+Note that setting 'sizeref' to a value greater than 1, decreases the rendered marker sizes, while setting 'sizeref' to less than 1, increases the rendered marker sizes. See https://plotly.com/python/reference/#scatter-marker-sizeref for more information.
+Additionally, we recommend setting the sizemode attribute: https://plotly.com/python/reference/#scatter-marker-sizemode to area.
 
 ```python
 import plotly.graph_objects as go
@@ -222,4 +222,4 @@ fig.show()
 
 ### Reference
 
-See https://plot.ly/python/reference/#scatter for more information and chart attribute options!
+See https://plotly.com/python/reference/#scatter for more information and chart attribute options!

--- a/doc/python/bubble-maps.md
+++ b/doc/python/bubble-maps.md
@@ -74,7 +74,7 @@ To scale the bubble size, use the attribute sizeref. We recommend using the foll
 
 Note that setting `sizeref` to a value greater than $1$, decreases the rendered marker sizes, while setting `sizeref` to less than $1$, increases the rendered marker sizes.
 
-See https://plot.ly/python/reference/#scatter-marker-sizeref for more information. Additionally, we recommend setting the sizemode attribute: https://plot.ly/python/reference/#scatter-marker-sizemode to area.
+See https://plotly.com/python/reference/#scatter-marker-sizeref for more information. Additionally, we recommend setting the sizemode attribute: https://plotly.com/python/reference/#scatter-marker-sizemode to area.
 
 ```python
 import plotly.graph_objects as go
@@ -208,4 +208,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#choropleth and https://plot.ly/python/reference/#scattergeo for more information and chart attribute options!
+See https://plotly.com/python/reference/#choropleth and https://plotly.com/python/reference/#scattergeo for more information and chart attribute options!

--- a/doc/python/bullet-charts.md
+++ b/doc/python/bullet-charts.md
@@ -34,8 +34,8 @@ jupyter:
 ---
 
 #### Basic Bullet Charts
-Stephen Few's Bullet Chart was invented to replace dashboard [gauges](https://plot.ly/python/gauge-charts/) and meters, combining both types of charts into simple bar charts with qualitative bars (steps), quantitative bar (bar) and performance line (threshold); all into one simple layout.
-  Steps typically are broken into several values, which are defined with an array. The bar represent the actual value that a particular variable reached, and the threshold usually indicate a goal point relative to the value achieved by the bar. See [indicator page](https://plot.ly/python/gauge-charts/) for more detail.
+Stephen Few's Bullet Chart was invented to replace dashboard [gauges](https://plotly.com/python/gauge-charts/) and meters, combining both types of charts into simple bar charts with qualitative bars (steps), quantitative bar (bar) and performance line (threshold); all into one simple layout.
+  Steps typically are broken into several values, which are defined with an array. The bar represent the actual value that a particular variable reached, and the threshold usually indicate a goal point relative to the value achieved by the bar. See [indicator page](https://plotly.com/python/gauge-charts/) for more detail.
 
 ```python
 import plotly.graph_objects as go
@@ -78,7 +78,7 @@ fig.show()
 ```
 
 #### Custom Bullet
-The following example shows how to customize your charts. For more information about all possible options check our [reference page](https://plot.ly/python/reference/#indicator).
+The following example shows how to customize your charts. For more information about all possible options check our [reference page](https://plotly.com/python/reference/#indicator).
 
 ```python
 import plotly.graph_objects as go
@@ -167,7 +167,7 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#indicator for more information and chart attribute options!
+See https://plotly.com/python/reference/#indicator for more information and chart attribute options!
 
 ```python
 

--- a/doc/python/candlestick-charts.md
+++ b/doc/python/candlestick-charts.md
@@ -144,4 +144,4 @@ fig.show()
 ```
 
 #### Reference
-For more information on candlestick attributes, see: https://plot.ly/python/reference/#candlestick
+For more information on candlestick attributes, see: https://plotly.com/python/reference/#candlestick

--- a/doc/python/carpet-contour.md
+++ b/doc/python/carpet-contour.md
@@ -37,7 +37,7 @@ jupyter:
 
 ### Basic Carpet Plot
 
-Set the `x` and `y` coorindates, using `x` and `y` attributes. If `x` coorindate values are ommitted a cheater plot will be created. To save parameter values use `a` and `b` attributes. To make changes to the axes, use `aaxis` or `baxis` attributes. For a more detailed list of axes attributes refer to [python reference](https://plot.ly/python/reference/#carpet-aaxis).
+Set the `x` and `y` coorindates, using `x` and `y` attributes. If `x` coorindate values are ommitted a cheater plot will be created. To save parameter values use `a` and `b` attributes. To make changes to the axes, use `aaxis` or `baxis` attributes. For a more detailed list of axes attributes refer to [python reference](https://plotly.com/python/reference/#carpet-aaxis).
 
 ```python
 import plotly.graph_objects as go
@@ -286,4 +286,4 @@ fig.show()
 
 ### Reference
 
-See https://plot.ly/python/reference/#contourcarpet for more information and chart attribute options!
+See https://plotly.com/python/reference/#contourcarpet for more information and chart attribute options!

--- a/doc/python/carpet-plot.md
+++ b/doc/python/carpet-plot.md
@@ -70,7 +70,7 @@ fig.show()
 
 ### Add A and B axis
 
-Use `aaxis` or `baxis` list to make changes to the axes. For a more detailed list of attributes refer to [R reference](https://plot.ly/r/reference/#carpet-aaxis).
+Use `aaxis` or `baxis` list to make changes to the axes. For a more detailed list of attributes refer to [R reference](https://plotly.com/r/reference/#carpet-aaxis).
 
 ```python inputHidden=false outputHidden=false
 import plotly.graph_objects as go
@@ -184,9 +184,9 @@ fig.show()
 
 ### Add Points and Contours
 
-To add points and lines see [Carpet Scatter Plots](https://plot.ly/python/carpet-scatter) or to add contours see [Carpet Contour Plots](https://plot.ly/python/carpet-contour)
+To add points and lines see [Carpet Scatter Plots](https://plotly.com/python/carpet-scatter) or to add contours see [Carpet Contour Plots](https://plotly.com/python/carpet-contour)
 
 
 ### Reference
 
-See https://plot.ly/python/reference/#carpet for more information and chart attribute options!
+See https://plotly.com/python/reference/#carpet for more information and chart attribute options!

--- a/doc/python/carpet-scatter.md
+++ b/doc/python/carpet-scatter.md
@@ -187,4 +187,4 @@ fig.show()
 ### Reference
 
 
-See https://plot.ly/python/reference/#scattercarpet for more information and chart attribute options!
+See https://plotly.com/python/reference/#scattercarpet for more information and chart attribute options!

--- a/doc/python/choropleth-maps.md
+++ b/doc/python/choropleth-maps.md
@@ -348,4 +348,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#choropleth for more information and chart attribute options!
+See https://plotly.com/python/reference/#choropleth for more information and chart attribute options!

--- a/doc/python/colorscales.md
+++ b/doc/python/colorscales.md
@@ -418,7 +418,7 @@ fig.show()
 
 ### Setting the Midpoint of a Diverging Color scale with Graph Objects
 
-The following example uses the [marker.cmid](https://plot.ly/python/reference/#scatter-marker-cmid) attribute to set the mid-point of the color domain by scaling 'cmin' and/or 'cmax' to be equidistant to this point. It only has impact when [marker.color](https://plot.ly/python/reference/#scattercarpet-marker-line-color) sets to a numerical array, and 'marker.cauto' is `True`.
+The following example uses the [marker.cmid](https://plotly.com/python/reference/#scatter-marker-cmid) attribute to set the mid-point of the color domain by scaling 'cmin' and/or 'cmax' to be equidistant to this point. It only has impact when [marker.color](https://plotly.com/python/reference/#scattercarpet-marker-line-color) sets to a numerical array, and 'marker.cauto' is `True`.
 
 ```python
 import plotly.graph_objects as go
@@ -432,7 +432,7 @@ fig.add_trace(go.Scatter(
 fig.show()
 ```
 
-The heatmap chart uses [marker.zmid](https://plot.ly/python/reference/#scatter-marker-zmid) attribute to set the mid-point of the color domain.
+The heatmap chart uses [marker.zmid](https://plotly.com/python/reference/#scatter-marker-zmid) attribute to set the mid-point of the color domain.
 
 ```python
 import plotly.graph_objects as go
@@ -508,7 +508,7 @@ fig.show()
 
 ### Sharing a Color Axis with Graph Objects
 
-To share colorscale information in multiple subplots, you can use [coloraxis](https://plot.ly/javascript/reference/#scatter-marker-line-coloraxis).
+To share colorscale information in multiple subplots, you can use [coloraxis](https://plotly.com/javascript/reference/#scatter-marker-line-coloraxis).
 
 ```python
 import plotly.graph_objects as go
@@ -558,4 +558,4 @@ fig.show()
 
 ### Reference
 
-See https://plot.ly/python/reference/ for more information and chart attribute options!
+See https://plotly.com/python/reference/ for more information and chart attribute options!

--- a/doc/python/compare-webgl-svg.md
+++ b/doc/python/compare-webgl-svg.md
@@ -101,5 +101,5 @@ fig.show()
 
 
 For more information see <br>
-`Scattergl()` : https://plot.ly/python/reference/#scattergl <br>
-`Scatter()` : https://plot.ly/python/reference/#scatter
+`Scattergl()` : https://plotly.com/python/reference/#scattergl <br>
+`Scatter()` : https://plotly.com/python/reference/#scatter

--- a/doc/python/cone-plot.md
+++ b/doc/python/cone-plot.md
@@ -127,5 +127,5 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/ for more information and chart attribute options!
+See https://plotly.com/python/reference/ for more information and chart attribute options!
 

--- a/doc/python/contour-plots.md
+++ b/doc/python/contour-plots.md
@@ -339,4 +339,4 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#contour for more information and chart attribute options!
+See https://plotly.com/python/reference/#contour for more information and chart attribute options!

--- a/doc/python/county-choropleth.md
+++ b/doc/python/county-choropleth.md
@@ -273,7 +273,7 @@ fig.layout.template = None
 fig.show()
 ```
 
-Also see Mapbox county choropleths made in Python: [https://plot.ly/python/mapbox-county-choropleth/](https://plot.ly/python/mapbox-county-choropleth/)
+Also see Mapbox county choropleths made in Python: [https://plotly.com/python/mapbox-county-choropleth/](https://plotly.com/python/mapbox-county-choropleth/)
 
 
 #### Reference

--- a/doc/python/creating-and-updating-figures.md
+++ b/doc/python/creating-and-updating-figures.md
@@ -62,7 +62,7 @@ The value of the top-level `"data"` key is a list of trace specifications. Each 
 
 The value of the top-level `"layout"` key is a dictionary that specifies the properties of the figure's layout. In contrast to trace configuration options that apply to individual traces, the layout configuration options apply to the figure as a whole, customizing items like the axes, annotations, shapes, legend, and more.
 
-The [_Full Reference_](https://plot.ly/python/reference/) page contains descriptions of all of the supported trace and layout options.
+The [_Full Reference_](https://plotly.com/python/reference/) page contains descriptions of all of the supported trace and layout options.
 
 If working from the _Full Reference_ to build figures as Python dictionaries and lists suites your needs, go for it! This is a perfectly valid way to use plotly.py to build figures. On the other hand, if you would like an API that offers a bit more assistance, read on to learn about graph objects.
 

--- a/doc/python/custom-buttons.md
+++ b/doc/python/custom-buttons.md
@@ -34,11 +34,11 @@ jupyter:
 ---
 
 #### Methods
-The [updatemenu method](https://plot.ly/python/reference/#layout-updatemenus-buttons-method) determines which [plotly.js function](https://plot.ly/javascript/plotlyjs-function-reference/) will be used to modify the chart. There are 4 possible methods:
+The [updatemenu method](https://plotly.com/python/reference/#layout-updatemenus-buttons-method) determines which [plotly.js function](https://plotly.com/javascript/plotlyjs-function-reference/) will be used to modify the chart. There are 4 possible methods:
 - `"restyle"`: modify data or data attributes
 - `"relayout"`: modify layout attributes
 - `"update"`: modify data **and** layout attributes
-- `"animate"`: start or pause an [animation](https://plot.ly/python/#animations))
+- `"animate"`: start or pause an [animation](https://plotly.com/python/#animations))
 
 
 #### Restyle Button
@@ -456,8 +456,8 @@ fig.show()
 ```
 
 #### Animate Button
-Refer to our animation docs: https://plot.ly/python/#animations for examples on how to use the `animate` method with Plotly buttons.
+Refer to our animation docs: https://plotly.com/python/#animations for examples on how to use the `animate` method with Plotly buttons.
 
 
 #### Reference
-See https://plot.ly/python/reference/#layout-updatemenus for more information about `updatemenu` buttons.
+See https://plotly.com/python/reference/#layout-updatemenus for more information about `updatemenu` buttons.

--- a/doc/python/distplot.md
+++ b/doc/python/distplot.md
@@ -35,7 +35,7 @@ jupyter:
 
 ## Combined statistical representations with px.histogram
 
-Several representations of statistical distributions are available in plotly, such as [histograms](https://plot.ly/python/histograms/), [violin plots](https://plot.ly/python/violin/), [box plots](https://plot.ly/python/box-plots/) (see [the complete list here](https://plot.ly/python/statistical-charts/)). It is also possible to combine several representations in the same plot.
+Several representations of statistical distributions are available in plotly, such as [histograms](https://plotly.com/python/histograms/), [violin plots](https://plotly.com/python/violin/), [box plots](https://plotly.com/python/box-plots/) (see [the complete list here](https://plotly.com/python/statistical-charts/)). It is also possible to combine several representations in the same plot.
 
 For example, the `plotly.express` function `px.histogram` can add a subplot with a different statistical representation than the histogram, given by the parameter `marginal`. [Plotly Express](/python/plotly-express/) is the easy-to-use, high-level interface to Plotly, which [operates on "tidy" data](/python/px-arguments/) and produces [easy-to-style figures](/python/styling-plotly-express/).
 

--- a/doc/python/dot-plots.md
+++ b/doc/python/dot-plots.md
@@ -158,4 +158,4 @@ fig.show()
 
 ### Reference
 
-See https://plot.ly/python/reference/#scatter for more information and chart attribute options!
+See https://plotly.com/python/reference/#scatter for more information and chart attribute options!

--- a/doc/python/dropdowns.md
+++ b/doc/python/dropdowns.md
@@ -34,11 +34,11 @@ jupyter:
 ---
 
 #### Methods
-The [updatemenu method](https://plot.ly/python/reference/#layout-updatemenus-buttons-method) determines which [plotly.js function](https://plot.ly/javascript/plotlyjs-function-reference/) will be used to modify the chart. There are 4 possible methods:
+The [updatemenu method](https://plotly.com/python/reference/#layout-updatemenus-buttons-method) determines which [plotly.js function](https://plotly.com/javascript/plotlyjs-function-reference/) will be used to modify the chart. There are 4 possible methods:
 - `"restyle"`: modify data or data attributes
 - `"relayout"`: modify layout attributes
 - `"update"`: modify data **and** layout attributes
-- `"animate"`: start or pause an [animation](https://plot.ly/python/#animations)
+- `"animate"`: start or pause an [animation](https://plotly.com/python/#animations)
 
 
 ## Restyle Dropdown
@@ -445,4 +445,4 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#layout-updatemenus for more information about `updatemenu` dropdowns.
+See https://plotly.com/python/reference/#layout-updatemenus for more information about `updatemenu` dropdowns.

--- a/doc/python/error-bars.md
+++ b/doc/python/error-bars.md
@@ -35,7 +35,7 @@ jupyter:
 
 ### Error Bars with Plotly Express
 
-[Plotly Express](/python/plotly-express/) is the easy-to-use, high-level interface to Plotly, which [operates on "tidy" data](/python/px-arguments/) and produces [easy-to-style figures](/python/styling-plotly-express/). For functions representing 2D data points such as [`px.scatter`](https://plot.ly/python/line-and-scatter/), [`px.line`](https://plot.ly/python/line-charts/), [`px.bar`](https://plot.ly/python/bar-charts/) etc., error bars are given as a column name which is the value of the `error_x` (for the error on x position) and `error_y` (for the error on y position).
+[Plotly Express](/python/plotly-express/) is the easy-to-use, high-level interface to Plotly, which [operates on "tidy" data](/python/px-arguments/) and produces [easy-to-style figures](/python/styling-plotly-express/). For functions representing 2D data points such as [`px.scatter`](https://plotly.com/python/line-and-scatter/), [`px.line`](https://plotly.com/python/line-charts/), [`px.bar`](https://plotly.com/python/bar-charts/) etc., error bars are given as a column name which is the value of the `error_x` (for the error on x position) and `error_y` (for the error on y position).
 
 ```python
 import plotly.express as px
@@ -202,4 +202,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#scatter for more information and chart attribute options!
+See https://plotly.com/python/reference/#scatter for more information and chart attribute options!

--- a/doc/python/facet-plots.md
+++ b/doc/python/facet-plots.md
@@ -103,7 +103,7 @@ fig.show()
 
 ### Customize Subplot Figure Titles
 
-Since subplot figure titles are [annotations](https://plot.ly/python/text-and-annotations/#simple-annotation), you can use the `for_each_annotation` function to customize them.
+Since subplot figure titles are [annotations](https://plotly.com/python/text-and-annotations/#simple-annotation), you can use the `for_each_annotation` function to customize them.
 
 In the following example, we pass a lambda function to `for_each_annotation` in order to change the figure subplot titles from `smoker=No` and `smoker=Yes` to just `No` and `Yes`. 
 
@@ -121,7 +121,7 @@ fig.show()
 
 ### Synchronizing axes in subplots with `matches`
 
-Using `facet_col` from `plotly.express` let [zoom](https://help.plot.ly/zoom-pan-hover-controls/#step-3-zoom-in-and-zoom-out-autoscale-the-plot) and [pan](https://help.plot.ly/zoom-pan-hover-controls/#step-6-pan-along-axes) each facet to the same range implicitly. However, if the subplots are created with `make_subplots`, the axis needs to be updated with `matches` parameter to update all the subplots accordingly. 
+Using `facet_col` from `plotly.express` let [zoom](https://help.plotly.com/zoom-pan-hover-controls/#step-3-zoom-in-and-zoom-out-autoscale-the-plot) and [pan](https://help.plotly.com/zoom-pan-hover-controls/#step-6-pan-along-axes) each facet to the same range implicitly. However, if the subplots are created with `make_subplots`, the axis needs to be updated with `matches` parameter to update all the subplots accordingly. 
 
 Zoom in one trace below, to see the other subplots zoomed to the same x-axis range. To pan all the subplots, click and drag from the center of x-axis to the side:
 

--- a/doc/python/figure-factory-subplots.md
+++ b/doc/python/figure-factory-subplots.md
@@ -210,4 +210,4 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/subplots/ for more information on working with subplots. See https://plot.ly/python/reference/ for more information regarding chart attributes!
+See https://plotly.com/python/subplots/ for more information on working with subplots. See https://plotly.com/python/reference/ for more information regarding chart attributes!

--- a/doc/python/figure-labels.md
+++ b/doc/python/figure-labels.md
@@ -69,7 +69,7 @@ fig.show()
 The configuration of the legend is discussed in detail in the [Legends](/python/legend/) page.
 
 ### Align Plot Title
-The following example shows how to align the plot title in [layout.title](https://plot.ly/python/reference/#layout-title). `x` sets the x position with respect to `xref` from "0" (left) to "1" (right), and `y` sets the y position with respect to `yref` from "0" (bottom) to "1" (top). Moreover, you can define `xanchor` to `left`,`right`, or `center` for setting the title's horizontal alignment with respect to its x position, and/or `yanchor` to `top`, `bottom`, or `middle` for setting the title's vertical alignment with respect to its y position.
+The following example shows how to align the plot title in [layout.title](https://plotly.com/python/reference/#layout-title). `x` sets the x position with respect to `xref` from "0" (left) to "1" (right), and `y` sets the y position with respect to `yref` from "0" (bottom) to "1" (top). Moreover, you can define `xanchor` to `left`,`right`, or `center` for setting the title's horizontal alignment with respect to its x position, and/or `yanchor` to `top`, `bottom`, or `middle` for setting the title's vertical alignment with respect to its y position.
 
 ```python
 import plotly.graph_objects as go
@@ -90,4 +90,4 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#layout for more information!
+See https://plotly.com/python/reference/#layout for more information!

--- a/doc/python/filled-area-on-mapbox.md
+++ b/doc/python/filled-area-on-mapbox.md
@@ -41,9 +41,9 @@ To plot on Mapbox maps with Plotly you _may_ need a Mapbox account and a public 
 
 There are three different ways to show a filled area in a Mapbox map:
 
-1. Use a [Scattermapbox](https://plot.ly/python/reference/#scattermapbox) trace and set `fill` attribute to 'toself'
-2. Use a Mapbox layout (i.e. by minimally using an empty [Scattermapbox](https://plot.ly/python/reference/#scattermapbox) trace) and add a GeoJSON layer
-3. Use the [Choroplethmapbox](https://plot.ly/python/mapbox-county-choropleth/) trace type
+1. Use a [Scattermapbox](https://plotly.com/python/reference/#scattermapbox) trace and set `fill` attribute to 'toself'
+2. Use a Mapbox layout (i.e. by minimally using an empty [Scattermapbox](https://plotly.com/python/reference/#scattermapbox) trace) and add a GeoJSON layer
+3. Use the [Choroplethmapbox](https://plotly.com/python/mapbox-county-choropleth/) trace type
    <!-- #endregion -->
 
 ### Filled `Scattermapbox` Trace
@@ -70,7 +70,7 @@ fig.show()
 
 ### Multiple Filled Areas with a `Scattermapbox` trace
 
-The following example shows how to use `None` in your data to draw multiple filled areas. Such gaps in trace data are unconnected by default, but this can be controlled via the [connectgaps](https://plot.ly/python/reference/#scattermapbox-connectgaps) attribute.
+The following example shows how to use `None` in your data to draw multiple filled areas. Such gaps in trace data are unconnected by default, but this can be controlled via the [connectgaps](https://plotly.com/python/reference/#scattermapbox-connectgaps) attribute.
 
 ```python
 import plotly.graph_objects as go
@@ -141,4 +141,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#scattermapbox for more information about mapbox and their attribute options.
+See https://plotly.com/python/reference/#scattermapbox for more information about mapbox and their attribute options.

--- a/doc/python/filled-area-plots.md
+++ b/doc/python/filled-area-plots.md
@@ -210,6 +210,6 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#scatter-line
-and https://plot.ly/python/reference/#scatter-fill
+See https://plotly.com/python/reference/#scatter-line
+and https://plotly.com/python/reference/#scatter-fill
 for more information and attribute options!

--- a/doc/python/filter.md
+++ b/doc/python/filter.md
@@ -64,4 +64,4 @@ pio.show(fig_dict, validate=False)
 ```
 
 #### Reference
-See https://plot.ly/python/reference/ for more information and chart attribute options!
+See https://plotly.com/python/reference/ for more information and chart attribute options!

--- a/doc/python/funnel-charts.md
+++ b/doc/python/funnel-charts.md
@@ -74,7 +74,7 @@ fig.show()
 
 ### Setting Marker Size and Color
 
-This example uses [textposition](https://plot.ly/python/reference/#scatter-textposition) and [textinfo](https://plot.ly/python/reference/#funnel-textinfo) to determine information apears on the graph, and shows how to customize the bars.
+This example uses [textposition](https://plotly.com/python/reference/#scatter-textposition) and [textinfo](https://plotly.com/python/reference/#funnel-textinfo) to determine information apears on the graph, and shows how to customize the bars.
 
 ```python
 from plotly import graph_objects as go
@@ -202,4 +202,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#funnel and https://plot.ly/python/reference/#funnelarea for more information and chart attribute options!
+See https://plotly.com/python/reference/#funnel and https://plotly.com/python/reference/#funnelarea for more information and chart attribute options!

--- a/doc/python/gantt.md
+++ b/doc/python/gantt.md
@@ -36,7 +36,7 @@ jupyter:
 
 A [Gantt chart](https://en.wikipedia.org/wiki/Gantt_chart) is a type of bar chart that illustrates a project schedule. The chart lists the tasks to be performed on the vertical axis, and time intervals on the horizontal axis. The width of the horizontal bars in the graph shows the duration of each activity.
 
-See also the [bar charts examples](https://plot.ly/python/bar-charts/).
+See also the [bar charts examples](https://plotly.com/python/bar-charts/).
 
 
 #### Simple Gantt Chart

--- a/doc/python/gauge-charts.md
+++ b/doc/python/gauge-charts.md
@@ -41,7 +41,7 @@ A radial gauge chart has a circular arc, which displays a single value to estima
   The bar shows the target value, and the shading represents the progress toward that goal. Gauge charts, known as
   speedometer charts as well. This chart type is usually used to illustrate key business indicators.
 
-  The example below displays a basic gauge chart with default attributes. For more information about different added attributes check [indicator](https://plot.ly/python/indicator/) tutorial.
+  The example below displays a basic gauge chart with default attributes. For more information about different added attributes check [indicator](https://plotly.com/python/indicator/) tutorial.
 
 ```python
 import plotly.graph_objects as go
@@ -78,7 +78,7 @@ fig.show()
 ```
 
 #### Custom Gauge Chart
-The following example shows how to style your gauge charts. For more information about all possible options check our [reference page](https://plot.ly/python/reference/#indicator).
+The following example shows how to style your gauge charts. For more information about all possible options check our [reference page](https://plotly.com/python/reference/#indicator).
 
 ```python
 import plotly.graph_objects as go
@@ -110,4 +110,4 @@ fig.show()
 
 
 #### Reference
-See https://plot.ly/python/reference/#indicator for more information and chart attribute options!
+See https://plotly.com/python/reference/#indicator for more information and chart attribute options!

--- a/doc/python/getting-started.md
+++ b/doc/python/getting-started.md
@@ -38,9 +38,9 @@ jupyter:
 
 ### Overview
 
-The plotly Python library ([plotly.py](https://plot.ly/python/)) is an interactive, [open-source](https://github.com/plotly/plotly.py) plotting library that supports over 40 unique chart types covering a wide range of statistical, financial, geographic, scientific, and 3-dimensional use-cases.
+The plotly Python library ([plotly.py](https://plotly.com/python/)) is an interactive, [open-source](https://github.com/plotly/plotly.py) plotting library that supports over 40 unique chart types covering a wide range of statistical, financial, geographic, scientific, and 3-dimensional use-cases.
 
-Built on top of the Plotly JavaScript library ([plotly.js](https://plot.ly/javascript/)), plotly.py enables Python users to create beautiful interactive web-based visualizations that can be displayed in Jupyter notebooks, saved to standalone HTML files, or served as part of pure Python-built web applications using Dash.
+Built on top of the Plotly JavaScript library ([plotly.js](https://plotly.com/javascript/)), plotly.py enables Python users to create beautiful interactive web-based visualizations that can be displayed in Jupyter notebooks, saved to standalone HTML files, or served as part of pure Python-built web applications using Dash.
 
 Thanks to deep integration with the [orca](https://github.com/plotly/orca) image export utility, plotly.py also provides great support for non-web contexts including desktop editors (e.g. QtConsole, Spyder, PyCharm) and static document publishing (e.g. exporting notebooks to PDF with high-quality vector images).
 
@@ -240,7 +240,7 @@ or conda.
 $ conda install -c plotly plotly-geo=1.0.0
 ```
 
-See [_USA County Choropleth Maps in Python_](https://plot.ly/python/county-choropleth/) for more information on the county choropleth figure factory.
+See [_USA County Choropleth Maps in Python_](https://plotly.com/python/county-choropleth/) for more information on the county choropleth figure factory.
 
 #### Chart Studio Support
 
@@ -271,8 +271,8 @@ For information on theming plotly figures, see [_Theming and templates with plot
 
 For information on all of the ways that plotly figures can be displayed, see [_Displaying plotly figures with plotly for Python_](/python/renderers/).
 
-For the full searchable reference of every figure property, see the [_Python figure reference_](https://plot.ly/python/reference/).
+For the full searchable reference of every figure property, see the [_Python figure reference_](https://plotly.com/python/reference/).
 
-For information on using Python to build web applications containing plotly figures, see the [_Dash User Guide_](https://dash.plot.ly/).
+For information on using Python to build web applications containing plotly figures, see the [_Dash User Guide_](https://dash.plotly.com/).
 
 <!-- #endregion -->

--- a/doc/python/graphing-multiple-chart-types.md
+++ b/doc/python/graphing-multiple-chart-types.md
@@ -98,4 +98,4 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/ for more information and attribute options!
+See https://plotly.com/python/reference/ for more information and attribute options!

--- a/doc/python/group-by.md
+++ b/doc/python/group-by.md
@@ -62,4 +62,4 @@ pio.show(fig_dict, validate=False)
 ```
 
 #### Reference
-See https://plot.ly/python/reference/ for more information and chart attribute options!
+See https://plotly.com/python/reference/ for more information and chart attribute options!

--- a/doc/python/heatmaps.md
+++ b/doc/python/heatmaps.md
@@ -67,7 +67,7 @@ fig.show()
 
 ### Heatmap with Categorical Axis Labels
 
-In this example we also show how to ignore [hovertext](https://plot.ly/python/hover-text-and-formatting/) when we have [missing values](https://plot.ly/python/missing_values) in the data by setting the [hoverongaps](https://plot.ly/python/reference/#heatmap-hoverongaps) to False. 
+In this example we also show how to ignore [hovertext](https://plotly.com/python/hover-text-and-formatting/) when we have [missing values](https://plotly.com/python/missing_values) in the data by setting the [hoverongaps](https://plotly.com/python/reference/#heatmap-hoverongaps) to False. 
 
 ```python
 import plotly.graph_objects as go
@@ -168,4 +168,4 @@ Arrays of rasterized values build by datashader can be visualized using
 plotly's heatmaps, as shown in the [plotly and datashader tutorial](/python/datashader/).
 
 #### Reference
-See https://plot.ly/python/reference/#heatmap for more information and chart attribute options!
+See https://plotly.com/python/reference/#heatmap for more information and chart attribute options!

--- a/doc/python/histograms.md
+++ b/doc/python/histograms.md
@@ -134,7 +134,7 @@ fig.show()
 
 #### Visualizing the distribution
 
-With the `marginal` keyword, a subplot is drawn alongside the histogram, visualizing the distribution. See [the distplot page](https://plot.ly/python/distplot/)for more examples of combined statistical representations.
+With the `marginal` keyword, a subplot is drawn alongside the histogram, visualizing the distribution. See [the distplot page](https://plotly.com/python/distplot/)for more examples of combined statistical representations.
 
 ```python
 import plotly.express as px
@@ -146,7 +146,7 @@ fig.show()
 
 ## Histograms with go.Histogram
 
-If Plotly Express does not provide a good starting point, it is also possible to use the more generic `go.Histogram` from `plotly.graph_objects`. All of the available histogram options are described in the histogram section of the reference page: https://plot.ly/python/reference#histogram.
+If Plotly Express does not provide a good starting point, it is also possible to use the more generic `go.Histogram` from `plotly.graph_objects`. All of the available histogram options are described in the histogram section of the reference page: https://plotly.com/python/reference#histogram.
 
 ### Basic Histogram
 
@@ -306,7 +306,7 @@ fig.show()
 
 ### Custom Binning
 
-For custom binning along x-axis, use the attribute [`nbinsx`](https://plot.ly/python/reference/#histogram-nbinsx). Please note that the autobin algorithm will choose a 'nice' round bin size that may result in somewhat fewer than `nbinsx` total bins. Alternatively, you can set the exact values for [`xbins`](https://plot.ly/python/reference/#histogram-xbins) along with `autobinx = False`.
+For custom binning along x-axis, use the attribute [`nbinsx`](https://plotly.com/python/reference/#histogram-nbinsx). Please note that the autobin algorithm will choose a 'nice' round bin size that may result in somewhat fewer than `nbinsx` total bins. Alternatively, you can set the exact values for [`xbins`](https://plotly.com/python/reference/#histogram-xbins) along with `autobinx = False`.
 
 ```python
 import plotly.graph_objects as go
@@ -369,7 +369,7 @@ fig2.show()
 
 ### Share bins between histograms
 
-In this example both histograms have a compatible bin settings using [bingroup](https://plot.ly/python/reference/#histogram-bingroup) attribute. Note that traces on the same subplot, and with the same `barmode` ("stack", "relative", "group") are forced into the same `bingroup`, however traces with `barmode = "overlay"` and on different axes (of the same axis type) can have compatible bin settings. Histogram and [histogram2d](https://plot.ly/python/2D-Histogram/) trace can share the same `bingroup`.
+In this example both histograms have a compatible bin settings using [bingroup](https://plotly.com/python/reference/#histogram-bingroup) attribute. Note that traces on the same subplot, and with the same `barmode` ("stack", "relative", "group") are forced into the same `bingroup`, however traces with `barmode = "overlay"` and on different axes (of the same axis type) can have compatible bin settings. Histogram and [histogram2d](https://plotly.com/python/2D-Histogram/) trace can share the same `bingroup`.
 
 ```python
 import plotly.graph_objects as go
@@ -392,4 +392,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#histogram for more information and chart attribute options!
+See https://plotly.com/python/reference/#histogram for more information and chart attribute options!

--- a/doc/python/horizontal-bar-charts.md
+++ b/doc/python/horizontal-bar-charts.md
@@ -33,7 +33,7 @@ jupyter:
     thumbnail: thumbnail/horizontal-bar.jpg
 ---
 
-See more examples of bar charts (including vertical bar charts) and styling options [here](https://plot.ly/python/bar-charts/).
+See more examples of bar charts (including vertical bar charts) and styling options [here](https://plotly.com/python/bar-charts/).
 
 ### Horizontal Bar Chart with Plotly Express
 
@@ -64,7 +64,7 @@ fig.show()
 
 ### Horizontal Bar Chart with go.Bar
 
-When data are not available as a tidy dataframe, you can use the more generic function `go.Bar` from `plotly.graph_objects`. All the options of `go.Bar` are documented in the reference https://plot.ly/python/reference/#bar
+When data are not available as a tidy dataframe, you can use the more generic function `go.Bar` from `plotly.graph_objects`. All the options of `go.Bar` are documented in the reference https://plotly.com/python/reference/#bar
 
 #### Basic Horizontal Bar Chart
 
@@ -335,4 +335,4 @@ fig.show()
 
 ### Reference
 
-See more examples of bar charts and styling options [here](https://plot.ly/python/bar-charts/).<br> See https://plot.ly/python/reference/#bar for more information and chart attribute options!
+See more examples of bar charts and styling options [here](https://plotly.com/python/bar-charts/).<br> See https://plotly.com/python/reference/#bar for more information and chart attribute options!

--- a/doc/python/hover-text-and-formatting.md
+++ b/doc/python/hover-text-and-formatting.md
@@ -103,10 +103,10 @@ fig.show()
 
 ### Customize tooltip text with a hovertemplate
 
-To customize the tooltip on your graph you can use [hovertemplate](https://plot.ly/python/reference/#pie-hovertemplate), which is a template string used for rendering the information that appear on hoverbox.
+To customize the tooltip on your graph you can use [hovertemplate](https://plotly.com/python/reference/#pie-hovertemplate), which is a template string used for rendering the information that appear on hoverbox.
 This template string can include `variables` in %{variable} format, `numbers` in [d3-format's syntax](https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3_forma), and `date` in [d3-time-format's syntax](https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format).
-Hovertemplate customize the tooltip text vs. [texttemplate](https://plot.ly/python/reference/#pie-texttemplate) which customizes the text that appears on your chart. <br>
-Set the horizontal alignment of the text within tooltip with [hoverlabel.align](https://plot.ly/python/reference/#layout-hoverlabel-align).
+Hovertemplate customize the tooltip text vs. [texttemplate](https://plotly.com/python/reference/#pie-texttemplate) which customizes the text that appears on your chart. <br>
+Set the horizontal alignment of the text within tooltip with [hoverlabel.align](https://plotly.com/python/reference/#layout-hoverlabel-align).
 
 ```python
 import plotly.graph_objects as go
@@ -150,7 +150,7 @@ fig.show()
 
 ### Advanced Hover Template
 
-The following example shows how to format hover template. [Here](https://plot.ly/python/v3/hover-text-and-formatting/#dash-example) is an example to see how to format hovertemplate in Dash.
+The following example shows how to format hover template. [Here](https://plotly.com/python/v3/hover-text-and-formatting/#dash-example) is an example to see how to format hovertemplate in Dash.
 
 ```python
 import plotly.graph_objects as go
@@ -260,4 +260,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/ for more information and chart attribute options!
+See https://plotly.com/python/reference/ for more information and chart attribute options!

--- a/doc/python/images.md
+++ b/doc/python/images.md
@@ -56,7 +56,7 @@ fig.add_trace(
 # Add images
 fig.add_layout_image(
         dict(
-            source="https://images.plot.ly/language-icons/api-home/python-logo.png",
+            source="https://images.plotly.com/language-icons/api-home/python-logo.png",
             xref="x",
             yref="y",
             x=0,
@@ -75,7 +75,7 @@ fig.show()
 ```
 
 #### Add a Logo
-See more examples of [adding logos to charts](https://plot.ly/python/logos/)!
+See more examples of [adding logos to charts](https://plotly.com/python/logos/)!
 
 ```python
 import plotly.graph_objects as go
@@ -301,9 +301,9 @@ fig.update_layout(
 )
 
 # Disable the autosize on double click because it adds unwanted margins around the image
-# More detail: https://plot.ly/python/configuration-options/
+# More detail: https://plotly.com/python/configuration-options/
 fig.show(config={'doubleClick': 'reset'})
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#layout-images for more information and chart attribute options!
+See https://plotly.com/python/reference/#layout-images for more information and chart attribute options!

--- a/doc/python/imshow.md
+++ b/doc/python/imshow.md
@@ -141,7 +141,7 @@ img = data.astronaut()
 # Increase contrast by clipping the data range between 50 and 200
 fig = px.imshow(img, zmin=50, zmax=200)
 # We customize the hovertemplate to show both the data and the color values
-# See https://plot.ly/python/hover-text-and-formatting/#customize-tooltip-text-with-a-hovertemplate
+# See https://plotly.com/python/hover-text-and-formatting/#customize-tooltip-text-with-a-hovertemplate
 fig.update_traces(hovertemplate="x: %{x} <br> y: %{y} <br> z: %{z} <br> color: %{color}")
 fig.show()
 ```
@@ -206,5 +206,5 @@ examples on how to use plotly and datashader.
 
 
 #### Reference
-See https://plot.ly/python/reference/#image for more information and chart attribute options!
+See https://plotly.com/python/reference/#image for more information and chart attribute options!
 

--- a/doc/python/indicator.md
+++ b/doc/python/indicator.md
@@ -63,7 +63,7 @@ In this tutorial we introduce a new trace named "Indicator". The purpose of "ind
       <li> position: position relative to `number` (either top, left, bottom, right)</li>
     </ol>
     Finally, we can have a simple title for the indicator via `title` with 'text' attribute which is a string, and 'align' which can be set to left, center, and right.
-    There are two gauge types: [angular](https://plot.ly/python/gauge-charts/) and [bullet](https://plot.ly/python/bullet-charts/). Here is a combination of both shapes (angular, bullet), and different modes (guage, delta, and value):
+    There are two gauge types: [angular](https://plotly.com/python/gauge-charts/) and [bullet](https://plotly.com/python/bullet-charts/). Here is a combination of both shapes (angular, bullet), and different modes (guage, delta, and value):
 
 ```python
 import plotly.graph_objects as go
@@ -202,7 +202,7 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#indicator for more information and chart attribute options!
+See https://plotly.com/python/reference/#indicator for more information and chart attribute options!
 
 ```python
 

--- a/doc/python/legend.md
+++ b/doc/python/legend.md
@@ -268,7 +268,7 @@ fig.show()
 
 #### Size of Legend Items
 
-In this example [itemsizing](https://plot.ly/python/reference/#layout-legend-itemsizing) attribute determines the legend items symbols remain constant, regardless of how tiny/huge the bubbles would be in the graph.
+In this example [itemsizing](https://plotly.com/python/reference/#layout-legend-itemsizing) attribute determines the legend items symbols remain constant, regardless of how tiny/huge the bubbles would be in the graph.
 
 ```python
 import plotly.graph_objects as go
@@ -434,4 +434,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#layout-legend for more information!
+See https://plotly.com/python/reference/#layout-legend for more information!

--- a/doc/python/line-and-scatter.md
+++ b/doc/python/line-and-scatter.md
@@ -88,7 +88,7 @@ fig.show()
 
 ## Scatter and line plot with go.Scatter
 
-If Plotly Express does not provide a good starting point, it is possible to use the more generic `go.Scatter` function from `plotly.graph_objects`. Whereas `plotly.express` has two functions `scatter` and `line`, `go.Scatter` can be used both for plotting points (makers) or lines, depending on the value of `mode`. The different options of `go.Scatter` are documented in its [reference page](https://plot.ly/python/reference/#scatter).
+If Plotly Express does not provide a good starting point, it is possible to use the more generic `go.Scatter` function from `plotly.graph_objects`. Whereas `plotly.express` has two functions `scatter` and `line`, `go.Scatter` can be used both for plotting points (makers) or lines, depending on the value of `mode`. The different options of `go.Scatter` are documented in its [reference page](https://plotly.com/python/reference/#scatter).
 
 #### Simple Scatter Plot
 
@@ -107,7 +107,7 @@ fig.show()
 
 #### Line and Scatter Plots
 
-Use `mode` argument to choose between markers, lines, or a combination of both. For more options about line plots, see also the [line charts notebook](https://plot.ly/python/line-charts/) and the [filled area plots notebook](https://plot.ly/python/filled-area-plots/).
+Use `mode` argument to choose between markers, lines, or a combination of both. For more options about line plots, see also the [line charts notebook](https://plotly.com/python/line-charts/) and the [filled area plots notebook](https://plotly.com/python/filled-area-plots/).
 
 ```python
 import plotly.graph_objects as go
@@ -140,7 +140,7 @@ fig.show()
 
 #### Bubble Scatter Plots
 
-In [bubble charts](https://en.wikipedia.org/wiki/Bubble_chart), a third dimension of the data is shown through the size of markers. For more examples, see the [bubble chart notebook](https://plot.ly/python/bubble-charts/)
+In [bubble charts](https://en.wikipedia.org/wiki/Bubble_chart), a third dimension of the data is shown through the size of markers. For more examples, see the [bubble chart notebook](https://plotly.com/python/bubble-charts/)
 
 ```python
 import plotly.graph_objects as go
@@ -276,4 +276,4 @@ fig.show()
 
 ### Reference
 
-See https://plot.ly/python/reference/#scatter or https://plot.ly/python/reference/#scattergl for more information and chart attribute options!
+See https://plotly.com/python/reference/#scatter or https://plotly.com/python/reference/#scattergl for more information and chart attribute options!

--- a/doc/python/line-charts.md
+++ b/doc/python/line-charts.md
@@ -39,7 +39,7 @@ jupyter:
 
 [Plotly Express](/python/plotly-express/) is the easy-to-use, high-level interface to Plotly, which [operates on "tidy" data](/python/px-arguments/) and produces [easy-to-style figures](/python/styling-plotly-express/). With `px.line`, each data point is represented as a vertex (which location is given by the `x` and `y` columns) of a **polyline mark** in 2D space.
 
-For more examples of line plots, see the [line and scatter notebook](https://plot.ly/python/line-and-scatter/).
+For more examples of line plots, see the [line and scatter notebook](https://plotly.com/python/line-and-scatter/).
 
 #### Simple Line Plot with plotly.express
 
@@ -72,7 +72,7 @@ fig.show()
 
 ### Line Plot with go.Scatter
 
-If Plotly Express does not provide a good starting point, it is possible to use the more generic `go.Scatter` function from `plotly.graph_objects`. Whereas `plotly.express` has two functions `scatter` and `line`, `go.Scatter` can be used both for plotting points (makers) or lines, depending on the value of `mode`. The different options of `go.Scatter` are documented in its [reference page](https://plot.ly/python/reference/#scatter).
+If Plotly Express does not provide a good starting point, it is possible to use the more generic `go.Scatter` function from `plotly.graph_objects`. Whereas `plotly.express` has two functions `scatter` and `line`, `go.Scatter` can be used both for plotting points (makers) or lines, depending on the value of `mode`. The different options of `go.Scatter` are documented in its [reference page](https://plotly.com/python/reference/#scatter).
 
 #### Simple Line Plot
 
@@ -161,7 +161,7 @@ fig.show()
 
 #### Connect Data Gaps
 
-[connectgaps](https://plot.ly/python/reference/#scatter-connectgaps) determines if missing values in the provided data are shown as a gap in the graph or not. In [this tutorial](https://plot.ly/python/filled-area-on-mapbox/#multiple-filled-areas-with-a-scattermapbox-trace), we showed how to take benefit of this feature and illustrate multiple areas in mapbox.
+[connectgaps](https://plotly.com/python/reference/#scatter-connectgaps) determines if missing values in the provided data are shown as a gap in the graph or not. In [this tutorial](https://plotly.com/python/filled-area-on-mapbox/#multiple-filled-areas-with-a-scattermapbox-trace), we showed how to take benefit of this feature and illustrate multiple areas in mapbox.
 
 ```python
 import plotly.graph_objects as go
@@ -408,4 +408,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#scatter for more information and chart attribute options!
+See https://plotly.com/python/reference/#scatter for more information and chart attribute options!

--- a/doc/python/lines-on-mapbox.md
+++ b/doc/python/lines-on-mapbox.md
@@ -37,7 +37,7 @@ jupyter:
 
 To plot on Mapbox maps with Plotly you _may_ need a Mapbox account and a public [Mapbox Access Token](https://www.mapbox.com/studio). See our [Mapbox Map Layers](/python/mapbox-layers/) documentation for more information.
 
-To draw a line on your map, you either can use [`px.line_mapbox()`](https://www.plotly.express/plotly_express/#plotly_express.line_mapbox) in Plotly Express, or [`Scattermapbox`](https://plot.ly/python/reference/#scattermapbox) traces. Below we show you how to draw a line on Mapbox using Plotly Express.
+To draw a line on your map, you either can use [`px.line_mapbox()`](https://www.plotly.express/plotly_express/#plotly_express.line_mapbox) in Plotly Express, or [`Scattermapbox`](https://plotly.com/python/reference/#scattermapbox) traces. Below we show you how to draw a line on Mapbox using Plotly Express.
 
 ### Lines on Mapbox maps using Plotly Express
 
@@ -60,7 +60,7 @@ fig.show()
 ### Lines on Mapbox maps using `Scattermapbox` traces
 
 This example uses `go.Scattermapbox` and sets
-the [mode](https://plot.ly/python/reference/#scattermapbox-mode) attribute to a combination of markers and line.
+the [mode](https://plotly.com/python/reference/#scattermapbox-mode) attribute to a combination of markers and line.
 
 ```python
 import plotly.graph_objects as go
@@ -90,4 +90,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#scattermapbox for more information about mapbox and their attribute options.
+See https://plotly.com/python/reference/#scattermapbox for more information about mapbox and their attribute options.

--- a/doc/python/lines-on-maps.md
+++ b/doc/python/lines-on-maps.md
@@ -215,4 +215,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#scattergeo for more information and chart attribute options!
+See https://plotly.com/python/reference/#scattergeo for more information and chart attribute options!

--- a/doc/python/log-plot.md
+++ b/doc/python/log-plot.md
@@ -54,5 +54,5 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#layout-xaxis-type for more information and chart attribute options!
+See https://plotly.com/python/reference/#layout-xaxis-type for more information and chart attribute options!
 

--- a/doc/python/map-configuration.md
+++ b/doc/python/map-configuration.md
@@ -220,7 +220,7 @@ fig.show()
 
 ### Reference
 
-See https://plot.ly/python/reference/#layout-geo for more information and chart attribute options!
+See https://plotly.com/python/reference/#layout-geo for more information and chart attribute options!
 
 ```python
 

--- a/doc/python/map-subplots-and-small-multiples.md
+++ b/doc/python/map-subplots-and-small-multiples.md
@@ -162,5 +162,5 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#scattergeo for more information and chart attribute options!
+See https://plotly.com/python/reference/#scattergeo for more information and chart attribute options!
 

--- a/doc/python/mapbox-county-choropleth.md
+++ b/doc/python/mapbox-county-choropleth.md
@@ -210,4 +210,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#choroplethmapbox for more information about mapbox and their attribute options.
+See https://plotly.com/python/reference/#choroplethmapbox for more information about mapbox and their attribute options.

--- a/doc/python/mapbox-density-heatmaps.md
+++ b/doc/python/mapbox-density-heatmaps.md
@@ -72,4 +72,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#densitymapbox for more information about mapbox and their attribute options.
+See https://plotly.com/python/reference/#densitymapbox for more information about mapbox and their attribute options.

--- a/doc/python/mapbox-layers.md
+++ b/doc/python/mapbox-layers.md
@@ -192,4 +192,4 @@ See the example in the [plotly and datashader tutorial](/python/datashader).
 
 #### Reference
 
-See https://plot.ly/python/reference/#layout-mapbox for more information and options!
+See https://plotly.com/python/reference/#layout-mapbox for more information and options!

--- a/doc/python/marker-style.md
+++ b/doc/python/marker-style.md
@@ -342,4 +342,4 @@ fig.show()
 
 ### Reference
 
-See https://plot.ly/python/reference/ for more information and chart attribute options!
+See https://plotly.com/python/reference/ for more information and chart attribute options!

--- a/doc/python/mixed-subplots.md
+++ b/doc/python/mixed-subplots.md
@@ -116,4 +116,4 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/ for more information and chart attribute options!
+See https://plotly.com/python/reference/ for more information and chart attribute options!

--- a/doc/python/multiple-axes.md
+++ b/doc/python/multiple-axes.md
@@ -225,4 +225,4 @@ fig.show()
 ```
 
 #### Reference
-All of the y-axis properties are found here: https://plot.ly/python/reference/#YAxis.  For more information on creating subplots see the [Subplots in Python](/python/subplots/) section.
+All of the y-axis properties are found here: https://plotly.com/python/reference/#YAxis.  For more information on creating subplots see the [Subplots in Python](/python/subplots/) section.

--- a/doc/python/multiple-transforms.md
+++ b/doc/python/multiple-transforms.md
@@ -208,4 +208,4 @@ pio.show(fig_dict, validate=False)
 ```
 
 #### Reference
-See https://plot.ly/python/reference/ for more information and chart attribute options!
+See https://plotly.com/python/reference/ for more information and chart attribute options!

--- a/doc/python/network-graphs.md
+++ b/doc/python/network-graphs.md
@@ -134,7 +134,7 @@ fig = go.Figure(data=[edge_trace, node_trace],
                 hovermode='closest',
                 margin=dict(b=20,l=5,r=5,t=40),
                 annotations=[ dict(
-                    text="Python code: <a href='https://plot.ly/ipython-notebooks/network-graphs/'> https://plot.ly/ipython-notebooks/network-graphs/</a>",
+                    text="Python code: <a href='https://plotly.com/ipython-notebooks/network-graphs/'> https://plotly.com/ipython-notebooks/network-graphs/</a>",
                     showarrow=False,
                     xref="paper", yref="paper",
                     x=0.005, y=-0.002 ) ],
@@ -146,4 +146,4 @@ fig.show()
 
 
 #### Reference
-See https://plot.ly/python/reference/#scatter for more information and chart attribute options!
+See https://plotly.com/python/reference/#scatter for more information and chart attribute options!

--- a/doc/python/ohlc-charts.md
+++ b/doc/python/ohlc-charts.md
@@ -25,7 +25,7 @@ jupyter:
 
 The [OHLC](https://en.wikipedia.org/wiki/Open-high-low-close_chart) chart (for open, high, low and close) is a style of financial chart describing open, high, low and close values for a given `x` coordinate (most likely time). The tip of the lines represent the `low` and `high` values and the horizontal segments represent the `open` and `close` values. Sample points where the close value is higher (lower) then the open value are called increasing (decreasing). By default, increasing items are drawn in green whereas decreasing are drawn in red.
 
-See also [Candlestick Charts](https://plot.ly/python/candlestick-charts/) and [other financial charts](https://plot.ly/python/#financial-charts).
+See also [Candlestick Charts](https://plotly.com/python/candlestick-charts/) and [other financial charts](https://plotly.com/python/#financial-charts).
 
 #### Simple OHLC Chart with Pandas
 
@@ -155,4 +155,4 @@ fig.show()
 ```
 
 #### Reference
-For more information on candlestick attributes, see: https://plot.ly/python/reference/#ohlc
+For more information on candlestick attributes, see: https://plotly.com/python/reference/#ohlc

--- a/doc/python/orca-management.md
+++ b/doc/python/orca-management.md
@@ -184,7 +184,7 @@ will be applied automatically in future sessions. You can do this as follows:
     >>> plotly.io.orca.config.save()
 
 If you're still having trouble, feel free to ask for help on the forums at
-https://community.plot.ly/c/api/python
+https://community.plotly.com/c/api/python
 ----------------------------------------------------------------------------
 ```
 If this happens, follow the instructions in the error message and specify the full path to you orca executable using the `plotly.io.orca.config.executable` configuration property.

--- a/doc/python/parallel-categories-diagram.md
+++ b/doc/python/parallel-categories-diagram.md
@@ -288,4 +288,4 @@ widgets.VBox([color_toggle, fig])
 
 #### Reference
 
-See [reference page](https://plot.ly/python/reference/#parcats) for more information and chart attribute options!
+See [reference page](https://plotly.com/python/reference/#parcats) for more information and chart attribute options!

--- a/doc/python/parallel-coordinates-plot.md
+++ b/doc/python/parallel-coordinates-plot.md
@@ -173,4 +173,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#parcoords for more information and chart attribute options!
+See https://plotly.com/python/reference/#parcoords for more information and chart attribute options!

--- a/doc/python/peak-finding.md
+++ b/doc/python/peak-finding.md
@@ -36,7 +36,7 @@ jupyter:
 
 #### Imports
 
-The tutorial below imports [Pandas](https://plot.ly/pandas/intro-to-pandas-tutorial/), and [SciPy](https://www.scipy.org/).
+The tutorial below imports [Pandas](https://plotly.com/pandas/intro-to-pandas-tutorial/), and [SciPy](https://www.scipy.org/).
 
 ```python
 import pandas as pd

--- a/doc/python/pie-charts.md
+++ b/doc/python/pie-charts.md
@@ -304,4 +304,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#pie for more information and chart attribute options!
+See https://plotly.com/python/reference/#pie for more information and chart attribute options!

--- a/doc/python/plot-data-from-csv.md
+++ b/doc/python/plot-data-from-csv.md
@@ -76,4 +76,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/getting-started for more information about Plotly's Python API!
+See https://plotly.com/python/getting-started for more information about Plotly's Python API!

--- a/doc/python/plotly-express.md
+++ b/doc/python/plotly-express.md
@@ -41,7 +41,7 @@ Plotly Express is the easy-to-use, high-level interface to Plotly, which [operat
 
 > **Note**: Plotly Express was previously its own separately-installed `plotly_express` package but is now part of `plotly` and importable via `import plotly.express as px`.
 
-This notebook demonstrates various `plotly.express` features. [Reference documentation](https://plot.ly/python-api-reference/plotly.express.html) is also available, as well as a [tutorial on input argument types](/python/px-arguments) and one on how to [style figures made with Plotly Express](/python/styling-plotly-express/).
+This notebook demonstrates various `plotly.express` features. [Reference documentation](https://plotly.com/python-api-reference/plotly.express.html) is also available, as well as a [tutorial on input argument types](/python/px-arguments) and one on how to [style figures made with Plotly Express](/python/styling-plotly-express/).
 
 You can also read our original [Medium announcement article](https://medium.com/@plotlygraphs/introducing-plotly-express-808df010143d) for more information on this library.
 

--- a/doc/python/polar-chart.md
+++ b/doc/python/polar-chart.md
@@ -72,7 +72,7 @@ fig = px.line_polar(df, r="frequency", theta="direction", color="strength", line
 fig.show()
 ```
 
-See also the [wind rose page](https://plot.ly/python/wind-rose-charts/) for more wind rose visualizations in polar coordinates.
+See also the [wind rose page](https://plotly.com/python/wind-rose-charts/) for more wind rose visualizations in polar coordinates.
 
 You can plot less than a whole circle with the `range_theta` argument, and also control the `start_angle` and `direction`:
 
@@ -85,7 +85,7 @@ fig.show()
 
 ## Polar Scatter Plot with go.Scatterpolar
 
-If Plotly Express does not provide a good starting point, you can use the more generic `go.Scatterpolar`. All the options are documented in the [reference page](https://plot.ly/python/reference/#scatterpolar).
+If Plotly Express does not provide a good starting point, you can use the more generic `go.Scatterpolar`. All the options are documented in the [reference page](https://plotly.com/python/reference/#scatterpolar).
 
 #### Basic Polar Chart
 
@@ -438,4 +438,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#scatterpolar for more information and chart attribute options!
+See https://plotly.com/python/reference/#scatterpolar for more information and chart attribute options!

--- a/doc/python/radar-chart.md
+++ b/doc/python/radar-chart.md
@@ -129,4 +129,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#scatterpolar for more information and chart attribute options!
+See https://plotly.com/python/reference/#scatterpolar for more information and chart attribute options!

--- a/doc/python/random-walk.md
+++ b/doc/python/random-walk.md
@@ -34,7 +34,7 @@ jupyter:
     thumbnail: /images/static-image
 ---
 
-A [random walk](https://en.wikipedia.org/wiki/Random_walk) can be thought of as a random process in which a token or a marker is randomly moved around some space, that is, a space with a metric used to compute distance. It is more commonly conceptualized in one dimension ($\mathbb{Z}$), two dimensions ($\mathbb{Z}^2$) or three dimensions ($\mathbb{Z}^3$) in Cartesian space, where $\mathbb{Z}$ represents the set of integers. In the visualizations below, we will be using [scatter plots](https://plot.ly/python/line-and-scatter/) as well as a colorscale to denote the time sequence of the walk.
+A [random walk](https://en.wikipedia.org/wiki/Random_walk) can be thought of as a random process in which a token or a marker is randomly moved around some space, that is, a space with a metric used to compute distance. It is more commonly conceptualized in one dimension ($\mathbb{Z}$), two dimensions ($\mathbb{Z}^2$) or three dimensions ($\mathbb{Z}^3$) in Cartesian space, where $\mathbb{Z}$ represents the set of integers. In the visualizations below, we will be using [scatter plots](https://plotly.com/python/line-and-scatter/) as well as a colorscale to denote the time sequence of the walk.
 
 #### Random Walk in 1D
 

--- a/doc/python/range-slider.md
+++ b/doc/python/range-slider.md
@@ -342,4 +342,4 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#layout-xaxis-rangeselector <br>and https://plot.ly/python/reference/#layout-xaxis-rangeslider <br>for more information and attribute options!
+See https://plotly.com/python/reference/#layout-xaxis-rangeselector <br>and https://plotly.com/python/reference/#layout-xaxis-rangeslider <br>for more information and attribute options!

--- a/doc/python/renderers.md
+++ b/doc/python/renderers.md
@@ -156,7 +156,7 @@ The `plotly_mimetype` renderer creates a specification of the plotly figure (cal
 These are aliases for `plotly_mimetype` since this renderer is a good choice when working in JupyterLab, nteract, and the Visual Studio Code notebook interface.
 
 ##### Static image renderers
-A set of renderers is provided for displaying figures as static images.  These renderers all rely on the orca static image export utility. See the [Static Image Export](https://plot.ly/python/static-image-export/) page for more information on getting set up with orca.
+A set of renderers is provided for displaying figures as static images.  These renderers all rely on the orca static image export utility. See the [Static Image Export](https://plotly.com/python/static-image-export/) page for more information on getting set up with orca.
 
 ###### `png`, `jpeg`, and `svg`
 These renderers display figures as static PNG, JPEG, and SVG images respectively.  These renderers are useful for user interfaces that do not support inline HTML output, but do support inline static images.  Examples include the [QtConsole](https://qtconsole.readthedocs.io/en/stable/), [Spyder](https://www.spyder-ide.org/), and the PyCharm [notebook interface](https://www.jetbrains.com/help/pycharm/jupyter-notebook-support.html).
@@ -224,11 +224,11 @@ fig.show(renderer="png", width=800, height=300)
 ```
 
 ### Displaying figures using Dash
-Dash is a Python framework for building web applications, and it provides built-in support for displaying Plotly figures. See the [Dash User Guide](https://dash.plot.ly/) for more information.
+Dash is a Python framework for building web applications, and it provides built-in support for displaying Plotly figures. See the [Dash User Guide](https://dash.plotly.com/) for more information.
 
 It is important to note that Dash does not use the renderers framework discussed above, so you should not use the `.show` figure method or the `plotly.io.show` function inside Dash applications.
 
 ## Displaying figures using ipywidgets
-Plotly figures can be displayed in [ipywidgets](https://ipywidgets.readthedocs.io/en/stable/) contexts using `plotly.graph_objects.FigureWidget` objects.  `FigureWidget` is a figure graph object (Just like `plotly.graph_objects.Figure`) so you can add traces to it and update it just like a regular `Figure`.  But `FigureWidget` is also an ipywidgets object, which means that you can display it alongside other ipywidgets to build user interfaces right in the notebook.  See the [Plotly FigureWidget Overview](https://plot.ly/python/figurewidget/) for more information on integrating plotly figures with ipywidgets.
+Plotly figures can be displayed in [ipywidgets](https://ipywidgets.readthedocs.io/en/stable/) contexts using `plotly.graph_objects.FigureWidget` objects.  `FigureWidget` is a figure graph object (Just like `plotly.graph_objects.Figure`) so you can add traces to it and update it just like a regular `Figure`.  But `FigureWidget` is also an ipywidgets object, which means that you can display it alongside other ipywidgets to build user interfaces right in the notebook.  See the [Plotly FigureWidget Overview](https://plotly.com/python/figurewidget/) for more information on integrating plotly figures with ipywidgets.
 
 It is important to note that `FigureWidget` does not use the renderers framework discussed above, so you should not use the `.show` figure method or the `plotly.io.show` function on `FigureWidget` objects.

--- a/doc/python/sankey-diagram.md
+++ b/doc/python/sankey-diagram.md
@@ -39,7 +39,7 @@ A [Sankey diagram](https://en.wikipedia.org/wiki/Sankey_diagram) is a flow diagr
 
 
 ### Basic Sankey Diagram
-Sankey diagrams visualize the contributions to a flow by defining [source](https://plot.ly/python/reference/#sankey-link-source) to represent the source node, [target](https://plot.ly/python/reference/#sankey-link-target) for the target node, [value](https://plot.ly/python/reference/#sankey-link-value) to set the flow volum, and [label](https://plot.ly/python/reference/#sankey-node-label) that shows the node name.
+Sankey diagrams visualize the contributions to a flow by defining [source](https://plotly.com/python/reference/#sankey-link-source) to represent the source node, [target](https://plotly.com/python/reference/#sankey-link-target) for the target node, [value](https://plotly.com/python/reference/#sankey-link-value) to set the flow volum, and [label](https://plotly.com/python/reference/#sankey-node-label) that shows the node name.
 
 ```python
 import plotly.graph_objects as go
@@ -96,7 +96,7 @@ fig.show()
 ```
 
 ### Style Sankey Diagram
-This example also uses [hovermode](https://plot.ly/python/reference/#layout-hovermode) to enable multiple tooltips.
+This example also uses [hovermode](https://plotly.com/python/reference/#layout-hovermode) to enable multiple tooltips.
 
 ```python
 import plotly.graph_objects as go
@@ -136,7 +136,7 @@ fig.show()
 
 ### Define Node Position
 
-The following example sets [node.x](https://plot.ly/python/reference/#sankey-node-x) and `node.y` to place nodes in the specified locations, except in the `snap arrangement` (default behaviour when `node.x` and `node.y` are not defined) to avoid overlapping of the nodes, therefore, an automatic snapping of elements will be set to define the padding between nodes via [nodepad](https://plot.ly/python/reference/#sankey-node-pad). The other possible arrangements are:<font color='blue'> 1)</font> perpendicular <font color='blue'>2)</font> freeform <font color='blue'>3)</font> fixed
+The following example sets [node.x](https://plotly.com/python/reference/#sankey-node-x) and `node.y` to place nodes in the specified locations, except in the `snap arrangement` (default behaviour when `node.x` and `node.y` are not defined) to avoid overlapping of the nodes, therefore, an automatic snapping of elements will be set to define the padding between nodes via [nodepad](https://plotly.com/python/reference/#sankey-node-pad). The other possible arrangements are:<font color='blue'> 1)</font> perpendicular <font color='blue'>2)</font> freeform <font color='blue'>3)</font> fixed
 
 ```python
 import plotly.graph_objects as go
@@ -158,4 +158,4 @@ fig.show()
 
 ### Reference
 
-See [https://plot.ly/python/reference/#sankey](https://plot.ly/python/reference/#sankey) for more information and options!
+See [https://plotly.com/python/reference/#sankey](https://plotly.com/python/reference/#sankey) for more information and options!

--- a/doc/python/scatter-plots-on-maps.md
+++ b/doc/python/scatter-plots-on-maps.md
@@ -215,4 +215,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#scattergeo and https://plot.ly/python/reference/#layout-geo for more information and chart attribute options!
+See https://plotly.com/python/reference/#scattergeo and https://plotly.com/python/reference/#layout-geo for more information and chart attribute options!

--- a/doc/python/scattermapbox.md
+++ b/doc/python/scattermapbox.md
@@ -196,7 +196,7 @@ fig.show()
 
 ### Set Marker Symbols
 
-You can define a symbol on your map by setting [symbol](https://plot.ly/python/reference/#scattermapbox-marker-symbol) attribute. This attribute only works on Mapbox-provided `style`s:
+You can define a symbol on your map by setting [symbol](https://plotly.com/python/reference/#scattermapbox-marker-symbol) attribute. This attribute only works on Mapbox-provided `style`s:
 
 - basic
 - streets
@@ -228,4 +228,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#scattermapbox for more information and options!
+See https://plotly.com/python/reference/#scattermapbox for more information and options!

--- a/doc/python/setting-graph-size.md
+++ b/doc/python/setting-graph-size.md
@@ -80,7 +80,7 @@ fig.show()
 
 ### Automatically Adjust Margins
 
-Set [automargin](https://plot.ly/python/reference/#layout-xaxis-automargin) to `True` and Plotly will automatically increase the margin size to prevent ticklabels from being cut off or overlapping with axis titles.
+Set [automargin](https://plotly.com/python/reference/#layout-xaxis-automargin) to `True` and Plotly will automatically increase the margin size to prevent ticklabels from being cut off or overlapping with axis titles.
 
 ```python
 import plotly.graph_objects as go
@@ -113,4 +113,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#layout for more information and chart attribute options!
+See https://plotly.com/python/reference/#layout for more information and chart attribute options!

--- a/doc/python/shapes.md
+++ b/doc/python/shapes.md
@@ -35,7 +35,7 @@ jupyter:
 
 ### Filled Area Chart
 
-There are two ways to draw filled shapes: scatter traces and [layout.shapes](https://plot.ly/python/reference/#layout-shapes-items-shape-type) which is mostly useful for the 2d subplots, and defines the shape type to be drawn, and can be rectangle, circle, line, or path (a custom SVG path). You also can use [scatterpolar](https://plot.ly/python/polar-chart/#categorical-polar-chart), scattergeo, [scattermapbox](https://plot.ly/python/filled-area-on-mapbox/#filled-scattermapbox-trace) to draw filled shapes on any kind of subplots. To set an area to be filled with a solid color, you need to define [Scatter.fill="toself"](https://plot.ly/python/reference/#scatter-fill) that connects the endpoints of the trace into a closed shape. If `mode=line` (default value), then you need to repeat the initial point of a shape at the of the sequence to have a closed shape. 
+There are two ways to draw filled shapes: scatter traces and [layout.shapes](https://plotly.com/python/reference/#layout-shapes-items-shape-type) which is mostly useful for the 2d subplots, and defines the shape type to be drawn, and can be rectangle, circle, line, or path (a custom SVG path). You also can use [scatterpolar](https://plotly.com/python/polar-chart/#categorical-polar-chart), scattergeo, [scattermapbox](https://plotly.com/python/filled-area-on-mapbox/#filled-scattermapbox-trace) to draw filled shapes on any kind of subplots. To set an area to be filled with a solid color, you need to define [Scatter.fill="toself"](https://plotly.com/python/reference/#scatter-fill) that connects the endpoints of the trace into a closed shape. If `mode=line` (default value), then you need to repeat the initial point of a shape at the of the sequence to have a closed shape. 
 
 ```python
 import plotly.graph_objects as go
@@ -44,7 +44,7 @@ fig = go.Figure(go.Scatter(x=[0,1,2,0], y=[0,2,0,0], fill="toself"))
 fig.show()
 ```
 
-You can have more shapes either by adding [more traces](https://plot.ly/python/filled-area-plots/) or interrupting the series with `None`.
+You can have more shapes either by adding [more traces](https://plotly.com/python/filled-area-plots/) or interrupting the series with `None`.
 
 ```python
 import plotly.graph_objects as go
@@ -717,4 +717,4 @@ fig.show()
 ```
 
 ### Reference
-See https://plot.ly/python/reference/#layout-shapes for more information and chart attribute options!
+See https://plotly.com/python/reference/#layout-shapes for more information and chart attribute options!

--- a/doc/python/sliders.md
+++ b/doc/python/sliders.md
@@ -81,4 +81,4 @@ fig.show()
 ```
 
 #### Reference
-Check out https://plot.ly/python/reference/#layout-updatemenus for more information!
+Check out https://plotly.com/python/reference/#layout-updatemenus for more information!

--- a/doc/python/smoothing.md
+++ b/doc/python/smoothing.md
@@ -36,7 +36,7 @@ jupyter:
 
 #### Imports
 
-The tutorial below imports [NumPy](http://www.numpy.org/), [Pandas](https://plot.ly/pandas/intro-to-pandas-tutorial/), [SciPy](https://www.scipy.org/) and [Plotly](https://plot.ly/python/getting-started/).
+The tutorial below imports [NumPy](http://www.numpy.org/), [Pandas](https://plotly.com/pandas/intro-to-pandas-tutorial/), [SciPy](https://www.scipy.org/) and [Plotly](https://plotly.com/python/getting-started/).
 
 ```python
 import plotly.graph_objects as go

--- a/doc/python/splom.md
+++ b/doc/python/splom.md
@@ -82,7 +82,7 @@ fig.show()
 
 ### Scatter matrix (splom) with go.Splom
 
-If Plotly Express does not provide a good starting point, it is possible to use the more generic `go.Splom` function. All its parameters are documented in the reference page https://plot.ly/python/reference/#splom.
+If Plotly Express does not provide a good starting point, it is possible to use the more generic `go.Splom` function. All its parameters are documented in the reference page https://plotly.com/python/reference/#splom.
 
 The Plotly splom trace implementation for the scatterplot matrix does not require to set $x=Xi$ , and $y=Xj$, for each scatter plot. All arrays, $X_1,X_2,…,X_n$ , are passed once, through a list of dicts called dimensions, i.e. each array/variable represents a dimension.
 

--- a/doc/python/streamtube-plot.md
+++ b/doc/python/streamtube-plot.md
@@ -131,5 +131,5 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#streamtube for more information and chart attribute options!
+See https://plotly.com/python/reference/#streamtube for more information and chart attribute options!
 

--- a/doc/python/subplots.md
+++ b/doc/python/subplots.md
@@ -298,7 +298,7 @@ fig.show()
 
 ### Subplots with Shared Colorscale
 
-To share colorscale information in multiple subplots, you can use [coloraxis](https://plot.ly/javascript/reference/#scatter-marker-line-coloraxis).
+To share colorscale information in multiple subplots, you can use [coloraxis](https://plotly.com/javascript/reference/#scatter-marker-line-coloraxis).
 
 ```python
 from plotly.subplots import make_subplots
@@ -572,8 +572,8 @@ fig.show()
 ```
 
 #### Reference
-All of the x-axis properties are found here: https://plot.ly/python/reference/#XAxis
-All of the y-axis properties are found here: https://plot.ly/python/reference/#YAxis
+All of the x-axis properties are found here: https://plotly.com/python/reference/#XAxis
+All of the y-axis properties are found here: https://plotly.com/python/reference/#YAxis
 
 ```python
 from plotly.subplots import make_subplots

--- a/doc/python/sunburst-charts.md
+++ b/doc/python/sunburst-charts.md
@@ -155,7 +155,7 @@ fig =go.Figure(go.Sunburst(
     values=[10, 14, 12, 10, 2, 6, 6, 4, 4],
 ))
 # Update layout for tight margin
-# See https://plot.ly/python/creating-and-updating-figures/
+# See https://plotly.com/python/creating-and-updating-figures/
 fig.update_layout(margin = dict(t=0, l=0, r=0, b=0))
 
 fig.show()
@@ -214,7 +214,7 @@ fig.show()
 
 ### Large Number of Slices
 
-This example uses a [plotly grid attribute](https://plot.ly/python/reference/#layout-grid) for the suplots. Reference the row and column destination using the [domain](https://plot.ly/python/reference/#sunburst-domain) attribute.
+This example uses a [plotly grid attribute](https://plotly.com/python/reference/#layout-grid) for the suplots. Reference the row and column destination using the [domain](https://plotly.com/python/reference/#sunburst-domain) attribute.
 
 ```python
 import plotly.graph_objects as go
@@ -380,4 +380,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#sunburst for more information and chart attribute options!
+See https://plotly.com/python/reference/#sunburst for more information and chart attribute options!

--- a/doc/python/table-subplots.md
+++ b/doc/python/table-subplots.md
@@ -103,5 +103,5 @@ fig.show()
 ```
 
 #### Reference
-See  https://plot.ly/python/reference/#table for more information regarding chart attributes! <br>
-For examples of Plotly Tables, see: https://plot.ly/python/table/
+See  https://plotly.com/python/reference/#table for more information regarding chart attributes! <br>
+For examples of Plotly Tables, see: https://plotly.com/python/table/

--- a/doc/python/table.md
+++ b/doc/python/table.md
@@ -26,7 +26,7 @@ jupyter:
 `go.Table` provides a Table object for detailed data viewing. The data are arranged in
 a grid of rows and columns. Most styling can be specified for header, columns, rows or individual cells. Table is using a column-major order, ie. the grid is represented as a vector of column vectors.
 
-Note that [Dash](https://dash.plot.ly/) provides a different type of [DataTable](https://dash.plot.ly/datatable).
+Note that [Dash](https://dash.plotly.com/) provides a different type of [DataTable](https://dash.plotly.com/datatable).
 
 #### Basic Table
 
@@ -211,4 +211,4 @@ fig.show()
 ```
 
 #### Reference
-For more information on tables and table attributes see: https://plot.ly/python/reference/#table.
+For more information on tables and table attributes see: https://plotly.com/python/reference/#table.

--- a/doc/python/ternary-plots.md
+++ b/doc/python/ternary-plots.md
@@ -126,4 +126,4 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#scatterternary for more information and chart attribute options!
+See https://plotly.com/python/reference/#scatterternary for more information and chart attribute options!

--- a/doc/python/text-and-annotations.md
+++ b/doc/python/text-and-annotations.md
@@ -536,9 +536,9 @@ fig.show()
 
 ### Customize Displayed Text with a Text Template
 
-To show an arbitrary text in your chart you can use [texttemplate](https://plot.ly/python/reference/#pie-texttemplate), which is a template string used for rendering the information, and will override [textinfo](https://plot.ly/python/reference/#treemap-textinfo).
+To show an arbitrary text in your chart you can use [texttemplate](https://plotly.com/python/reference/#pie-texttemplate), which is a template string used for rendering the information, and will override [textinfo](https://plotly.com/python/reference/#treemap-textinfo).
 This template string can include `variables` in %{variable} format, `numbers` in [d3-format's syntax](https://github.com/d3/d3-3.x-api-reference/blob/master/Formatting.md#d3_forma), and `date` in [d3-time-format's syntax](https://github.com/d3/d3-3.x-api-reference/blob/master/Time-Formatting.md#format).
-`texttemplate` customizes the text that appears on your plot vs. [hovertemplate](https://plot.ly/python/reference/#pie-hovertemplate) that customizes the tooltip text.
+`texttemplate` customizes the text that appears on your plot vs. [hovertemplate](https://plotly.com/python/reference/#pie-hovertemplate) that customizes the tooltip text.
 
 ```python
 import plotly.graph_objects as go
@@ -554,7 +554,7 @@ fig.show()
 
 ### Customize Text Template
 
-The following example uses [textfont](https://plot.ly/python/reference/#scatterternary-textfont) to customize the added text.
+The following example uses [textfont](https://plotly.com/python/reference/#scatterternary-textfont) to customize the added text.
 
 ```python
 import plotly.graph_objects as go
@@ -575,8 +575,8 @@ fig.show()
 
 ### Set Date in Text Template
 
-The following example shows how to show date by setting [axis.type](https://plot.ly/python/reference/#layout-yaxis-type) in [funnel charts](https://plot.ly/python/funnel-charts/).
-As you can see [textinfo](https://plot.ly/python/reference/#funnel-textinfo) and [texttemplate](https://plot.ly/python/reference/#funnel-texttemplate) have the same functionality when you want to determine 'just' the trace information on the graph.
+The following example shows how to show date by setting [axis.type](https://plotly.com/python/reference/#layout-yaxis-type) in [funnel charts](https://plotly.com/python/funnel-charts/).
+As you can see [textinfo](https://plotly.com/python/reference/#funnel-textinfo) and [texttemplate](https://plotly.com/python/reference/#funnel-texttemplate) have the same functionality when you want to determine 'just' the trace information on the graph.
 
 ```python
 from plotly import graph_objects as go
@@ -606,4 +606,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#layout-annotations for more information and chart attribute options!
+See https://plotly.com/python/reference/#layout-annotations for more information and chart attribute options!

--- a/doc/python/tick-formatting.md
+++ b/doc/python/tick-formatting.md
@@ -194,5 +194,5 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#layout-xaxis for more information and chart attribute options!
+See https://plotly.com/python/reference/#layout-xaxis for more information and chart attribute options!
 

--- a/doc/python/time-series.md
+++ b/doc/python/time-series.md
@@ -35,7 +35,7 @@ jupyter:
 
 ### Time Series Plot with `datetime` Objects ###
 
-Time series can be represented using either `plotly.express` functions (`px.line`, `px.scatter`) or `plotly.graph_objects` charts objects (`go.Scatter`). For more examples of such charts, see the documentation of [line and scatter plots](https://plot.ly/python/line-and-scatter/).
+Time series can be represented using either `plotly.express` functions (`px.line`, `px.scatter`) or `plotly.graph_objects` charts objects (`go.Scatter`). For more examples of such charts, see the documentation of [line and scatter plots](https://plotly.com/python/line-and-scatter/).
 
 Plotly auto-sets the axis type to a date format when the corresponding data are either ISO-formatted date strings or if they're a [date pandas column](https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html) or [datetime NumPy array](https://docs.scipy.org/doc/numpy/reference/arrays.datetime.html).
 
@@ -128,4 +128,4 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#layout-xaxis-rangeslider and<br> https://plot.ly/python/reference/#layout-xaxis-rangeselector for more information and chart attribute options!
+See https://plotly.com/python/reference/#layout-xaxis-rangeslider and<br> https://plotly.com/python/reference/#layout-xaxis-rangeselector for more information and chart attribute options!

--- a/doc/python/tree-plots.md
+++ b/doc/python/tree-plots.md
@@ -137,4 +137,4 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/ for more information and chart attribute options and http://igraph.org/python/ for more information about the igraph package!
+See https://plotly.com/python/reference/ for more information and chart attribute options and http://igraph.org/python/ for more information about the igraph package!

--- a/doc/python/treemaps.md
+++ b/doc/python/treemaps.md
@@ -33,7 +33,7 @@ jupyter:
     thumbnail: thumbnail/treemap.png
 ---
 
-[Treemap charts](https://en.wikipedia.org/wiki/Treemapping) visualize hierarchical data using nested rectangles. Same as [Sunburst](https://plot.ly/python/sunburst-charts/) the hierarchy is defined by [labels](https://plot.ly/python/reference/#treemap-labels) (`names` for `px.treemap`) and [parents](https://plot.ly/python/reference/#treemap-parents) attributes. Click on one sector to zoom in/out, which also displays a pathbar in the upper-left corner of your treemap. To zoom out you can use the path bar as well.
+[Treemap charts](https://en.wikipedia.org/wiki/Treemapping) visualize hierarchical data using nested rectangles. Same as [Sunburst](https://plotly.com/python/sunburst-charts/) the hierarchy is defined by [labels](https://plotly.com/python/reference/#treemap-labels) (`names` for `px.treemap`) and [parents](https://plotly.com/python/reference/#treemap-parents) attributes. Click on one sector to zoom in/out, which also displays a pathbar in the upper-left corner of your treemap. To zoom out you can use the path bar as well.
 
 ### Basic Treemap with plotly.express
 
@@ -154,10 +154,10 @@ fig.show()
 
 This example uses the following attributes:
 
-1.  [values](https://plot.ly/python/reference/#treemap-values): sets the values associated with each of the sectors.
-2.  [textinfo](https://plot.ly/python/reference/#treemap-textinfo): determines which trace information appear on the graph that can be 'text', 'value', 'current path', 'percent root', 'percent entry', and 'percent parent', or any combination of them.
-3.  [pathbar](https://plot.ly/python/reference/#treemap-pathbar): a main extra feature of treemap to display the current path of the visible portion of the hierarchical map. It may also be useful for zooming out of the graph.
-4.  [branchvalues](https://plot.ly/python/reference/#treemap-branchvalues): determines how the items in `values` are summed. When set to "total", items in `values` are taken to be value of all its descendants. In the example below Eva = 65, which is equal to 14 + 12 + 10 + 2 + 6 + 6 + 1 + 4.
+1.  [values](https://plotly.com/python/reference/#treemap-values): sets the values associated with each of the sectors.
+2.  [textinfo](https://plotly.com/python/reference/#treemap-textinfo): determines which trace information appear on the graph that can be 'text', 'value', 'current path', 'percent root', 'percent entry', and 'percent parent', or any combination of them.
+3.  [pathbar](https://plotly.com/python/reference/#treemap-pathbar): a main extra feature of treemap to display the current path of the visible portion of the hierarchical map. It may also be useful for zooming out of the graph.
+4.  [branchvalues](https://plotly.com/python/reference/#treemap-branchvalues): determines how the items in `values` are summed. When set to "total", items in `values` are taken to be value of all its descendants. In the example below Eva = 65, which is equal to 14 + 12 + 10 + 2 + 6 + 6 + 1 + 4.
     When set to "remainder", items in `values` corresponding to the root and the branches sectors are taken to be the extra part not part of the sum of the values at their leaves.
 
 ```python
@@ -200,7 +200,7 @@ fig.show()
 
 There are three different ways to change the color of the sectors in Treemap:
 
-1.  [marker.colors](https://plot.ly/python/reference/#treemap-marker-colors), 2) [colorway](https://plot.ly/python/reference/#treemap-colorway), 3) [colorscale](https://plot.ly/python/reference/#treemap-colorscale). The following examples show how to use each of them.
+1.  [marker.colors](https://plotly.com/python/reference/#treemap-marker-colors), 2) [colorway](https://plotly.com/python/reference/#treemap-colorway), 3) [colorscale](https://plotly.com/python/reference/#treemap-colorscale). The following examples show how to use each of them.
 
 ```python
 import plotly.graph_objects as go
@@ -332,7 +332,7 @@ fig.show()
 
 ### Nested Layers in Treemap
 
-The following example uses hierarchical data that includes layers and grouping. Treemap and [Sunburst](https://plot.ly/python/sunburst-charts/) charts reveal insights into the data, and the format of your hierarchical data. [maxdepth](https://plot.ly/python/reference/#treemap-maxdepth) attribute sets the number of rendered sectors from the given level.
+The following example uses hierarchical data that includes layers and grouping. Treemap and [Sunburst](https://plotly.com/python/sunburst-charts/) charts reveal insights into the data, and the format of your hierarchical data. [maxdepth](https://plotly.com/python/reference/#treemap-maxdepth) attribute sets the number of rendered sectors from the given level.
 
 ```python
 import plotly.graph_objects as go
@@ -391,4 +391,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#treemap for more information and chart attribute options!
+See https://plotly.com/python/reference/#treemap for more information and chart attribute options!

--- a/doc/python/troubleshooting.md
+++ b/doc/python/troubleshooting.md
@@ -37,7 +37,7 @@ jupyter:
 <!-- #region -->
 ### Version Problems
 
-In order to follow the examples in this documentation, you should have the latest version of `plotly` installed (4.x), as detailed in the [Getting Started](/python/getting-started) guide. This documentation (under https://plot.ly/python) is incompatible with `plotly` version 3.x, for which the documentation is available under https://plot.ly/python/v3.
+In order to follow the examples in this documentation, you should have the latest version of `plotly` installed (4.x), as detailed in the [Getting Started](/python/getting-started) guide. This documentation (under https://plotly.com/python) is incompatible with `plotly` version 3.x, for which the documentation is available under https://plotly.com/python/v3.
 
 ### Import Problems
 

--- a/doc/python/v4-migration.md
+++ b/doc/python/v4-migration.md
@@ -39,7 +39,7 @@ Upgrading to version 4 of `plotly` is a matter of following the instructions in 
 
 ### Getting Help
 
-If you encounter issues in upgrading from version 3 to version 4, please reach out in our [Community Forum](https://community.plot.ly/c/api/python) or if you've found an issue or regression in version 4, please report a [Github Issue](https://github.com/plotly/plotly.py/issues/new)
+If you encounter issues in upgrading from version 3 to version 4, please reach out in our [Community Forum](https://community.plotly.com/c/api/python) or if you've found an issue or regression in version 4, please report a [Github Issue](https://github.com/plotly/plotly.py/issues/new)
 
 <!-- #region -->
 ### Online features (`plotly.plotly`) moved to `chart-studio` package

--- a/doc/python/violin.md
+++ b/doc/python/violin.md
@@ -36,9 +36,9 @@ jupyter:
 
 ## Violin Plot with Plotly Express
 
-A [violin plot](https://en.wikipedia.org/wiki/Violin_plot) is a statistical representation of numerical data. It is similar to a [box plot](https://plot.ly/python/box-plots/), with the addition of a rotated [kernel density](https://en.wikipedia.org/wiki/Kernel_density_estimation) plot on each side.
+A [violin plot](https://en.wikipedia.org/wiki/Violin_plot) is a statistical representation of numerical data. It is similar to a [box plot](https://plotly.com/python/box-plots/), with the addition of a rotated [kernel density](https://en.wikipedia.org/wiki/Kernel_density_estimation) plot on each side.
 
-See also the [list of other statistical charts](https://plot.ly/python/statistical-charts/).
+See also the [list of other statistical charts](https://plotly.com/python/statistical-charts/).
 
 ### Basic Violin Plot with Plotly Express
 
@@ -88,7 +88,7 @@ fig.show()
 
 ## Violin Plot with go.Violin
 
-If Plotly Express does not provide a good starting point, you can use the more generic function `go.Violin` from `plotly.graph_objects`. All the options of `go.Violin` are documented in the reference https://plot.ly/python/reference/#violin
+If Plotly Express does not provide a good starting point, you can use the more generic function `go.Violin` from `plotly.graph_objects`. All the options of `go.Violin` are documented in the reference https://plotly.com/python/reference/#violin
 
 #### Basic Violin Plot
 
@@ -260,4 +260,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#violin for more information and chart attribute options!
+See https://plotly.com/python/reference/#violin for more information and chart attribute options!

--- a/doc/python/visualizing-mri-volume-slices.md
+++ b/doc/python/visualizing-mri-volume-slices.md
@@ -140,5 +140,5 @@ Here's where you can find her:
 
 
 #### Reference
-For additional information and help setting up a slider in an animation, see https://plot.ly/python/gapminder-example/. For more documentation on creating animations with Plotly, see https://plot.ly/python/#animations.
+For additional information and help setting up a slider in an animation, see https://plotly.com/python/gapminder-example/. For more documentation on creating animations with Plotly, see https://plotly.com/python/#animations.
 

--- a/doc/python/waterfall-charts.md
+++ b/doc/python/waterfall-charts.md
@@ -57,7 +57,7 @@ fig.show()
 ```
 
 ### Multi Category Waterfall Chart
-This example uses the [waterfallgroupgap attribute](https://plot.ly/python/reference/#layout-waterfallgroupgap), which sets a gap between bars.
+This example uses the [waterfallgroupgap attribute](https://plotly.com/python/reference/#layout-waterfallgroupgap), which sets a gap between bars.
 
 ```python
 import plotly.graph_objects as go
@@ -88,7 +88,7 @@ fig.show()
 ```
 
 ### Setting Marker Size and Color
-This example uses [decreasing, increasing, and total](https://plot.ly/python/reference/#waterfall-increasing) attributes to customize the bars.
+This example uses [decreasing, increasing, and total](https://plotly.com/python/reference/#waterfall-increasing) attributes to customize the bars.
 
 ```python
 import plotly.graph_objects as go
@@ -129,4 +129,4 @@ fig.show()
 ```
 
 #### Reference
-See https://plot.ly/python/reference/#waterfall for more information and chart attribute options!
+See https://plotly.com/python/reference/#waterfall for more information and chart attribute options!

--- a/doc/python/webgl-vs-svg.md
+++ b/doc/python/webgl-vs-svg.md
@@ -38,7 +38,7 @@ For larger datasets, or for a clearer visualization of the density of points,
 it is also possible to use [datashader](/python/datashader/).
 
 #### Compare WebGL and SVG
-Checkout [this notebook](https://plot.ly/python/compare-webgl-svg) to compare WebGL and SVG scatter plots with 75,000 random data points
+Checkout [this notebook](https://plotly.com/python/compare-webgl-svg) to compare WebGL and SVG scatter plots with 75,000 random data points
 
 #### WebGL with Plotly Express
 
@@ -149,4 +149,4 @@ fig.show()
 
 ### Reference
 
-See https://plot.ly/python/reference/#scattergl for more information and chart attribute options!
+See https://plotly.com/python/reference/#scattergl for more information and chart attribute options!

--- a/doc/python/wind-rose-charts.md
+++ b/doc/python/wind-rose-charts.md
@@ -92,4 +92,4 @@ fig.show()
 
 #### Reference
 
-See https://plot.ly/python/reference/#barpolar for more information and chart attribute options!
+See https://plotly.com/python/reference/#barpolar for more information and chart attribute options!


### PR DESCRIPTION
The purpose of this PR is to change hyperlinks in the documentation from the `.ly` to the `.com` TLD. 
