### PR TITLE
Add `colorscale_range` to `create_gantt()` for custom gradient min/max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,20 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [4.8.2] - unreleased
 
+### Added
+
+- `colorscale_range` variable in `figure_factory.create_gantt` function allows for custom gradient range sizes. ([Issue #1237](https://github.com/plotly/plotly.py/issues/1237))
+
 ### Fixed
 
 - Fixed special cases with `px.sunburst` and `px.treemap` with `path` input ([#2524](https://github.com/plotly/plotly.py/pull/2524))
 - Fixed bug in `hover_data` argument of `px` functions, when the column name is changed with labels and `hover_data` is a dictionary setting up a specific format for the hover data ([#2544](https://github.com/plotly/plotly.py/pull/2544)).
 - Made the Plotly Express `trendline` argument more robust and made it work with datetime `x` values ([#2554](https://github.com/plotly/plotly.py/pull/2554))
-- Fixed bug in `px.sunburst` and `px.treemap`: when the `color` and `values`
-  arguments correspond to the same column, a different aggregation function has
-  to be used for the two arguments ([#2591](https://github.com/plotly/plotly.py/pull/2591))
+- Fixed bug in `px.sunburst` and `px.treemap`: when the `color` and `values` arguments correspond to the same column, a different aggregation function has to be used for the two arguments ([#2591](https://github.com/plotly/plotly.py/pull/2591))
 - Plotly Express wide mode now accepts mixed integer and float columns ([#2598](https://github.com/plotly/plotly.py/pull/2598))
 - Plotly Express `range_(x|y)` should not impact the unlinked range of marginal subplots ([#2600](https://github.com/plotly/plotly.py/pull/2600))
 - `px.line` now sets `line_group=<variable>` in wide mode by default ([#2599](https://github.com/plotly/plotly.py/pull/2599))
+- Fixed various bugs dealing with colors in gantt figure_factory, specifically regarding gradient scale range errors. ([Issue #1237](https://github.com/plotly/plotly.py/issues/1237))
 
 ## [4.8.1] - 2020-05-28
 

--- a/doc/python/gantt.md
+++ b/doc/python/gantt.md
@@ -43,90 +43,130 @@ Gantt charts can be made using a [figure factory](/python/figure-factories/) as 
 #### Simple Gantt Chart
 
 ```python
-import plotly.figure_factory as ff
+from plotly.figure_factory import create_gantt
 
-df = [dict(Task="Job A", Start='2009-01-01', Finish='2009-02-28'),
-      dict(Task="Job B", Start='2009-03-05', Finish='2009-04-15'),
-      dict(Task="Job C", Start='2009-02-20', Finish='2009-05-30')]
+data = [dict(Task="Job A", Start='2009-01-01', Finish='2009-02-28'),
+        dict(Task="Job B", Start='2009-03-05', Finish='2009-04-15'),
+        dict(Task="Job C", Start='2009-02-20', Finish='2009-05-30')]
 
-fig = ff.create_gantt(df)
+fig = create_gantt(data)
 fig.show()
 ```
 
 #### Index by Numeric Variable
 
 ```python
-import plotly.figure_factory as ff
+from plotly.figure_factory import create_gantt
 
-df = [dict(Task="Job A", Start='2009-01-01', Finish='2009-02-28', Complete=10),
-      dict(Task="Job B", Start='2008-12-05', Finish='2009-04-15', Complete=60),
-      dict(Task="Job C", Start='2009-02-20', Finish='2009-05-30', Complete=95)]
+data = [dict(Task="Job A", Start='2009-01-01', Finish='2009-02-28', Complete=10),
+        dict(Task="Job B", Start='2008-12-05', Finish='2009-04-15', Complete=60),
+        dict(Task="Job C", Start='2009-02-20', Finish='2009-05-30', Complete=95)]
 
-fig = ff.create_gantt(df, colors='Viridis', index_col='Complete', show_colorbar=True)
+fig = create_gantt(data, colors='Viridis', index_col='Complete', show_colorbar=True)
 fig.show()
 ```
 
 #### Index by String Variable
 
 ```python
-import plotly.figure_factory as ff
+from plotly.figure_factory import create_gantt
 
-df = [dict(Task="Job A", Start='2009-01-01', Finish='2009-02-01', Resource='Apple'),
-      dict(Task="Job B", Start='2009-03-05', Finish='2009-04-15', Resource='Grape'),
-      dict(Task="Job C", Start='2009-04-20', Finish='2009-09-30', Resource='Banana')]
+data = [dict(Task="Job A", Start='2009-01-01', Finish='2009-02-01', Resource='Apple'),
+        dict(Task="Job B", Start='2009-03-05', Finish='2009-04-15', Resource='Grape'),
+        dict(Task="Job C", Start='2009-04-20', Finish='2009-09-30', Resource='Banana')]
 
 colors = ['#7a0504', (0.2, 0.7, 0.3), 'rgb(210, 60, 180)']
 
-fig = ff.create_gantt(df, colors=colors, index_col='Resource', reverse_colors=True,
-                      show_colorbar=True)
+fig = create_gantt(data, colors=colors, index_col='Resource', reverse_colors=True, show_colorbar=True)
 fig.show()
 ```
 
 #### Use a Dictionary for Colors
 
 ```python
-import plotly.figure_factory as ff
+from plotly.figure_factory import create_gantt
 
-df = [dict(Task="Job A", Start='2016-01-01', Finish='2016-01-02', Resource='Apple'),
-      dict(Task="Job B", Start='2016-01-02', Finish='2016-01-04', Resource='Grape'),
-      dict(Task="Job C", Start='2016-01-02', Finish='2016-01-03', Resource='Banana')]
+data = [dict(Task="Job A", Start='2016-01-01', Finish='2016-01-02', Resource='Apple'),
+        dict(Task="Job B", Start='2016-01-02', Finish='2016-01-04', Resource='Grape'),
+        dict(Task="Job C", Start='2016-01-02', Finish='2016-01-03', Resource='Banana')]
 
 colors = dict(Apple='rgb(220, 0, 0)', Grape='rgb(170, 14, 200)', Banana=(1, 0.9, 0.16))
 
-fig = ff.create_gantt(df, colors=colors, index_col='Resource', show_colorbar=True)
+fig = create_gantt(data, colors=colors, index_col='Resource', show_colorbar=True)
+fig.show()
+```
+
+#### Automatically set a color scale gradient based on min/max `index_col` values
+
+The default colorscale_range is set to a minimum of 0 and a maximum of 100. 
+While this works well for task completion values which are usually reported in percentages, 
+it is less useful when plotting other arbitrary values or for data closely clustered together within a narrow band. 
+
+If you want plotly to evaluate your data, find the minimum and maximum values, and use those for the color gradient range, 
+set `colorscale_range` to `'auto'`.
+
+```python
+from plotly.figure_factory import create_gantt
+
+data = [dict(Task="Job A", Start='2016-01-01', Finish='2016-01-02', Resource='Apple', Complete=40),
+        dict(Task="Job B", Start='2016-01-02', Finish='2016-01-04', Resource='Grape', Complete=120),
+        dict(Task="Job C", Start='2016-01-02', Finish='2016-01-03', Resource='Banana', Complete=10)]
+
+# For gantt charts, colors must be rbg, hex, or "plotly scales" strings. CSS colors are not permitted.
+colors = ['rgb(5, 92, 98)', 'rgb(250, 5, 5)']
+
+fig = create_gantt(data, colors=colors, index_col='Complete', show_colorbar=True, colorscale_range='auto')
+fig.show()
+```
+
+#### Manually set a color scale gradient using custom values (tuple of min/max)
+
+If your data has outliers that skew your colors when `colorscale_range` is set to `'auto'`--or you otherwise wish to 
+manually define the gradient range--set `colorscale_range` to a min/max tuple of desired integers, i.e. `(9, 56)`
+
+```python
+from plotly.figure_factory import create_gantt
+
+data = [dict(Task="Job A", Start='2016-01-01', Finish='2016-01-02', Resource='Apple', Complete=40),
+        dict(Task="Job B", Start='2016-01-02', Finish='2016-01-04', Resource='Grape', Complete=120),
+        dict(Task="Job C", Start='2016-01-02', Finish='2016-01-03', Resource='Banana', Complete=10)]
+
+# For gantt charts, colors must be rbg, hex, or "plotly scales" strings. CSS colors are not permitted.
+colors = ['#7a0504', (0.2, 0.7, 0.3)]
+
+fig = create_gantt(data, colors=colors, index_col='Complete', show_colorbar=True, colorscale_range=(9, 111))
 fig.show()
 ```
 
 #### Use a Pandas Dataframe
 
 ```python
-import plotly.figure_factory as ff
-
+from plotly.figure_factory import create_gantt
 import pandas as pd
+
 df = pd.read_csv('https://raw.githubusercontent.com/plotly/datasets/master/gantt_example.csv')
 
-fig = ff.create_gantt(df, colors=['#333F44', '#93e4c1'], index_col='Complete',
-                      show_colorbar=True, bar_width=0.2, showgrid_x=True, showgrid_y=True)
+fig = create_gantt(df, colors=['#333F44', '#93e4c1'], index_col='Complete',
+                   show_colorbar=True, bar_width=0.2, showgrid_x=True, showgrid_y=True)
 fig.show()
 ```
 
 #### Using Hours and Minutes in Times
 
 ```python
-import plotly.figure_factory as ff
+from plotly.figure_factory import create_gantt
 
-df = [
-    dict(Task='Morning Sleep', Start='2016-01-01', Finish='2016-01-01 6:00:00', Resource='Sleep'),
-    dict(Task='Breakfast', Start='2016-01-01 7:00:00', Finish='2016-01-01 7:30:00', Resource='Food'),
-    dict(Task='Work', Start='2016-01-01 9:00:00', Finish='2016-01-01 11:25:00', Resource='Brain'),
-    dict(Task='Break', Start='2016-01-01 11:30:00', Finish='2016-01-01 12:00:00', Resource='Rest'),
-    dict(Task='Lunch', Start='2016-01-01 12:00:00', Finish='2016-01-01 13:00:00', Resource='Food'),
-    dict(Task='Work', Start='2016-01-01 13:00:00', Finish='2016-01-01 17:00:00', Resource='Brain'),
-    dict(Task='Exercise', Start='2016-01-01 17:30:00', Finish='2016-01-01 18:30:00', Resource='Cardio'),
-    dict(Task='Post Workout Rest', Start='2016-01-01 18:30:00', Finish='2016-01-01 19:00:00', Resource='Rest'),
-    dict(Task='Dinner', Start='2016-01-01 19:00:00', Finish='2016-01-01 20:00:00', Resource='Food'),
-    dict(Task='Evening Sleep', Start='2016-01-01 21:00:00', Finish='2016-01-01 23:59:00', Resource='Sleep')
-]
+data = [dict(Task='Morning Sleep', Start='2016-01-01', Finish='2016-01-01 6:00:00', Resource='Sleep'),
+        dict(Task='Breakfast', Start='2016-01-01 7:00:00', Finish='2016-01-01 7:30:00', Resource='Food'),
+        dict(Task='Work', Start='2016-01-01 9:00:00', Finish='2016-01-01 11:25:00', Resource='Brain'),
+        dict(Task='Break', Start='2016-01-01 11:30:00', Finish='2016-01-01 12:00:00', Resource='Rest'),
+        dict(Task='Lunch', Start='2016-01-01 12:00:00', Finish='2016-01-01 13:00:00', Resource='Food'),
+        dict(Task='Work', Start='2016-01-01 13:00:00', Finish='2016-01-01 17:00:00', Resource='Brain'),
+        dict(Task='Exercise', Start='2016-01-01 17:30:00', Finish='2016-01-01 18:30:00', Resource='Cardio'),
+        dict(Task='Post Workout Rest', Start='2016-01-01 18:30:00', Finish='2016-01-01 19:00:00', Resource='Rest'),
+        dict(Task='Dinner', Start='2016-01-01 19:00:00', Finish='2016-01-01 20:00:00', Resource='Food'),
+        dict(Task='Evening Sleep', Start='2016-01-01 21:00:00', Finish='2016-01-01 23:59:00', Resource='Sleep')
+        ]
 
 colors = dict(Cardio = 'rgb(46, 137, 205)',
               Food = 'rgb(114, 44, 121)',
@@ -134,15 +174,15 @@ colors = dict(Cardio = 'rgb(46, 137, 205)',
               Brain = 'rgb(58, 149, 136)',
               Rest = 'rgb(107, 127, 135)')
 
-fig = ff.create_gantt(df, colors=colors, index_col='Resource', title='Daily Schedule',
-                      show_colorbar=True, bar_width=0.8, showgrid_x=True, showgrid_y=True)
+fig = create_gantt(data, colors=colors, index_col='Resource', title='Daily Schedule',
+                   show_colorbar=True, bar_width=0.8, showgrid_x=True, showgrid_y=True)
 fig.show()
 ```
 
 #### Group Tasks Together
 
 ```python
-import plotly.figure_factory as ff
+from plotly.figure_factory import create_gantt
 
 df = [dict(Task="Job-1", Start='2017-01-01', Finish='2017-02-02', Resource='Complete'),
       dict(Task="Job-1", Start='2017-02-15', Finish='2017-03-15', Resource='Incomplete'),
@@ -157,12 +197,12 @@ colors = {'Not Started': 'rgb(220, 0, 0)',
           'Incomplete': (1, 0.9, 0.16),
           'Complete': 'rgb(0, 255, 100)'}
 
-fig = ff.create_gantt(df, colors=colors, index_col='Resource', show_colorbar=True,
-                      group_tasks=True)
+fig = create_gantt(df, colors=colors, index_col='Resource', show_colorbar=True,
+                   group_tasks=True)
 fig.show()
 ```
 
 #### Reference
 
 
-For more info on `ff.create_gantt()`, see the [full function reference](https://plotly.com/python-api-reference/generated/plotly.figure_factory.create_gantt.html)
+For more info on `create_gantt()`, see the [full function reference](https://plotly.com/python-api-reference/generated/plotly.figure_factory.create_gantt.html)

--- a/packages/python/plotly/plotly/figure_factory/_gantt.py
+++ b/packages/python/plotly/plotly/figure_factory/_gantt.py
@@ -265,6 +265,7 @@ def gantt_colorscale(
     showgrid_y,
     height,
     width,
+    colorscale_range="default",
     tasks=None,
     task_names=None,
     data=None,
@@ -280,6 +281,7 @@ def gantt_colorscale(
         task_names = []
     if data is None:
         data = []
+
     showlegend = False
 
     for index in range(len(chart)):
@@ -354,10 +356,52 @@ def gantt_colorscale(
         if group_tasks:
             task_names.reverse()
 
+        # Test for validity of colorscale_range tuple or compute range automatically.
+        # set default values and then test against submitted values.
+        c_min = 0
+        c_max = 100
+        if isinstance(colorscale_range, tuple):
+            if len(colorscale_range) != 2:
+                raise exceptions.PlotlyError(
+                    "colorscale_range must be a 2 item tuple of min/max values or a string. "
+                    f"There were {len(colorscale_range)} values in this tuple"
+                )
+            else:
+                for c_param in colorscale_range:
+                    if not isinstance(c_param, int) and not isinstance(c_param, float):
+                        raise exceptions.PlotlyError(
+                            "colorscale_range tuple values must be of type integer or float"
+                        )
+                c_min = colorscale_range[0]
+                c_max = colorscale_range[1]
+                if float(c_min) > float(c_max):
+                    raise exceptions.PlotlyError(
+                        "colorscale_range tuple values must be in order of (min, max). "
+                        f"Minimum value of {c_min} was larger than maximum value {c_max}."
+                    )
+                elif c_min < 0:
+                    raise exceptions.PlotlyError(
+                        f"colorscale_range minimum tuple value '{c_min}' is less than zero. "
+                        f"Negative numbers cannot be converted into a color."
+                    )
+        elif isinstance(colorscale_range, str):
+            # replicate previous functionality to avoid breaking changes
+            if colorscale_range == "default":
+                c_min = 0
+                c_max = 100
+            # generate null value to force automatic calculation
+            elif colorscale_range == "auto":
+                c_min = None
+                c_max = None
+            else:
+                raise exceptions.PlotlyError(
+                    f"Unrecognized colorscale_range string: '{colorscale_range}'. "
+                    "Acceptable string values for colorscale_range are 'default' or 'auto'."
+                )
+
         for index in range(len(tasks)):
             tn = tasks[index]["name"]
             del tasks[index]["name"]
-
             # If group_tasks is True, all tasks with the same name belong
             # to the same row.
             groupID = index
@@ -366,12 +410,46 @@ def gantt_colorscale(
             tasks[index]["y0"] = groupID - bar_width
             tasks[index]["y1"] = groupID + bar_width
 
+            # automatically derive complete value range for color scales to address issue #1237
+            if c_min is None:
+                c_min = min([c[index_col] for c in chart])
+            if c_max is None:
+                c_max = max([c[index_col] for c in chart])
+            if c_min < 0:
+                raise exceptions.PlotlyError(
+                    f"colorscale_range minimum value '{c_min}' is less than zero. "
+                    f"Negative numbers cannot be converted into a color. "
+                    f"If this results from 'auto' setting, set min/max manually, i.e. (0,100)."
+                )
+            # avoid division by zero
+            if c_max <= 0:
+                raise exceptions.PlotlyError(
+                    f"colorscale_range maximum value '{c_max}' less than or equal zero. "
+                    f"This value cannot be converted into a color range."
+                )
+
+            # _plotly_utils\colors requires an integer for calculating values
+            c_min = int(c_min)
+            c_max = int(c_max)
+
             # unlabel color
-            colors = clrs.color_parser(colors, clrs.unlabel_rgb)
+            try:
+                colors = clrs.color_parser(colors, clrs.unlabel_rgb)
+            except TypeError:
+                raise exceptions.PlotlyError(
+                    f"Error parsing color: '{c_min}'. Please note CSS color names are not supported. "
+                    f"Acceptable string color values for gantt charts are rgb, hex, and Plotly Scale labels."
+                )
             lowcolor = colors[0]
             highcolor = colors[1]
 
-            intermed = (chart[index][index_col]) / 100.0
+            # clrs.find_intermediate_color fails if 'intermed' is greater than 1. This allows colorscales to have
+            # a maximum scale value lower than the maximum data value to avoid distortion by outliers.
+            col_numerator = chart[index][index_col]
+            if col_numerator > c_max:
+                c_max = col_numerator
+
+            intermed = col_numerator / c_max
             intermed_color = clrs.find_intermediate_color(lowcolor, highcolor, intermed)
             intermed_color = clrs.color_parser(intermed_color, clrs.label_rgb)
             tasks[index]["fillcolor"] = intermed_color
@@ -431,8 +509,8 @@ def gantt_colorscale(
                 dict(
                     colorscale=[[0, colors[0]], [1, colors[1]]],
                     showscale=True,
-                    cmax=100,
-                    cmin=0,
+                    cmax=c_max,
+                    cmin=c_min,
                 )
             )
 
@@ -812,6 +890,7 @@ def create_gantt(
     showgrid_y=False,
     height=600,
     width=None,
+    colorscale_range="default",
     tasks=None,
     task_names=None,
     data=None,
@@ -849,18 +928,21 @@ def create_gantt(
     :param (bool) showgrid_y: show/hide the y-axis grid
     :param (float) height: the height of the chart
     :param (float) width: the width of the chart
+    :param (tuple|str) colorscale_range: string or tuple of min/max range values for colorscale.
+        'default' is the traditional setting (0, 100), and 'auto' will compute min/max from data.
+         Manually set min/max to custom values if outliers are distorting 'auto' scaling.
 
     Example 1: Simple Gantt Chart
 
     >>> from plotly.figure_factory import create_gantt
 
     >>> # Make data for chart
-    >>> df = [dict(Task="Job A", Start='2009-01-01', Finish='2009-02-30'),
-    ...       dict(Task="Job B", Start='2009-03-05', Finish='2009-04-15'),
-    ...       dict(Task="Job C", Start='2009-02-20', Finish='2009-05-30')]
+    >>> data = [dict(Task="Job A", Start='2009-01-01', Finish='2009-02-30'),
+    ...         dict(Task="Job B", Start='2009-03-05', Finish='2009-04-15'),
+    ...         dict(Task="Job C", Start='2009-02-20', Finish='2009-05-30')]
 
     >>> # Create a figure
-    >>> fig = create_gantt(df)
+    >>> fig = create_gantt(data)
     >>> fig.show()
 
 
@@ -869,15 +951,15 @@ def create_gantt(
     >>> from plotly.figure_factory import create_gantt
 
     >>> # Make data for chart
-    >>> df = [dict(Task="Job A", Start='2009-01-01',
-    ...            Finish='2009-02-30', Complete=10),
-    ...       dict(Task="Job B", Start='2009-03-05',
-    ...            Finish='2009-04-15', Complete=60),
-    ...       dict(Task="Job C", Start='2009-02-20',
-    ...            Finish='2009-05-30', Complete=95)]
+    >>> data = [dict(Task="Job A", Start='2009-01-01',
+    ...              Finish='2009-02-30', Complete=10),
+    ...         dict(Task="Job B", Start='2009-03-05',
+    ...              Finish='2009-04-15', Complete=60),
+    ...         dict(Task="Job C", Start='2009-02-20',
+    ...              Finish='2009-05-30', Complete=95)]
 
     >>> # Create a figure with Plotly colorscale
-    >>> fig = create_gantt(df, colors='Blues', index_col='Complete',
+    >>> fig = create_gantt(data, colors='Blues', index_col='Complete',
     ...                    show_colorbar=True, bar_width=0.5,
     ...                    showgrid_x=True, showgrid_y=True)
     >>> fig.show()
@@ -888,15 +970,15 @@ def create_gantt(
     >>> from plotly.figure_factory import create_gantt
 
     >>> # Make data for chart
-    >>> df = [dict(Task="Job A", Start='2009-01-01',
-    ...            Finish='2009-02-30', Resource='Apple'),
-    ...       dict(Task="Job B", Start='2009-03-05',
-    ...            Finish='2009-04-15', Resource='Grape'),
-    ...       dict(Task="Job C", Start='2009-02-20',
-    ...            Finish='2009-05-30', Resource='Banana')]
+    >>> data = [dict(Task="Job A", Start='2009-01-01',
+    ...              Finish='2009-02-30', Resource='Apple'),
+    ...         dict(Task="Job B", Start='2009-03-05',
+    ...              Finish='2009-04-15', Resource='Grape'),
+    ...         dict(Task="Job C", Start='2009-02-20',
+    ...              Finish='2009-05-30', Resource='Banana')]
 
     >>> # Create a figure with Plotly colorscale
-    >>> fig = create_gantt(df, colors=['rgb(200, 50, 25)', (1, 0, 1), '#6c4774'],
+    >>> fig = create_gantt(data, colors=['rgb(200, 50, 25)', (1, 0, 1), '#6c4774'],
     ...                    index_col='Resource', reverse_colors=True,
     ...                    show_colorbar=True)
     >>> fig.show()
@@ -906,12 +988,12 @@ def create_gantt(
 
     >>> from plotly.figure_factory import create_gantt
     >>> # Make data for chart
-    >>> df = [dict(Task="Job A", Start='2009-01-01',
-    ...            Finish='2009-02-30', Resource='Apple'),
-    ...       dict(Task="Job B", Start='2009-03-05',
-    ...            Finish='2009-04-15', Resource='Grape'),
-    ...       dict(Task="Job C", Start='2009-02-20',
-    ...            Finish='2009-05-30', Resource='Banana')]
+    >>> data = [dict(Task="Job A", Start='2009-01-01',
+    ...              Finish='2009-02-30', Resource='Apple'),
+    ...         dict(Task="Job B", Start='2009-03-05',
+    ...              Finish='2009-04-15', Resource='Grape'),
+    ...         dict(Task="Job C", Start='2009-02-20',
+    ...              Finish='2009-05-30', Resource='Banana')]
 
     >>> # Make a dictionary of colors
     >>> colors = {'Apple': 'rgb(255, 0, 0)',
@@ -924,7 +1006,23 @@ def create_gantt(
 
     >>> fig.show()
 
-    Example 5: Use a pandas dataframe
+
+    Example 5: Manually set a colorscale gradient value range
+
+    >>> from plotly.figure_factory import create_gantt
+
+    >>> data = [dict(Task="Job A", Start='2016-01-01', Finish='2016-01-02', Resource='Apple', Complete=40),
+    >>>         dict(Task="Job B", Start='2016-01-02', Finish='2016-01-04', Resource='Grape', Complete=80),
+    >>>         dict(Task="Job C", Start='2016-01-02', Finish='2016-01-03', Resource='Banana', Complete=10)]
+
+    >>> # For gantt charts, colors must be rbg, hex, or "plotly scales" strings. CSS colors are not permitted.
+    >>> colors = ['rgb(5, 92, 98)', 'rgb(250, 5, 5)']
+
+    >>> fig = create_gantt(data, colors=colors, index_col='Complete', show_colorbar=True, colorscale_range=(9, 56))
+    >>> fig.show()
+
+
+    Example 6: Use a pandas dataframe
 
     >>> from plotly.figure_factory import create_gantt
     >>> import pandas as pd
@@ -963,7 +1061,14 @@ def create_gantt(
     if isinstance(colors, dict):
         colors = clrs.validate_colors_dict(colors, "rgb")
     else:
-        colors = clrs.validate_colors(colors, "rgb")
+        # added more descriptive failure message when users input CSS color names.
+        try:
+            colors = clrs.validate_colors(colors, "rgb")
+        except TypeError:
+            raise exceptions.PlotlyError(
+                f"Error parsing colors: {colors}. Please note CSS color names are not supported. "
+                f"Acceptable string color values for gantt charts are rgb, hex, and Plotly Scale labels."
+            )
 
     if reverse_colors is True:
         colors.reverse()
@@ -1005,6 +1110,7 @@ def create_gantt(
                 showgrid_y,
                 height,
                 width,
+                colorscale_range,
                 tasks=None,
                 task_names=None,
                 data=None,

--- a/packages/python/plotly/plotly/tests/test_optional/test_figure_factory/test_figure_factory.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_figure_factory/test_figure_factory.py
@@ -20,7 +20,6 @@ sk_measure = optional_imports.get_module("skimage")
 
 class TestDistplot(NumpyTestUtilsMixin, TestCaseNoTemplate):
     def test_wrong_curve_type(self):
-
         # check: PlotlyError (and specific message) is raised if curve_type is
         # not 'kde' or 'normal'
 
@@ -37,7 +36,6 @@ class TestDistplot(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
     def test_wrong_histdata_format(self):
-
         # check: PlotlyError if hist_data is not a list of lists or list of
         # np.ndarrays (if hist_data is entered as just a list the function
         # will fail)
@@ -53,7 +51,6 @@ class TestDistplot(NumpyTestUtilsMixin, TestCaseNoTemplate):
         self.assertRaises(PlotlyError, ff.create_distplot, **kwargs)
 
     def test_simple_distplot_prob_density(self):
-
         # we should be able to create a single distplot with a simple dataset
         # and default kwargs
 
@@ -107,7 +104,6 @@ class TestDistplot(NumpyTestUtilsMixin, TestCaseNoTemplate):
         self.assert_fig_equal(dp["data"][2], expected_dp_data_rug)
 
     def test_simple_distplot_prob(self):
-
         # we should be able to create a single distplot with a simple dataset
         # and default kwargs
 
@@ -159,7 +155,6 @@ class TestDistplot(NumpyTestUtilsMixin, TestCaseNoTemplate):
         self.assert_fig_equal(dp["data"][2], expected_dp_data_rug)
 
     def test_distplot_more_args_prob_dens(self):
-
         # we should be able to create a distplot with 2 datasets no
         # rugplot, defined bin_size, and added title
 
@@ -283,7 +278,6 @@ class TestDistplot(NumpyTestUtilsMixin, TestCaseNoTemplate):
         self.assert_fig_equal(dp["data"][1], expected_dp_data_hist_2)
 
     def test_distplot_more_args_prob(self):
-
         # we should be able to create a distplot with 2 datasets no
         # rugplot, defined bin_size, and added title
 
@@ -627,7 +621,6 @@ class TestDistplot(NumpyTestUtilsMixin, TestCaseNoTemplate):
 
 class TestStreamline(TestCaseNoTemplate):
     def test_wrong_arrow_scale(self):
-
         # check for ValueError if arrow_scale is <= 0
 
         kwargs = {
@@ -640,7 +633,6 @@ class TestStreamline(TestCaseNoTemplate):
         self.assertRaises(ValueError, ff.create_streamline, **kwargs)
 
     def test_wrong_density(self):
-
         # check for ValueError if density is <= 0
 
         kwargs = {
@@ -653,7 +645,6 @@ class TestStreamline(TestCaseNoTemplate):
         self.assertRaises(ValueError, ff.create_streamline, **kwargs)
 
     def test_uneven_x(self):
-
         # check for PlotlyError if x is not evenly spaced
 
         kwargs = {
@@ -665,7 +656,6 @@ class TestStreamline(TestCaseNoTemplate):
         self.assertRaises(PlotlyError, ff.create_streamline, **kwargs)
 
     def test_uneven_y(self):
-
         # check for PlotlyError if y is not evenly spaced
 
         kwargs = {
@@ -677,7 +667,6 @@ class TestStreamline(TestCaseNoTemplate):
         self.assertRaises(PlotlyError, ff.create_streamline, **kwargs)
 
     def test_unequal_length_xy(self):
-
         # check for PlotlyError if u and v are not the same length
 
         kwargs = {
@@ -689,7 +678,6 @@ class TestStreamline(TestCaseNoTemplate):
         self.assertRaises(PlotlyError, ff.create_streamline, **kwargs)
 
     def test_unequal_length_uv(self):
-
         # check for PlotlyError if u and v are not the same length
 
         kwargs = {
@@ -701,7 +689,6 @@ class TestStreamline(TestCaseNoTemplate):
         self.assertRaises(PlotlyError, ff.create_streamline, **kwargs)
 
     def test_simple_streamline(self):
-
         # Need np to check streamline data,
         # this checks that the first 101 x and y values from streamline are
         # what we expect for a simple streamline where:
@@ -1267,7 +1254,6 @@ class TestDendrogram(NumpyTestUtilsMixin, TestCaseNoTemplate):
 
 class TestTrisurf(NumpyTestUtilsMixin, TestCaseNoTemplate):
     def test_vmin_and_vmax(self):
-
         # check if vmin is greater than or equal to vmax
         u = np.linspace(0, 2, 2)
         v = np.linspace(0, 2, 2)
@@ -1293,7 +1279,6 @@ class TestTrisurf(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
     def test_valid_colormap(self):
-
         # create data for trisurf plot
         u = np.linspace(-np.pi, np.pi, 3)
         v = np.linspace(-np.pi, np.pi, 3)
@@ -1355,7 +1340,6 @@ class TestTrisurf(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
     def test_trisurf_all_args(self):
-
         # check if trisurf plot matches with expected output
         u = np.linspace(-1, 1, 3)
         v = np.linspace(-1, 1, 3)
@@ -1606,7 +1590,6 @@ class TestTrisurf(NumpyTestUtilsMixin, TestCaseNoTemplate):
 
 class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
     def test_dataframe_input(self):
-
         # check: dataframe is imported
         df = "foo"
 
@@ -1618,7 +1601,6 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
         self.assertRaisesRegexp(PlotlyError, pattern, ff.create_scatterplotmatrix, df)
 
     def test_one_column_dataframe(self):
-
         # check: dataframe has 1 column or less
         df = pd.DataFrame([1, 2, 3])
 
@@ -1630,14 +1612,12 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
         self.assertRaisesRegexp(PlotlyError, pattern, ff.create_scatterplotmatrix, df)
 
     def test_valid_diag_choice(self):
-
         # make sure that the diagonal param is valid
         df = pd.DataFrame([[1, 2, 3], [4, 5, 6]])
 
         self.assertRaises(PlotlyError, ff.create_scatterplotmatrix, df, diag="foo")
 
     def test_forbidden_params(self):
-
         # check: the forbidden params of 'marker' in **kwargs
         df = pd.DataFrame([[1, 2, 3], [4, 5, 6]])
 
@@ -1655,7 +1635,6 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
     def test_valid_index_choice(self):
-
         # check: index is a column name
         df = pd.DataFrame([[1, 2], [3, 4]], columns=["apple", "pear"])
 
@@ -1669,7 +1648,6 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
     def test_same_data_in_dataframe_columns(self):
-
         # check: either all numbers or strings in each dataframe column
         df = pd.DataFrame([["a", 2], [3, 4]])
 
@@ -1685,7 +1663,6 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
         self.assertRaisesRegexp(PlotlyError, pattern, ff.create_scatterplotmatrix, df)
 
     def test_same_data_in_index(self):
-
         # check: either all numbers or strings in index column
         df = pd.DataFrame([["a", 2], [3, 4]], columns=["apple", "pear"])
 
@@ -1705,7 +1682,6 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
     def test_valid_colormap(self):
-
         # check: the colormap argument is in a valid form
         df = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]], columns=["a", "b", "c"])
 
@@ -1765,7 +1741,6 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
     def test_valid_endpts(self):
-
         # check: the endpts is a list or a tuple
         df = pd.DataFrame([[1, 2, 3], [4, 5, 6], [7, 8, 9]], columns=["a", "b", "c"])
 
@@ -1807,7 +1782,6 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
     def test_dictionary_colormap(self):
-
         # if colormap is a dictionary, make sure it all the values in the
         # index column are keys in colormap
         df = pd.DataFrame(
@@ -1830,7 +1804,6 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
     def test_scatter_plot_matrix(self):
-
         # check if test scatter plot matrix without index or theme matches
         # with the expected output
         df = pd.DataFrame(
@@ -1942,7 +1915,6 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
     def test_scatter_plot_matrix_kwargs(self):
-
         # check if test scatter plot matrix matches with
         # the expected output
         df = pd.DataFrame(
@@ -2027,6 +1999,202 @@ class TestGantt(NumpyTestUtilsMixin, TestCaseNoTemplate):
         # validate dataframe has correct column names
         df1 = pd.DataFrame([[2, "Apple"]], columns=["Numbers", "Fruit"])
         self.assertRaises(PlotlyError, ff.create_gantt, df1)
+
+    # Example 1 functionality covered by later tests
+    # Example 3 functionality covered by Example 5
+    # Example 4 functionality covered by Example 8
+    # Example 6 functionality covered by Example 7
+
+    def test_doc_example_2(self):
+        # evaluate if documentation example #2 still works
+        # also tests use of plotly color scale label
+
+        exp2 = [
+            dict(Task="Job A", Start="2009-01-01", Finish="2009-02-28", Complete=10),
+            dict(Task="Job B", Start="2008-12-05", Finish="2009-04-15", Complete=60),
+            dict(Task="Job C", Start="2009-02-20", Finish="2009-05-30", Complete=95),
+        ]
+        with self.assertRaises(Exception):
+            try:
+                ff.create_gantt(
+                    exp2, colors="Viridis", index_col="Complete", show_colorbar=True
+                )
+            except PlotlyError:
+                pass
+            else:
+                raise Exception
+
+    def test_doc_example_5(self):
+        # evaluate if documentation example #5 still works
+        # tests colorscale_range use of 'auto' string
+        exp5 = [
+            dict(
+                Task="Job A",
+                Start="2016-01-01",
+                Finish="2016-01-02",
+                Resource="Apple",
+                Complete=40,
+            ),
+            dict(
+                Task="Job B",
+                Start="2016-01-02",
+                Finish="2016-01-04",
+                Resource="Grape",
+                Complete=120,
+            ),
+            dict(
+                Task="Job C",
+                Start="2016-01-02",
+                Finish="2016-01-03",
+                Resource="Banana",
+                Complete=10,
+            ),
+        ]
+        colors = ["rgb(5, 92, 98)", "rgb(250, 5, 5)"]
+        with self.assertRaises(Exception):
+            try:
+                ff.create_gantt(
+                    exp5,
+                    colors=colors,
+                    index_col="Complete",
+                    reverse_colors=True,
+                    show_colorbar=True,
+                    colorscale_range="auto",
+                )
+            except PlotlyError:
+                pass
+            else:
+                raise Exception
+
+    def test_doc_example_6(self):
+        # evaluate if documentation example #6 still works
+        # test colorscale_range use of integer tuple
+        exp6 = [
+            dict(
+                Task="Job A",
+                Start="2016-01-01",
+                Finish="2016-01-02",
+                Resource="Apple",
+                Complete=40,
+            ),
+            dict(
+                Task="Job B",
+                Start="2016-01-02",
+                Finish="2016-01-04",
+                Resource="Grape",
+                Complete=120,
+            ),
+            dict(
+                Task="Job C",
+                Start="2016-01-02",
+                Finish="2016-01-03",
+                Resource="Banana",
+                Complete=10,
+            ),
+        ]
+        colors = ["#7a0504", (0.2, 0.7, 0.3)]
+        with self.assertRaises(Exception):
+            try:
+                ff.create_gantt(
+                    exp6,
+                    colors=colors,
+                    index_col="Complete",
+                    show_colorbar=True,
+                    colorscale_range=(9, 111),
+                )
+            except PlotlyError:
+                pass
+            else:
+                raise Exception
+
+    def test_doc_example_8(self):
+        # example #7 is covered by dataframe_all_args test below. Evaluate if documentation example #8 still works
+        exp8 = [
+            dict(
+                Task="Morning Sleep",
+                Start="2016-01-01",
+                Finish="2016-01-01 6:00:00",
+                Resource="Sleep",
+            ),
+            dict(
+                Task="Breakfast",
+                Start="2016-01-01 7:00:00",
+                Finish="2016-01-01 7:30:00",
+                Resource="Food",
+            ),
+            dict(
+                Task="Work",
+                Start="2016-01-01 9:00:00",
+                Finish="2016-01-01 11:25:00",
+                Resource="Brain",
+            ),
+            dict(
+                Task="Break",
+                Start="2016-01-01 11:30:00",
+                Finish="2016-01-01 12:00:00",
+                Resource="Rest",
+            ),
+            dict(
+                Task="Lunch",
+                Start="2016-01-01 12:00:00",
+                Finish="2016-01-01 13:00:00",
+                Resource="Food",
+            ),
+            dict(
+                Task="Work",
+                Start="2016-01-01 13:00:00",
+                Finish="2016-01-01 17:00:00",
+                Resource="Brain",
+            ),
+            dict(
+                Task="Exercise",
+                Start="2016-01-01 17:30:00",
+                Finish="2016-01-01 18:30:00",
+                Resource="Cardio",
+            ),
+            dict(
+                Task="Post Workout Rest",
+                Start="2016-01-01 18:30:00",
+                Finish="2016-01-01 19:00:00",
+                Resource="Rest",
+            ),
+            dict(
+                Task="Dinner",
+                Start="2016-01-01 19:00:00",
+                Finish="2016-01-01 20:00:00",
+                Resource="Food",
+            ),
+            dict(
+                Task="Evening Sleep",
+                Start="2016-01-01 21:00:00",
+                Finish="2016-01-01 23:59:00",
+                Resource="Sleep",
+            ),
+        ]
+        colors = dict(
+            Cardio="rgb(46, 137, 205)",
+            Food="Viridis",
+            Sleep=(0.2, 0.7, 0.3),
+            Brain="#7a0504",
+            Rest="rgb(107, 127, 135)",
+        )
+        with self.assertRaises(Exception):
+            try:
+                ff.create_gantt(
+                    exp8,
+                    colors=colors,
+                    index_col="Resource",
+                    title="Daily Schedule",
+                    reverse_colors=True,
+                    show_colorbar=True,
+                    bar_width=0.8,
+                    showgrid_x=True,
+                    showgrid_y=True,
+                )
+            except PlotlyError:
+                pass
+            else:
+                raise Exception
 
     def test_df_dataframe_all_args(self):
 
@@ -2154,14 +2322,14 @@ class TestGantt(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
         self.assert_fig_equal(test_gantt_chart["data"][1], exp_gantt_chart["data"][1])
-        self.assert_fig_equal(test_gantt_chart["data"][1], exp_gantt_chart["data"][1])
+        # unknown why the following test was duplicated. removed.
+        # self.assert_fig_equal(test_gantt_chart["data"][1], exp_gantt_chart["data"][1])
         self.assert_fig_equal(test_gantt_chart["data"][2], exp_gantt_chart["data"][2])
         self.assert_fig_equal(test_gantt_chart["data"][3], exp_gantt_chart["data"][3])
 
 
 class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
     def test_colors_validation(self):
-
         # check: colors is in an acceptable form
 
         data = [1, 5, 8]
@@ -2204,7 +2372,6 @@ class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
         self.assertRaises(PlotlyError, ff.create_violin, data, colors="foo")
 
     def test_data_header(self):
-
         # make sure data_header is entered
 
         data = pd.DataFrame([["apple", 2], ["pear", 4]], columns=["a", "b"])
@@ -2224,7 +2391,6 @@ class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
     def test_data_as_list(self):
-
         # check: data is a non empty list of numbers
 
         data = []
@@ -2243,7 +2409,6 @@ class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
         self.assertRaisesRegexp(PlotlyError, pattern2, ff.create_violin, data)
 
     def test_dataframe_input(self):
-
         # check: dataframe is entered if group_header is True
 
         data = [1, 2, 3]
@@ -2257,7 +2422,6 @@ class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
     def test_colors_dict(self):
-
         # check: if colorscale is True, make sure colors is not a dictionary
 
         data = pd.DataFrame([["apple", 2], ["pear", 4]], columns=["a", "b"])
@@ -2296,7 +2460,6 @@ class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
     def test_valid_colorscale(self):
-
         # check: if colorscale is enabled, colors is a list with 2+ items
 
         data = pd.DataFrame([["apple", 2], ["pear", 4]], columns=["a", "b"])
@@ -2318,7 +2481,6 @@ class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
     def test_group_stats(self):
-
         # check: group_stats is a dictionary
 
         data = pd.DataFrame([["apple", 2], ["pear", 4]], columns=["a", "b"])
@@ -2357,7 +2519,6 @@ class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
     def test_violin_fig(self):
-
         # check: test violin fig matches expected fig
 
         test_violin = ff.create_violin(data=[1, 2])
@@ -4055,7 +4216,6 @@ class TestBullet(NumpyTestUtilsMixin, TestCaseNoTemplate):
 
 
 class TestChoropleth(NumpyTestUtilsMixin, TestCaseNoTemplate):
-
     # run tests if required packages are installed
     if shapely and shapefile and gp:
 
@@ -4095,7 +4255,6 @@ class TestChoropleth(NumpyTestUtilsMixin, TestCaseNoTemplate):
             )
 
         def test_scope_is_not_list(self):
-
             pattern = "'scope' must be a list/tuple/sequence"
 
             self.assertRaisesRegexp(


### PR DESCRIPTION
Also dealt with a few colour-related bugs in the gantt figure_factory file to minimize migration disruption to plotly 3/4. 

There likely were not many users encountering this error as it required a fairly specific use of range scales in gantt charts, but for those of us who were getting that value error it was a game stopper and required holding plotly.py at version 2.7.0.  This should allow those users to upgrade to the newest versions. 

<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to 
 **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist below :-).

### Documentation PR

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)
-->
## Code PR

- [X] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [X] I have added tests (if submitting a new feature or correcting a bug) or modified existing tests.
- [X] For a new feature, I have added documentation examples in an existing or new tutorial notebook (please see the doc checklist as well).
- [X] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.