### PR TITLE
Fix FigureWidget attribute error on wildcard import with ipywidgets not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.7.1] - ???
+
+### Fixed
+
+ - Fix `AttributeError: module 'plotly.graph_objs' has no attribute 'FigureWidget'` exception on `from plotly.graph_objs import *` when `ipywidgets` is not installed. Error also occurred when importing `plotly.figure_factor`. It is now possible to import `plotly.graph_objs.FigureWidget` when `ipywidgets` is not installed, and an informative `ImportError` exception will be raised in the `FigureWidget` constructor ([#2443](https://github.com/plotly/plotly.py/issues/2443), [#1111](https://github.com/plotly/plotly.py/issues/1111)).  
+
+
 ## [4.7.0] - 2020-05-06
 
 ### Updated

--- a/packages/python/plotly/codegen/__init__.py
+++ b/packages/python/plotly/codegen/__init__.py
@@ -269,14 +269,14 @@ def perform_codegen():
     optional_figure_widget_import = f"""
 if sys.version_info < (3, 7):
     try:
-        import ipywidgets
-        from distutils.version import LooseVersion
-        if LooseVersion(ipywidgets.__version__) >= LooseVersion('7.0.0'):
+        import ipywidgets as _ipywidgets
+        from distutils.version import LooseVersion as _LooseVersion
+        if _LooseVersion(_ipywidgets.__version__) >= _LooseVersion("7.0.0"):
             from ..graph_objs._figurewidget import FigureWidget
-        del LooseVersion
-        del ipywidgets
-    except ImportError:
-        pass
+        else:
+            raise ImportError()
+    except Exception:
+        from ..missing_ipywidgets import FigureWidget
 else:
     __all__.append("FigureWidget")
     orig_getattr = __getattr__
@@ -285,12 +285,17 @@ else:
             try:
                 import ipywidgets
                 from distutils.version import LooseVersion
-                if LooseVersion(ipywidgets.__version__) >= LooseVersion('7.0.0'):
+
+                if LooseVersion(ipywidgets.__version__) >= LooseVersion("7.0.0"):
                     from ..graph_objs._figurewidget import FigureWidget
+
                     return FigureWidget
-            except ImportError:
-                    pass
-        
+                else:
+                    raise ImportError()
+            except Exception:
+                from ..missing_ipywidgets import FigureWidget
+                return FigureWidget
+
         return orig_getattr(import_name)
 """
     # ### __all__ ###

--- a/packages/python/plotly/plotly/graph_objects/__init__.py
+++ b/packages/python/plotly/plotly/graph_objects/__init__.py
@@ -261,15 +261,15 @@ else:
 
 if sys.version_info < (3, 7):
     try:
-        import ipywidgets
-        from distutils.version import LooseVersion
+        import ipywidgets as _ipywidgets
+        from distutils.version import LooseVersion as _LooseVersion
 
-        if LooseVersion(ipywidgets.__version__) >= LooseVersion("7.0.0"):
+        if _LooseVersion(_ipywidgets.__version__) >= _LooseVersion("7.0.0"):
             from ..graph_objs._figurewidget import FigureWidget
-        del LooseVersion
-        del ipywidgets
-    except ImportError:
-        pass
+        else:
+            raise ImportError()
+    except Exception:
+        from ..missing_ipywidgets import FigureWidget
 else:
     __all__.append("FigureWidget")
     orig_getattr = __getattr__
@@ -284,7 +284,11 @@ else:
                     from ..graph_objs._figurewidget import FigureWidget
 
                     return FigureWidget
-            except ImportError:
-                pass
+                else:
+                    raise ImportError()
+            except Exception:
+                from ..missing_ipywidgets import FigureWidget
+
+                return FigureWidget
 
         return orig_getattr(import_name)

--- a/packages/python/plotly/plotly/graph_objs/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/__init__.py
@@ -261,15 +261,15 @@ else:
 
 if sys.version_info < (3, 7):
     try:
-        import ipywidgets
-        from distutils.version import LooseVersion
+        import ipywidgets as _ipywidgets
+        from distutils.version import LooseVersion as _LooseVersion
 
-        if LooseVersion(ipywidgets.__version__) >= LooseVersion("7.0.0"):
+        if _LooseVersion(_ipywidgets.__version__) >= _LooseVersion("7.0.0"):
             from ..graph_objs._figurewidget import FigureWidget
-        del LooseVersion
-        del ipywidgets
-    except ImportError:
-        pass
+        else:
+            raise ImportError()
+    except Exception:
+        from ..missing_ipywidgets import FigureWidget
 else:
     __all__.append("FigureWidget")
     orig_getattr = __getattr__
@@ -284,7 +284,11 @@ else:
                     from ..graph_objs._figurewidget import FigureWidget
 
                     return FigureWidget
-            except ImportError:
-                pass
+                else:
+                    raise ImportError()
+            except Exception:
+                from ..missing_ipywidgets import FigureWidget
+
+                return FigureWidget
 
         return orig_getattr(import_name)

--- a/packages/python/plotly/plotly/missing_ipywidgets.py
+++ b/packages/python/plotly/plotly/missing_ipywidgets.py
@@ -1,0 +1,15 @@
+from .basedatatypes import BaseFigure
+
+
+class FigureWidget(BaseFigure):
+    """
+    FigureWidget stand-in for use when ipywidgets is not installed. The only purpose
+    of this class is to provide something to import as
+    `plotly.graph_objs.FigureWidget` when ipywidgets is not installed. This class
+    simply raises an informative error message when the constructor is called
+    """
+
+    def __init__(self, *args, **kwargs):
+        raise ImportError(
+            "Please install ipywidgets>=7.0.0 to use the FigureWidget class"
+        )

--- a/packages/python/plotly/plotly/tests/test_core/test_figure_widget_backend/test_missing_ipywigets.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_figure_widget_backend/test_missing_ipywigets.py
@@ -1,0 +1,38 @@
+import pytest
+
+# Use wildcard import to make sure FigureWidget is always included
+from plotly.graph_objects import *
+from plotly.missing_ipywidgets import FigureWidget as FigureWidgetMissingIPywidgets
+
+try:
+    import ipywidgets as _ipywidgets
+    from distutils.version import LooseVersion as _LooseVersion
+
+    if _LooseVersion(_ipywidgets.__version__) >= _LooseVersion("7.0.0"):
+        missing_ipywidgets = False
+    else:
+        raise ImportError()
+except Exception:
+    missing_ipywidgets = True
+
+
+if missing_ipywidgets:
+
+    def test_import_figurewidget_without_ipywidgets():
+        assert FigureWidget is FigureWidgetMissingIPywidgets
+
+        with pytest.raises(ImportError):
+            # ipywidgets import error raised on construction, not import
+            FigureWidget()
+
+
+else:
+
+    def test_import_figurewidget_with_ipywidgets():
+        from plotly.graph_objs._figurewidget import (
+            FigureWidget as FigureWidgetWithIPywidgets,
+        )
+
+        assert FigureWidget is FigureWidgetWithIPywidgets
+        fig = FigureWidget()
+        assert isinstance(fig, FigureWidgetWithIPywidgets)

--- a/packages/python/plotly/plotly/tests/test_core/test_figure_widget_backend/test_validate_no_frames.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_figure_widget_backend/test_validate_no_frames.py
@@ -2,9 +2,15 @@ from unittest import TestCase
 import plotly.graph_objs as go
 import pytest
 
+try:
+    go.FigureWidget()
+    figure_widget_available = True
+except ImportError:
+    figure_widget_available = False
+
 
 class TestNoFrames(TestCase):
-    if "FigureWidget" in go.__dict__.keys():
+    if figure_widget_available:
 
         def test_no_frames_in_constructor_kwarg(self):
             with pytest.raises(ValueError):


### PR DESCRIPTION
Fixes the regression in 4.7.0 reported in https://github.com/plotly/plotly.py/issues/2443.  Also takes care of https://github.com/plotly/plotly.py/issues/1111 by producing a more informative error message.

The problem is that with Python 3.7+, we add `"FigureWidget"` to the `__all__` list in the `plotly.graph_objs`/`plotly.graph_objects` modules regardless of whether `ipywidgets` is installed.  But when `FigureWidget` is lazily imported, an exception is raised if a supported version of `ipywidgets` is not installed.  This results in the reported error when a user, or library, calls `from plotly.graph_objs import *`.

One option would be to check for the proper version of `ipywidgets` when `plotly.graph_objs` is imported and only add `FigureWidget` to `__all__` if it is found. But this results in a performance hit on every import of `plotly.graph_objs`, whether or not `FigureWidget` is used.

Another option would be to always allow `FigureWidget` to be imported, but raise an exception when a user tries to construct a `FigureWidget` if `ipywidgets` is not found.  Unfortunately, this isn't possible because `ipywidgets` is required in order to define the `FigureWidget` class itself so we can't import it without `ipywidgets`.

Instead, this PR introduces a new `plotly.missing_ipywidgets.FigureWidget` class. This class is a subclass of `BaseFigure` (just like the standard `Figure`), but all it does is raise an informative exception in the constructor informing the user that they need to install `ipywidgets` in order to use `FigureWidget`.  With this approach, `"FigureWidget"` is still always added to `__all__`, but on lazy import we check whether `ipywidgets` is installed. If it is, the current `plotly.graph_objs._figurewidget.FigureWidget` class is returned, otherwise the new `plotly.missing_ipywidgets.FigureWidget` class is returned.

Tests added in `plotly/tests/test_core/test_figure_widget_backend/test_missing_ipywigets.py`.

## Code PR
- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [x] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
