### PR TITLE
Remove plotly express from delayed submodule import.

### DIFF
--- a/packages/python/plotly/plotly/__init__.py
+++ b/packages/python/plotly/plotly/__init__.py
@@ -72,7 +72,6 @@ else:
             ".io",
             ".data",
             ".colors",
-            ".express",
         ],
         [".version.__version__"],
     )

--- a/packages/python/plotly/test_init/test_lazy_imports.py
+++ b/packages/python/plotly/test_init/test_lazy_imports.py
@@ -15,7 +15,7 @@ def test_lazy_imports():
 
     # Check that submodules are not auto-imported, but can be be accessed using
     # attribute syntax
-    submodules = ["graph_objs", "io", "express"]
+    submodules = ["graph_objs", "io"]
     for m in submodules:
         module_str = "plotly." + m
         assert module_str not in sys.modules


### PR DESCRIPTION
Follow on to https://github.com/plotly/plotly.py/pull/2368 to address https://github.com/plotly/plotly.py/issues/2389.

The `express` module was mistakenly added as a submodule to auto-import on demand. This module was not previously auto-imported because it requires pandas.  It seems that requesting tab completion in ipython from an environemnt without pandas installed triggers an error here.