### PR TITLE
fix bug in trendline in the case of missing values

### DIFF
--- a/.circleci/create_conda_optional_env.sh
+++ b/.circleci/create_conda_optional_env.sh
@@ -16,7 +16,7 @@ if [ ! -d $HOME/miniconda/envs/circle_optional ]; then
     # Create environment
     # PYTHON_VERSION=2.7 or 3.5
     $HOME/miniconda/bin/conda create -n circle_optional --yes python=$PYTHON_VERSION \
-requests nbformat six retrying psutil pandas decorator pytest mock nose poppler xarray scikit-image ipython jupyter ipykernel ipywidgets
+requests nbformat six retrying psutil pandas decorator pytest mock nose poppler xarray scikit-image ipython jupyter ipykernel ipywidgets statsmodels
 
     # Install orca into environment
     $HOME/miniconda/bin/conda install --yes -n circle_optional -c plotly plotly-orca==1.3.1

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -249,14 +249,18 @@ def make_trace_kwargs(args, trace_spec, trace_data, mapping_labels, sizeref):
                     if attr_value == "lowess":
                         # missing ='drop' is the default value for lowess but not for OLS (None)
                         # we force it here in case statsmodels change their defaults
-                        trendline = sm.nonparametric.lowess(y, x, missing='drop')
+                        trendline = sm.nonparametric.lowess(y, x, missing="drop")
                         trace_patch["x"] = trendline[:, 0]
                         trace_patch["y"] = trendline[:, 1]
                         hover_header = "<b>LOWESS trendline</b><br><br>"
                     elif attr_value == "ols":
-                        fit_results = sm.OLS(y.values, sm.add_constant(x.values), missing='drop').fit()
+                        fit_results = sm.OLS(
+                            y.values, sm.add_constant(x.values), missing="drop"
+                        ).fit()
                         trace_patch["y"] = fit_results.predict()
-                        trace_patch["x"] = x[np.logical_not(np.logical_or(np.isnan(y), np.isnan(x)))]
+                        trace_patch["x"] = x[
+                            np.logical_not(np.logical_or(np.isnan(y), np.isnan(x)))
+                        ]
                         hover_header = "<b>OLS trendline</b><br>"
                         hover_header += "%s = %g * %s + %g<br>" % (
                             args["y"],

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_trendline.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_trendline.py
@@ -5,8 +5,8 @@ import numpy as np
 def test_trendline_nan_values():
     df = px.data.gapminder().query("continent == 'Oceania'")
     start_date = 1970
-    df['pop'][df['year'] < start_date] = np.nan
-    fig = px.scatter(df, x='year', y='pop', color='country', trendline='ols')
-    country_numbers = len(fig['data']) // 2
-    for trendline in fig['data'][1::2]:
+    df["pop"][df["year"] < start_date] = np.nan
+    fig = px.scatter(df, x="year", y="pop", color="country", trendline="ols")
+    country_numbers = len(fig["data"]) // 2
+    for trendline in fig["data"][1::2]:
         assert trendline.x[0] >= start_date

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_trendline.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_trendline.py
@@ -6,7 +6,10 @@ def test_trendline_nan_values():
     df = px.data.gapminder().query("continent == 'Oceania'")
     start_date = 1970
     df["pop"][df["year"] < start_date] = np.nan
-    fig = px.scatter(df, x="year", y="pop", color="country", trendline="ols")
-    country_numbers = len(fig["data"]) // 2
-    for trendline in fig["data"][1::2]:
-        assert trendline.x[0] >= start_date
+    modes = ["ols", "lowess"]
+    for mode in modes:
+        fig = px.scatter(df, x="year", y="pop", color="country", trendline=mode)
+        country_numbers = len(fig["data"]) // 2
+        for trendline in fig["data"][1::2]:
+            assert trendline.x[0] >= start_date
+            assert len(trendline.x) == len(trendline.y)

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_trendline.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_trendline.py
@@ -9,7 +9,6 @@ def test_trendline_nan_values():
     modes = ["ols", "lowess"]
     for mode in modes:
         fig = px.scatter(df, x="year", y="pop", color="country", trendline=mode)
-        country_numbers = len(fig["data"]) // 2
         for trendline in fig["data"][1::2]:
             assert trendline.x[0] >= start_date
             assert len(trendline.x) == len(trendline.y)

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_trendline.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_trendline.py
@@ -1,0 +1,12 @@
+import plotly.express as px
+import numpy as np
+
+
+def test_trendline_nan_values():
+    df = px.data.gapminder().query("continent == 'Oceania'")
+    start_date = 1970
+    df['pop'][df['year'] < start_date] = np.nan
+    fig = px.scatter(df, x='year', y='pop', color='country', trendline='ols')
+    country_numbers = len(fig['data']) // 2
+    for trendline in fig['data'][1::2]:
+        assert trendline.x[0] >= start_date

--- a/packages/python/plotly/tox.ini
+++ b/packages/python/plotly/tox.ini
@@ -59,7 +59,7 @@ deps=
     pytest==3.5.1
     pandas==0.24.2
     xarray==0.10.9
-    statsmodels==0.11.1
+    statsmodels==0.10.2
     backports.tempfile==1.0
     optional: --editable=file:///{toxinidir}/../plotly-geo
     optional: numpy==1.16.5

--- a/packages/python/plotly/tox.ini
+++ b/packages/python/plotly/tox.ini
@@ -59,6 +59,7 @@ deps=
     pytest==3.5.1
     pandas==0.24.2
     xarray==0.10.9
+    statsmodels==0.11.1
     backports.tempfile==1.0
     optional: --editable=file:///{toxinidir}/../plotly-geo
     optional: numpy==1.16.5


### PR DESCRIPTION
See https://community.plotly.com/t/plotly-trendlines-not-displaying-correctly-due-to-np-nan-values/37202

The case of nan values was not handled properly for trendlines:
- for lowess, the default value of statsmodels is to drop nans which is fine, but then the x values were not properly aligned with the y
- for ols, the default value is to do nothing with nans, resulting in all nans in the estimation.

This PR fixes the two cases and adds a test.