### PR TITLE
add mapbox argument source attribution to example in docs

### DIFF
--- a/doc/python/mapbox-layers.md
+++ b/doc/python/mapbox-layers.md
@@ -116,6 +116,7 @@ fig.update_layout(
         {
             "below": 'traces',
             "sourcetype": "raster",
+            "sourceattribution": "United States Geological Survey",
             "source": [
                 "https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}"
             ]
@@ -147,12 +148,14 @@ fig.update_layout(
         {
             "below": 'traces',
             "sourcetype": "raster",
+            "sourceattribution": "United States Geological Survey",
             "source": [
                 "https://basemap.nationalmap.gov/arcgis/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}"
             ]
         },
         {
             "sourcetype": "raster",
+            "sourceattribution": "Government of Canada",
             "source": ["https://geo.weather.gc.ca/geomet/?"
                        "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&BBOX={bbox-epsg-3857}&CRS=EPSG:3857"
                        "&WIDTH=1000&HEIGHT=1000&LAYERS=RADAR_1KM_RDBR&TILED=true&FORMAT=image/png"],


### PR DESCRIPTION
#1965


Please uncomment this block and take a look at this checklist if your PR is making substantial changes to **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [x] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [x] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [x] Every new/modified example is independently runnable
- [x] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [x] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [x] The random seed is set if using randomly-generated data in new/modified examples
- [x] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [x] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [x] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [x] Data frames are always called `df`
- [x] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [x] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [x] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [x] `fig.show()` is at the end of each new/modified example
- [x] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [x] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)
