### PR TITLE
bug_2410: Allowing Ints to be passed for rows/cols and refactored int…

### DIFF
--- a/packages/python/plotly/_plotly_utils/utils.py
+++ b/packages/python/plotly/_plotly_utils/utils.py
@@ -247,3 +247,12 @@ def _natural_sort_strings(vals, reverse=False):
         return tuple(v_parts)
 
     return sorted(vals, key=key, reverse=reverse)
+
+
+def _get_int_type():
+    np = get_module("numpy", should_load=False)
+    if np:
+        int_type = (int, np.integer)
+    else:
+        int_type = (int,)
+    return int_type

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -1676,7 +1676,7 @@ Invalid property path '{key_path_str}' for trace class {trace_class}
             List of subplot row indexes (starting from 1) for the traces to be
             added. Only valid if figure was created using
             `plotly.tools.make_subplots`
-            If a single integer is added, all traces will be added to row number
+            If a single integer is passed, all traces will be added to row number
 
         cols : None or list[int] (default None)
             List of subplot column indexes (starting from 1) for the traces

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -9,7 +9,7 @@ import warnings
 from contextlib import contextmanager
 from copy import deepcopy, copy
 
-from _plotly_utils.utils import _natural_sort_strings
+from _plotly_utils.utils import _natural_sort_strings, _get_int_type
 from .optional_imports import get_module
 
 # Create Undefined sentinel value
@@ -1560,12 +1560,7 @@ Invalid property path '{key_path_str}' for trace class {trace_class}
             if len(vals) != n:
                 BaseFigure._raise_invalid_rows_cols(name=name, n=n, invalid=vals)
 
-            try:
-                import numpy as np
-
-                int_type = (int, np.integer)
-            except ImportError:
-                int_type = (int,)
+            int_type = _get_int_type()
 
             if [r for r in vals if not isinstance(r, int_type)]:
                 BaseFigure._raise_invalid_rows_cols(name=name, n=n, invalid=vals)
@@ -1677,14 +1672,19 @@ Invalid property path '{key_path_str}' for trace class {trace_class}
                   - All remaining properties are passed to the constructor
                     of the specified trace type.
 
-        rows : None or list[int] (default None)
+        rows : None, list[int], or int (default None)
             List of subplot row indexes (starting from 1) for the traces to be
             added. Only valid if figure was created using
             `plotly.tools.make_subplots`
+            If a single integer is added, all traces will be added to row number
+
         cols : None or list[int] (default None)
             List of subplot column indexes (starting from 1) for the traces
             to be added. Only valid if figure was created using
             `plotly.tools.make_subplots`
+            If a single integer is added, all traces will be added to column number
+
+
         secondary_ys: None or list[boolean] (default None)
             List of secondary_y booleans for traces to be added. See the
             docstring for `add_trace` for more info.
@@ -1722,6 +1722,15 @@ Invalid property path '{key_path_str}' for trace class {trace_class}
         # Set trace indexes
         for ind, new_trace in enumerate(data):
             new_trace._trace_ind = ind + len(self.data)
+
+        # Allow integers as inputs to subplots
+        int_type = _get_int_type()
+
+        if isinstance(rows, int_type):
+            rows = [rows] * len(data)
+
+        if isinstance(cols, int_type):
+            cols = [cols] * len(data)
 
         # Validate rows / cols
         n = len(data)

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -1682,7 +1682,7 @@ Invalid property path '{key_path_str}' for trace class {trace_class}
             List of subplot column indexes (starting from 1) for the traces
             to be added. Only valid if figure was created using
             `plotly.tools.make_subplots`
-            If a single integer is added, all traces will be added to column number
+            If a single integer is passed, all traces will be added to column number
 
 
         secondary_ys: None or list[boolean] (default None)

--- a/packages/python/plotly/plotly/tests/test_core/test_figure_messages/test_add_traces.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_figure_messages/test_add_traces.py
@@ -63,3 +63,33 @@ class TestAddTracesMessage(TestCase):
                 {"type": "histogram2dcontour", "line": {"color": "cyan"}},
             ]
         )
+
+
+class TestAddTracesRowsColsDataTypes(TestCase):
+    def test_add_traces_with_iterable(self):
+        import plotly.express as px
+
+        df = px.data.tips()
+        fig = px.scatter(df, x="total_bill", y="tip", color="day")
+        from plotly.subplots import make_subplots
+
+        fig2 = make_subplots(1, 2)
+        fig2.add_traces(fig.data, rows=[1,] * len(fig.data), cols=[1,] * len(fig.data))
+
+        expected_data_length = 4
+
+        self.assertEqual(expected_data_length, len(fig2.data))
+
+    def test_add_traces_with_integers(self):
+        import plotly.express as px
+
+        df = px.data.tips()
+        fig = px.scatter(df, x="total_bill", y="tip", color="day")
+        from plotly.subplots import make_subplots
+
+        fig2 = make_subplots(1, 2)
+        fig2.add_traces(fig.data, rows=1, cols=2)
+
+        expected_data_length = 4
+
+        self.assertEqual(expected_data_length, len(fig2.data))

--- a/packages/python/plotly/plotly/tests/test_core/test_utils/test_utils.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_utils/test_utils.py
@@ -70,3 +70,28 @@ class TestNumpyIntegerBaseType(TestCase):
         value = get_by_path(fig, data_path)
         expected_value = (1,)
         self.assertEqual(value, expected_value)
+
+    def test_get_numpy_int_type(self):
+        import numpy as np
+        from _plotly_utils.utils import _get_int_type
+
+        int_type_tuple = _get_int_type()
+        expected_tuple = (int, np.integer)
+
+        self.assertEqual(int_type_tuple, expected_tuple)
+
+
+class TestNoNumpyIntegerBaseType(TestCase):
+    def test_no_numpy_int_type(self):
+        import sys
+        from _plotly_utils.utils import _get_int_type
+        from _plotly_utils.optional_imports import get_module
+
+        np = get_module("numpy", should_load=False)
+        if np:
+            sys.modules.pop("numpy")
+
+        int_type_tuple = _get_int_type()
+        expected_tuple = (int,)
+
+        self.assertEqual(int_type_tuple, expected_tuple)


### PR DESCRIPTION
## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [x] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [x] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.

**Changes in this PR:**

- Now allowing the "add_traces" method to take single integers for the rows/cols parameters.
- Also refactored the numpy integer check to be more reusable, and added more tests


Fixes #2410