### PR TITLE
Fix warning regarding ABC import from collections

### DIFF
--- a/packages/python/plotly/plotly/figure_factory/utils.py
+++ b/packages/python/plotly/plotly/figure_factory/utils.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import collections
 import decimal
 import six
 
@@ -24,9 +23,13 @@ from plotly.colors import (
     validate_scale_values,
 )
 
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 def is_sequence(obj):
-    return isinstance(obj, collections.Sequence) and not isinstance(obj, str)
+    return isinstance(obj, Sequence) and not isinstance(obj, str)
 
 
 def validate_index(index_vals):


### PR DESCRIPTION
Similar to https://github.com/plotly/plotly.py/pull/1417
