### PR TITLE
Fix selection behaviour of histograms

### DIFF
--- a/packages/javascript/plotlywidget/src/Figure.js
+++ b/packages/javascript/plotlywidget/src/Figure.js
@@ -928,7 +928,6 @@ var FigureView = widgets.DOMWidgetView.extend({
         }
       }
 
-
       // Add z if present
       var hasZ =
         pointObjects[0] !== undefined && pointObjects[0].hasOwnProperty("z");

--- a/packages/javascript/plotlywidget/src/Figure.js
+++ b/packages/javascript/plotlywidget/src/Figure.js
@@ -889,10 +889,17 @@ var FigureView = widgets.DOMWidgetView.extend({
       var pointObjects = data["points"];
       var numPoints = pointObjects.length;
 
-      var hasNestedPointObjects = pointObjects.every(value => value.hasOwnProperty("pointNumbers"));
+      var hasNestedPointObjects = true;
+      for (let i = 0; i < numPoints; i++) {
+        hasNestedPointObjects = (hasNestedPointObjects && pointObjects[i].hasOwnProperty("pointNumbers"));
+        if (!hasNestedPointObjects) break;
+      }
       var numPointNumbers = numPoints;
       if (hasNestedPointObjects) {
-        numPointNumbers = pointObjects.reduce((acc, v) => acc + v["pointNumbers"].length, 0)
+        numPointNumbers = 0;
+        for (let i = 0; i < numPoints; i++) {
+          numPointNumbers += pointObjects[i]["pointNumbers"].length;
+        }
       }
       pointsObject = {
         trace_indexes: new Array(numPointNumbers),

--- a/packages/javascript/plotlywidget/src/Figure.js
+++ b/packages/javascript/plotlywidget/src/Figure.js
@@ -888,19 +888,39 @@ var FigureView = widgets.DOMWidgetView.extend({
       // Most cartesian plots
       var pointObjects = data["points"];
       var numPoints = pointObjects.length;
+
+      var hasNestedPointObjects = pointObjects.every(value => value.hasOwnProperty("pointNumbers"));
+      var numPointNumbers = numPoints;
+      if (hasNestedPointObjects) {
+        numPointNumbers = pointObjects.reduce((acc, v) => acc + v["pointNumbers"].length, 0)
+      }
       pointsObject = {
-        trace_indexes: new Array(numPoints),
-        point_indexes: new Array(numPoints),
-        xs: new Array(numPoints),
-        ys: new Array(numPoints),
+        trace_indexes: new Array(numPointNumbers),
+        point_indexes: new Array(numPointNumbers),
+        xs: new Array(numPointNumbers),
+        ys: new Array(numPointNumbers),
       };
 
-      for (var p = 0; p < numPoints; p++) {
-        pointsObject["trace_indexes"][p] = pointObjects[p]["curveNumber"];
-        pointsObject["point_indexes"][p] = pointObjects[p]["pointNumber"];
-        pointsObject["xs"][p] = pointObjects[p]["x"];
-        pointsObject["ys"][p] = pointObjects[p]["y"];
+      var flatPointIndex = 0;
+      if (hasNestedPointObjects) {
+        for (var p = 0; p < numPoints; p++) {
+          for (let i = 0; i < pointObjects[p]["pointNumbers"].length; i++, flatPointIndex++) {
+            pointsObject["point_indexes"][flatPointIndex] = pointObjects[p]["pointNumbers"][i]
+            // also add xs, ys and traces so that the array doesn't get truncated later
+            pointsObject["xs"][flatPointIndex] = pointObjects[p]["x"];
+            pointsObject["ys"][flatPointIndex] = pointObjects[p]["y"];
+            pointsObject["trace_indexes"][flatPointIndex] = pointObjects[p]["curveNumber"];
+          }
+        }
+      } else {
+        for (var p = 0; p < numPoints; p++) {
+          pointsObject["trace_indexes"][p] = pointObjects[p]["curveNumber"];
+          pointsObject["point_indexes"][p] = pointObjects[p]["pointNumber"];
+          pointsObject["xs"][p] = pointObjects[p]["x"];
+          pointsObject["ys"][p] = pointObjects[p]["y"];
+        }
       }
+
 
       // Add z if present
       var hasZ =

--- a/packages/javascript/plotlywidget/src/Figure.js
+++ b/packages/javascript/plotlywidget/src/Figure.js
@@ -908,8 +908,8 @@ var FigureView = widgets.DOMWidgetView.extend({
         ys: new Array(numPointNumbers),
       };
 
-      var flatPointIndex = 0;
       if (hasNestedPointObjects) {
+        var flatPointIndex = 0;
         for (var p = 0; p < numPoints; p++) {
           for (let i = 0; i < pointObjects[p]["pointNumbers"].length; i++, flatPointIndex++) {
             pointsObject["point_indexes"][flatPointIndex] = pointObjects[p]["pointNumbers"][i]

--- a/packages/javascript/plotlywidget/src/Figure.js
+++ b/packages/javascript/plotlywidget/src/Figure.js
@@ -919,6 +919,9 @@ var FigureView = widgets.DOMWidgetView.extend({
             pointsObject["trace_indexes"][flatPointIndex] = pointObjects[p]["curveNumber"];
           }
         }
+        pointsObject["point_indexes"].sort(function(a, b) {
+          return a - b;
+        });
       } else {
         for (var p = 0; p < numPoints; p++) {
           pointsObject["trace_indexes"][p] = pointObjects[p]["curveNumber"];


### PR DESCRIPTION
This change addresses the selection behaviour in histograms. 

A selection now returns the point indices in a single list like scatter plots or others. In the past, the selection was just a list of empty objects due to histograms having a different structure of the selected points. More information can be found in my [comment](https://github.com/plotly/plotly.py/issues/2698#issuecomment-674785363) on the original issue.

Now the indices of the selection are passed correctly:
<img width="1000" alt="histogram selection" src="https://user-images.githubusercontent.com/37695050/90419421-d165c980-e0b6-11ea-95c8-2b39fb53a311.png">



Fixes #2698.
