### PR TITLE
Fix markdown syntax, typo in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.7.1] - ???
+
+### Fixed
+
+ - Fix `AttributeError: module 'plotly.graph_objs' has no attribute 'FigureWidget'` exception on `from plotly.graph_objs import *` when `ipywidgets` is not installed. Error also occurred when importing `plotly.figure_factor`. It is now possible to import `plotly.graph_objs.FigureWidget` when `ipywidgets` is not installed, and an informative `ImportError` exception will be raised in the `FigureWidget` constructor ([#2443](https://github.com/plotly/plotly.py/issues/2443), [#1111](https://github.com/plotly/plotly.py/issues/1111)).  
+
+
 ## [4.7.0] - 2020-05-06
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [4.7.1] - ???
+## [4.7.1] - 2020-05-08
 
 ### Fixed
 
- - Fix `AttributeError: module 'plotly.graph_objs' has no attribute 'FigureWidget'` exception on `from plotly.graph_objs import *` when `ipywidgets` is not installed. Error also occurred when importing `plotly.figure_factor`. It is now possible to import `plotly.graph_objs.FigureWidget` when `ipywidgets` is not installed, and an informative `ImportError` exception will be raised in the `FigureWidget` constructor ([#2443](https://github.com/plotly/plotly.py/issues/2443), [#1111](https://github.com/plotly/plotly.py/issues/1111)).  
+ - Fix `AttributeError: module 'plotly.graph_objs' has no attribute 'FigureWidget'` exception on `from plotly.graph_objs import *` when `ipywidgets` is not installed. Error also occurred when importing `plotly.figure_factor`. It is now possible to import `plotly.graph_objs.FigureWidget` when `ipywidgets` is not installed, and an informative `ImportError` exception will be raised in the `FigureWidget` constructor ([#2443](https://github.com/plotly/plotly.py/issues/2443), [#1111](https://github.com/plotly/plotly.py/issues/1111)).
  - Fix `TypeError: unhashable type: 'Template'` during `Figure` construction when `plotly.io.templates.default` is set to a `Template` object rather than a string.
 
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 ## Quickstart
 
-`pip install plotly==4.7.0`
+`pip install plotly==4.7.1`
 
 Inside [Jupyter notebook](https://jupyter.org/install) (installable with `pip install "notebook>=5.3" "ipywidgets>=7.2"`):
 
@@ -82,13 +82,13 @@ Built on top of [plotly.js](https://github.com/plotly/plotly.js), `plotly.py` is
 plotly.py may be installed using pip...
 
 ```
-pip install plotly==4.7.0
+pip install plotly==4.7.1
 ```
 
 or conda.
 
 ```
-conda install -c plotly plotly=4.7.0
+conda install -c plotly plotly=4.7.1
 ```
 
 ### Jupyter Notebook Support
@@ -125,10 +125,10 @@ Then run the following commands to install the required JupyterLab extensions (n
 
 ```
 # Basic JupyterLab renderer support
-jupyter labextension install jupyterlab-plotly@4.7.0
+jupyter labextension install jupyterlab-plotly@4.7.1
 
 # OPTIONAL: Jupyter widgets extension for FigureWidget support
-jupyter labextension install @jupyter-widgets/jupyterlab-manager plotlywidget@4.7.0
+jupyter labextension install @jupyter-widgets/jupyterlab-manager plotlywidget@4.7.1
 ```
 
 Please check out our [Troubleshooting guide](https://plotly.com/python/troubleshooting/) if you run into any problems with JupyterLab.

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,5 +1,5 @@
 jupytext
-plotly==4.6.0
+plotly==4.7.0
 jupyter
 notebook
 pandas

--- a/doc/apidoc/conf.py
+++ b/doc/apidoc/conf.py
@@ -28,7 +28,7 @@ author = "plotly team"
 # The short X.Y version
 version = ""
 # The full version, including alpha/beta/rc tags
-release = "4.6.0"
+release = "4.7.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/python/creating-and-updating-figures.md
+++ b/doc/python/creating-and-updating-figures.md
@@ -613,20 +613,22 @@ There are also `for_each_xaxis()` and `for_each_yaxis()` methods that are analog
 ### Other Update Methods
 
 Figures created with the plotly.py graphing library also support:
-    - the `update_layout_images()` method in order to [update background layout images](/python/images/), 
-    - `update_annotations()` in order to [update annotations](/python/text-and-annotations/#multiple-annotations), 
-    - and `update-shapes()` in order to [update shapes](/python/shapes/).
+
+  - the `update_layout_images()` method in order to [update background layout images](/python/images/), 
+  - `update_annotations()` in order to [update annotations](/python/text-and-annotations/#multiple-annotations), 
+  - and `update_shapes()` in order to [update shapes](/python/shapes/).
 
 #### Chaining Figure Operations
 
 All of the figure update operations described above are methods that return a reference to the figure being modified. This makes it possible the chain multiple figure modification operations together into a single expression.
 
 Here is an example of a chained expression that creates:
-    - a faceted scatter plot with OLS trend lines using Plotly Express, 
-    - sets the title font size using `update_layout()`, 
-    - disables vertical grid lines using `update_xaxes()`, 
-    - updates the width and dash pattern of the trend lines using `update_traces()`, 
-    - and then displays the figure using `show()`.
+
+  - a faceted scatter plot with OLS trend lines using Plotly Express, 
+  - sets the title font size using `update_layout()`, 
+  - disables vertical grid lines using `update_xaxes()`, 
+  - updates the width and dash pattern of the trend lines using `update_traces()`, 
+  - and then displays the figure using `show()`.
 
 ```python
 import plotly.express as px

--- a/doc/python/getting-started.md
+++ b/doc/python/getting-started.md
@@ -49,13 +49,13 @@ Thanks to deep integration with the [orca](https://github.com/plotly/orca) image
 plotly.py may be installed using pip...
 
 ```
-$ pip install plotly==4.7.0
+$ pip install plotly==4.7.1
 ```
 
 or conda.
 
 ```
-$ conda install -c plotly plotly=4.7.0
+$ conda install -c plotly plotly=4.7.1
 ```
 
 This package contains everything you need to write figures to standalone HTML files.
@@ -135,10 +135,10 @@ Then run the following commands to install the required JupyterLab extensions (n
 
 ```
 # JupyterLab renderer support
-jupyter labextension install jupyterlab-plotly@4.7.0
+jupyter labextension install jupyterlab-plotly@4.7.1
 
 # OPTIONAL: Jupyter widgets extension
-jupyter labextension install @jupyter-widgets/jupyterlab-manager plotlywidget@4.7.0
+jupyter labextension install @jupyter-widgets/jupyterlab-manager plotlywidget@4.7.1
 ```
 
 These packages contain everything you need to run JupyterLab...

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-plotly==4.6.0
+plotly==4.7.0
 jupytext==1.1.1
 jupyter
 notebook

--- a/packages/javascript/jupyterlab-plotly/package-lock.json
+++ b/packages/javascript/jupyterlab-plotly/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-plotly",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/javascript/jupyterlab-plotly/package.json
+++ b/packages/javascript/jupyterlab-plotly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-plotly",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "The plotly JupyterLab extension",
   "author": "The plotly.py team",
   "license": "MIT",

--- a/packages/javascript/plotlywidget/package-lock.json
+++ b/packages/javascript/plotlywidget/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlywidget",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/javascript/plotlywidget/package.json
+++ b/packages/javascript/plotlywidget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plotlywidget",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "The plotly JupyterLab extension",
   "author": "The plotly.py team",
   "license": "MIT",

--- a/packages/python/plotly/codegen/__init__.py
+++ b/packages/python/plotly/codegen/__init__.py
@@ -269,14 +269,14 @@ def perform_codegen():
     optional_figure_widget_import = f"""
 if sys.version_info < (3, 7):
     try:
-        import ipywidgets
-        from distutils.version import LooseVersion
-        if LooseVersion(ipywidgets.__version__) >= LooseVersion('7.0.0'):
+        import ipywidgets as _ipywidgets
+        from distutils.version import LooseVersion as _LooseVersion
+        if _LooseVersion(_ipywidgets.__version__) >= _LooseVersion("7.0.0"):
             from ..graph_objs._figurewidget import FigureWidget
-        del LooseVersion
-        del ipywidgets
-    except ImportError:
-        pass
+        else:
+            raise ImportError()
+    except Exception:
+        from ..missing_ipywidgets import FigureWidget
 else:
     __all__.append("FigureWidget")
     orig_getattr = __getattr__
@@ -285,12 +285,17 @@ else:
             try:
                 import ipywidgets
                 from distutils.version import LooseVersion
-                if LooseVersion(ipywidgets.__version__) >= LooseVersion('7.0.0'):
+
+                if LooseVersion(ipywidgets.__version__) >= LooseVersion("7.0.0"):
                     from ..graph_objs._figurewidget import FigureWidget
+
                     return FigureWidget
-            except ImportError:
-                    pass
-        
+                else:
+                    raise ImportError()
+            except Exception:
+                from ..missing_ipywidgets import FigureWidget
+                return FigureWidget
+
         return orig_getattr(import_name)
 """
     # ### __all__ ###

--- a/packages/python/plotly/plotly/_widget_version.py
+++ b/packages/python/plotly/plotly/_widget_version.py
@@ -2,4 +2,4 @@
 # for automated dev builds
 #
 # It is edited by hand prior to official releases
-__frontend_version__ = "4.7.0"
+__frontend_version__ = "4.7.1"

--- a/packages/python/plotly/plotly/graph_objects/__init__.py
+++ b/packages/python/plotly/plotly/graph_objects/__init__.py
@@ -261,15 +261,15 @@ else:
 
 if sys.version_info < (3, 7):
     try:
-        import ipywidgets
-        from distutils.version import LooseVersion
+        import ipywidgets as _ipywidgets
+        from distutils.version import LooseVersion as _LooseVersion
 
-        if LooseVersion(ipywidgets.__version__) >= LooseVersion("7.0.0"):
+        if _LooseVersion(_ipywidgets.__version__) >= _LooseVersion("7.0.0"):
             from ..graph_objs._figurewidget import FigureWidget
-        del LooseVersion
-        del ipywidgets
-    except ImportError:
-        pass
+        else:
+            raise ImportError()
+    except Exception:
+        from ..missing_ipywidgets import FigureWidget
 else:
     __all__.append("FigureWidget")
     orig_getattr = __getattr__
@@ -284,7 +284,11 @@ else:
                     from ..graph_objs._figurewidget import FigureWidget
 
                     return FigureWidget
-            except ImportError:
-                pass
+                else:
+                    raise ImportError()
+            except Exception:
+                from ..missing_ipywidgets import FigureWidget
+
+                return FigureWidget
 
         return orig_getattr(import_name)

--- a/packages/python/plotly/plotly/graph_objs/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/__init__.py
@@ -261,15 +261,15 @@ else:
 
 if sys.version_info < (3, 7):
     try:
-        import ipywidgets
-        from distutils.version import LooseVersion
+        import ipywidgets as _ipywidgets
+        from distutils.version import LooseVersion as _LooseVersion
 
-        if LooseVersion(ipywidgets.__version__) >= LooseVersion("7.0.0"):
+        if _LooseVersion(_ipywidgets.__version__) >= _LooseVersion("7.0.0"):
             from ..graph_objs._figurewidget import FigureWidget
-        del LooseVersion
-        del ipywidgets
-    except ImportError:
-        pass
+        else:
+            raise ImportError()
+    except Exception:
+        from ..missing_ipywidgets import FigureWidget
 else:
     __all__.append("FigureWidget")
     orig_getattr = __getattr__
@@ -284,7 +284,11 @@ else:
                     from ..graph_objs._figurewidget import FigureWidget
 
                     return FigureWidget
-            except ImportError:
-                pass
+                else:
+                    raise ImportError()
+            except Exception:
+                from ..missing_ipywidgets import FigureWidget
+
+                return FigureWidget
 
         return orig_getattr(import_name)

--- a/packages/python/plotly/plotly/missing_ipywidgets.py
+++ b/packages/python/plotly/plotly/missing_ipywidgets.py
@@ -1,0 +1,15 @@
+from .basedatatypes import BaseFigure
+
+
+class FigureWidget(BaseFigure):
+    """
+    FigureWidget stand-in for use when ipywidgets is not installed. The only purpose
+    of this class is to provide something to import as
+    `plotly.graph_objs.FigureWidget` when ipywidgets is not installed. This class
+    simply raises an informative error message when the constructor is called
+    """
+
+    def __init__(self, *args, **kwargs):
+        raise ImportError(
+            "Please install ipywidgets>=7.0.0 to use the FigureWidget class"
+        )

--- a/packages/python/plotly/plotly/tests/test_core/test_figure_widget_backend/test_missing_ipywigets.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_figure_widget_backend/test_missing_ipywigets.py
@@ -1,0 +1,38 @@
+import pytest
+
+# Use wildcard import to make sure FigureWidget is always included
+from plotly.graph_objects import *
+from plotly.missing_ipywidgets import FigureWidget as FigureWidgetMissingIPywidgets
+
+try:
+    import ipywidgets as _ipywidgets
+    from distutils.version import LooseVersion as _LooseVersion
+
+    if _LooseVersion(_ipywidgets.__version__) >= _LooseVersion("7.0.0"):
+        missing_ipywidgets = False
+    else:
+        raise ImportError()
+except Exception:
+    missing_ipywidgets = True
+
+
+if missing_ipywidgets:
+
+    def test_import_figurewidget_without_ipywidgets():
+        assert FigureWidget is FigureWidgetMissingIPywidgets
+
+        with pytest.raises(ImportError):
+            # ipywidgets import error raised on construction, not import
+            FigureWidget()
+
+
+else:
+
+    def test_import_figurewidget_with_ipywidgets():
+        from plotly.graph_objs._figurewidget import (
+            FigureWidget as FigureWidgetWithIPywidgets,
+        )
+
+        assert FigureWidget is FigureWidgetWithIPywidgets
+        fig = FigureWidget()
+        assert isinstance(fig, FigureWidgetWithIPywidgets)

--- a/packages/python/plotly/plotly/tests/test_core/test_figure_widget_backend/test_validate_no_frames.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_figure_widget_backend/test_validate_no_frames.py
@@ -2,9 +2,15 @@ from unittest import TestCase
 import plotly.graph_objs as go
 import pytest
 
+try:
+    go.FigureWidget()
+    figure_widget_available = True
+except ImportError:
+    figure_widget_available = False
+
 
 class TestNoFrames(TestCase):
-    if "FigureWidget" in go.__dict__.keys():
+    if figure_widget_available:
 
         def test_no_frames_in_constructor_kwarg(self):
             with pytest.raises(ValueError):

--- a/packages/python/plotly/plotlywidget/static/index.js
+++ b/packages/python/plotly/plotlywidget/static/index.js
@@ -94,7 +94,7 @@ module.exports = g;
 /* 1 */
 /***/ (function(module, exports) {
 
-module.exports = {"name":"plotlywidget","version":"4.7.0","description":"The plotly JupyterLab extension","author":"The plotly.py team","license":"MIT","main":"src/index.js","repository":{"type":"git","url":"https://github.com/plotly/plotly.py"},"keywords":["jupyter","widgets","ipython","ipywidgets","plotly"],"files":["src/**/*.js","dist/*.js","style/*.*"],"scripts":{"build":"webpack","clean":"rimraf dist/ && rimraf  ../../python/plotly/plotlywidget/static'","test":"echo \"Error: no test specified\" && exit 1"},"devDependencies":{"webpack":"^3.10.0","rimraf":"^2.6.1","ify-loader":"^1.1.0","typescript":"~3.1.1"},"dependencies":{"plotly.js":"^1.54.1","@jupyter-widgets/base":"^2.0.0 || ^3.0.0","lodash":"^4.17.4"},"jupyterlab":{"extension":"src/jupyterlab-plugin.js"}}
+module.exports = {"name":"plotlywidget","version":"4.7.1","description":"The plotly JupyterLab extension","author":"The plotly.py team","license":"MIT","main":"src/index.js","repository":{"type":"git","url":"https://github.com/plotly/plotly.py"},"keywords":["jupyter","widgets","ipython","ipywidgets","plotly"],"files":["src/**/*.js","dist/*.js","style/*.*"],"scripts":{"build":"webpack","clean":"rimraf dist/ && rimraf  ../../python/plotly/plotlywidget/static'","test":"echo \"Error: no test specified\" && exit 1"},"devDependencies":{"webpack":"^3.10.0","rimraf":"^2.6.1","ify-loader":"^1.1.0","typescript":"~3.1.1"},"dependencies":{"plotly.js":"^1.54.1","@jupyter-widgets/base":"^2.0.0 || ^3.0.0","lodash":"^4.17.4"},"jupyterlab":{"extension":"src/jupyterlab-plugin.js"}}
 
 /***/ }),
 /* 2 */


### PR DESCRIPTION
Pretty simple fix.

[This list in the docs](https://plotly.com/python/creating-and-updating-figures/#other-update-methods) doesn't render properly. This commit fixes the markdown source, and for one other list just like it.

### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [x] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [x] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [x] Every new/modified example is independently runnable
- [x] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [x] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [x] The random seed is set if using randomly-generated data in new/modified examples
- [x] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [x] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [x] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [x] Data frames are always called `df`
- [x] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [x] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [x] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [x] `fig.show()` is at the end of each new/modified example
- [x] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [x] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)
