### PR TITLE
KeyError when running the create_dendrogram example

### DIFF
--- a/packages/python/plotly/plotly/figure_factory/_dendrogram.py
+++ b/packages/python/plotly/plotly/figure_factory/_dendrogram.py
@@ -198,7 +198,7 @@ class _Dendrogram(object):
         default_colors = OrderedDict(sorted(d.items(), key=lambda t: t[0]))
 
         if colorscale is None:
-            colorscale = [
+            rgb_colorscale = [
                 "rgb(0,116,217)",  # blue
                 "rgb(35,205,205)",  # cyan
                 "rgb(61,153,112)",  # green
@@ -206,13 +206,37 @@ class _Dendrogram(object):
                 "rgb(133,20,75)",  # magenta
                 "rgb(255,65,54)",  # red
                 "rgb(255,255,255)",  # white
-                "rgb(255,220,0)",
-            ]  # yellow
+                "rgb(255,220,0)",  # yellow
+            ]
+        else:
+            rgb_colorscale = colorscale
 
         for i in range(len(default_colors.keys())):
             k = list(default_colors.keys())[i]  # PY3 won't index keys
-            if i < len(colorscale):
-                default_colors[k] = colorscale[i]
+            if i < len(rgb_colorscale):
+                default_colors[k] = rgb_colorscale[i]
+
+        # add support for cyclic format colors as introduced in scipy===1.5.0
+        # before this, color_list, from which the color_key is obtained was:
+        # ['g', 'r', 'b', 'c', 'm', 'b', 'b', 'b', 'b'], now it is
+        # ['C1', 'C2', 'C0', 'C3', 'C4', 'C0', 'C0', 'C0', 'C0'], so to keep the
+        # colors consistent regardless of the version of scipy, 'C1' is mapped
+        # to 'rgb(61,153,112)' (what 'g' was mapped to before), 'C2' is mapped
+        # to 'rgb(255,65,54)', etc.
+        cyclic_color_names = ["C%d" % (n,) for n in range(5)]
+        if colorscale is None:
+            cyclic_color_rgb = [
+                "rgb(0,116,217)",
+                "rgb(61,153,112)",
+                "rgb(255,65,54)",
+                "rgb(35,205,205)",
+                "rgb(133,20,75)",
+            ]
+        else:
+            cyclic_color_rgb = colorscale
+
+        for k, c in zip(cyclic_color_names, cyclic_color_rgb):
+            default_colors[k] = c
 
         return default_colors
 

--- a/packages/python/plotly/plotly/figure_factory/_dendrogram.py
+++ b/packages/python/plotly/plotly/figure_factory/_dendrogram.py
@@ -25,36 +25,22 @@ def create_dendrogram(
     color_threshold=None,
 ):
     """
-    Function that returns a dendrogram Plotly figure object.
+    Function that returns a dendrogram Plotly figure object. This is a thin
+    wrapper around scipy.cluster.hierarchy.dendrogram.
 
     See also https://dash.plot.ly/dash-bio/clustergram.
 
     :param (ndarray) X: Matrix of observations as array of arrays
     :param (str) orientation: 'top', 'right', 'bottom', or 'left'
     :param (list) labels: List of axis category labels(observation labels)
-    :param (list) colorscale: Optional colorscale for dendrogram tree. To
-                              totally replace the default colorscale, a custom 
-                              colorscale must contain 8 colors, corresponding 
-                              to when the underlying 
-                              scipy.cluster.hierarchy.dendrogram specifies 
-                              'b', 'c', 'g', 'k', 'm', 'r', 'w', 'y', in that 
-                              order. So if you want 'b', 'c', 'g', 'k', to map 
-                              to rgb(255,0,0) and 'm', 'r', 'w', 'y', to map 
-                              to rgb(0,255,0), the colorscale should be 
-                              ['rgb(255,0,0)','rgb(255,0,0)','rgb(255,0,0)',
-                              'rgb(255,0,0)','rgb(0,255,0)','rgb(0,255,0)',
-                              'rgb(0,255,0)','rgb(0,255,0)',] If using 
-                              scipy >= 1.5.1, instead of the letters above, the
-                              colors are specfied as 'C0', 'C1', etc. and in
-                              that case the list corresponds to the colors:
-                              'C0', 'C3' or 'C9', 'C1' or 'C7', 'C6', 'C2',
-                              'C4', 'C8',<ignored>, 'C5', 'C7', e.g., if
-                              scipy.cluster.hierarchy.dendrogram uses the color
-                              'C3' or 'C9' this is mapped to the rgb value in
-                              index 1, and there is not color that maps to index
-                              7, of the colorscale.  If the colorscale has less
-                              than 8 colors, the remaining colors remain the
-                              default.
+    :param (list) colorscale: Optional colorscale for the dendrogram tree. With
+                              scipy<=1.4.1 requires 8 colors to be specified,
+                              the 7th of which is ignored.  With scipy>=1.5.0,
+                              requires 10 colors. In this case the 8th color is
+                              ignored and the 2nd, 3rd and 6th are used twice as
+                              often as the others. Given a shorter list, the
+                              missing values are replaced with defaults and with
+                              a longer list the extra values are ignored.
     :param (function) distfun: Function to compute the pairwise distance from
                                the observations
     :param (function) linkagefun: Function to compute the linkage matrix from

--- a/packages/python/plotly/plotly/figure_factory/_dendrogram.py
+++ b/packages/python/plotly/plotly/figure_factory/_dendrogram.py
@@ -33,14 +33,13 @@ def create_dendrogram(
     :param (ndarray) X: Matrix of observations as array of arrays
     :param (str) orientation: 'top', 'right', 'bottom', or 'left'
     :param (list) labels: List of axis category labels(observation labels)
-    :param (list) colorscale: Optional colorscale for the dendrogram tree. With
-                              scipy<=1.4.1 requires 8 colors to be specified,
-                              the 7th of which is ignored.  With scipy>=1.5.0,
-                              requires 10 colors. In this case the 8th color is
-                              ignored and the 2nd, 3rd and 6th are used twice as
-                              often as the others. Given a shorter list, the
-                              missing values are replaced with defaults and with
-                              a longer list the extra values are ignored.
+    :param (list) colorscale: Optional colorscale for the dendrogram tree.
+                              Requires 8 colors to be specified, the 7th of
+                              which is ignored.  With scipy>=1.5.0, the 2nd, 3rd
+                              and 6th are used twice as often as the others.
+                              Given a shorter list, the missing values are
+                              replaced with defaults and with a longer list the
+                              extra values are ignored.
     :param (function) distfun: Function to compute the pairwise distance from
                                the observations
     :param (function) linkagefun: Function to compute the linkage matrix from


### PR DESCRIPTION
closes #2618 

With the new color names ('C0','C1', 'C2', ...) I only added 5 colours whereas with the old names 8 colours were added. Looking at `matplotlib.rcParams['axes.prop_cycle']` it seems up to `'C9'` is possible, so do we add mappings for colours 'C5' to 'C9'?

