### PR TITLE
title.text everywhere in PX

### DIFF
--- a/doc/python/imshow.md
+++ b/doc/python/imshow.md
@@ -6,7 +6,7 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.2'
-      jupytext_version: 1.3.1
+      jupytext_version: 1.4.2
   kernelspec:
     display_name: Python 3
     language: python
@@ -20,7 +20,7 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.6.8
+    version: 3.7.7
   plotly:
     description: How to display image data in Python with Plotly.
     display_as: scientific

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1615,13 +1615,15 @@ def make_figure(args, constructor, trace_patch={}, layout_patch={}):
                 title_text=get_decorated_label(args, args[colorvar], colorvar)
             ),
         )
-    for v in ["title", "height", "width"]:
+    for v in ["height", "width"]:
         if args[v]:
-            layout_patch[v if v != "title" else "title_text"] = args[v]
+            layout_patch[v] = args[v]
     layout_patch["legend"] = dict(tracegroupgap=0)
     if trace_name_labels:
-        layout_patch["legend"]["title"] = dict(text=", ".join(trace_name_labels))
-    if "title" not in layout_patch and args["template"].layout.margin.t is None:
+        layout_patch["legend"]["title_text"] = ", ".join(trace_name_labels)
+    if args["title"]:
+        layout_patch["title_text"] = args["title"]
+    elif args["template"].layout.margin.t is None:
         layout_patch["margin"] = {"t": 60}
     if (
         "size" in args
@@ -1651,7 +1653,7 @@ def make_figure(args, constructor, trace_patch={}, layout_patch={}):
 
     # Add traces, layout and frames to figure
     fig.add_traces(frame_list[0]["data"] if len(frame_list) > 0 else [])
-    fig.layout.update(layout_patch)
+    fig.update_layout(layout_patch)
     if "template" in args and args["template"] is not None:
         fig.update_layout(template=args["template"], overwrite=True)
     fig.frames = frame_list if len(frames) > 1 else []

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -551,9 +551,9 @@ def configure_cartesian_axes(args, fig, orders):
 def configure_ternary_axes(args, fig, orders):
     fig.update_layout(
         ternary=dict(
-            aaxis=dict(title=get_label(args, args["a"])),
-            baxis=dict(title=get_label(args, args["b"])),
-            caxis=dict(title=get_label(args, args["c"])),
+            aaxis=dict(title_text=get_label(args, args["a"])),
+            baxis=dict(title_text=get_label(args, args["b"])),
+            caxis=dict(title_text=get_label(args, args["c"])),
         )
     )
 
@@ -588,9 +588,9 @@ def configure_polar_axes(args, fig, orders):
 def configure_3d_axes(args, fig, orders):
     layout = dict(
         scene=dict(
-            xaxis=dict(title=get_label(args, args["x"])),
-            yaxis=dict(title=get_label(args, args["y"])),
-            zaxis=dict(title=get_label(args, args["z"])),
+            xaxis=dict(title_text=get_label(args, args["x"])),
+            yaxis=dict(title_text=get_label(args, args["y"])),
+            zaxis=dict(title_text=get_label(args, args["z"])),
         )
     )
 
@@ -1611,14 +1611,16 @@ def make_figure(args, constructor, trace_patch={}, layout_patch={}):
             cmid=args["color_continuous_midpoint"],
             cmin=range_color[0],
             cmax=range_color[1],
-            colorbar=dict(title=get_decorated_label(args, args[colorvar], colorvar)),
+            colorbar=dict(
+                title_text=get_decorated_label(args, args[colorvar], colorvar)
+            ),
         )
     for v in ["title", "height", "width"]:
         if args[v]:
-            layout_patch[v] = args[v]
+            layout_patch[v if v != "title" else "title_text"] = args[v]
     layout_patch["legend"] = dict(tracegroupgap=0)
     if trace_name_labels:
-        layout_patch["legend"]["title"] = ", ".join(trace_name_labels)
+        layout_patch["legend"]["title"] = dict(text=", ".join(trace_name_labels))
     if "title" not in layout_patch and args["template"].layout.margin.t is None:
         layout_patch["margin"] = {"t": 60}
     if (

--- a/packages/python/plotly/plotly/express/_imshow.py
+++ b/packages/python/plotly/plotly/express/_imshow.py
@@ -244,7 +244,7 @@ def imshow(
             cmax=range_color[1],
         )
         if labels["color"]:
-            layout["coloraxis1"]["colorbar"] = dict(title=labels["color"])
+            layout["coloraxis1"]["colorbar"] = dict(title_text=labels["color"])
 
     # For 2D+RGB data, use Image trace
     elif img.ndim == 3 and img.shape[-1] in [3, 4]:
@@ -262,10 +262,12 @@ def imshow(
         )
 
     layout_patch = dict()
-    for attr_name in ["title", "height", "width"]:
+    for attr_name in ["height", "width"]:
         if args[attr_name]:
             layout_patch[attr_name] = args[attr_name]
-    if "title" not in layout_patch and args["template"].layout.margin.t is None:
+    if args["title"]:
+        layout_patch["title_text"] = args["title"]
+    elif args["template"].layout.margin.t is None:
         layout_patch["margin"] = {"t": 60}
     fig = go.Figure(data=trace, layout=layout)
     fig.update_layout(layout_patch)


### PR DESCRIPTION
PX should use `title.text` instead of `title` everywhere... This should be a no-op as the validators handle this internally, but it's cleaner for PX not to rely on that so much IMO.