### PR TITLE
Fixed command for installing ipywidgets using pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ For use in JupyterLab, install the `jupyterlab` and `ipywidgets`
 packages using pip...
 
 ```
-pip install jupyterlab "ipywidgets=7.5"
+pip install jupyterlab "ipywidgets==7.5"
 ```
 
 or conda.


### PR DESCRIPTION
There's a minor typo on the README for installing `ipywidgets` using `pip`, which I've fixed now.