### PR TITLE
Opacity in px.density_mapbox

### DIFF
--- a/packages/python/plotly/plotly/express/_chart_types.py
+++ b/packages/python/plotly/plotly/express/_chart_types.py
@@ -1399,9 +1399,7 @@ def funnel(
     rectangular sector of a funnel.
     """
     return make_figure(
-        args=locals(),
-        constructor=go.Funnel,
-        trace_patch=dict(opacity=opacity, orientation=orientation),
+        args=locals(), constructor=go.Funnel, trace_patch=dict(orientation=orientation),
     )
 
 

--- a/packages/python/plotly/plotly/express/_chart_types.py
+++ b/packages/python/plotly/plotly/express/_chart_types.py
@@ -1234,6 +1234,7 @@ def pie(
     template=None,
     width=None,
     height=None,
+    opacity=None,
     hole=None,
 ):
     """
@@ -1422,6 +1423,7 @@ def funnel_area(
     template=None,
     width=None,
     height=None,
+    opacity=None,
 ):
     """
     In a funnel area plot, each row of `data_frame` is represented as a

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1278,6 +1278,8 @@ def infer_config(args, constructor, trace_patch):
         if args["opacity"] is None:
             if "barmode" in args and args["barmode"] == "overlay":
                 trace_patch["marker"] = dict(opacity=0.5)
+        elif constructor in [go.Densitymapbox, go.Pie, go.Funnel, go.Funnelarea]:
+            trace_patch["opacity"] = args["opacity"]
         else:
             trace_patch["marker"] = dict(opacity=args["opacity"])
     if "line_group" in args:


### PR DESCRIPTION
Hello,
This is a fix for #2316 that correctly map the opacity attribute in the `trace_path`.
It allows to correctly pass `opacity` as an attribute in `px.density_mapbox`. Check the issue for reproducible code.

***Limitations:*** I'm not aware of another mapbox figure that would require this change as they use proper markers (scatter, line), but if you are, then please comment and I'll add that.

Thanks for your time.
plotly version=4.5.4
<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to documentation/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

-->
