### PR TITLE
Repr html

### DIFF
--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -422,7 +422,26 @@ class BaseFigure(object):
         """
         Customize html representation
         """
-        return self.to_html(full_html=False, include_plotlyjs="cdn", auto_play=False)
+        bundle = self._repr_mimebundle_()
+        if 'text/html' in bundle:
+            return bundle['text/html']
+        else:
+            return ''
+            #return self.to_html(full_html=False, include_plotlyjs="cdn")
+
+    def _repr_mimebundle_(self, include=None, exclude=None, validate=True, **kwargs):
+        """
+        Return mimebundle corresponding to default renderer.
+        """
+        import plotly.io as pio
+        renderer_str = pio.renderers.default
+        renderers = pio._renderers.renderers
+        from plotly.io._utils import validate_coerce_fig_to_dict
+        fig_dict = validate_coerce_fig_to_dict(self, validate)
+        # Mimetype renderers
+        renderer = renderers[renderer_str]
+        bundle = renderer.to_mimebundle(fig_dict)
+        return bundle
 
     def _ipython_display_(self):
         """

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -418,13 +418,11 @@ class BaseFigure(object):
 
         return repr_str
 
-
     def _repr_html_(self):
         """
-        Customizes html representation
+        Customize html representation
         """
-        return self.to_html(full_html=False, include_plotlyjs='cdn')
-
+        return self.to_html(full_html=False, include_plotlyjs="cdn", auto_play=False)
 
     def _ipython_display_(self):
         """

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -418,6 +418,14 @@ class BaseFigure(object):
 
         return repr_str
 
+
+    def _repr_html_(self):
+        """
+        Customizes html representation
+        """
+        return self.to_html(full_html=False, include_plotlyjs='cdn')
+
+
     def _ipython_display_(self):
         """
         Handle rich display of figures in ipython contexts

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -423,24 +423,30 @@ class BaseFigure(object):
         Customize html representation
         """
         bundle = self._repr_mimebundle_()
-        if 'text/html' in bundle:
-            return bundle['text/html']
+        if "text/html" in bundle:
+            return bundle["text/html"]
         else:
-            return ''
-            #return self.to_html(full_html=False, include_plotlyjs="cdn")
+            return self.to_html(full_html=False, include_plotlyjs="cdn")
 
     def _repr_mimebundle_(self, include=None, exclude=None, validate=True, **kwargs):
         """
         Return mimebundle corresponding to default renderer.
         """
         import plotly.io as pio
+
         renderer_str = pio.renderers.default
         renderers = pio._renderers.renderers
+        renderer_names = renderers._validate_coerce_renderers(renderer_str)
+        renderers_list = [renderers[name] for name in renderer_names]
         from plotly.io._utils import validate_coerce_fig_to_dict
+        from plotly.io._renderers import MimetypeRenderer
+
         fig_dict = validate_coerce_fig_to_dict(self, validate)
         # Mimetype renderers
-        renderer = renderers[renderer_str]
-        bundle = renderer.to_mimebundle(fig_dict)
+        bundle = {}
+        for renderer in renderers_list:
+            if isinstance(renderer, MimetypeRenderer):
+                bundle.update(renderer.to_mimebundle(fig_dict))
         return bundle
 
     def _ipython_display_(self):

--- a/packages/python/plotly/plotly/io/_base_renderers.py
+++ b/packages/python/plotly/plotly/io/_base_renderers.py
@@ -796,7 +796,30 @@ supported when called from within the Databricks notebook environment."""
         self.displayHTML(html)
 
 
-class SphinxGalleryRenderer(ExternalRenderer):
+class SphinxGalleryHtmlRenderer(HtmlRenderer):
+
+    def __init__(
+        self,
+        connected=True,
+        config=None,
+        auto_play=False,
+        post_script=None,
+        animation_opts=None,
+    ):
+        super(SphinxGalleryHtmlRenderer, self).__init__(
+            connected=connected,
+            full_html=False,
+            requirejs=False,
+            global_init=False,
+            config=config,
+            auto_play=auto_play,
+            post_script=post_script,
+            animation_opts=animation_opts,
+        )
+
+
+class SphinxGalleryOrcaRenderer(ExternalRenderer):
+
     def render(self, fig_dict):
         stack = inspect.stack()
         # Name of script from which plot function was called is retrieved
@@ -809,4 +832,17 @@ class SphinxGalleryRenderer(ExternalRenderer):
         filename_png = filename_root + ".png"
         figure = return_figure_from_figure_or_data(fig_dict, True)
         _ = write_html(fig_dict, file=filename_html)
-        write_image(figure, filename_png)
+        try:
+            write_image(figure, filename_png)
+        except (ValueError, ImportError):
+            raise ImportError(
+            "orca and psutil are required to use the `sphinx-gallery-orca` renderer. "
+            "See https://plotly.com/python/static-image-export/ for instructions on"
+            "how to install orca. Alternatively, you can use the `sphinx-gallery`"
+            "renderer (note that png thumbnails can only be generated with"
+            "the `sphinx-gallery-orca` renderer)."
+            )
+
+
+
+

--- a/packages/python/plotly/plotly/io/_base_renderers.py
+++ b/packages/python/plotly/plotly/io/_base_renderers.py
@@ -797,7 +797,6 @@ supported when called from within the Databricks notebook environment."""
 
 
 class SphinxGalleryHtmlRenderer(HtmlRenderer):
