### PR TITLE
Makefile: modify docstrings to use temporarily graph_objs

### DIFF
--- a/doc/apidoc/Makefile
+++ b/doc/apidoc/Makefile
@@ -18,9 +18,15 @@ help:
 # For sphinx-apidoc the first positional path is the module to document
 # then all the other ones are paths to exclude for the doc generation
 %: Makefile
+	sed -i 's/:class:`plotly.graph_objects/:class:`plotly.graph_objs/g' ../../packages/python/plotly/plotly/graph_objs/*.py
+	sed -i 's/:class:`plotly.graph_objects/:class:`plotly.graph_objs/g' ../../packages/python/plotly/plotly/graph_objs/*/*.py
+	sed -i 's/:class:`plotly.graph_objects/:class:`plotly.graph_objs/g' ../../packages/python/plotly/plotly/graph_objs/*/*/*.py
+	sed -i 's/:class:`plotly.graph_objects/:class:`plotly.graph_objs/g' ../../packages/python/plotly/plotly/graph_objs/*/*/*/*.py
 	sphinx-apidoc -o generated ../../packages/python/plotly/plotly ../../packages/python/plotly/plotly/validators ../../packages/python/plotly/plotly/tests ../../packages/python/plotly/plotly/matplotlylib/ ../../packages/python/plotly/plotly/offline ../../packages/python/plotly/plotly/api
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	git checkout -- ../../packages/python/plotly/plotly/graph_objs
 	rename 's/graph_objs/graph_objects/' _build/html/*.html _build/html/generated/*.html
+	mv _build/html/generated/plotly.graph_objs.html _build/html/generated/plotly.graph_objects.html
 	sed -i 's/graph_objs/graph_objects/g' _build/html/*.html 
 	sed -i 's/graph_objs/graph_objects/g' _build/html/*.inv 
 	sed -i 's/graph_objs/graph_objects/g' _build/html/*.js 

--- a/doc/apidoc/_templates/trace.rst
+++ b/doc/apidoc/_templates/trace.rst
@@ -15,9 +15,9 @@
 
 .. autosummary::
    
-   plotly.graph_objects.{{ objname.lower() }}
+   plotly.graph_objs.{{ objname.lower() }}
 
-.. automodule:: plotly.graph_objects.{{ objname.lower() }}
+.. automodule:: plotly.graph_objs.{{ objname.lower() }}
    :members:
    :undoc-members:
 

--- a/packages/python/plotly/codegen/__init__.py
+++ b/packages/python/plotly/codegen/__init__.py
@@ -304,8 +304,8 @@ else:
     # ### Output datatype __init__.py files ###
     graph_objs_pkg = opath.join(outdir, "graph_objs")
     for path_parts in datatype_rel_class_imports:
-        rel_classes = datatype_rel_class_imports[path_parts]
-        rel_modules = datatype_rel_module_imports.get(path_parts, [])
+        rel_classes = sorted(datatype_rel_class_imports[path_parts])
+        rel_modules = sorted(datatype_rel_module_imports.get(path_parts, []))
         if path_parts == ():
             init_extra = validate_import + optional_figure_widget_import
         else:

--- a/packages/python/plotly/plotly/graph_objs/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/__init__.py
@@ -1,67 +1,30 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._waterfall import Waterfall
-    from ._volume import Volume
-    from ._violin import Violin
-    from ._treemap import Treemap
-    from ._table import Table
-    from ._surface import Surface
-    from ._sunburst import Sunburst
-    from ._streamtube import Streamtube
-    from ._splom import Splom
-    from ._scatterternary import Scatterternary
-    from ._scatterpolargl import Scatterpolargl
-    from ._scatterpolar import Scatterpolar
-    from ._scattermapbox import Scattermapbox
-    from ._scattergl import Scattergl
-    from ._scattergeo import Scattergeo
-    from ._scattercarpet import Scattercarpet
-    from ._scatter3d import Scatter3d
-    from ._scatter import Scatter
-    from ._sankey import Sankey
-    from ._pointcloud import Pointcloud
-    from ._pie import Pie
-    from ._parcoords import Parcoords
-    from ._parcats import Parcats
-    from ._ohlc import Ohlc
-    from ._mesh3d import Mesh3d
-    from ._isosurface import Isosurface
-    from ._indicator import Indicator
-    from ._image import Image
-    from ._histogram2dcontour import Histogram2dContour
-    from ._histogram2d import Histogram2d
-    from ._histogram import Histogram
-    from ._heatmapgl import Heatmapgl
-    from ._heatmap import Heatmap
-    from ._funnelarea import Funnelarea
-    from ._funnel import Funnel
-    from ._densitymapbox import Densitymapbox
-    from ._contourcarpet import Contourcarpet
-    from ._contour import Contour
-    from ._cone import Cone
-    from ._choroplethmapbox import Choroplethmapbox
-    from ._choropleth import Choropleth
-    from ._carpet import Carpet
-    from ._candlestick import Candlestick
-    from ._box import Box
-    from ._barpolar import Barpolar
-    from ._bar import Bar
     from ._area import Area
-    from ._layout import Layout
-    from ._frame import Frame
-    from ._figure import Figure
-    from ._deprecations import Data
-    from ._deprecations import Annotations
-    from ._deprecations import Frames
+    from ._bar import Bar
+    from ._barpolar import Barpolar
+    from ._box import Box
+    from ._candlestick import Candlestick
+    from ._carpet import Carpet
+    from ._choropleth import Choropleth
+    from ._choroplethmapbox import Choroplethmapbox
+    from ._cone import Cone
+    from ._contour import Contour
+    from ._contourcarpet import Contourcarpet
+    from ._densitymapbox import Densitymapbox
     from ._deprecations import AngularAxis
     from ._deprecations import Annotation
+    from ._deprecations import Annotations
     from ._deprecations import ColorBar
     from ._deprecations import Contours
+    from ._deprecations import Data
     from ._deprecations import ErrorX
     from ._deprecations import ErrorY
     from ._deprecations import ErrorZ
     from ._deprecations import Font
+    from ._deprecations import Frames
+    from ._deprecations import Histogram2dcontour
     from ._deprecations import Legend
     from ._deprecations import Line
     from ._deprecations import Margin
@@ -69,178 +32,178 @@ if sys.version_info < (3, 7):
     from ._deprecations import RadialAxis
     from ._deprecations import Scene
     from ._deprecations import Stream
-    from ._deprecations import XAxis
-    from ._deprecations import YAxis
-    from ._deprecations import ZAxis
-    from ._deprecations import XBins
-    from ._deprecations import YBins
     from ._deprecations import Trace
-    from ._deprecations import Histogram2dcontour
-    from . import waterfall
-    from . import volume
-    from . import violin
-    from . import treemap
-    from . import table
-    from . import surface
-    from . import sunburst
-    from . import streamtube
-    from . import splom
-    from . import scatterternary
-    from . import scatterpolargl
-    from . import scatterpolar
-    from . import scattermapbox
-    from . import scattergl
-    from . import scattergeo
-    from . import scattercarpet
-    from . import scatter3d
-    from . import scatter
-    from . import sankey
-    from . import pointcloud
-    from . import pie
-    from . import parcoords
-    from . import parcats
-    from . import ohlc
-    from . import mesh3d
-    from . import isosurface
-    from . import indicator
-    from . import image
-    from . import histogram2dcontour
-    from . import histogram2d
-    from . import histogram
-    from . import heatmapgl
-    from . import heatmap
-    from . import funnelarea
-    from . import funnel
-    from . import densitymapbox
-    from . import contourcarpet
-    from . import contour
-    from . import cone
-    from . import choroplethmapbox
-    from . import choropleth
-    from . import carpet
-    from . import candlestick
-    from . import box
-    from . import barpolar
-    from . import bar
+    from ._deprecations import XAxis
+    from ._deprecations import XBins
+    from ._deprecations import YAxis
+    from ._deprecations import YBins
+    from ._deprecations import ZAxis
+    from ._figure import Figure
+    from ._frame import Frame
+    from ._funnel import Funnel
+    from ._funnelarea import Funnelarea
+    from ._heatmap import Heatmap
+    from ._heatmapgl import Heatmapgl
+    from ._histogram import Histogram
+    from ._histogram2d import Histogram2d
+    from ._histogram2dcontour import Histogram2dContour
+    from ._image import Image
+    from ._indicator import Indicator
+    from ._isosurface import Isosurface
+    from ._layout import Layout
+    from ._mesh3d import Mesh3d
+    from ._ohlc import Ohlc
+    from ._parcats import Parcats
+    from ._parcoords import Parcoords
+    from ._pie import Pie
+    from ._pointcloud import Pointcloud
+    from ._sankey import Sankey
+    from ._scatter import Scatter
+    from ._scatter3d import Scatter3d
+    from ._scattercarpet import Scattercarpet
+    from ._scattergeo import Scattergeo
+    from ._scattergl import Scattergl
+    from ._scattermapbox import Scattermapbox
+    from ._scatterpolar import Scatterpolar
+    from ._scatterpolargl import Scatterpolargl
+    from ._scatterternary import Scatterternary
+    from ._splom import Splom
+    from ._streamtube import Streamtube
+    from ._sunburst import Sunburst
+    from ._surface import Surface
+    from ._table import Table
+    from ._treemap import Treemap
+    from ._violin import Violin
+    from ._volume import Volume
+    from ._waterfall import Waterfall
     from . import area
+    from . import bar
+    from . import barpolar
+    from . import box
+    from . import candlestick
+    from . import carpet
+    from . import choropleth
+    from . import choroplethmapbox
+    from . import cone
+    from . import contour
+    from . import contourcarpet
+    from . import densitymapbox
+    from . import funnel
+    from . import funnelarea
+    from . import heatmap
+    from . import heatmapgl
+    from . import histogram
+    from . import histogram2d
+    from . import histogram2dcontour
+    from . import image
+    from . import indicator
+    from . import isosurface
     from . import layout
+    from . import mesh3d
+    from . import ohlc
+    from . import parcats
+    from . import parcoords
+    from . import pie
+    from . import pointcloud
+    from . import sankey
+    from . import scatter
+    from . import scatter3d
+    from . import scattercarpet
+    from . import scattergeo
+    from . import scattergl
+    from . import scattermapbox
+    from . import scatterpolar
+    from . import scatterpolargl
+    from . import scatterternary
+    from . import splom
+    from . import streamtube
+    from . import sunburst
+    from . import surface
+    from . import table
+    from . import treemap
+    from . import violin
+    from . import volume
+    from . import waterfall
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [
-            ".waterfall",
-            ".volume",
-            ".violin",
-            ".treemap",
-            ".table",
-            ".surface",
-            ".sunburst",
-            ".streamtube",
-            ".splom",
-            ".scatterternary",
-            ".scatterpolargl",
-            ".scatterpolar",
-            ".scattermapbox",
-            ".scattergl",
-            ".scattergeo",
-            ".scattercarpet",
-            ".scatter3d",
-            ".scatter",
-            ".sankey",
-            ".pointcloud",
-            ".pie",
-            ".parcoords",
-            ".parcats",
-            ".ohlc",
-            ".mesh3d",
-            ".isosurface",
-            ".indicator",
-            ".image",
-            ".histogram2dcontour",
-            ".histogram2d",
-            ".histogram",
-            ".heatmapgl",
-            ".heatmap",
-            ".funnelarea",
-            ".funnel",
-            ".densitymapbox",
-            ".contourcarpet",
-            ".contour",
-            ".cone",
-            ".choroplethmapbox",
-            ".choropleth",
-            ".carpet",
-            ".candlestick",
-            ".box",
-            ".barpolar",
-            ".bar",
             ".area",
+            ".bar",
+            ".barpolar",
+            ".box",
+            ".candlestick",
+            ".carpet",
+            ".choropleth",
+            ".choroplethmapbox",
+            ".cone",
+            ".contour",
+            ".contourcarpet",
+            ".densitymapbox",
+            ".funnel",
+            ".funnelarea",
+            ".heatmap",
+            ".heatmapgl",
+            ".histogram",
+            ".histogram2d",
+            ".histogram2dcontour",
+            ".image",
+            ".indicator",
+            ".isosurface",
             ".layout",
+            ".mesh3d",
+            ".ohlc",
+            ".parcats",
+            ".parcoords",
+            ".pie",
+            ".pointcloud",
+            ".sankey",
+            ".scatter",
+            ".scatter3d",
+            ".scattercarpet",
+            ".scattergeo",
+            ".scattergl",
+            ".scattermapbox",
+            ".scatterpolar",
+            ".scatterpolargl",
+            ".scatterternary",
+            ".splom",
+            ".streamtube",
+            ".sunburst",
+            ".surface",
+            ".table",
+            ".treemap",
+            ".violin",
+            ".volume",
+            ".waterfall",
         ],
         [
-            "._waterfall.Waterfall",
-            "._volume.Volume",
-            "._violin.Violin",
-            "._treemap.Treemap",
-            "._table.Table",
-            "._surface.Surface",
-            "._sunburst.Sunburst",
-            "._streamtube.Streamtube",
-            "._splom.Splom",
-            "._scatterternary.Scatterternary",
-            "._scatterpolargl.Scatterpolargl",
-            "._scatterpolar.Scatterpolar",
-            "._scattermapbox.Scattermapbox",
-            "._scattergl.Scattergl",
-            "._scattergeo.Scattergeo",
-            "._scattercarpet.Scattercarpet",
-            "._scatter3d.Scatter3d",
-            "._scatter.Scatter",
-            "._sankey.Sankey",
-            "._pointcloud.Pointcloud",
-            "._pie.Pie",
-            "._parcoords.Parcoords",
-            "._parcats.Parcats",
-            "._ohlc.Ohlc",
-            "._mesh3d.Mesh3d",
-            "._isosurface.Isosurface",
-            "._indicator.Indicator",
-            "._image.Image",
-            "._histogram2dcontour.Histogram2dContour",
-            "._histogram2d.Histogram2d",
-            "._histogram.Histogram",
-            "._heatmapgl.Heatmapgl",
-            "._heatmap.Heatmap",
-            "._funnelarea.Funnelarea",
-            "._funnel.Funnel",
-            "._densitymapbox.Densitymapbox",
-            "._contourcarpet.Contourcarpet",
-            "._contour.Contour",
-            "._cone.Cone",
-            "._choroplethmapbox.Choroplethmapbox",
-            "._choropleth.Choropleth",
-            "._carpet.Carpet",
-            "._candlestick.Candlestick",
-            "._box.Box",
-            "._barpolar.Barpolar",
-            "._bar.Bar",
             "._area.Area",
-            "._layout.Layout",
-            "._frame.Frame",
-            "._figure.Figure",
-            "._deprecations.Data",
-            "._deprecations.Annotations",
-            "._deprecations.Frames",
+            "._bar.Bar",
+            "._barpolar.Barpolar",
+            "._box.Box",
+            "._candlestick.Candlestick",
+            "._carpet.Carpet",
+            "._choropleth.Choropleth",
+            "._choroplethmapbox.Choroplethmapbox",
+            "._cone.Cone",
+            "._contour.Contour",
+            "._contourcarpet.Contourcarpet",
+            "._densitymapbox.Densitymapbox",
             "._deprecations.AngularAxis",
             "._deprecations.Annotation",
+            "._deprecations.Annotations",
             "._deprecations.ColorBar",
             "._deprecations.Contours",
+            "._deprecations.Data",
             "._deprecations.ErrorX",
             "._deprecations.ErrorY",
             "._deprecations.ErrorZ",
             "._deprecations.Font",
+            "._deprecations.Frames",
+            "._deprecations.Histogram2dcontour",
             "._deprecations.Legend",
             "._deprecations.Line",
             "._deprecations.Margin",
@@ -248,13 +211,50 @@ else:
             "._deprecations.RadialAxis",
             "._deprecations.Scene",
             "._deprecations.Stream",
-            "._deprecations.XAxis",
-            "._deprecations.YAxis",
-            "._deprecations.ZAxis",
-            "._deprecations.XBins",
-            "._deprecations.YBins",
             "._deprecations.Trace",
-            "._deprecations.Histogram2dcontour",
+            "._deprecations.XAxis",
+            "._deprecations.XBins",
+            "._deprecations.YAxis",
+            "._deprecations.YBins",
+            "._deprecations.ZAxis",
+            "._figure.Figure",
+            "._frame.Frame",
+            "._funnel.Funnel",
+            "._funnelarea.Funnelarea",
+            "._heatmap.Heatmap",
+            "._heatmapgl.Heatmapgl",
+            "._histogram.Histogram",
+            "._histogram2d.Histogram2d",
+            "._histogram2dcontour.Histogram2dContour",
+            "._image.Image",
+            "._indicator.Indicator",
+            "._isosurface.Isosurface",
+            "._layout.Layout",
+            "._mesh3d.Mesh3d",
+            "._ohlc.Ohlc",
+            "._parcats.Parcats",
+            "._parcoords.Parcoords",
+            "._pie.Pie",
+            "._pointcloud.Pointcloud",
+            "._sankey.Sankey",
+            "._scatter.Scatter",
+            "._scatter3d.Scatter3d",
+            "._scattercarpet.Scattercarpet",
+            "._scattergeo.Scattergeo",
+            "._scattergl.Scattergl",
+            "._scattermapbox.Scattermapbox",
+            "._scatterpolar.Scatterpolar",
+            "._scatterpolargl.Scatterpolargl",
+            "._scatterternary.Scatterternary",
+            "._splom.Splom",
+            "._streamtube.Streamtube",
+            "._sunburst.Sunburst",
+            "._surface.Surface",
+            "._table.Table",
+            "._treemap.Treemap",
+            "._violin.Violin",
+            "._volume.Volume",
+            "._waterfall.Waterfall",
         ],
     )
 

--- a/packages/python/plotly/plotly/graph_objs/area/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/area/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._stream import Stream
-    from ._marker import Marker
     from ._hoverlabel import Hoverlabel
+    from ._marker import Marker
+    from ._stream import Stream
     from . import hoverlabel
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".hoverlabel"],
-        ["._stream.Stream", "._marker.Marker", "._hoverlabel.Hoverlabel"],
+        ["._hoverlabel.Hoverlabel", "._marker.Marker", "._stream.Stream"],
     )

--- a/packages/python/plotly/plotly/graph_objs/bar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/bar/__init__.py
@@ -1,36 +1,36 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._unselected import Unselected
-    from ._textfont import Textfont
-    from ._stream import Stream
-    from ._selected import Selected
-    from ._outsidetextfont import Outsidetextfont
-    from ._marker import Marker
-    from ._insidetextfont import Insidetextfont
-    from ._hoverlabel import Hoverlabel
-    from ._error_y import ErrorY
     from ._error_x import ErrorX
-    from . import unselected
-    from . import selected
-    from . import marker
+    from ._error_y import ErrorY
+    from ._hoverlabel import Hoverlabel
+    from ._insidetextfont import Insidetextfont
+    from ._marker import Marker
+    from ._outsidetextfont import Outsidetextfont
+    from ._selected import Selected
+    from ._stream import Stream
+    from ._textfont import Textfont
+    from ._unselected import Unselected
     from . import hoverlabel
+    from . import marker
+    from . import selected
+    from . import unselected
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".unselected", ".selected", ".marker", ".hoverlabel"],
+        [".hoverlabel", ".marker", ".selected", ".unselected"],
         [
-            "._unselected.Unselected",
-            "._textfont.Textfont",
-            "._stream.Stream",
-            "._selected.Selected",
-            "._outsidetextfont.Outsidetextfont",
-            "._marker.Marker",
-            "._insidetextfont.Insidetextfont",
-            "._hoverlabel.Hoverlabel",
-            "._error_y.ErrorY",
             "._error_x.ErrorX",
+            "._error_y.ErrorY",
+            "._hoverlabel.Hoverlabel",
+            "._insidetextfont.Insidetextfont",
+            "._marker.Marker",
+            "._outsidetextfont.Outsidetextfont",
+            "._selected.Selected",
+            "._stream.Stream",
+            "._textfont.Textfont",
+            "._unselected.Unselected",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/bar/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/bar/marker/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
     from ._colorbar import ColorBar
+    from ._line import Line
     from . import colorbar
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".colorbar"], ["._line.Line", "._colorbar.ColorBar"]
+        __name__, [".colorbar"], ["._colorbar.ColorBar", "._line.Line"]
     )

--- a/packages/python/plotly/plotly/graph_objs/bar/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/bar/marker/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/bar/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/bar/selected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/bar/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/bar/unselected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/barpolar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/barpolar/__init__.py
@@ -1,26 +1,26 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._unselected import Unselected
-    from ._stream import Stream
-    from ._selected import Selected
-    from ._marker import Marker
     from ._hoverlabel import Hoverlabel
-    from . import unselected
-    from . import selected
-    from . import marker
+    from ._marker import Marker
+    from ._selected import Selected
+    from ._stream import Stream
+    from ._unselected import Unselected
     from . import hoverlabel
+    from . import marker
+    from . import selected
+    from . import unselected
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".unselected", ".selected", ".marker", ".hoverlabel"],
+        [".hoverlabel", ".marker", ".selected", ".unselected"],
         [
-            "._unselected.Unselected",
-            "._stream.Stream",
-            "._selected.Selected",
-            "._marker.Marker",
             "._hoverlabel.Hoverlabel",
+            "._marker.Marker",
+            "._selected.Selected",
+            "._stream.Stream",
+            "._unselected.Unselected",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/barpolar/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/barpolar/marker/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
     from ._colorbar import ColorBar
+    from ._line import Line
     from . import colorbar
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".colorbar"], ["._line.Line", "._colorbar.ColorBar"]
+        __name__, [".colorbar"], ["._colorbar.ColorBar", "._line.Line"]
     )

--- a/packages/python/plotly/plotly/graph_objs/barpolar/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/barpolar/marker/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/barpolar/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/barpolar/selected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/barpolar/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/barpolar/unselected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/box/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/box/__init__.py
@@ -1,28 +1,28 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._unselected import Unselected
-    from ._stream import Stream
-    from ._selected import Selected
-    from ._marker import Marker
-    from ._line import Line
     from ._hoverlabel import Hoverlabel
-    from . import unselected
-    from . import selected
-    from . import marker
+    from ._line import Line
+    from ._marker import Marker
+    from ._selected import Selected
+    from ._stream import Stream
+    from ._unselected import Unselected
     from . import hoverlabel
+    from . import marker
+    from . import selected
+    from . import unselected
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".unselected", ".selected", ".marker", ".hoverlabel"],
+        [".hoverlabel", ".marker", ".selected", ".unselected"],
         [
-            "._unselected.Unselected",
-            "._stream.Stream",
-            "._selected.Selected",
-            "._marker.Marker",
-            "._line.Line",
             "._hoverlabel.Hoverlabel",
+            "._line.Line",
+            "._marker.Marker",
+            "._selected.Selected",
+            "._stream.Stream",
+            "._unselected.Unselected",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/candlestick/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/candlestick/__init__.py
@@ -1,25 +1,25 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._stream import Stream
-    from ._line import Line
-    from ._increasing import Increasing
-    from ._hoverlabel import Hoverlabel
     from ._decreasing import Decreasing
-    from . import increasing
-    from . import hoverlabel
+    from ._hoverlabel import Hoverlabel
+    from ._increasing import Increasing
+    from ._line import Line
+    from ._stream import Stream
     from . import decreasing
+    from . import hoverlabel
+    from . import increasing
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".increasing", ".hoverlabel", ".decreasing"],
+        [".decreasing", ".hoverlabel", ".increasing"],
         [
-            "._stream.Stream",
-            "._line.Line",
-            "._increasing.Increasing",
-            "._hoverlabel.Hoverlabel",
             "._decreasing.Decreasing",
+            "._hoverlabel.Hoverlabel",
+            "._increasing.Increasing",
+            "._line.Line",
+            "._stream.Stream",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/carpet/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/carpet/__init__.py
@@ -1,17 +1,17 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._stream import Stream
-    from ._font import Font
-    from ._baxis import Baxis
     from ._aaxis import Aaxis
-    from . import baxis
+    from ._baxis import Baxis
+    from ._font import Font
+    from ._stream import Stream
     from . import aaxis
+    from . import baxis
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".baxis", ".aaxis"],
-        ["._stream.Stream", "._font.Font", "._baxis.Baxis", "._aaxis.Aaxis"],
+        [".aaxis", ".baxis"],
+        ["._aaxis.Aaxis", "._baxis.Baxis", "._font.Font", "._stream.Stream"],
     )

--- a/packages/python/plotly/plotly/graph_objs/carpet/aaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/carpet/aaxis/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/carpet/baxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/carpet/baxis/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/choropleth/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choropleth/__init__.py
@@ -1,29 +1,29 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._unselected import Unselected
-    from ._stream import Stream
-    from ._selected import Selected
-    from ._marker import Marker
-    from ._hoverlabel import Hoverlabel
     from ._colorbar import ColorBar
-    from . import unselected
-    from . import selected
-    from . import marker
-    from . import hoverlabel
+    from ._hoverlabel import Hoverlabel
+    from ._marker import Marker
+    from ._selected import Selected
+    from ._stream import Stream
+    from ._unselected import Unselected
     from . import colorbar
+    from . import hoverlabel
+    from . import marker
+    from . import selected
+    from . import unselected
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".unselected", ".selected", ".marker", ".hoverlabel", ".colorbar"],
+        [".colorbar", ".hoverlabel", ".marker", ".selected", ".unselected"],
         [
-            "._unselected.Unselected",
-            "._stream.Stream",
-            "._selected.Selected",
-            "._marker.Marker",
-            "._hoverlabel.Hoverlabel",
             "._colorbar.ColorBar",
+            "._hoverlabel.Hoverlabel",
+            "._marker.Marker",
+            "._selected.Selected",
+            "._stream.Stream",
+            "._unselected.Unselected",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/choropleth/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choropleth/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/choroplethmapbox/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choroplethmapbox/__init__.py
@@ -1,29 +1,29 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._unselected import Unselected
-    from ._stream import Stream
-    from ._selected import Selected
-    from ._marker import Marker
-    from ._hoverlabel import Hoverlabel
     from ._colorbar import ColorBar
-    from . import unselected
-    from . import selected
-    from . import marker
-    from . import hoverlabel
+    from ._hoverlabel import Hoverlabel
+    from ._marker import Marker
+    from ._selected import Selected
+    from ._stream import Stream
+    from ._unselected import Unselected
     from . import colorbar
+    from . import hoverlabel
+    from . import marker
+    from . import selected
+    from . import unselected
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".unselected", ".selected", ".marker", ".hoverlabel", ".colorbar"],
+        [".colorbar", ".hoverlabel", ".marker", ".selected", ".unselected"],
         [
-            "._unselected.Unselected",
-            "._stream.Stream",
-            "._selected.Selected",
-            "._marker.Marker",
-            "._hoverlabel.Hoverlabel",
             "._colorbar.ColorBar",
+            "._hoverlabel.Hoverlabel",
+            "._marker.Marker",
+            "._selected.Selected",
+            "._stream.Stream",
+            "._unselected.Unselected",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/choroplethmapbox/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choroplethmapbox/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/cone/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/cone/__init__.py
@@ -1,24 +1,24 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._stream import Stream
-    from ._lightposition import Lightposition
-    from ._lighting import Lighting
-    from ._hoverlabel import Hoverlabel
     from ._colorbar import ColorBar
-    from . import hoverlabel
+    from ._hoverlabel import Hoverlabel
+    from ._lighting import Lighting
+    from ._lightposition import Lightposition
+    from ._stream import Stream
     from . import colorbar
+    from . import hoverlabel
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".hoverlabel", ".colorbar"],
+        [".colorbar", ".hoverlabel"],
         [
-            "._stream.Stream",
-            "._lightposition.Lightposition",
-            "._lighting.Lighting",
-            "._hoverlabel.Hoverlabel",
             "._colorbar.ColorBar",
+            "._hoverlabel.Hoverlabel",
+            "._lighting.Lighting",
+            "._lightposition.Lightposition",
+            "._stream.Stream",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/cone/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/cone/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/contour/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/contour/__init__.py
@@ -1,25 +1,25 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._stream import Stream
-    from ._line import Line
-    from ._hoverlabel import Hoverlabel
-    from ._contours import Contours
     from ._colorbar import ColorBar
-    from . import hoverlabel
-    from . import contours
+    from ._contours import Contours
+    from ._hoverlabel import Hoverlabel
+    from ._line import Line
+    from ._stream import Stream
     from . import colorbar
+    from . import contours
+    from . import hoverlabel
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".hoverlabel", ".contours", ".colorbar"],
+        [".colorbar", ".contours", ".hoverlabel"],
         [
-            "._stream.Stream",
-            "._line.Line",
-            "._hoverlabel.Hoverlabel",
-            "._contours.Contours",
             "._colorbar.ColorBar",
+            "._contours.Contours",
+            "._hoverlabel.Hoverlabel",
+            "._line.Line",
+            "._stream.Stream",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/contour/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/contour/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/contourcarpet/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/contourcarpet/__init__.py
@@ -1,22 +1,22 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._stream import Stream
-    from ._line import Line
-    from ._contours import Contours
     from ._colorbar import ColorBar
-    from . import contours
+    from ._contours import Contours
+    from ._line import Line
+    from ._stream import Stream
     from . import colorbar
+    from . import contours
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".contours", ".colorbar"],
+        [".colorbar", ".contours"],
         [
-            "._stream.Stream",
-            "._line.Line",
-            "._contours.Contours",
             "._colorbar.ColorBar",
+            "._contours.Contours",
+            "._line.Line",
+            "._stream.Stream",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/contourcarpet/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/contourcarpet/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/densitymapbox/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/densitymapbox/__init__.py
@@ -1,16 +1,16 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._stream import Stream
-    from ._hoverlabel import Hoverlabel
     from ._colorbar import ColorBar
-    from . import hoverlabel
+    from ._hoverlabel import Hoverlabel
+    from ._stream import Stream
     from . import colorbar
+    from . import hoverlabel
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".hoverlabel", ".colorbar"],
-        ["._stream.Stream", "._hoverlabel.Hoverlabel", "._colorbar.ColorBar"],
+        [".colorbar", ".hoverlabel"],
+        ["._colorbar.ColorBar", "._hoverlabel.Hoverlabel", "._stream.Stream"],
     )

--- a/packages/python/plotly/plotly/graph_objs/densitymapbox/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/densitymapbox/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/funnel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/funnel/__init__.py
@@ -1,29 +1,29 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
-    from ._stream import Stream
-    from ._outsidetextfont import Outsidetextfont
-    from ._marker import Marker
-    from ._insidetextfont import Insidetextfont
-    from ._hoverlabel import Hoverlabel
     from ._connector import Connector
-    from . import marker
-    from . import hoverlabel
+    from ._hoverlabel import Hoverlabel
+    from ._insidetextfont import Insidetextfont
+    from ._marker import Marker
+    from ._outsidetextfont import Outsidetextfont
+    from ._stream import Stream
+    from ._textfont import Textfont
     from . import connector
+    from . import hoverlabel
+    from . import marker
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".marker", ".hoverlabel", ".connector"],
+        [".connector", ".hoverlabel", ".marker"],
         [
-            "._textfont.Textfont",
-            "._stream.Stream",
-            "._outsidetextfont.Outsidetextfont",
-            "._marker.Marker",
-            "._insidetextfont.Insidetextfont",
-            "._hoverlabel.Hoverlabel",
             "._connector.Connector",
+            "._hoverlabel.Hoverlabel",
+            "._insidetextfont.Insidetextfont",
+            "._marker.Marker",
+            "._outsidetextfont.Outsidetextfont",
+            "._stream.Stream",
+            "._textfont.Textfont",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/funnel/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/funnel/marker/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
     from ._colorbar import ColorBar
+    from ._line import Line
     from . import colorbar
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".colorbar"], ["._line.Line", "._colorbar.ColorBar"]
+        __name__, [".colorbar"], ["._colorbar.ColorBar", "._line.Line"]
     )

--- a/packages/python/plotly/plotly/graph_objs/funnel/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/funnel/marker/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/funnelarea/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/funnelarea/__init__.py
@@ -1,29 +1,29 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._textfont import Textfont
-    from ._stream import Stream
-    from ._marker import Marker
-    from ._insidetextfont import Insidetextfont
-    from ._hoverlabel import Hoverlabel
     from ._domain import Domain
-    from . import title
-    from . import marker
+    from ._hoverlabel import Hoverlabel
+    from ._insidetextfont import Insidetextfont
+    from ._marker import Marker
+    from ._stream import Stream
+    from ._textfont import Textfont
+    from ._title import Title
     from . import hoverlabel
+    from . import marker
+    from . import title
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".title", ".marker", ".hoverlabel"],
+        [".hoverlabel", ".marker", ".title"],
         [
-            "._title.Title",
-            "._textfont.Textfont",
-            "._stream.Stream",
-            "._marker.Marker",
-            "._insidetextfont.Insidetextfont",
-            "._hoverlabel.Hoverlabel",
             "._domain.Domain",
+            "._hoverlabel.Hoverlabel",
+            "._insidetextfont.Insidetextfont",
+            "._marker.Marker",
+            "._stream.Stream",
+            "._textfont.Textfont",
+            "._title.Title",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/heatmap/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/heatmap/__init__.py
@@ -1,16 +1,16 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._stream import Stream
-    from ._hoverlabel import Hoverlabel
     from ._colorbar import ColorBar
-    from . import hoverlabel
+    from ._hoverlabel import Hoverlabel
+    from ._stream import Stream
     from . import colorbar
+    from . import hoverlabel
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".hoverlabel", ".colorbar"],
-        ["._stream.Stream", "._hoverlabel.Hoverlabel", "._colorbar.ColorBar"],
+        [".colorbar", ".hoverlabel"],
+        ["._colorbar.ColorBar", "._hoverlabel.Hoverlabel", "._stream.Stream"],
     )

--- a/packages/python/plotly/plotly/graph_objs/heatmap/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/heatmap/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/heatmapgl/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/heatmapgl/__init__.py
@@ -1,16 +1,16 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._stream import Stream
-    from ._hoverlabel import Hoverlabel
     from ._colorbar import ColorBar
-    from . import hoverlabel
+    from ._hoverlabel import Hoverlabel
+    from ._stream import Stream
     from . import colorbar
+    from . import hoverlabel
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".hoverlabel", ".colorbar"],
-        ["._stream.Stream", "._hoverlabel.Hoverlabel", "._colorbar.ColorBar"],
+        [".colorbar", ".hoverlabel"],
+        ["._colorbar.ColorBar", "._hoverlabel.Hoverlabel", "._stream.Stream"],
     )

--- a/packages/python/plotly/plotly/graph_objs/heatmapgl/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/heatmapgl/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/histogram/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram/__init__.py
@@ -1,36 +1,36 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._ybins import YBins
-    from ._xbins import XBins
-    from ._unselected import Unselected
-    from ._stream import Stream
-    from ._selected import Selected
-    from ._marker import Marker
-    from ._hoverlabel import Hoverlabel
-    from ._error_y import ErrorY
-    from ._error_x import ErrorX
     from ._cumulative import Cumulative
-    from . import unselected
-    from . import selected
-    from . import marker
+    from ._error_x import ErrorX
+    from ._error_y import ErrorY
+    from ._hoverlabel import Hoverlabel
+    from ._marker import Marker
+    from ._selected import Selected
+    from ._stream import Stream
+    from ._unselected import Unselected
+    from ._xbins import XBins
+    from ._ybins import YBins
     from . import hoverlabel
+    from . import marker
+    from . import selected
+    from . import unselected
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".unselected", ".selected", ".marker", ".hoverlabel"],
+        [".hoverlabel", ".marker", ".selected", ".unselected"],
         [
-            "._ybins.YBins",
-            "._xbins.XBins",
-            "._unselected.Unselected",
-            "._stream.Stream",
-            "._selected.Selected",
-            "._marker.Marker",
-            "._hoverlabel.Hoverlabel",
-            "._error_y.ErrorY",
-            "._error_x.ErrorX",
             "._cumulative.Cumulative",
+            "._error_x.ErrorX",
+            "._error_y.ErrorY",
+            "._hoverlabel.Hoverlabel",
+            "._marker.Marker",
+            "._selected.Selected",
+            "._stream.Stream",
+            "._unselected.Unselected",
+            "._xbins.XBins",
+            "._ybins.YBins",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/histogram/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram/marker/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
     from ._colorbar import ColorBar
+    from ._line import Line
     from . import colorbar
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".colorbar"], ["._line.Line", "._colorbar.ColorBar"]
+        __name__, [".colorbar"], ["._colorbar.ColorBar", "._line.Line"]
     )

--- a/packages/python/plotly/plotly/graph_objs/histogram/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram/marker/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/histogram/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram/selected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/histogram/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram/unselected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/histogram2d/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram2d/__init__.py
@@ -1,26 +1,26 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._ybins import YBins
-    from ._xbins import XBins
-    from ._stream import Stream
-    from ._marker import Marker
-    from ._hoverlabel import Hoverlabel
     from ._colorbar import ColorBar
-    from . import hoverlabel
+    from ._hoverlabel import Hoverlabel
+    from ._marker import Marker
+    from ._stream import Stream
+    from ._xbins import XBins
+    from ._ybins import YBins
     from . import colorbar
+    from . import hoverlabel
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".hoverlabel", ".colorbar"],
+        [".colorbar", ".hoverlabel"],
         [
-            "._ybins.YBins",
-            "._xbins.XBins",
-            "._stream.Stream",
-            "._marker.Marker",
-            "._hoverlabel.Hoverlabel",
             "._colorbar.ColorBar",
+            "._hoverlabel.Hoverlabel",
+            "._marker.Marker",
+            "._stream.Stream",
+            "._xbins.XBins",
+            "._ybins.YBins",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/histogram2d/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram2d/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/histogram2dcontour/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram2dcontour/__init__.py
@@ -1,31 +1,31 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._ybins import YBins
-    from ._xbins import XBins
-    from ._stream import Stream
-    from ._marker import Marker
-    from ._line import Line
-    from ._hoverlabel import Hoverlabel
-    from ._contours import Contours
     from ._colorbar import ColorBar
-    from . import hoverlabel
-    from . import contours
+    from ._contours import Contours
+    from ._hoverlabel import Hoverlabel
+    from ._line import Line
+    from ._marker import Marker
+    from ._stream import Stream
+    from ._xbins import XBins
+    from ._ybins import YBins
     from . import colorbar
+    from . import contours
+    from . import hoverlabel
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".hoverlabel", ".contours", ".colorbar"],
+        [".colorbar", ".contours", ".hoverlabel"],
         [
-            "._ybins.YBins",
-            "._xbins.XBins",
-            "._stream.Stream",
-            "._marker.Marker",
-            "._line.Line",
-            "._hoverlabel.Hoverlabel",
-            "._contours.Contours",
             "._colorbar.ColorBar",
+            "._contours.Contours",
+            "._hoverlabel.Hoverlabel",
+            "._line.Line",
+            "._marker.Marker",
+            "._stream.Stream",
+            "._xbins.XBins",
+            "._ybins.YBins",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/histogram2dcontour/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram2dcontour/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/image/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/image/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._stream import Stream
     from ._hoverlabel import Hoverlabel
+    from ._stream import Stream
     from . import hoverlabel
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".hoverlabel"], ["._stream.Stream", "._hoverlabel.Hoverlabel"]
+        __name__, [".hoverlabel"], ["._hoverlabel.Hoverlabel", "._stream.Stream"]
     )

--- a/packages/python/plotly/plotly/graph_objs/indicator/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/indicator/__init__.py
@@ -1,28 +1,28 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._stream import Stream
-    from ._number import Number
-    from ._gauge import Gauge
-    from ._domain import Domain
     from ._delta import Delta
-    from . import title
-    from . import number
-    from . import gauge
+    from ._domain import Domain
+    from ._gauge import Gauge
+    from ._number import Number
+    from ._stream import Stream
+    from ._title import Title
     from . import delta
+    from . import gauge
+    from . import number
+    from . import title
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".title", ".number", ".gauge", ".delta"],
+        [".delta", ".gauge", ".number", ".title"],
         [
-            "._title.Title",
-            "._stream.Stream",
-            "._number.Number",
-            "._gauge.Gauge",
-            "._domain.Domain",
             "._delta.Delta",
+            "._domain.Domain",
+            "._gauge.Gauge",
+            "._number.Number",
+            "._stream.Stream",
+            "._title.Title",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/indicator/delta/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/indicator/delta/__init__.py
@@ -1,14 +1,14 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._increasing import Increasing
-    from ._font import Font
     from ._decreasing import Decreasing
+    from ._font import Font
+    from ._increasing import Increasing
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [],
-        ["._increasing.Increasing", "._font.Font", "._decreasing.Decreasing"],
+        ["._decreasing.Decreasing", "._font.Font", "._increasing.Increasing"],
     )

--- a/packages/python/plotly/plotly/graph_objs/indicator/gauge/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/indicator/gauge/__init__.py
@@ -1,19 +1,19 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._threshold import Threshold
-    from ._step import Step
-    from ._bar import Bar
     from ._axis import Axis
-    from . import threshold
-    from . import step
-    from . import bar
+    from ._bar import Bar
+    from ._step import Step
+    from ._threshold import Threshold
     from . import axis
+    from . import bar
+    from . import step
+    from . import threshold
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".threshold", ".step", ".bar", ".axis"],
-        ["._threshold.Threshold", "._step.Step", "._bar.Bar", "._axis.Axis"],
+        [".axis", ".bar", ".step", ".threshold"],
+        ["._axis.Axis", "._bar.Bar", "._step.Step", "._threshold.Threshold"],
     )

--- a/packages/python/plotly/plotly/graph_objs/indicator/gauge/axis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/indicator/gauge/axis/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._tickformatstop.Tickformatstop", "._tickfont.Tickfont"]
+        __name__, [], ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop"]
     )

--- a/packages/python/plotly/plotly/graph_objs/isosurface/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/isosurface/__init__.py
@@ -1,36 +1,36 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._surface import Surface
-    from ._stream import Stream
-    from ._spaceframe import Spaceframe
-    from ._slices import Slices
-    from ._lightposition import Lightposition
-    from ._lighting import Lighting
-    from ._hoverlabel import Hoverlabel
-    from ._contour import Contour
-    from ._colorbar import ColorBar
     from ._caps import Caps
-    from . import slices
-    from . import hoverlabel
-    from . import colorbar
+    from ._colorbar import ColorBar
+    from ._contour import Contour
+    from ._hoverlabel import Hoverlabel
+    from ._lighting import Lighting
+    from ._lightposition import Lightposition
+    from ._slices import Slices
+    from ._spaceframe import Spaceframe
+    from ._stream import Stream
+    from ._surface import Surface
     from . import caps
+    from . import colorbar
+    from . import hoverlabel
+    from . import slices
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".slices", ".hoverlabel", ".colorbar", ".caps"],
+        [".caps", ".colorbar", ".hoverlabel", ".slices"],
         [
-            "._surface.Surface",
-            "._stream.Stream",
-            "._spaceframe.Spaceframe",
-            "._slices.Slices",
-            "._lightposition.Lightposition",
-            "._lighting.Lighting",
-            "._hoverlabel.Hoverlabel",
-            "._contour.Contour",
-            "._colorbar.ColorBar",
             "._caps.Caps",
+            "._colorbar.ColorBar",
+            "._contour.Contour",
+            "._hoverlabel.Hoverlabel",
+            "._lighting.Lighting",
+            "._lightposition.Lightposition",
+            "._slices.Slices",
+            "._spaceframe.Spaceframe",
+            "._stream.Stream",
+            "._surface.Surface",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/isosurface/caps/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/isosurface/caps/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._z import Z
-    from ._y import Y
     from ._x import X
+    from ._y import Y
+    from ._z import Z
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._z.Z", "._y.Y", "._x.X"]
+        __name__, [], ["._x.X", "._y.Y", "._z.Z"]
     )

--- a/packages/python/plotly/plotly/graph_objs/isosurface/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/isosurface/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/isosurface/slices/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/isosurface/slices/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._z import Z
-    from ._y import Y
     from ._x import X
+    from ._y import Y
+    from ._z import Z
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._z.Z", "._y.Y", "._x.X"]
+        __name__, [], ["._x.X", "._y.Y", "._z.Z"]
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/__init__.py
@@ -1,99 +1,99 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._yaxis import YAxis
-    from ._xaxis import XAxis
-    from ._updatemenu import Updatemenu
-    from ._uniformtext import Uniformtext
-    from ._transition import Transition
-    from ._title import Title
-    from ._ternary import Ternary
-    from ._template import Template
-    from ._slider import Slider
-    from ._shape import Shape
-    from ._scene import Scene
-    from ._radialaxis import RadialAxis
-    from ._polar import Polar
-    from ._modebar import Modebar
-    from ._margin import Margin
-    from ._mapbox import Mapbox
-    from ._legend import Legend
-    from ._image import Image
-    from ._hoverlabel import Hoverlabel
-    from ._grid import Grid
-    from ._geo import Geo
-    from ._font import Font
-    from ._colorscale import Colorscale
-    from ._coloraxis import Coloraxis
-    from ._annotation import Annotation
     from ._angularaxis import AngularAxis
-    from . import yaxis
-    from . import xaxis
-    from . import updatemenu
-    from . import title
-    from . import ternary
-    from . import template
-    from . import slider
-    from . import shape
-    from . import scene
-    from . import polar
-    from . import mapbox
-    from . import legend
-    from . import hoverlabel
-    from . import grid
-    from . import geo
-    from . import coloraxis
+    from ._annotation import Annotation
+    from ._coloraxis import Coloraxis
+    from ._colorscale import Colorscale
+    from ._font import Font
+    from ._geo import Geo
+    from ._grid import Grid
+    from ._hoverlabel import Hoverlabel
+    from ._image import Image
+    from ._legend import Legend
+    from ._mapbox import Mapbox
+    from ._margin import Margin
+    from ._modebar import Modebar
+    from ._polar import Polar
+    from ._radialaxis import RadialAxis
+    from ._scene import Scene
+    from ._shape import Shape
+    from ._slider import Slider
+    from ._template import Template
+    from ._ternary import Ternary
+    from ._title import Title
+    from ._transition import Transition
+    from ._uniformtext import Uniformtext
+    from ._updatemenu import Updatemenu
+    from ._xaxis import XAxis
+    from ._yaxis import YAxis
     from . import annotation
+    from . import coloraxis
+    from . import geo
+    from . import grid
+    from . import hoverlabel
+    from . import legend
+    from . import mapbox
+    from . import polar
+    from . import scene
+    from . import shape
+    from . import slider
+    from . import template
+    from . import ternary
+    from . import title
+    from . import updatemenu
+    from . import xaxis
+    from . import yaxis
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [
-            ".yaxis",
-            ".xaxis",
-            ".updatemenu",
-            ".title",
-            ".ternary",
-            ".template",
-            ".slider",
-            ".shape",
-            ".scene",
-            ".polar",
-            ".mapbox",
-            ".legend",
-            ".hoverlabel",
-            ".grid",
-            ".geo",
-            ".coloraxis",
             ".annotation",
+            ".coloraxis",
+            ".geo",
+            ".grid",
+            ".hoverlabel",
+            ".legend",
+            ".mapbox",
+            ".polar",
+            ".scene",
+            ".shape",
+            ".slider",
+            ".template",
+            ".ternary",
+            ".title",
+            ".updatemenu",
+            ".xaxis",
+            ".yaxis",
         ],
         [
-            "._yaxis.YAxis",
-            "._xaxis.XAxis",
-            "._updatemenu.Updatemenu",
-            "._uniformtext.Uniformtext",
-            "._transition.Transition",
-            "._title.Title",
-            "._ternary.Ternary",
-            "._template.Template",
-            "._slider.Slider",
-            "._shape.Shape",
-            "._scene.Scene",
-            "._radialaxis.RadialAxis",
-            "._polar.Polar",
-            "._modebar.Modebar",
-            "._margin.Margin",
-            "._mapbox.Mapbox",
-            "._legend.Legend",
-            "._image.Image",
-            "._hoverlabel.Hoverlabel",
-            "._grid.Grid",
-            "._geo.Geo",
-            "._font.Font",
-            "._colorscale.Colorscale",
-            "._coloraxis.Coloraxis",
-            "._annotation.Annotation",
             "._angularaxis.AngularAxis",
+            "._annotation.Annotation",
+            "._coloraxis.Coloraxis",
+            "._colorscale.Colorscale",
+            "._font.Font",
+            "._geo.Geo",
+            "._grid.Grid",
+            "._hoverlabel.Hoverlabel",
+            "._image.Image",
+            "._legend.Legend",
+            "._mapbox.Mapbox",
+            "._margin.Margin",
+            "._modebar.Modebar",
+            "._polar.Polar",
+            "._radialaxis.RadialAxis",
+            "._scene.Scene",
+            "._shape.Shape",
+            "._slider.Slider",
+            "._template.Template",
+            "._ternary.Ternary",
+            "._title.Title",
+            "._transition.Transition",
+            "._uniformtext.Uniformtext",
+            "._updatemenu.Updatemenu",
+            "._xaxis.XAxis",
+            "._yaxis.YAxis",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/annotation/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/annotation/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._hoverlabel import Hoverlabel
     from ._font import Font
+    from ._hoverlabel import Hoverlabel
     from . import hoverlabel
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".hoverlabel"], ["._hoverlabel.Hoverlabel", "._font.Font"]
+        __name__, [".hoverlabel"], ["._font.Font", "._hoverlabel.Hoverlabel"]
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/coloraxis/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/coloraxis/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/geo/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/geo/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._projection import Projection
-    from ._lonaxis import Lonaxis
-    from ._lataxis import Lataxis
-    from ._domain import Domain
     from ._center import Center
+    from ._domain import Domain
+    from ._lataxis import Lataxis
+    from ._lonaxis import Lonaxis
+    from ._projection import Projection
     from . import projection
 else:
     from _plotly_utils.importers import relative_import
@@ -14,10 +14,10 @@ else:
         __name__,
         [".projection"],
         [
-            "._projection.Projection",
-            "._lonaxis.Lonaxis",
-            "._lataxis.Lataxis",
-            "._domain.Domain",
             "._center.Center",
+            "._domain.Domain",
+            "._lataxis.Lataxis",
+            "._lonaxis.Lonaxis",
+            "._projection.Projection",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/legend/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/legend/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
     from ._font import Font
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".title"], ["._title.Title", "._font.Font"]
+        __name__, [".title"], ["._font.Font", "._title.Title"]
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/mapbox/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/mapbox/__init__.py
@@ -1,13 +1,13 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._layer import Layer
-    from ._domain import Domain
     from ._center import Center
+    from ._domain import Domain
+    from ._layer import Layer
     from . import layer
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".layer"], ["._layer.Layer", "._domain.Domain", "._center.Center"]
+        __name__, [".layer"], ["._center.Center", "._domain.Domain", "._layer.Layer"]
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/mapbox/layer/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/mapbox/layer/__init__.py
@@ -1,10 +1,10 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._symbol import Symbol
-    from ._line import Line
-    from ._fill import Fill
     from ._circle import Circle
+    from ._fill import Fill
+    from ._line import Line
+    from ._symbol import Symbol
     from . import symbol
 else:
     from _plotly_utils.importers import relative_import
@@ -12,5 +12,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".symbol"],
-        ["._symbol.Symbol", "._line.Line", "._fill.Fill", "._circle.Circle"],
+        ["._circle.Circle", "._fill.Fill", "._line.Line", "._symbol.Symbol"],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/polar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/polar/__init__.py
@@ -1,16 +1,16 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._radialaxis import RadialAxis
-    from ._domain import Domain
     from ._angularaxis import AngularAxis
-    from . import radialaxis
+    from ._domain import Domain
+    from ._radialaxis import RadialAxis
     from . import angularaxis
+    from . import radialaxis
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".radialaxis", ".angularaxis"],
-        ["._radialaxis.RadialAxis", "._domain.Domain", "._angularaxis.AngularAxis"],
+        [".angularaxis", ".radialaxis"],
+        ["._angularaxis.AngularAxis", "._domain.Domain", "._radialaxis.RadialAxis"],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/polar/angularaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/polar/angularaxis/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._tickformatstop.Tickformatstop", "._tickfont.Tickfont"]
+        __name__, [], ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop"]
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/polar/radialaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/polar/radialaxis/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/__init__.py
@@ -1,31 +1,31 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._zaxis import ZAxis
-    from ._yaxis import YAxis
-    from ._xaxis import XAxis
-    from ._domain import Domain
-    from ._camera import Camera
-    from ._aspectratio import Aspectratio
     from ._annotation import Annotation
-    from . import zaxis
-    from . import yaxis
-    from . import xaxis
-    from . import camera
+    from ._aspectratio import Aspectratio
+    from ._camera import Camera
+    from ._domain import Domain
+    from ._xaxis import XAxis
+    from ._yaxis import YAxis
+    from ._zaxis import ZAxis
     from . import annotation
+    from . import camera
+    from . import xaxis
+    from . import yaxis
+    from . import zaxis
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".zaxis", ".yaxis", ".xaxis", ".camera", ".annotation"],
+        [".annotation", ".camera", ".xaxis", ".yaxis", ".zaxis"],
         [
-            "._zaxis.ZAxis",
-            "._yaxis.YAxis",
-            "._xaxis.XAxis",
-            "._domain.Domain",
-            "._camera.Camera",
-            "._aspectratio.Aspectratio",
             "._annotation.Annotation",
+            "._aspectratio.Aspectratio",
+            "._camera.Camera",
+            "._domain.Domain",
+            "._xaxis.XAxis",
+            "._yaxis.YAxis",
+            "._zaxis.ZAxis",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/annotation/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/annotation/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._hoverlabel import Hoverlabel
     from ._font import Font
+    from ._hoverlabel import Hoverlabel
     from . import hoverlabel
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".hoverlabel"], ["._hoverlabel.Hoverlabel", "._font.Font"]
+        __name__, [".hoverlabel"], ["._font.Font", "._hoverlabel.Hoverlabel"]
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/camera/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/camera/__init__.py
@@ -1,15 +1,15 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._up import Up
-    from ._projection import Projection
-    from ._eye import Eye
     from ._center import Center
+    from ._eye import Eye
+    from ._projection import Projection
+    from ._up import Up
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [],
-        ["._up.Up", "._projection.Projection", "._eye.Eye", "._center.Center"],
+        ["._center.Center", "._eye.Eye", "._projection.Projection", "._up.Up"],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/xaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/xaxis/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/yaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/yaxis/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/zaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/zaxis/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/slider/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/slider/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._transition import Transition
-    from ._step import Step
-    from ._pad import Pad
-    from ._font import Font
     from ._currentvalue import Currentvalue
+    from ._font import Font
+    from ._pad import Pad
+    from ._step import Step
+    from ._transition import Transition
     from . import currentvalue
 else:
     from _plotly_utils.importers import relative_import
@@ -14,10 +14,10 @@ else:
         __name__,
         [".currentvalue"],
         [
-            "._transition.Transition",
-            "._step.Step",
-            "._pad.Pad",
-            "._font.Font",
             "._currentvalue.Currentvalue",
+            "._font.Font",
+            "._pad.Pad",
+            "._step.Step",
+            "._transition.Transition",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/template/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/template/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._layout import Layout
     from ._data import Data
+    from ._layout import Layout
     from . import data
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".data"], ["._layout.Layout", "._data.Data"]
+        __name__, [".data"], ["._data.Data", "._layout.Layout"]
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/template/data/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/template/data/__init__.py
@@ -1,53 +1,53 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._waterfall import Waterfall
-    from ._volume import Volume
-    from ._violin import Violin
-    from ._treemap import Treemap
-    from ._table import Table
-    from ._surface import Surface
-    from ._sunburst import Sunburst
-    from ._streamtube import Streamtube
-    from ._splom import Splom
-    from ._scatterternary import Scatterternary
-    from ._scatter import Scatter
-    from ._scatterpolar import Scatterpolar
-    from ._scatterpolargl import Scatterpolargl
-    from ._scattermapbox import Scattermapbox
-    from ._scattergl import Scattergl
-    from ._scattergeo import Scattergeo
-    from ._scattercarpet import Scattercarpet
-    from ._scatter3d import Scatter3d
-    from ._sankey import Sankey
-    from ._pointcloud import Pointcloud
-    from ._pie import Pie
-    from ._parcoords import Parcoords
-    from ._parcats import Parcats
-    from ._ohlc import Ohlc
-    from ._mesh3d import Mesh3d
-    from ._isosurface import Isosurface
-    from ._indicator import Indicator
-    from ._image import Image
+    from ._area import Area
+    from ._bar import Bar
+    from ._barpolar import Barpolar
+    from ._box import Box
+    from ._candlestick import Candlestick
+    from ._carpet import Carpet
+    from ._choropleth import Choropleth
+    from ._choroplethmapbox import Choroplethmapbox
+    from ._cone import Cone
+    from ._contour import Contour
+    from ._contourcarpet import Contourcarpet
+    from ._densitymapbox import Densitymapbox
+    from ._funnel import Funnel
+    from ._funnelarea import Funnelarea
+    from ._heatmap import Heatmap
+    from ._heatmapgl import Heatmapgl
     from ._histogram import Histogram
     from ._histogram2d import Histogram2d
     from ._histogram2dcontour import Histogram2dContour
-    from ._heatmap import Heatmap
-    from ._heatmapgl import Heatmapgl
-    from ._funnel import Funnel
-    from ._funnelarea import Funnelarea
-    from ._densitymapbox import Densitymapbox
-    from ._contour import Contour
-    from ._contourcarpet import Contourcarpet
-    from ._cone import Cone
-    from ._choropleth import Choropleth
-    from ._choroplethmapbox import Choroplethmapbox
-    from ._carpet import Carpet
-    from ._candlestick import Candlestick
-    from ._box import Box
-    from ._bar import Bar
-    from ._barpolar import Barpolar
-    from ._area import Area
+    from ._image import Image
+    from ._indicator import Indicator
+    from ._isosurface import Isosurface
+    from ._mesh3d import Mesh3d
+    from ._ohlc import Ohlc
+    from ._parcats import Parcats
+    from ._parcoords import Parcoords
+    from ._pie import Pie
+    from ._pointcloud import Pointcloud
+    from ._sankey import Sankey
+    from ._scatter import Scatter
+    from ._scatter3d import Scatter3d
+    from ._scattercarpet import Scattercarpet
+    from ._scattergeo import Scattergeo
+    from ._scattergl import Scattergl
+    from ._scattermapbox import Scattermapbox
+    from ._scatterpolar import Scatterpolar
+    from ._scatterpolargl import Scatterpolargl
+    from ._scatterternary import Scatterternary
+    from ._splom import Splom
+    from ._streamtube import Streamtube
+    from ._sunburst import Sunburst
+    from ._surface import Surface
+    from ._table import Table
+    from ._treemap import Treemap
+    from ._violin import Violin
+    from ._volume import Volume
+    from ._waterfall import Waterfall
 else:
     from _plotly_utils.importers import relative_import
 
@@ -55,52 +55,52 @@ else:
         __name__,
         [],
         [
-            "._waterfall.Waterfall",
-            "._volume.Volume",
-            "._violin.Violin",
-            "._treemap.Treemap",
-            "._table.Table",
-            "._surface.Surface",
-            "._sunburst.Sunburst",
-            "._streamtube.Streamtube",
-            "._splom.Splom",
-            "._scatterternary.Scatterternary",
-            "._scatter.Scatter",
-            "._scatterpolar.Scatterpolar",
-            "._scatterpolargl.Scatterpolargl",
-            "._scattermapbox.Scattermapbox",
-            "._scattergl.Scattergl",
-            "._scattergeo.Scattergeo",
-            "._scattercarpet.Scattercarpet",
-            "._scatter3d.Scatter3d",
-            "._sankey.Sankey",
-            "._pointcloud.Pointcloud",
-            "._pie.Pie",
-            "._parcoords.Parcoords",
-            "._parcats.Parcats",
-            "._ohlc.Ohlc",
-            "._mesh3d.Mesh3d",
-            "._isosurface.Isosurface",
-            "._indicator.Indicator",
-            "._image.Image",
+            "._area.Area",
+            "._bar.Bar",
+            "._barpolar.Barpolar",
+            "._box.Box",
+            "._candlestick.Candlestick",
+            "._carpet.Carpet",
+            "._choropleth.Choropleth",
+            "._choroplethmapbox.Choroplethmapbox",
+            "._cone.Cone",
+            "._contour.Contour",
+            "._contourcarpet.Contourcarpet",
+            "._densitymapbox.Densitymapbox",
+            "._funnel.Funnel",
+            "._funnelarea.Funnelarea",
+            "._heatmap.Heatmap",
+            "._heatmapgl.Heatmapgl",
             "._histogram.Histogram",
             "._histogram2d.Histogram2d",
             "._histogram2dcontour.Histogram2dContour",
-            "._heatmap.Heatmap",
-            "._heatmapgl.Heatmapgl",
-            "._funnel.Funnel",
-            "._funnelarea.Funnelarea",
-            "._densitymapbox.Densitymapbox",
-            "._contour.Contour",
-            "._contourcarpet.Contourcarpet",
-            "._cone.Cone",
-            "._choropleth.Choropleth",
-            "._choroplethmapbox.Choroplethmapbox",
-            "._carpet.Carpet",
-            "._candlestick.Candlestick",
-            "._box.Box",
-            "._bar.Bar",
-            "._barpolar.Barpolar",
-            "._area.Area",
+            "._image.Image",
+            "._indicator.Indicator",
+            "._isosurface.Isosurface",
+            "._mesh3d.Mesh3d",
+            "._ohlc.Ohlc",
+            "._parcats.Parcats",
+            "._parcoords.Parcoords",
+            "._pie.Pie",
+            "._pointcloud.Pointcloud",
+            "._sankey.Sankey",
+            "._scatter.Scatter",
+            "._scatter3d.Scatter3d",
+            "._scattercarpet.Scattercarpet",
+            "._scattergeo.Scattergeo",
+            "._scattergl.Scattergl",
+            "._scattermapbox.Scattermapbox",
+            "._scatterpolar.Scatterpolar",
+            "._scatterpolargl.Scatterpolargl",
+            "._scatterternary.Scatterternary",
+            "._splom.Splom",
+            "._streamtube.Streamtube",
+            "._sunburst.Sunburst",
+            "._surface.Surface",
+            "._table.Table",
+            "._treemap.Treemap",
+            "._violin.Violin",
+            "._volume.Volume",
+            "._waterfall.Waterfall",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/ternary/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/ternary/__init__.py
@@ -1,18 +1,18 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._domain import Domain
-    from ._caxis import Caxis
-    from ._baxis import Baxis
     from ._aaxis import Aaxis
-    from . import caxis
-    from . import baxis
+    from ._baxis import Baxis
+    from ._caxis import Caxis
+    from ._domain import Domain
     from . import aaxis
+    from . import baxis
+    from . import caxis
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".caxis", ".baxis", ".aaxis"],
-        ["._domain.Domain", "._caxis.Caxis", "._baxis.Baxis", "._aaxis.Aaxis"],
+        [".aaxis", ".baxis", ".caxis"],
+        ["._aaxis.Aaxis", "._baxis.Baxis", "._caxis.Caxis", "._domain.Domain"],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/ternary/aaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/ternary/aaxis/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/ternary/baxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/ternary/baxis/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/ternary/caxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/ternary/caxis/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/title/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._pad import Pad
     from ._font import Font
+    from ._pad import Pad
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._pad.Pad", "._font.Font"]
+        __name__, [], ["._font.Font", "._pad.Pad"]
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/updatemenu/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/updatemenu/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._pad import Pad
-    from ._font import Font
     from ._button import Button
+    from ._font import Font
+    from ._pad import Pad
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._pad.Pad", "._font.Font", "._button.Button"]
+        __name__, [], ["._button.Button", "._font.Font", "._pad.Pad"]
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/xaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/xaxis/__init__.py
@@ -1,27 +1,27 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
-    from ._tickfont import Tickfont
-    from ._rangeslider import Rangeslider
-    from ._rangeselector import Rangeselector
     from ._rangebreak import Rangebreak
-    from . import title
-    from . import rangeslider
+    from ._rangeselector import Rangeselector
+    from ._rangeslider import Rangeslider
+    from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import rangeselector
+    from . import rangeslider
+    from . import title
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".title", ".rangeslider", ".rangeselector"],
+        [".rangeselector", ".rangeslider", ".title"],
         [
-            "._title.Title",
-            "._tickformatstop.Tickformatstop",
-            "._tickfont.Tickfont",
-            "._rangeslider.Rangeslider",
-            "._rangeselector.Rangeselector",
             "._rangebreak.Rangebreak",
+            "._rangeselector.Rangeselector",
+            "._rangeslider.Rangeslider",
+            "._tickfont.Tickfont",
+            "._tickformatstop.Tickformatstop",
+            "._title.Title",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/xaxis/rangeselector/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/xaxis/rangeselector/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._font import Font
     from ._button import Button
+    from ._font import Font
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._font.Font", "._button.Button"]
+        __name__, [], ["._button.Button", "._font.Font"]
     )

--- a/packages/python/plotly/plotly/graph_objs/layout/yaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/yaxis/__init__.py
@@ -1,10 +1,10 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
-    from ._tickfont import Tickfont
     from ._rangebreak import Rangebreak
+    from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -13,9 +13,9 @@ else:
         __name__,
         [".title"],
         [
-            "._title.Title",
-            "._tickformatstop.Tickformatstop",
-            "._tickfont.Tickfont",
             "._rangebreak.Rangebreak",
+            "._tickfont.Tickfont",
+            "._tickformatstop.Tickformatstop",
+            "._title.Title",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/mesh3d/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/mesh3d/__init__.py
@@ -1,26 +1,26 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._stream import Stream
-    from ._lightposition import Lightposition
-    from ._lighting import Lighting
-    from ._hoverlabel import Hoverlabel
-    from ._contour import Contour
     from ._colorbar import ColorBar
-    from . import hoverlabel
+    from ._contour import Contour
+    from ._hoverlabel import Hoverlabel
+    from ._lighting import Lighting
+    from ._lightposition import Lightposition
+    from ._stream import Stream
     from . import colorbar
+    from . import hoverlabel
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".hoverlabel", ".colorbar"],
+        [".colorbar", ".hoverlabel"],
         [
-            "._stream.Stream",
-            "._lightposition.Lightposition",
-            "._lighting.Lighting",
-            "._hoverlabel.Hoverlabel",
-            "._contour.Contour",
             "._colorbar.ColorBar",
+            "._contour.Contour",
+            "._hoverlabel.Hoverlabel",
+            "._lighting.Lighting",
+            "._lightposition.Lightposition",
+            "._stream.Stream",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/mesh3d/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/mesh3d/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/ohlc/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/ohlc/__init__.py
@@ -1,25 +1,25 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._stream import Stream
-    from ._line import Line
-    from ._increasing import Increasing
-    from ._hoverlabel import Hoverlabel
     from ._decreasing import Decreasing
-    from . import increasing
-    from . import hoverlabel
+    from ._hoverlabel import Hoverlabel
+    from ._increasing import Increasing
+    from ._line import Line
+    from ._stream import Stream
     from . import decreasing
+    from . import hoverlabel
+    from . import increasing
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".increasing", ".hoverlabel", ".decreasing"],
+        [".decreasing", ".hoverlabel", ".increasing"],
         [
-            "._stream.Stream",
-            "._line.Line",
-            "._increasing.Increasing",
-            "._hoverlabel.Hoverlabel",
             "._decreasing.Decreasing",
+            "._hoverlabel.Hoverlabel",
+            "._increasing.Increasing",
+            "._line.Line",
+            "._stream.Stream",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/parcats/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/parcats/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._tickfont import Tickfont
-    from ._stream import Stream
-    from ._line import Line
-    from ._labelfont import Labelfont
-    from ._domain import Domain
     from ._dimension import Dimension
+    from ._domain import Domain
+    from ._labelfont import Labelfont
+    from ._line import Line
+    from ._stream import Stream
+    from ._tickfont import Tickfont
     from . import line
 else:
     from _plotly_utils.importers import relative_import
@@ -15,11 +15,11 @@ else:
         __name__,
         [".line"],
         [
-            "._tickfont.Tickfont",
-            "._stream.Stream",
-            "._line.Line",
-            "._labelfont.Labelfont",
-            "._domain.Domain",
             "._dimension.Dimension",
+            "._domain.Domain",
+            "._labelfont.Labelfont",
+            "._line.Line",
+            "._stream.Stream",
+            "._tickfont.Tickfont",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/parcats/line/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/parcats/line/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/parcoords/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/parcoords/__init__.py
@@ -1,13 +1,13 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._tickfont import Tickfont
-    from ._stream import Stream
-    from ._rangefont import Rangefont
-    from ._line import Line
-    from ._labelfont import Labelfont
-    from ._domain import Domain
     from ._dimension import Dimension
+    from ._domain import Domain
+    from ._labelfont import Labelfont
+    from ._line import Line
+    from ._rangefont import Rangefont
+    from ._stream import Stream
+    from ._tickfont import Tickfont
     from . import line
 else:
     from _plotly_utils.importers import relative_import
@@ -16,12 +16,12 @@ else:
         __name__,
         [".line"],
         [
-            "._tickfont.Tickfont",
-            "._stream.Stream",
-            "._rangefont.Rangefont",
-            "._line.Line",
-            "._labelfont.Labelfont",
-            "._domain.Domain",
             "._dimension.Dimension",
+            "._domain.Domain",
+            "._labelfont.Labelfont",
+            "._line.Line",
+            "._rangefont.Rangefont",
+            "._stream.Stream",
+            "._tickfont.Tickfont",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/parcoords/line/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/parcoords/line/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/pie/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/pie/__init__.py
@@ -1,31 +1,31 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._textfont import Textfont
-    from ._stream import Stream
-    from ._outsidetextfont import Outsidetextfont
-    from ._marker import Marker
-    from ._insidetextfont import Insidetextfont
-    from ._hoverlabel import Hoverlabel
     from ._domain import Domain
-    from . import title
-    from . import marker
+    from ._hoverlabel import Hoverlabel
+    from ._insidetextfont import Insidetextfont
+    from ._marker import Marker
+    from ._outsidetextfont import Outsidetextfont
+    from ._stream import Stream
+    from ._textfont import Textfont
+    from ._title import Title
     from . import hoverlabel
+    from . import marker
+    from . import title
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".title", ".marker", ".hoverlabel"],
+        [".hoverlabel", ".marker", ".title"],
         [
-            "._title.Title",
-            "._textfont.Textfont",
-            "._stream.Stream",
-            "._outsidetextfont.Outsidetextfont",
-            "._marker.Marker",
-            "._insidetextfont.Insidetextfont",
-            "._hoverlabel.Hoverlabel",
             "._domain.Domain",
+            "._hoverlabel.Hoverlabel",
+            "._insidetextfont.Insidetextfont",
+            "._marker.Marker",
+            "._outsidetextfont.Outsidetextfont",
+            "._stream.Stream",
+            "._textfont.Textfont",
+            "._title.Title",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/pointcloud/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/pointcloud/__init__.py
@@ -1,16 +1,16 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._stream import Stream
-    from ._marker import Marker
     from ._hoverlabel import Hoverlabel
-    from . import marker
+    from ._marker import Marker
+    from ._stream import Stream
     from . import hoverlabel
+    from . import marker
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".marker", ".hoverlabel"],
-        ["._stream.Stream", "._marker.Marker", "._hoverlabel.Hoverlabel"],
+        [".hoverlabel", ".marker"],
+        ["._hoverlabel.Hoverlabel", "._marker.Marker", "._stream.Stream"],
     )

--- a/packages/python/plotly/plotly/graph_objs/sankey/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sankey/__init__.py
@@ -1,27 +1,27 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
-    from ._stream import Stream
-    from ._node import Node
-    from ._link import Link
-    from ._hoverlabel import Hoverlabel
     from ._domain import Domain
-    from . import node
-    from . import link
+    from ._hoverlabel import Hoverlabel
+    from ._link import Link
+    from ._node import Node
+    from ._stream import Stream
+    from ._textfont import Textfont
     from . import hoverlabel
+    from . import link
+    from . import node
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".node", ".link", ".hoverlabel"],
+        [".hoverlabel", ".link", ".node"],
         [
-            "._textfont.Textfont",
-            "._stream.Stream",
-            "._node.Node",
-            "._link.Link",
-            "._hoverlabel.Hoverlabel",
             "._domain.Domain",
+            "._hoverlabel.Hoverlabel",
+            "._link.Link",
+            "._node.Node",
+            "._stream.Stream",
+            "._textfont.Textfont",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/sankey/link/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sankey/link/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
-    from ._hoverlabel import Hoverlabel
     from ._colorscale import Colorscale
+    from ._hoverlabel import Hoverlabel
+    from ._line import Line
     from . import hoverlabel
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".hoverlabel"],
-        ["._line.Line", "._hoverlabel.Hoverlabel", "._colorscale.Colorscale"],
+        ["._colorscale.Colorscale", "._hoverlabel.Hoverlabel", "._line.Line"],
     )

--- a/packages/python/plotly/plotly/graph_objs/sankey/node/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sankey/node/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
     from ._hoverlabel import Hoverlabel
+    from ._line import Line
     from . import hoverlabel
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".hoverlabel"], ["._line.Line", "._hoverlabel.Hoverlabel"]
+        __name__, [".hoverlabel"], ["._hoverlabel.Hoverlabel", "._line.Line"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scatter/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter/__init__.py
@@ -1,34 +1,34 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._unselected import Unselected
-    from ._textfont import Textfont
-    from ._stream import Stream
-    from ._selected import Selected
-    from ._marker import Marker
-    from ._line import Line
-    from ._hoverlabel import Hoverlabel
-    from ._error_y import ErrorY
     from ._error_x import ErrorX
-    from . import unselected
-    from . import selected
-    from . import marker
+    from ._error_y import ErrorY
+    from ._hoverlabel import Hoverlabel
+    from ._line import Line
+    from ._marker import Marker
+    from ._selected import Selected
+    from ._stream import Stream
+    from ._textfont import Textfont
+    from ._unselected import Unselected
     from . import hoverlabel
+    from . import marker
+    from . import selected
+    from . import unselected
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".unselected", ".selected", ".marker", ".hoverlabel"],
+        [".hoverlabel", ".marker", ".selected", ".unselected"],
         [
-            "._unselected.Unselected",
-            "._textfont.Textfont",
-            "._stream.Stream",
-            "._selected.Selected",
-            "._marker.Marker",
-            "._line.Line",
-            "._hoverlabel.Hoverlabel",
-            "._error_y.ErrorY",
             "._error_x.ErrorX",
+            "._error_y.ErrorY",
+            "._hoverlabel.Hoverlabel",
+            "._line.Line",
+            "._marker.Marker",
+            "._selected.Selected",
+            "._stream.Stream",
+            "._textfont.Textfont",
+            "._unselected.Unselected",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/scatter/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter/marker/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
-    from ._gradient import Gradient
     from ._colorbar import ColorBar
+    from ._gradient import Gradient
+    from ._line import Line
     from . import colorbar
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".colorbar"],
-        ["._line.Line", "._gradient.Gradient", "._colorbar.ColorBar"],
+        ["._colorbar.ColorBar", "._gradient.Gradient", "._line.Line"],
     )

--- a/packages/python/plotly/plotly/graph_objs/scatter/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter/marker/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/scatter/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter/selected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scatter/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter/unselected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/__init__.py
@@ -1,34 +1,34 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
-    from ._stream import Stream
-    from ._projection import Projection
-    from ._marker import Marker
-    from ._line import Line
-    from ._hoverlabel import Hoverlabel
-    from ._error_z import ErrorZ
-    from ._error_y import ErrorY
     from ._error_x import ErrorX
-    from . import projection
-    from . import marker
-    from . import line
+    from ._error_y import ErrorY
+    from ._error_z import ErrorZ
+    from ._hoverlabel import Hoverlabel
+    from ._line import Line
+    from ._marker import Marker
+    from ._projection import Projection
+    from ._stream import Stream
+    from ._textfont import Textfont
     from . import hoverlabel
+    from . import line
+    from . import marker
+    from . import projection
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".projection", ".marker", ".line", ".hoverlabel"],
+        [".hoverlabel", ".line", ".marker", ".projection"],
         [
-            "._textfont.Textfont",
-            "._stream.Stream",
-            "._projection.Projection",
-            "._marker.Marker",
-            "._line.Line",
-            "._hoverlabel.Hoverlabel",
-            "._error_z.ErrorZ",
-            "._error_y.ErrorY",
             "._error_x.ErrorX",
+            "._error_y.ErrorY",
+            "._error_z.ErrorZ",
+            "._hoverlabel.Hoverlabel",
+            "._line.Line",
+            "._marker.Marker",
+            "._projection.Projection",
+            "._stream.Stream",
+            "._textfont.Textfont",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/line/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/line/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/marker/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
     from ._colorbar import ColorBar
+    from ._line import Line
     from . import colorbar
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".colorbar"], ["._line.Line", "._colorbar.ColorBar"]
+        __name__, [".colorbar"], ["._colorbar.ColorBar", "._line.Line"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/marker/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/projection/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/projection/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._z import Z
-    from ._y import Y
     from ._x import X
+    from ._y import Y
+    from ._z import Z
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._z.Z", "._y.Y", "._x.X"]
+        __name__, [], ["._x.X", "._y.Y", "._z.Z"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scattercarpet/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattercarpet/__init__.py
@@ -1,30 +1,30 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._unselected import Unselected
-    from ._textfont import Textfont
-    from ._stream import Stream
-    from ._selected import Selected
-    from ._marker import Marker
-    from ._line import Line
     from ._hoverlabel import Hoverlabel
-    from . import unselected
-    from . import selected
-    from . import marker
+    from ._line import Line
+    from ._marker import Marker
+    from ._selected import Selected
+    from ._stream import Stream
+    from ._textfont import Textfont
+    from ._unselected import Unselected
     from . import hoverlabel
+    from . import marker
+    from . import selected
+    from . import unselected
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".unselected", ".selected", ".marker", ".hoverlabel"],
+        [".hoverlabel", ".marker", ".selected", ".unselected"],
         [
-            "._unselected.Unselected",
-            "._textfont.Textfont",
-            "._stream.Stream",
-            "._selected.Selected",
-            "._marker.Marker",
-            "._line.Line",
             "._hoverlabel.Hoverlabel",
+            "._line.Line",
+            "._marker.Marker",
+            "._selected.Selected",
+            "._stream.Stream",
+            "._textfont.Textfont",
+            "._unselected.Unselected",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/scattercarpet/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattercarpet/marker/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
-    from ._gradient import Gradient
     from ._colorbar import ColorBar
+    from ._gradient import Gradient
+    from ._line import Line
     from . import colorbar
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".colorbar"],
-        ["._line.Line", "._gradient.Gradient", "._colorbar.ColorBar"],
+        ["._colorbar.ColorBar", "._gradient.Gradient", "._line.Line"],
     )

--- a/packages/python/plotly/plotly/graph_objs/scattercarpet/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattercarpet/marker/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/scattercarpet/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattercarpet/selected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scattercarpet/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattercarpet/unselected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scattergeo/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergeo/__init__.py
@@ -1,30 +1,30 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._unselected import Unselected
-    from ._textfont import Textfont
-    from ._stream import Stream
-    from ._selected import Selected
-    from ._marker import Marker
-    from ._line import Line
     from ._hoverlabel import Hoverlabel
-    from . import unselected
-    from . import selected
-    from . import marker
+    from ._line import Line
+    from ._marker import Marker
+    from ._selected import Selected
+    from ._stream import Stream
+    from ._textfont import Textfont
+    from ._unselected import Unselected
     from . import hoverlabel
+    from . import marker
+    from . import selected
+    from . import unselected
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".unselected", ".selected", ".marker", ".hoverlabel"],
+        [".hoverlabel", ".marker", ".selected", ".unselected"],
         [
-            "._unselected.Unselected",
-            "._textfont.Textfont",
-            "._stream.Stream",
-            "._selected.Selected",
-            "._marker.Marker",
-            "._line.Line",
             "._hoverlabel.Hoverlabel",
+            "._line.Line",
+            "._marker.Marker",
+            "._selected.Selected",
+            "._stream.Stream",
+            "._textfont.Textfont",
+            "._unselected.Unselected",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/scattergeo/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergeo/marker/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
-    from ._gradient import Gradient
     from ._colorbar import ColorBar
+    from ._gradient import Gradient
+    from ._line import Line
     from . import colorbar
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".colorbar"],
-        ["._line.Line", "._gradient.Gradient", "._colorbar.ColorBar"],
+        ["._colorbar.ColorBar", "._gradient.Gradient", "._line.Line"],
     )

--- a/packages/python/plotly/plotly/graph_objs/scattergeo/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergeo/marker/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/scattergeo/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergeo/selected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scattergeo/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergeo/unselected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scattergl/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergl/__init__.py
@@ -1,34 +1,34 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._unselected import Unselected
-    from ._textfont import Textfont
-    from ._stream import Stream
-    from ._selected import Selected
-    from ._marker import Marker
-    from ._line import Line
-    from ._hoverlabel import Hoverlabel
-    from ._error_y import ErrorY
     from ._error_x import ErrorX
-    from . import unselected
-    from . import selected
-    from . import marker
+    from ._error_y import ErrorY
+    from ._hoverlabel import Hoverlabel
+    from ._line import Line
+    from ._marker import Marker
+    from ._selected import Selected
+    from ._stream import Stream
+    from ._textfont import Textfont
+    from ._unselected import Unselected
     from . import hoverlabel
+    from . import marker
+    from . import selected
+    from . import unselected
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".unselected", ".selected", ".marker", ".hoverlabel"],
+        [".hoverlabel", ".marker", ".selected", ".unselected"],
         [
-            "._unselected.Unselected",
-            "._textfont.Textfont",
-            "._stream.Stream",
-            "._selected.Selected",
-            "._marker.Marker",
-            "._line.Line",
-            "._hoverlabel.Hoverlabel",
-            "._error_y.ErrorY",
             "._error_x.ErrorX",
+            "._error_y.ErrorY",
+            "._hoverlabel.Hoverlabel",
+            "._line.Line",
+            "._marker.Marker",
+            "._selected.Selected",
+            "._stream.Stream",
+            "._textfont.Textfont",
+            "._unselected.Unselected",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/scattergl/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergl/marker/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
     from ._colorbar import ColorBar
+    from ._line import Line
     from . import colorbar
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".colorbar"], ["._line.Line", "._colorbar.ColorBar"]
+        __name__, [".colorbar"], ["._colorbar.ColorBar", "._line.Line"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scattergl/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergl/marker/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/scattergl/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergl/selected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scattergl/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergl/unselected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scattermapbox/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattermapbox/__init__.py
@@ -1,30 +1,30 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._unselected import Unselected
-    from ._textfont import Textfont
-    from ._stream import Stream
-    from ._selected import Selected
-    from ._marker import Marker
-    from ._line import Line
     from ._hoverlabel import Hoverlabel
-    from . import unselected
-    from . import selected
-    from . import marker
+    from ._line import Line
+    from ._marker import Marker
+    from ._selected import Selected
+    from ._stream import Stream
+    from ._textfont import Textfont
+    from ._unselected import Unselected
     from . import hoverlabel
+    from . import marker
+    from . import selected
+    from . import unselected
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".unselected", ".selected", ".marker", ".hoverlabel"],
+        [".hoverlabel", ".marker", ".selected", ".unselected"],
         [
-            "._unselected.Unselected",
-            "._textfont.Textfont",
-            "._stream.Stream",
-            "._selected.Selected",
-            "._marker.Marker",
-            "._line.Line",
             "._hoverlabel.Hoverlabel",
+            "._line.Line",
+            "._marker.Marker",
+            "._selected.Selected",
+            "._stream.Stream",
+            "._textfont.Textfont",
+            "._unselected.Unselected",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/scattermapbox/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattermapbox/marker/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/scatterpolar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolar/__init__.py
@@ -1,30 +1,30 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._unselected import Unselected
-    from ._textfont import Textfont
-    from ._stream import Stream
-    from ._selected import Selected
-    from ._marker import Marker
-    from ._line import Line
     from ._hoverlabel import Hoverlabel
-    from . import unselected
-    from . import selected
-    from . import marker
+    from ._line import Line
+    from ._marker import Marker
+    from ._selected import Selected
+    from ._stream import Stream
+    from ._textfont import Textfont
+    from ._unselected import Unselected
     from . import hoverlabel
+    from . import marker
+    from . import selected
+    from . import unselected
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".unselected", ".selected", ".marker", ".hoverlabel"],
+        [".hoverlabel", ".marker", ".selected", ".unselected"],
         [
-            "._unselected.Unselected",
-            "._textfont.Textfont",
-            "._stream.Stream",
-            "._selected.Selected",
-            "._marker.Marker",
-            "._line.Line",
             "._hoverlabel.Hoverlabel",
+            "._line.Line",
+            "._marker.Marker",
+            "._selected.Selected",
+            "._stream.Stream",
+            "._textfont.Textfont",
+            "._unselected.Unselected",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/scatterpolar/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolar/marker/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
-    from ._gradient import Gradient
     from ._colorbar import ColorBar
+    from ._gradient import Gradient
+    from ._line import Line
     from . import colorbar
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".colorbar"],
-        ["._line.Line", "._gradient.Gradient", "._colorbar.ColorBar"],
+        ["._colorbar.ColorBar", "._gradient.Gradient", "._line.Line"],
     )

--- a/packages/python/plotly/plotly/graph_objs/scatterpolar/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolar/marker/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/scatterpolar/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolar/selected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scatterpolar/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolar/unselected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scatterpolargl/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolargl/__init__.py
@@ -1,30 +1,30 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._unselected import Unselected
-    from ._textfont import Textfont
-    from ._stream import Stream
-    from ._selected import Selected
-    from ._marker import Marker
-    from ._line import Line
     from ._hoverlabel import Hoverlabel
-    from . import unselected
-    from . import selected
-    from . import marker
+    from ._line import Line
+    from ._marker import Marker
+    from ._selected import Selected
+    from ._stream import Stream
+    from ._textfont import Textfont
+    from ._unselected import Unselected
     from . import hoverlabel
+    from . import marker
+    from . import selected
+    from . import unselected
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".unselected", ".selected", ".marker", ".hoverlabel"],
+        [".hoverlabel", ".marker", ".selected", ".unselected"],
         [
-            "._unselected.Unselected",
-            "._textfont.Textfont",
-            "._stream.Stream",
-            "._selected.Selected",
-            "._marker.Marker",
-            "._line.Line",
             "._hoverlabel.Hoverlabel",
+            "._line.Line",
+            "._marker.Marker",
+            "._selected.Selected",
+            "._stream.Stream",
+            "._textfont.Textfont",
+            "._unselected.Unselected",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/scatterpolargl/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolargl/marker/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
     from ._colorbar import ColorBar
+    from ._line import Line
     from . import colorbar
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".colorbar"], ["._line.Line", "._colorbar.ColorBar"]
+        __name__, [".colorbar"], ["._colorbar.ColorBar", "._line.Line"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scatterpolargl/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolargl/marker/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/scatterpolargl/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolargl/selected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scatterpolargl/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolargl/unselected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scatterternary/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterternary/__init__.py
@@ -1,30 +1,30 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._unselected import Unselected
-    from ._textfont import Textfont
-    from ._stream import Stream
-    from ._selected import Selected
-    from ._marker import Marker
-    from ._line import Line
     from ._hoverlabel import Hoverlabel
-    from . import unselected
-    from . import selected
-    from . import marker
+    from ._line import Line
+    from ._marker import Marker
+    from ._selected import Selected
+    from ._stream import Stream
+    from ._textfont import Textfont
+    from ._unselected import Unselected
     from . import hoverlabel
+    from . import marker
+    from . import selected
+    from . import unselected
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".unselected", ".selected", ".marker", ".hoverlabel"],
+        [".hoverlabel", ".marker", ".selected", ".unselected"],
         [
-            "._unselected.Unselected",
-            "._textfont.Textfont",
-            "._stream.Stream",
-            "._selected.Selected",
-            "._marker.Marker",
-            "._line.Line",
             "._hoverlabel.Hoverlabel",
+            "._line.Line",
+            "._marker.Marker",
+            "._selected.Selected",
+            "._stream.Stream",
+            "._textfont.Textfont",
+            "._unselected.Unselected",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/scatterternary/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterternary/marker/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
-    from ._gradient import Gradient
     from ._colorbar import ColorBar
+    from ._gradient import Gradient
+    from ._line import Line
     from . import colorbar
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".colorbar"],
-        ["._line.Line", "._gradient.Gradient", "._colorbar.ColorBar"],
+        ["._colorbar.ColorBar", "._gradient.Gradient", "._line.Line"],
     )

--- a/packages/python/plotly/plotly/graph_objs/scatterternary/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterternary/marker/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/scatterternary/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterternary/selected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/scatterternary/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterternary/unselected/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
     from ._marker import Marker
+    from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._textfont.Textfont", "._marker.Marker"]
+        __name__, [], ["._marker.Marker", "._textfont.Textfont"]
     )

--- a/packages/python/plotly/plotly/graph_objs/splom/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/splom/__init__.py
@@ -1,31 +1,31 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._unselected import Unselected
-    from ._stream import Stream
-    from ._selected import Selected
-    from ._marker import Marker
-    from ._hoverlabel import Hoverlabel
-    from ._dimension import Dimension
     from ._diagonal import Diagonal
-    from . import unselected
-    from . import selected
-    from . import marker
-    from . import hoverlabel
+    from ._dimension import Dimension
+    from ._hoverlabel import Hoverlabel
+    from ._marker import Marker
+    from ._selected import Selected
+    from ._stream import Stream
+    from ._unselected import Unselected
     from . import dimension
+    from . import hoverlabel
+    from . import marker
+    from . import selected
+    from . import unselected
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".unselected", ".selected", ".marker", ".hoverlabel", ".dimension"],
+        [".dimension", ".hoverlabel", ".marker", ".selected", ".unselected"],
         [
-            "._unselected.Unselected",
-            "._stream.Stream",
-            "._selected.Selected",
-            "._marker.Marker",
-            "._hoverlabel.Hoverlabel",
-            "._dimension.Dimension",
             "._diagonal.Diagonal",
+            "._dimension.Dimension",
+            "._hoverlabel.Hoverlabel",
+            "._marker.Marker",
+            "._selected.Selected",
+            "._stream.Stream",
+            "._unselected.Unselected",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/splom/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/splom/marker/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
     from ._colorbar import ColorBar
+    from ._line import Line
     from . import colorbar
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".colorbar"], ["._line.Line", "._colorbar.ColorBar"]
+        __name__, [".colorbar"], ["._colorbar.ColorBar", "._line.Line"]
     )

--- a/packages/python/plotly/plotly/graph_objs/splom/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/splom/marker/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/streamtube/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/streamtube/__init__.py
@@ -1,26 +1,26 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._stream import Stream
-    from ._starts import Starts
-    from ._lightposition import Lightposition
-    from ._lighting import Lighting
-    from ._hoverlabel import Hoverlabel
     from ._colorbar import ColorBar
-    from . import hoverlabel
+    from ._hoverlabel import Hoverlabel
+    from ._lighting import Lighting
+    from ._lightposition import Lightposition
+    from ._starts import Starts
+    from ._stream import Stream
     from . import colorbar
+    from . import hoverlabel
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".hoverlabel", ".colorbar"],
+        [".colorbar", ".hoverlabel"],
         [
-            "._stream.Stream",
-            "._starts.Starts",
-            "._lightposition.Lightposition",
-            "._lighting.Lighting",
-            "._hoverlabel.Hoverlabel",
             "._colorbar.ColorBar",
+            "._hoverlabel.Hoverlabel",
+            "._lighting.Lighting",
+            "._lightposition.Lightposition",
+            "._starts.Starts",
+            "._stream.Stream",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/streamtube/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/streamtube/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/sunburst/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sunburst/__init__.py
@@ -1,30 +1,30 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._textfont import Textfont
-    from ._stream import Stream
-    from ._outsidetextfont import Outsidetextfont
-    from ._marker import Marker
-    from ._leaf import Leaf
-    from ._insidetextfont import Insidetextfont
-    from ._hoverlabel import Hoverlabel
     from ._domain import Domain
-    from . import marker
+    from ._hoverlabel import Hoverlabel
+    from ._insidetextfont import Insidetextfont
+    from ._leaf import Leaf
+    from ._marker import Marker
+    from ._outsidetextfont import Outsidetextfont
+    from ._stream import Stream
+    from ._textfont import Textfont
     from . import hoverlabel
+    from . import marker
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".marker", ".hoverlabel"],
+        [".hoverlabel", ".marker"],
         [
-            "._textfont.Textfont",
-            "._stream.Stream",
-            "._outsidetextfont.Outsidetextfont",
-            "._marker.Marker",
-            "._leaf.Leaf",
-            "._insidetextfont.Insidetextfont",
-            "._hoverlabel.Hoverlabel",
             "._domain.Domain",
+            "._hoverlabel.Hoverlabel",
+            "._insidetextfont.Insidetextfont",
+            "._leaf.Leaf",
+            "._marker.Marker",
+            "._outsidetextfont.Outsidetextfont",
+            "._stream.Stream",
+            "._textfont.Textfont",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/sunburst/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sunburst/marker/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
     from ._colorbar import ColorBar
+    from ._line import Line
     from . import colorbar
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".colorbar"], ["._line.Line", "._colorbar.ColorBar"]
+        __name__, [".colorbar"], ["._colorbar.ColorBar", "._line.Line"]
     )

--- a/packages/python/plotly/plotly/graph_objs/sunburst/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sunburst/marker/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/surface/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/surface/__init__.py
@@ -1,27 +1,27 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._stream import Stream
-    from ._lightposition import Lightposition
-    from ._lighting import Lighting
-    from ._hoverlabel import Hoverlabel
-    from ._contours import Contours
     from ._colorbar import ColorBar
-    from . import hoverlabel
-    from . import contours
+    from ._contours import Contours
+    from ._hoverlabel import Hoverlabel
+    from ._lighting import Lighting
+    from ._lightposition import Lightposition
+    from ._stream import Stream
     from . import colorbar
+    from . import contours
+    from . import hoverlabel
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".hoverlabel", ".contours", ".colorbar"],
+        [".colorbar", ".contours", ".hoverlabel"],
         [
-            "._stream.Stream",
-            "._lightposition.Lightposition",
-            "._lighting.Lighting",
-            "._hoverlabel.Hoverlabel",
-            "._contours.Contours",
             "._colorbar.ColorBar",
+            "._contours.Contours",
+            "._hoverlabel.Hoverlabel",
+            "._lighting.Lighting",
+            "._lightposition.Lightposition",
+            "._stream.Stream",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/surface/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/surface/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/surface/contours/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/surface/contours/__init__.py
@@ -1,15 +1,15 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._z import Z
-    from ._y import Y
     from ._x import X
-    from . import z
-    from . import y
+    from ._y import Y
+    from ._z import Z
     from . import x
+    from . import y
+    from . import z
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".z", ".y", ".x"], ["._z.Z", "._y.Y", "._x.X"]
+        __name__, [".x", ".y", ".z"], ["._x.X", "._y.Y", "._z.Z"]
     )

--- a/packages/python/plotly/plotly/graph_objs/table/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/table/__init__.py
@@ -1,25 +1,25 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._stream import Stream
-    from ._hoverlabel import Hoverlabel
-    from ._header import Header
-    from ._domain import Domain
     from ._cells import Cells
-    from . import hoverlabel
-    from . import header
+    from ._domain import Domain
+    from ._header import Header
+    from ._hoverlabel import Hoverlabel
+    from ._stream import Stream
     from . import cells
+    from . import header
+    from . import hoverlabel
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".hoverlabel", ".header", ".cells"],
+        [".cells", ".header", ".hoverlabel"],
         [
-            "._stream.Stream",
-            "._hoverlabel.Hoverlabel",
-            "._header.Header",
-            "._domain.Domain",
             "._cells.Cells",
+            "._domain.Domain",
+            "._header.Header",
+            "._hoverlabel.Hoverlabel",
+            "._stream.Stream",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/table/cells/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/table/cells/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
-    from ._font import Font
     from ._fill import Fill
+    from ._font import Font
+    from ._line import Line
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._line.Line", "._font.Font", "._fill.Fill"]
+        __name__, [], ["._fill.Fill", "._font.Font", "._line.Line"]
     )

--- a/packages/python/plotly/plotly/graph_objs/table/header/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/table/header/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._line import Line
-    from ._font import Font
     from ._fill import Fill
+    from ._font import Font
+    from ._line import Line
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._line.Line", "._font.Font", "._fill.Fill"]
+        __name__, [], ["._fill.Fill", "._font.Font", "._line.Line"]
     )

--- a/packages/python/plotly/plotly/graph_objs/treemap/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/treemap/__init__.py
@@ -1,33 +1,33 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._tiling import Tiling
-    from ._textfont import Textfont
-    from ._stream import Stream
-    from ._pathbar import Pathbar
-    from ._outsidetextfont import Outsidetextfont
-    from ._marker import Marker
-    from ._insidetextfont import Insidetextfont
-    from ._hoverlabel import Hoverlabel
     from ._domain import Domain
-    from . import pathbar
-    from . import marker
+    from ._hoverlabel import Hoverlabel
+    from ._insidetextfont import Insidetextfont
+    from ._marker import Marker
+    from ._outsidetextfont import Outsidetextfont
+    from ._pathbar import Pathbar
+    from ._stream import Stream
+    from ._textfont import Textfont
+    from ._tiling import Tiling
     from . import hoverlabel
+    from . import marker
+    from . import pathbar
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".pathbar", ".marker", ".hoverlabel"],
+        [".hoverlabel", ".marker", ".pathbar"],
         [
-            "._tiling.Tiling",
-            "._textfont.Textfont",
-            "._stream.Stream",
-            "._pathbar.Pathbar",
-            "._outsidetextfont.Outsidetextfont",
-            "._marker.Marker",
-            "._insidetextfont.Insidetextfont",
-            "._hoverlabel.Hoverlabel",
             "._domain.Domain",
+            "._hoverlabel.Hoverlabel",
+            "._insidetextfont.Insidetextfont",
+            "._marker.Marker",
+            "._outsidetextfont.Outsidetextfont",
+            "._pathbar.Pathbar",
+            "._stream.Stream",
+            "._textfont.Textfont",
+            "._tiling.Tiling",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/treemap/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/treemap/marker/__init__.py
@@ -1,13 +1,13 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._pad import Pad
-    from ._line import Line
     from ._colorbar import ColorBar
+    from ._line import Line
+    from ._pad import Pad
     from . import colorbar
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [".colorbar"], ["._pad.Pad", "._line.Line", "._colorbar.ColorBar"]
+        __name__, [".colorbar"], ["._colorbar.ColorBar", "._line.Line", "._pad.Pad"]
     )

--- a/packages/python/plotly/plotly/graph_objs/treemap/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/treemap/marker/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/violin/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/violin/__init__.py
@@ -1,33 +1,33 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._unselected import Unselected
-    from ._stream import Stream
-    from ._selected import Selected
-    from ._meanline import Meanline
-    from ._marker import Marker
-    from ._line import Line
-    from ._hoverlabel import Hoverlabel
     from ._box import Box
-    from . import unselected
-    from . import selected
-    from . import marker
-    from . import hoverlabel
+    from ._hoverlabel import Hoverlabel
+    from ._line import Line
+    from ._marker import Marker
+    from ._meanline import Meanline
+    from ._selected import Selected
+    from ._stream import Stream
+    from ._unselected import Unselected
     from . import box
+    from . import hoverlabel
+    from . import marker
+    from . import selected
+    from . import unselected
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".unselected", ".selected", ".marker", ".hoverlabel", ".box"],
+        [".box", ".hoverlabel", ".marker", ".selected", ".unselected"],
         [
-            "._unselected.Unselected",
-            "._stream.Stream",
-            "._selected.Selected",
-            "._meanline.Meanline",
-            "._marker.Marker",
-            "._line.Line",
-            "._hoverlabel.Hoverlabel",
             "._box.Box",
+            "._hoverlabel.Hoverlabel",
+            "._line.Line",
+            "._marker.Marker",
+            "._meanline.Meanline",
+            "._selected.Selected",
+            "._stream.Stream",
+            "._unselected.Unselected",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/volume/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/volume/__init__.py
@@ -1,36 +1,36 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._surface import Surface
-    from ._stream import Stream
-    from ._spaceframe import Spaceframe
-    from ._slices import Slices
-    from ._lightposition import Lightposition
-    from ._lighting import Lighting
-    from ._hoverlabel import Hoverlabel
-    from ._contour import Contour
-    from ._colorbar import ColorBar
     from ._caps import Caps
-    from . import slices
-    from . import hoverlabel
-    from . import colorbar
+    from ._colorbar import ColorBar
+    from ._contour import Contour
+    from ._hoverlabel import Hoverlabel
+    from ._lighting import Lighting
+    from ._lightposition import Lightposition
+    from ._slices import Slices
+    from ._spaceframe import Spaceframe
+    from ._stream import Stream
+    from ._surface import Surface
     from . import caps
+    from . import colorbar
+    from . import hoverlabel
+    from . import slices
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".slices", ".hoverlabel", ".colorbar", ".caps"],
+        [".caps", ".colorbar", ".hoverlabel", ".slices"],
         [
-            "._surface.Surface",
-            "._stream.Stream",
-            "._spaceframe.Spaceframe",
-            "._slices.Slices",
-            "._lightposition.Lightposition",
-            "._lighting.Lighting",
-            "._hoverlabel.Hoverlabel",
-            "._contour.Contour",
-            "._colorbar.ColorBar",
             "._caps.Caps",
+            "._colorbar.ColorBar",
+            "._contour.Contour",
+            "._hoverlabel.Hoverlabel",
+            "._lighting.Lighting",
+            "._lightposition.Lightposition",
+            "._slices.Slices",
+            "._spaceframe.Spaceframe",
+            "._stream.Stream",
+            "._surface.Surface",
         ],
     )

--- a/packages/python/plotly/plotly/graph_objs/volume/caps/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/volume/caps/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._z import Z
-    from ._y import Y
     from ._x import X
+    from ._y import Y
+    from ._z import Z
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._z.Z", "._y.Y", "._x.X"]
+        __name__, [], ["._x.X", "._y.Y", "._z.Z"]
     )

--- a/packages/python/plotly/plotly/graph_objs/volume/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/volume/colorbar/__init__.py
@@ -1,9 +1,9 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._title import Title
-    from ._tickformatstop import Tickformatstop
     from ._tickfont import Tickfont
+    from ._tickformatstop import Tickformatstop
+    from ._title import Title
     from . import title
 else:
     from _plotly_utils.importers import relative_import
@@ -11,5 +11,5 @@ else:
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
         [".title"],
-        ["._title.Title", "._tickformatstop.Tickformatstop", "._tickfont.Tickfont"],
+        ["._tickfont.Tickfont", "._tickformatstop.Tickformatstop", "._title.Title"],
     )

--- a/packages/python/plotly/plotly/graph_objs/volume/slices/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/volume/slices/__init__.py
@@ -1,12 +1,12 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._z import Z
-    from ._y import Y
     from ._x import X
+    from ._y import Y
+    from ._z import Z
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
-        __name__, [], ["._z.Z", "._y.Y", "._x.X"]
+        __name__, [], ["._x.X", "._y.Y", "._z.Z"]
     )

--- a/packages/python/plotly/plotly/graph_objs/waterfall/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/waterfall/__init__.py
@@ -1,35 +1,35 @@
 import sys
 
 if sys.version_info < (3, 7):
-    from ._totals import Totals
-    from ._textfont import Textfont
-    from ._stream import Stream
-    from ._outsidetextfont import Outsidetextfont
-    from ._insidetextfont import Insidetextfont
-    from ._increasing import Increasing
-    from ._hoverlabel import Hoverlabel
-    from ._decreasing import Decreasing
     from ._connector import Connector
-    from . import totals
-    from . import increasing
-    from . import hoverlabel
-    from . import decreasing
+    from ._decreasing import Decreasing
+    from ._hoverlabel import Hoverlabel
+    from ._increasing import Increasing
+    from ._insidetextfont import Insidetextfont
+    from ._outsidetextfont import Outsidetextfont
+    from ._stream import Stream
+    from ._textfont import Textfont
+    from ._totals import Totals
     from . import connector
+    from . import decreasing
+    from . import hoverlabel
+    from . import increasing
+    from . import totals
 else:
     from _plotly_utils.importers import relative_import
 
     __all__, __getattr__, __dir__ = relative_import(
         __name__,
-        [".totals", ".increasing", ".hoverlabel", ".decreasing", ".connector"],
+        [".connector", ".decreasing", ".hoverlabel", ".increasing", ".totals"],
         [
-            "._totals.Totals",
-            "._textfont.Textfont",
-            "._stream.Stream",
-            "._outsidetextfont.Outsidetextfont",
-            "._insidetextfont.Insidetextfont",
-            "._increasing.Increasing",
-            "._hoverlabel.Hoverlabel",
-            "._decreasing.Decreasing",
             "._connector.Connector",
+            "._decreasing.Decreasing",
+            "._hoverlabel.Hoverlabel",
+            "._increasing.Increasing",
+            "._insidetextfont.Insidetextfont",
+            "._outsidetextfont.Outsidetextfont",
+            "._stream.Stream",
+            "._textfont.Textfont",
+            "._totals.Totals",
         ],
     )


### PR DESCRIPTION
This PR fixes the build of the API doc. The problem was that `graph_objs` objects have docstrings with intersphinx references like :class:`plotly.graph_objects.scatter.Marker` but (from my understanding, which might be incorrect) graph_objects are lazily imported and not found by sphinx when generating html files from the docstrings, hence no links were generated.

I solved the problem by temporarily changing the docstrings thanks to a massive sed, and reverting everything with git checkout after the sphinx build. A more robust long-term solution would be to have all the codegened code inside the `graph_objects` directory.

I tested that the solution works both on master and on the branch of #2403. 

@nicolaskruchten @jonmmease 