### PR TITLE
Fix "Advanced Hover Template" typo

### DIFF
--- a/doc/python/hover-text-and-formatting.md
+++ b/doc/python/hover-text-and-formatting.md
@@ -268,8 +268,8 @@ for continent_name, continent in continent_data.items():
         text=df_2007['continent'],
         hovertemplate=
         "<b>%{text}</b><br><br>" +
-        "GDP per Capita: %{y:$,.0f}<br>" +
-        "Life Expectation: %{x:.0%}<br>" +
+        "GDP per Capita: %{x:$,.0f}<br>" +
+        "Life Expectation: %{y:.0%}<br>" +
         "Population: %{marker.size:,}" +
         "<extra></extra>",
         marker_size=continent['size'],


### PR DESCRIPTION
Tiny typo fix: x and y were swapped ([rendered](https://plotly.com/python/hover-text-and-formatting/)):
![image](https://user-images.githubusercontent.com/2772505/80948454-68ea2980-8df2-11ea-80b8-295634335e1c.png)

