### PR TITLE
Fixed make_docstring's override_dict 

### DIFF
--- a/packages/python/plotly/plotly/express/_doc.py
+++ b/packages/python/plotly/plotly/express/_doc.py
@@ -530,7 +530,7 @@ def make_docstring(fn, override_dict={}, append_dict={}):
         param_desc_list = param_doc[1:]
         param_desc = (
             tw.fill(" ".join(param_desc_list or ""))
-            if param in docs
+            if param in docs or param in override_dict
             else "(documentation missing from map)"
         )
 


### PR DESCRIPTION
For arguments that are not in `docs`, the override_dict only displayed the first argument of the docstring (the type) but not the rest of the description. This was the case for `px.pie` with the `hole` argument for instance.