### PR TITLE
Sg scraper

### DIFF
--- a/packages/python/plotly/plotly/io/_sg_scraper.py
+++ b/packages/python/plotly/plotly/io/_sg_scraper.py
@@ -1,7 +1,7 @@
 # This module defines an image scraper for sphinx-gallery
 # https://sphinx-gallery.github.io/
 # which can be used by projects using plotly in their documentation.
-import inspect, os
+import inspect, os, pathlib
 
 import plotly
 from glob import glob
@@ -45,10 +45,20 @@ def plotly_sg_scraper(block, block_vars, gallery_conf, **kwargs):
     Add this function to the image scrapers 
     """
     examples_dirs = gallery_conf["examples_dirs"]
-    if isinstance(examples_dirs, (list, tuple)):
-        examples_dirs = examples_dirs[0]
-    pngs = sorted(glob(os.path.join(examples_dirs, "*.png")))
-    htmls = sorted(glob(os.path.join(examples_dirs, "*.html")))
+    if not isinstance(examples_dirs, (list, tuple)):
+        examples_dirs = [examples_dirs]
+    pngs = []
+    htmls = []
+    for examples_dir in examples_dirs:
+        # sphinx hack, since the conf file can be either in the same dir as Makefile
+        # or in a subdirectory
+        if not os.path.isabs(examples_dir) and not os.path.exists(examples_dir):
+            examples_dir = pathlib.Path(*pathlib.Path(examples_dir).parts[1:])
+        # Look for pngs and htmls in examples_dirs and subdirectories
+        pngs += sorted(glob(os.path.join(examples_dir, "*.png")) +
+            glob(os.path.join(examples_dir, "*", "*.png")))
+        htmls += sorted(glob(os.path.join(examples_dir, "*.html")) + 
+            glob(os.path.join(examples_dir, "*", "*.html")))
     image_path_iterator = block_vars["image_path_iterator"]
     image_names = list()
     seen = set()

--- a/packages/python/plotly/plotly/io/_sg_scraper.py
+++ b/packages/python/plotly/plotly/io/_sg_scraper.py
@@ -1,7 +1,7 @@
 # This module defines an image scraper for sphinx-gallery
 # https://sphinx-gallery.github.io/
 # which can be used by projects using plotly in their documentation.
-import inspect, os, pathlib
+import inspect, os
 
 import plotly
 from glob import glob

--- a/packages/python/plotly/plotly/io/_sg_scraper.py
+++ b/packages/python/plotly/plotly/io/_sg_scraper.py
@@ -44,8 +44,8 @@ def plotly_sg_scraper(block, block_vars, gallery_conf, **kwargs):
     -----
     Add this function to the image scrapers 
     """
-    examples_dir = os.path.dirname(block_vars['src_file'])
-    print('----------------------')
+    examples_dir = os.path.dirname(block_vars["src_file"])
+    print("----------------------")
     pngs = sorted(glob(os.path.join(examples_dir, "*.png")))
     htmls = sorted(glob(os.path.join(examples_dir, "*.html")))
     image_path_iterator = block_vars["image_path_iterator"]

--- a/packages/python/plotly/plotly/io/_sg_scraper.py
+++ b/packages/python/plotly/plotly/io/_sg_scraper.py
@@ -42,10 +42,9 @@ def plotly_sg_scraper(block, block_vars, gallery_conf, **kwargs):
 
     Notes
     -----
-    Add this function to the image scrapers 
+    Add this function to the image scrapers
     """
     examples_dir = os.path.dirname(block_vars["src_file"])
-    print("----------------------")
     pngs = sorted(glob(os.path.join(examples_dir, "*.png")))
     htmls = sorted(glob(os.path.join(examples_dir, "*.html")))
     image_path_iterator = block_vars["image_path_iterator"]

--- a/packages/python/plotly/plotly/io/_sg_scraper.py
+++ b/packages/python/plotly/plotly/io/_sg_scraper.py
@@ -44,21 +44,10 @@ def plotly_sg_scraper(block, block_vars, gallery_conf, **kwargs):
     -----
     Add this function to the image scrapers 
     """
-    examples_dirs = gallery_conf["examples_dirs"]
-    if not isinstance(examples_dirs, (list, tuple)):
-        examples_dirs = [examples_dirs]
-    pngs = []
-    htmls = []
-    for examples_dir in examples_dirs:
-        # sphinx hack, since the conf file can be either in the same dir as Makefile
-        # or in a subdirectory
-        if not os.path.isabs(examples_dir) and not os.path.exists(examples_dir):
-            examples_dir = pathlib.Path(*pathlib.Path(examples_dir).parts[1:])
-        # Look for pngs and htmls in examples_dirs and subdirectories
-        pngs += sorted(glob(os.path.join(examples_dir, "*.png")) +
-            glob(os.path.join(examples_dir, "*", "*.png")))
-        htmls += sorted(glob(os.path.join(examples_dir, "*.html")) + 
-            glob(os.path.join(examples_dir, "*", "*.html")))
+    examples_dir = os.path.dirname(block_vars['src_file'])
+    print('----------------------')
+    pngs = sorted(glob(os.path.join(examples_dir, "*.png")))
+    htmls = sorted(glob(os.path.join(examples_dir, "*.html")))
     image_path_iterator = block_vars["image_path_iterator"]
     image_names = list()
     seen = set()

--- a/packages/python/plotly/plotly/tests/test_orca/test_sg_scraper.py
+++ b/packages/python/plotly/plotly/tests/test_orca/test_sg_scraper.py
@@ -52,7 +52,10 @@ def test_scraper():
     tempdir = tempfile.mkdtemp()
     gallery_conf = {"src_dir": tempdir, "examples_dirs": here}
     names = iter(["0", "1", "2"])
-    block_vars = {"image_path_iterator": names}
+    block_vars = {
+        "image_path_iterator": names,
+        "src_file": os.path.join(here, "plot_example.py"),
+    }
     execute_plotly_example()
     res = plotly_sg_scraper(block, block_vars, gallery_conf)
     shutil.rmtree(tempdir)


### PR DESCRIPTION
This is an improvement of the sphinx-gallery scraper, which crawls only the directory of the example and now works for different structures of galleries (I was trying to add a plotly example to the gallery of scikit-image and it did not work with the scraper, with this change it is working).

A more sustainable mid-term change would be to add a `_repr_html_` method to the `BaseFigure` class (since the html would then be captured by sphinx-gallery) but for now the scraper works. 