### PR TITLE
bug_2931: resolving numpy integer check and adding test

### DIFF
--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -1529,7 +1529,14 @@ Invalid property path '{key_path_str}' for trace class {trace_class}
             if len(vals) != n:
                 BaseFigure._raise_invalid_rows_cols(name=name, n=n, invalid=vals)
 
-            if [r for r in vals if not isinstance(r, int)]:
+            try:
+                import numpy as np
+
+                int_type = (int, np.integer)
+            except ImportError:
+                int_type = (int,)
+
+            if [r for r in vals if not isinstance(r, int_type)]:
                 BaseFigure._raise_invalid_rows_cols(name=name, n=n, invalid=vals)
         else:
             BaseFigure._raise_invalid_rows_cols(name=name, n=n, invalid=vals)

--- a/packages/python/plotly/plotly/tests/test_core/test_utils/test_utils.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_utils/test_utils.py
@@ -52,3 +52,21 @@ class TestNodeGenerator(TestCase):
         ]
         for i, item in enumerate(node_generator(node0)):
             self.assertEqual(item, expected_node_path_tuples[i])
+
+
+class TestNumpyIntegerBaseType(TestCase):
+    def test_numpy_integer_import(self):
+        # should generate a figure with subplots of array and not throw a ValueError
+        import numpy as np
+        import plotly.graph_objects as go
+        from plotly.subplots import make_subplots
+
+        indices_rows = np.array([1], dtype=np.int)
+        indices_cols = np.array([1], dtype=np.int)
+        fig = make_subplots(rows=1, cols=1)
+        fig.add_trace(go.Scatter(y=[1]), row=indices_rows[0], col=indices_cols[0])
+
+        data_path = ("data", 0, "y")
+        value = get_by_path(fig, data_path)
+        expected_value = (1,)
+        self.assertEqual(value, expected_value)


### PR DESCRIPTION
Thanks to @emmanuelle for directing where this fix would live and even some code to make it work!

I also looked for similar checks and found some in subplots.py, but by that time this check must have already passed since I'm using subplots in my unit test. 

Also considered if we should leverage what is in `packages\python\plotly\_plotly_utils\basevalidators.py` for coercion, but opted for this simple import try. Open to all feedback on how to improve this PR!


## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [x] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [x] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
