### PR TITLE
Don't disable validation when constructing FigureWidget's template.

### DIFF
--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -37,6 +37,7 @@ class BaseFigure(object):
     }
 
     _set_trace_uid = False
+    _allow_disable_validation = True
 
     # Constructor
     # -----------
@@ -1947,7 +1948,8 @@ Please use the add_trace method with the row and col parameters.
         if self._layout_obj._props.get("template", None) is None:
             if pio.templates.default is not None:
                 # Assume default template is already validated
-                self._layout_obj._validate = False
+                if self._allow_disable_validation:
+                    self._layout_obj._validate = False
                 try:
                     template_dict = pio.templates[pio.templates.default]
                     self._layout_obj.template = template_dict

--- a/packages/python/plotly/plotly/basewidget.py
+++ b/packages/python/plotly/plotly/basewidget.py
@@ -101,6 +101,7 @@ class BaseFigureWidget(BaseFigure, widgets.DOMWidget):
     _last_trace_edit_id = Integer(0).tag(sync=True)
 
     _set_trace_uid = True
+    _allow_disable_validation = False
 
     # Constructor
     # -----------


### PR DESCRIPTION
Closes https://github.com/plotly/plotly.py/issues/2437.

As things are structured right now, we need to run through all of the validation logic in order to generate the messages to send to the `FigureWidget` front-end.  This PR makes sure that we leave validation on when constructing a `FigureWidget`'s default template.
