### PR TITLE
fix PX timezone treatment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   `binary_backend`, `binary_format` and `binary_compression_level` control
   how to generate the b64 string ([#2691](https://github.com/plotly/plotly.py/pull/2691)
 - `px.imshow` has a new `constrast_rescaling` argument in order to choose how
-  to set data values corresponding to the bounds of the color range 
+  to set data values corresponding to the bounds of the color range
   ([#2691](https://github.com/plotly/plotly.py/pull/2691)
+
+### Fixed
+
+- Plotly Express no longer converts datetime columns of input dataframes to UTC ([#2749](https://github.com/plotly/plotly.py/pull/2749))
+- Plotly Express has more complete support for datetimes as additional `hover_data` ([#2749](https://github.com/plotly/plotly.py/pull/2749))
+
 
 ## [4.9.0] - 2020-07-16
 

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_hover.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_hover.py
@@ -163,3 +163,10 @@ def test_sunburst_hoverdict_color():
         hover_data={"pop": ":,"},
     )
     assert "color" in fig.data[0].hovertemplate
+
+
+def test_date_in_hover():
+    df = pd.DataFrame({"date": ["2015-04-04 19:31:30+1:00"], "value": [3]})
+    df["date"] = pd.to_datetime(df["date"])
+    fig = px.scatter(df, x="value", y="value", hover_data=["date"])
+    assert str(fig.data[0].customdata[0][0]) == str(df["date"][0])

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_px_input.py
@@ -233,6 +233,14 @@ def test_build_df_with_index():
     assert_frame_equal(tips.reset_index()[out["data_frame"].columns], out["data_frame"])
 
 
+def test_timezones():
+    df = pd.DataFrame({"date": ["2015-04-04 19:31:30+1:00"], "value": [3]})
+    df["date"] = pd.to_datetime(df["date"])
+    args = dict(data_frame=df, x="date", y="value")
+    out = build_dataframe(args, go.Scatter)
+    assert str(out["data_frame"]["date"][0]) == str(df["date"][0])
+
+
 def test_non_matching_index():
     df = pd.DataFrame(dict(y=[1, 2, 3]), index=["a", "b", "c"])
 

--- a/packages/python/plotly/plotly/tests/test_core/test_px/test_trendline.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_px/test_trendline.py
@@ -102,9 +102,11 @@ def test_trendline_on_timeseries(mode):
     )
 
     df["date"] = pd.to_datetime(df["date"])
+    df["date"] = df["date"].dt.tz_localize("CET")  # force a timezone
     fig = px.scatter(df, x="date", y="GOOG", trendline=mode)
     assert len(fig.data) == 2
     assert len(fig.data[0].x) == len(fig.data[1].x)
     assert type(fig.data[0].x[0]) == datetime
     assert type(fig.data[1].x[0]) == datetime
     assert np.all(fig.data[0].x == fig.data[1].x)
+    assert str(fig.data[0].x[0]) == str(fig.data[1].x[0])

--- a/packages/python/plotly/tox.ini
+++ b/packages/python/plotly/tox.ini
@@ -24,13 +24,13 @@
 ; PASSING ADDITONAL ARGUMENTS TO TEST COMMANDS
 ; The {posargs} is tox-specific and passes in any command line args after `--`.
 ; For example, given the testing command in *this* file:
-;   pytest {posargs} -x plotly/tests/test_core
+;   pytest {posargs} plotly/tests/test_core
 ;
 ; The following command:
 ;   tox -- -k 'not nodev'
 ;
 ; Tells tox to call:
-;   pytest -k 'not nodev' -x plotly/tests/test_core
+;   pytest -k 'not nodev' plotly/tests/test_core
 ;
 
 [tox]
@@ -81,25 +81,25 @@ deps=
 basepython={env:PLOTLY_TOX_PYTHON_27:}
 commands=
     python --version
-    pytest {posargs} -x plotly/tests/test_core
+    pytest {posargs} plotly/tests/test_core
 
 [testenv:py35-core]
 basepython={env:PLOTLY_TOX_PYTHON_35:}
 commands=
     python --version
-    pytest {posargs} -x plotly/tests/test_core
+    pytest {posargs} plotly/tests/test_core
 
 [testenv:py36-core]
 basepython={env:PLOTLY_TOX_PYTHON_36:}
 commands=
     python --version
-    pytest {posargs} -x plotly/tests/test_core
+    pytest {posargs} plotly/tests/test_core
 
 [testenv:py37-core]
 basepython={env:PLOTLY_TOX_PYTHON_37:}
 commands=
     python --version
-    pytest {posargs} -x plotly/tests/test_core
+    pytest {posargs} plotly/tests/test_core
     pytest {posargs} -x test_init/test_dependencies_not_imported.py
     pytest {posargs} -x test_init/test_lazy_imports.py
 
@@ -111,15 +111,15 @@ commands=
 ;;   Do some coverage reporting. No need to do this for all environments.
 ;    mkdir -p {envbindir}/../../coverage-reports/{envname}
 ;    coverage erase
-;    coverage run --include="*/plotly/*" --omit="*/tests*" {envbindir}/nosetests {posargs} -x plotly/tests
+;    coverage run --include="*/plotly/*" --omit="*/tests*" {envbindir}/nosetests {posargs} plotly/tests
 ;    coverage html -d "{envbindir}/../../coverage-reports/{envname}" --title={envname}
 
 [testenv:py27-optional]
 basepython={env:PLOTLY_TOX_PYTHON_27:}
 commands=
     python --version
-    pytest {posargs} -x plotly/tests/test_core
-    pytest {posargs} -x plotly/tests/test_optional
+    pytest {posargs} plotly/tests/test_core
+    pytest {posargs} plotly/tests/test_optional
     pytest _plotly_utils/tests/
     pytest plotly/tests/test_io
 
@@ -127,8 +127,8 @@ commands=
 basepython={env:PLOTLY_TOX_PYTHON_35:}
 commands=
     python --version
-    pytest {posargs} -x plotly/tests/test_core
-    pytest {posargs} -x plotly/tests/test_optional
+    pytest {posargs} plotly/tests/test_core
+    pytest {posargs} plotly/tests/test_optional
     pytest _plotly_utils/tests/
     pytest plotly/tests/test_io
 
@@ -136,8 +136,8 @@ commands=
 basepython={env:PLOTLY_TOX_PYTHON_36:}
 commands=
     python --version
-    pytest {posargs} -x plotly/tests/test_core
-    pytest {posargs} -x plotly/tests/test_optional
+    pytest {posargs} plotly/tests/test_core
+    pytest {posargs} plotly/tests/test_optional
     pytest _plotly_utils/tests/
     pytest plotly/tests/test_io
 
@@ -145,7 +145,7 @@ commands=
 basepython={env:PLOTLY_TOX_PYTHON_37:}
 commands=
     python --version
-    pytest {posargs} -x plotly/tests/test_core
-    pytest {posargs} -x plotly/tests/test_optional
+    pytest {posargs} plotly/tests/test_core
+    pytest {posargs} plotly/tests/test_optional
     pytest _plotly_utils/tests/
     pytest plotly/tests/test_io


### PR DESCRIPTION
Closes https://github.com/plotly/plotly.py/issues/2311 essentially by removing calls to `pd.Series.values`, which seems to always convert datetimes to UTC.

- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [x] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
