### PR TITLE
Fix TypeError: unhashable type: 'Template' during Figure construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
  - Fix `AttributeError: module 'plotly.graph_objs' has no attribute 'FigureWidget'` exception on `from plotly.graph_objs import *` when `ipywidgets` is not installed. Error also occurred when importing `plotly.figure_factor`. It is now possible to import `plotly.graph_objs.FigureWidget` when `ipywidgets` is not installed, and an informative `ImportError` exception will be raised in the `FigureWidget` constructor ([#2443](https://github.com/plotly/plotly.py/issues/2443), [#1111](https://github.com/plotly/plotly.py/issues/1111)).  
+ - Fix `TypeError: unhashable type: 'Template'` during `Figure` construction when `plotly.io.templates.default` is set to a `Template` object rather than a string.
 
 
 ## [4.7.0] - 2020-05-06

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -1951,8 +1951,14 @@ Please use the add_trace method with the row and col parameters.
                 if self._allow_disable_validation:
                     self._layout_obj._validate = False
                 try:
-                    template_dict = pio.templates[pio.templates.default]
-                    self._layout_obj.template = template_dict
+                    if isinstance(pio.templates.default, BasePlotlyType):
+                        # Template object. Don't want to actually import `Template`
+                        # here for performance so we check against `BasePlotlyType`
+                        template_object = pio.templates.default
+                    else:
+                        # Name of registered template object
+                        template_object = pio.templates[pio.templates.default]
+                    self._layout_obj.template = template_object
                 finally:
                     self._layout_obj._validate = self._validate
 

--- a/packages/python/plotly/plotly/tests/test_core/test_graph_objs/test_template.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_graph_objs/test_template.py
@@ -175,6 +175,12 @@ class TemplateTest(TestCase):
     def test_template_iter(self):
         self.assertIn("test_template", set(pio.templates))
 
+    def test_template_default_as_object(self):
+        template = go.layout.Template({"layout": {"font": {"family": "Rockwell"}}})
+        pio.templates.default = template
+        fig = go.Figure()
+        self.assertEqual(fig.layout.template, template)
+
 
 class TestToTemplated(TestCaseNoTemplate):
     def test_move_layout_nested_properties(self):


### PR DESCRIPTION
... when `plotly.io.templates.default` is set to a `Template` object rather than a string.

## Code PR
- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [x] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
