### PR TITLE
Add `colorscale_range` to `create_gantt()` for custom gradient min/max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [4.8.2] - unreleased
 
+### Added
+
+- Added a new `colorscale_range` to `figure_factory.create_gantt` function to allow for custom gradient range sizes. ([Issue #1237](https://github.com/plotly/plotly.py/issues/1237))
+
 ### Fixed
 
+- Fixed various bugs dealing with colors in gantt figure_factory, specifically regarding gradient scale range errors. ([Issue #1237](https://github.com/plotly/plotly.py/issues/1237))
 - Fixed special cases with `px.sunburst` and `px.treemap` with `path` input ([#2524](https://github.com/plotly/plotly.py/pull/2524))
 - Fixed bug in `hover_data` argument of `px` functions, when the column name is changed with labels and `hover_data` is a dictionary setting up a specific format for the hover data ([#2544](https://github.com/plotly/plotly.py/pull/2544)).
 - Made the Plotly Express `trendline` argument more robust and made it work with datetime `x` values ([#2554](https://github.com/plotly/plotly.py/pull/2554))

--- a/doc/python/gantt.md
+++ b/doc/python/gantt.md
@@ -97,6 +97,22 @@ fig = ff.create_gantt(df, colors=colors, index_col='Resource', show_colorbar=Tru
 fig.show()
 ```
 
+#### Set a color scale gradient based on values
+
+```python
+import plotly.figure_factory as ff
+
+df = [dict(Task="Job A", Start='2016-01-01', Finish='2016-01-02', Resource='Apple', Complete=40),
+      dict(Task="Job B", Start='2016-01-02', Finish='2016-01-04', Resource='Grape', Complete=80),
+      dict(Task="Job C", Start='2016-01-02', Finish='2016-01-03', Resource='Banana', Complete=10)]
+
+# For gantt charts, colors must be rbg, hex, or "plotly scales" strings. CSS colors are not permitted.
+colors = ['rgb(5, 92, 98)', 'rgb(250, 5, 5)']
+
+fig = ff.create_gantt(df, colors=colors, index_col='Complete', show_colorbar=True, colorscale_range='auto')
+fig.show()
+```
+
 #### Use a Pandas Dataframe
 
 ```python


### PR DESCRIPTION
Also dealt with a few colour-related bugs in the gantt figure_factory file to minimize migration disruption to plotly 3/4. 

There are likely few who were getting this error as it required a fairly specific use of range scales in gantt charts, but for those of us who were getting that value error it was a game stopper and required holding plotly at version 2.7.0.  This should allow those users to easily upgrade to the newest versions. 

<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)
-->
## Code PR

- [X] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [X] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [X] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.


