### PR TITLE
order fixups

### DIFF
--- a/doc/python/click-events.md
+++ b/doc/python/click-events.md
@@ -27,7 +27,7 @@ jupyter:
     language: python
     layout: base
     name: Click Events
-    order: 24
+    order: 4
     page_type: example_index
     permalink: python/click-events/
     thumbnail: thumbnail/figurewidget-click-events.gif

--- a/doc/python/figurewidget-app.md
+++ b/doc/python/figurewidget-app.md
@@ -27,7 +27,7 @@ jupyter:
     language: python
     layout: base
     name: Interactive Data Analysis with FigureWidget ipywidgets
-    order: 23
+    order: 3
     page_type: example_index
     permalink: python/figurewidget-app/
     thumbnail: thumbnail/multi-widget.jpg

--- a/doc/python/figurewidget.md
+++ b/doc/python/figurewidget.md
@@ -27,7 +27,7 @@ jupyter:
     language: python
     layout: base
     name: Plotly FigureWidget Overview
-    order: 0
+    order: 1
     page_type: example_index
     permalink: python/figurewidget/
     thumbnail: thumbnail/figurewidget-overview.gif

--- a/doc/python/random-walk.md
+++ b/doc/python/random-walk.md
@@ -28,7 +28,7 @@ jupyter:
     language: python
     layout: base
     name: Random Walk
-    order: 10
+    order: 2
     page_type: example_index
     permalink: python/random-walk/
     thumbnail: /images/static-image

--- a/doc/python/smoothing.md
+++ b/doc/python/smoothing.md
@@ -28,7 +28,7 @@ jupyter:
     language: python
     layout: base
     name: Smoothing
-    order: 1
+    order: 4
     page_type: example_index
     permalink: python/smoothing/
     thumbnail: /images/static-image


### PR DESCRIPTION
The purpose of this PR is to fixup the order of examples in the `advanced_opt` and `chart_events` sections. 