### PR TITLE
div formatting with `to_html()` + full_html=False

### DIFF
--- a/packages/python/plotly/plotly/io/_html.py
+++ b/packages/python/plotly/plotly/io/_html.py
@@ -230,14 +230,14 @@ def to_html(
     # Serialize config dict to JSON
     jconfig = json.dumps(config)
 
-    script = """
-                if (document.getElementById("{id}")) {{
-                    Plotly.newPlot(
-                        '{id}',
-                        {data},
-                        {layout},
-                        {config}
-                    ){then_addframes}{then_animate}{then_post_script}
+    script = """\
+                if (document.getElementById("{id}")) {{\
+                    Plotly.newPlot(\
+                        "{id}",\
+                        {data},\
+                        {layout},\
+                        {config}\
+                    ){then_addframes}{then_animate}{then_post_script}\
                 }}""".format(
         id=plotdivid,
         data=jdata,

--- a/packages/python/plotly/plotly/io/_html.py
+++ b/packages/python/plotly/plotly/io/_html.py
@@ -333,25 +333,24 @@ def to_html(
 Invalid value of type {typ} received as the include_mathjax argument
     Received value: {val}
 
-include_mathjax may be specified as False, 'cdn', or a string ending with '.js' 
+include_mathjax may be specified as False, 'cdn', or a string ending with '.js'
     """.format(
                 typ=type(include_mathjax), val=repr(include_mathjax)
             )
         )
 
     plotly_html_div = """\
-<div>
-        {mathjax_script}
-        {load_plotlyjs}
-            <div id="{id}" class="plotly-graph-div" \
-style="height:{height}; width:{width};"></div>
-            <script type="text/javascript">
-                {require_start}
-                    window.PLOTLYENV=window.PLOTLYENV || {{}};{base_url_line}
-                    {script};
-                {require_end}
-            </script>
-        </div>""".format(
+        <div>\
+            {mathjax_script}\
+            {load_plotlyjs}\
+                <div id="{id}" class="plotly-graph-div" \
+                    style="height:{height}; width:{width};">\
+                </div>\
+                <script type="text/javascript">\
+                    {require_start}window.PLOTLYENV=window.PLOTLYENV || {{}};{base_url_line}{script};{require_end}\
+                </script>\
+        </div>\
+        """.format(
         mathjax_script=mathjax_script,
         load_plotlyjs=load_plotlyjs,
         id=plotdivid,

--- a/packages/python/plotly/plotly/io/_html.py
+++ b/packages/python/plotly/plotly/io/_html.py
@@ -360,7 +360,7 @@ include_mathjax may be specified as False, 'cdn', or a string ending with '.js'
         require_start=require_start,
         script=script,
         require_end=require_end,
-    )
+    ).strip()
 
     if full_html:
         return """\


### PR DESCRIPTION
## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.

The inclusion of newlines "`\n`" as well as the plot `id` tag being referenced by single quotes
instead of double quotes results in the following output of a figure:

This has been resolved by ensuring now newline characters are included in the formatted string for
and `base_url_line` now encapsulates `plotly_platform_url` in double quotes.

This has been tested in a markdown setting:

*Before*:
![image](https://user-images.githubusercontent.com/8843728/81928852-dc9fe980-95dd-11ea-95c5-6f49c7e3f436.png)

*After*:
![image](https://user-images.githubusercontent.com/8843728/81928872-e1fd3400-95dd-11ea-9f17-6fd419702c37.png)


Fixes #2468 