### PR TITLE
remove dash app section from 3d scatter doc

### DIFF
--- a/doc/python/3d-scatter-plots.md
+++ b/doc/python/3d-scatter-plots.md
@@ -120,20 +120,6 @@ fig.update_layout(margin=dict(l=0, r=0, b=0, t=0))
 fig.show()
 ```
 
-### Dash App
-
-[Dash](https://plotly.com/products/dash/) is an Open Source Python library which can help you convert plotly figures into a reactive, web-based application. Below is a simple example of a dashboard created using Dash. Its [source code](https://github.com/plotly/simple-example-chart-apps/tree/master/dash-3dscatterplot) can easily be deployed to a PaaS.
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-3dscatterplot/", width="100%", height="950px",frameBorder="0")
-```
-
-```python
-from IPython.display import IFrame
-IFrame(src= "https://dash-simple-apps.plotly.host/dash-3dscatterplot/code", width="100%", height="500px",frameBorder="0")
-```
-
 #### Reference
 
 See https://plotly.com/python/reference/#scatter3d for more information and chart attribute options!


### PR DESCRIPTION
This section should have been removed as part of https://github.com/plotly/plotly.py/pull/2085. 

It's existence was brought up by https://community.plotly.com/t/part-of-plotlys-webpage-appears-to-be-broken/39976/4.

I have searched the rest of the documentation for similar occurrences of this- this is the only instance still in production. 

Screenshot:

![Screen Shot 2020-05-23 at 4 18 48 PM](https://user-images.githubusercontent.com/1557650/82739868-86375700-9d11-11ea-96db-58511128e478.png)