-
     def __init__(
         self,
         connected=True,
@@ -831,7 +830,6 @@ class SphinxGalleryHtmlRenderer(HtmlRenderer):
             include_plotlyjs = True
             include_mathjax = "cdn"
 
-
         html = to_html(
             fig_dict,
             config=self.config,
@@ -848,10 +846,7 @@ class SphinxGalleryHtmlRenderer(HtmlRenderer):
         return {"text/html": html}
 
 
-
-
 class SphinxGalleryOrcaRenderer(ExternalRenderer):
-
     def render(self, fig_dict):
         stack = inspect.stack()
         # Name of script from which plot function was called is retrieved
@@ -868,13 +863,9 @@ class SphinxGalleryOrcaRenderer(ExternalRenderer):
             write_image(figure, filename_png)
         except (ValueError, ImportError):
             raise ImportError(
-            "orca and psutil are required to use the `sphinx-gallery-orca` renderer. "
-            "See https://plotly.com/python/static-image-export/ for instructions on"
-            "how to install orca. Alternatively, you can use the `sphinx-gallery`"
-            "renderer (note that png thumbnails can only be generated with"
-            "the `sphinx-gallery-orca` renderer)."
+                "orca and psutil are required to use the `sphinx-gallery-orca` renderer. "
+                "See https://plotly.com/python/static-image-export/ for instructions on"
+                "how to install orca. Alternatively, you can use the `sphinx-gallery`"
+                "renderer (note that png thumbnails can only be generated with"
+                "the `sphinx-gallery-orca` renderer)."
             )
-
-
-
-

--- a/packages/python/plotly/plotly/io/_base_renderers.py
+++ b/packages/python/plotly/plotly/io/_base_renderers.py
@@ -817,6 +817,38 @@ class SphinxGalleryHtmlRenderer(HtmlRenderer):
             animation_opts=animation_opts,
         )
 
+    def to_mimebundle(self, fig_dict):
+
+        from plotly.io import to_html
+
+        if self.requirejs:
+            include_plotlyjs = "require"
+            include_mathjax = False
+        elif self.connected:
+            include_plotlyjs = "cdn"
+            include_mathjax = "cdn"
+        else:
+            include_plotlyjs = True
+            include_mathjax = "cdn"
+
+
+        html = to_html(
+            fig_dict,
+            config=self.config,
+            auto_play=self.auto_play,
+            include_plotlyjs=include_plotlyjs,
+            include_mathjax=include_mathjax,
+            full_html=self.full_html,
+            animation_opts=self.animation_opts,
+            default_width="100%",
+            default_height=525,
+            validate=False,
+        )
+
+        return {"text/html": html}
+
+
+
 
 class SphinxGalleryOrcaRenderer(ExternalRenderer):
 

--- a/packages/python/plotly/plotly/io/_renderers.py
+++ b/packages/python/plotly/plotly/io/_renderers.py
@@ -24,7 +24,8 @@ from plotly.io._base_renderers import (
     PdfRenderer,
     BrowserRenderer,
     IFrameRenderer,
-    SphinxGalleryRenderer,
+    SphinxGalleryHtmlRenderer,
+    SphinxGalleryOrcaRenderer,
     CoCalcRenderer,
     DatabricksRenderer,
 )
@@ -430,7 +431,8 @@ renderers["chrome"] = BrowserRenderer(config=config, using="chrome")
 renderers["chromium"] = BrowserRenderer(config=config, using="chromium")
 renderers["iframe"] = IFrameRenderer(config=config, include_plotlyjs=True)
 renderers["iframe_connected"] = IFrameRenderer(config=config, include_plotlyjs="cdn")
-renderers["sphinx_gallery"] = SphinxGalleryRenderer()
+renderers["sphinx_gallery"] = SphinxGalleryHtmlRenderer()
+renderers["sphinx_gallery_png"] = SphinxGalleryOrcaRenderer()
 
 # Set default renderer
 # --------------------

--- a/packages/python/plotly/plotly/io/_sg_scraper.py
+++ b/packages/python/plotly/plotly/io/_sg_scraper.py
@@ -7,7 +7,7 @@ import plotly
 from glob import glob
 import shutil
 
-plotly.io.renderers.default = "sphinx_gallery"
+plotly.io.renderers.default = "sphinx_gallery_png"
 
 
 def plotly_sg_scraper(block, block_vars, gallery_conf, **kwargs):

--- a/packages/python/plotly/plotly/tests/test_io/test_renderers.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_renderers.py
@@ -287,3 +287,29 @@ def test_reject_invalid_renderer(renderer):
 )
 def test_accept_valid_renderer(renderer):
     pio.renderers.default = renderer
