### PR TITLE
distplot: only compute traces that will be shown

### DIFF
--- a/packages/python/plotly/plotly/figure_factory/_distplot.py
+++ b/packages/python/plotly/plotly/figure_factory/_distplot.py
@@ -183,61 +183,66 @@ def create_distplot(
     if isinstance(bin_size, (float, int)):
         bin_size = [bin_size] * len(hist_data)
 
-    hist = _Distplot(
-        hist_data,
-        histnorm,
-        group_labels,
-        bin_size,
-        curve_type,
-        colors,
-        rug_text,
-        show_hist,
-        show_curve,
-    ).make_hist()
-
-    if curve_type == "normal":
-        curve = _Distplot(
-            hist_data,
-            histnorm,
-            group_labels,
-            bin_size,
-            curve_type,
-            colors,
-            rug_text,
-            show_hist,
-            show_curve,
-        ).make_normal()
-    else:
-        curve = _Distplot(
-            hist_data,
-            histnorm,
-            group_labels,
-            bin_size,
-            curve_type,
-            colors,
-            rug_text,
-            show_hist,
-            show_curve,
-        ).make_kde()
-
-    rug = _Distplot(
-        hist_data,
-        histnorm,
-        group_labels,
-        bin_size,
-        curve_type,
-        colors,
-        rug_text,
-        show_hist,
-        show_curve,
-    ).make_rug()
-
     data = []
     if show_hist:
+
+        hist = _Distplot(
+            hist_data,
+            histnorm,
+            group_labels,
+            bin_size,
+            curve_type,
+            colors,
+            rug_text,
+            show_hist,
+            show_curve,
+        ).make_hist()
+
         data.append(hist)
+
     if show_curve:
+
+        if curve_type == "normal":
+            curve = _Distplot(
+                hist_data,
+                histnorm,
+                group_labels,
+                bin_size,
+                curve_type,
+                colors,
+                rug_text,
+                show_hist,
+                show_curve,
+            ).make_normal()
+        else:
+            curve = _Distplot(
+                hist_data,
+                histnorm,
+                group_labels,
+                bin_size,
+                curve_type,
+                colors,
+                rug_text,
+                show_hist,
+                show_curve,
+            ).make_kde()
+
         data.append(curve)
+
     if show_rug:
+
+        rug = _Distplot(
+            hist_data,
+            histnorm,
+            group_labels,
+            bin_size,
+            curve_type,
+            colors,
+            rug_text,
+            show_hist,
+            show_curve,
+        ).make_rug()
+
         data.append(rug)
         layout = graph_objs.Layout(
             barmode="overlay",


### PR DESCRIPTION
In this pull request I make a small change to ff.create_distplot. ff.create_distplot produces a figure showing the distribution of some data. It can create three traces (histogram, kernel density estimation (KDE) and rug) and it has switches that let users select, which of the aforementioned traces to include in the resulting figure.

Independent of the user choice (boolean parameters: show_hist, show_curve and show_rug), it will compute all three traces whether they will be included in the resulting figure or not. I changed the code so that only the traces that will be included in the resulting figure get computed. 

This will make the function more efficient in situations where a user doesn't need all three traces. 

Also (this is my use case), it allows one corner case that currently doesn't work: The function currently doesn't support being called with a dataset (hist_data parameter) that only contains a single entry. What happens in this case is that scipy throws an exception when trying to compute the KDE. However, in some use cases, there is no need for a KDE (show_curve=False). It should be possible to create a distplot with a single-entry dataset without a KDE.

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