+
+
+# _repr_html
+# ----------
+# independent of renderer
+def test_repr_html():
+    fig = go.Figure()
+    fig.update_layout(template=None)
+    s = fig._repr_html_()
+    # id number of figure
+    id_figure = s.split('document.getElementById("')[1].split('")')[0]
+    id_pattern = "cd462b94-79ce-42a2-887f-2650a761a144"
+    template = (
+        '<div>\n        \n                <script type="text/javascript">'
+        "window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n        "
+        '<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>    \n            '
+        '<div id="cd462b94-79ce-42a2-887f-2650a761a144" class="plotly-graph-div" '
+        'style="height:100%; width:100%;"></div>\n            <script type="text/javascript">'
+        "\n                \n                    window.PLOTLYENV=window.PLOTLYENV || {};"
+        '\n                    \n                if (document.getElementById("cd462b94-79ce-42a2-887f-2650a761a144"))'
+        " {\n                    Plotly.newPlot(\n                        'cd462b94-79ce-42a2-887f-2650a761a144',"
+        '\n                        [],\n                        {"template": {}},'
+        '\n                        {"responsive": true}\n                    )\n                };'
+        "\n                \n            </script>\n        </div>"
+    )
+    assert s.replace(id_figure, id_pattern) == template

--- a/packages/python/plotly/plotly/tests/test_io/test_renderers.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_renderers.py
@@ -344,3 +344,10 @@ def test_repr_mimebundle(renderer_str):
                 assert bundle[key].replace(id1, "") == ref_bundle[key].replace(id2, "")
     else:
         assert bundle == {}
+
+
+def test_repr_mimebundle_mixed_renderer(fig1):
+    pio.renderers.default = "notebook+plotly_mimetype"
+    assert set(fig1._repr_mimebundle_().keys()) == set(
+        {"application/vnd.plotly.v1+json", "text/html"}
+    )

--- a/packages/python/plotly/plotly/tests/test_io/test_renderers.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_renderers.py
@@ -324,7 +324,30 @@ def test_repr_html(renderer):
         assert str_html.replace(id_html, "") == template.replace(id_pattern, "")
 
 
-@pytest.mark.parametrize("renderer_str", pio.renderers)
+all_renderers_without_orca = [
+    "plotly_mimetype",
+    "jupyterlab",
+    "nteract",
+    "vscode",
+    "notebook",
+    "notebook_connected",
+    "kaggle",
+    "azure",
+    "colab",
+    "cocalc",
+    "databricks",
+    "json",
+    "browser",
+    "firefox",
+    "chrome",
+    "chromium",
+    "iframe",
+    "iframe_connected",
+    "sphinx_gallery",
+]
+
+
+@pytest.mark.parametrize("renderer_str", all_renderers_without_orca)
 def test_repr_mimebundle(renderer_str):
     pio.renderers.default = renderer_str
     fig = go.Figure()

--- a/packages/python/plotly/plotly/tests/test_orca/test_sg_scraper.py
+++ b/packages/python/plotly/plotly/tests/test_orca/test_sg_scraper.py
@@ -44,7 +44,7 @@ def test_scraper():
     from plotly.io._sg_scraper import plotly_sg_scraper
 
     # test that monkey-patching worked ok
-    assert plotly.io.renderers.default == "sphinx_gallery"
+    assert plotly.io.renderers.default == "sphinx_gallery_png"
     # Use dummy values for arguments of plotly_sg_scraper
     block = ""  # we don't need actually code
     import tempfile


### PR DESCRIPTION
This PR proposes to add a `_repr_html_` method to `go.Figure` and `go.FigureWidget`, which is a hook used by some notebook-like environments and other packages such as sphinx-gallery. For notebook environments using an ipython kernel, `_ipython_display_` has precedence over `_repr_html_`  (see https://ipython.readthedocs.io/en/stable/config/integrating.html) so this will not change anything.

When/if this PR is accepted I will submit a pull request to sphinx-gallery to show a plotly figure on their website (not possible at the moment) since they don't want to user scrapers in their configuration.

@jonmmease 