### PR TITLE
Fix selection of histograms with multiple traces

### DIFF
--- a/packages/javascript/plotlywidget/src/Figure.js
+++ b/packages/javascript/plotlywidget/src/Figure.js
@@ -919,9 +919,6 @@ var FigureView = widgets.DOMWidgetView.extend({
             pointsObject["trace_indexes"][flatPointIndex] = pointObjects[p]["curveNumber"];
           }
         }
-        pointsObject["point_indexes"].sort(function(a, b) {
-          return a - b;
-        });
       } else {
         for (var p = 0; p < numPoints; p++) {
           pointsObject["trace_indexes"][p] = pointObjects[p]["curveNumber"];

--- a/packages/javascript/plotlywidget/src/Figure.js
+++ b/packages/javascript/plotlywidget/src/Figure.js
@@ -1,7 +1,7 @@
 var widgets = require("@jupyter-widgets/base");
 var _ = require("lodash");
 
-window.PlotlyConfig = { MathJaxConfig: "local" };
+window.PlotlyConfig = {MathJaxConfig: "local"};
 var Plotly = require("plotly.js/dist/plotly");
 var semver_range = "^" + require("../package.json").version;
 
@@ -437,14 +437,16 @@ var FigureModel = widgets.DOMWidgetModel.extend(
      *
      * This should only happed on FigureModel initialization
      */
-    do_data: function () {},
+    do_data: function () {
+    },
 
     /**
      * Log changes to the _layout trait
      *
      * This should only happed on FigureModel initialization
      */
-    do_layout: function () {},
+    do_layout: function () {
+    },
 
     /**
      * Handle addTraces message
@@ -600,7 +602,7 @@ var FigureModel = widgets.DOMWidgetModel.extend(
   {
     serializers: _.extend(
       {
-        _data: { deserialize: py2js_deserializer, serialize: js2py_serializer },
+        _data: {deserialize: py2js_deserializer, serialize: js2py_serializer},
         _layout: {
           deserialize: py2js_deserializer,
           serialize: js2py_serializer,
@@ -707,7 +709,7 @@ var FigureView = widgets.DOMWidgetView.extend({
     // MathJax configuration
     // ---------------------
     if (window.MathJax) {
-      MathJax.Hub.Config({ SVG: { font: "STIX-Web" } });
+      MathJax.Hub.Config({SVG: {font: "STIX-Web"}});
     }
 
     // Get message ids
@@ -769,7 +771,7 @@ var FigureView = widgets.DOMWidgetView.extend({
         // Emit event indicating that the widget has finished
         // rendering
         var event = new CustomEvent("plotlywidget-after-render", {
-          detail: { element: that.el, viewID: that.viewID },
+          detail: {element: that.el, viewID: that.viewID},
         });
 
         // Dispatch/Trigger/Fire the event
@@ -919,6 +921,18 @@ var FigureView = widgets.DOMWidgetView.extend({
             pointsObject["trace_indexes"][flatPointIndex] = pointObjects[p]["curveNumber"];
           }
         }
+
+        let single_trace = true;
+        for (let i = 1; i < numPointNumbers; i++) {
+          single_trace = single_trace && (pointsObject["trace_indexes"][i - 1] === pointsObject["trace_indexes"][i])
+          if (!single_trace) break;
+        }
+        if (single_trace) {
+          pointsObject["point_indexes"].sort((function (a, b) {
+            return a - b
+          }))
+        }
+
       } else {
         for (var p = 0; p < numPoints; p++) {
           pointsObject["trace_indexes"][p] = pointObjects[p]["curveNumber"];
@@ -1166,7 +1180,8 @@ var FigureView = widgets.DOMWidgetView.extend({
    * Stub for future handling of plotly_doubleclick
    * @param data
    */
-  handle_plotly_doubleclick: function (data) {},
+  handle_plotly_doubleclick: function (data) {
+  },
 
   /**
    * Handle Plotly.addTraces request

--- a/packages/javascript/plotlywidget/src/Figure.js
+++ b/packages/javascript/plotlywidget/src/Figure.js
@@ -437,16 +437,14 @@ var FigureModel = widgets.DOMWidgetModel.extend(
      *
      * This should only happed on FigureModel initialization
      */
-    do_data: function () {
-    },
+    do_data: function () {},
 
     /**
      * Log changes to the _layout trait
      *
      * This should only happed on FigureModel initialization
      */
-    do_layout: function () {
-    },
+    do_layout: function () {},
 
     /**
      * Handle addTraces message
@@ -602,7 +600,7 @@ var FigureModel = widgets.DOMWidgetModel.extend(
   {
     serializers: _.extend(
       {
-        _data: {deserialize: py2js_deserializer, serialize: js2py_serializer},
+        _data: { deserialize: py2js_deserializer, serialize: js2py_serializer },
         _layout: {
           deserialize: py2js_deserializer,
           serialize: js2py_serializer,
@@ -709,7 +707,7 @@ var FigureView = widgets.DOMWidgetView.extend({
     // MathJax configuration
     // ---------------------
     if (window.MathJax) {
-      MathJax.Hub.Config({SVG: {font: "STIX-Web"}});
+      MathJax.Hub.Config({ SVG: { font: "STIX-Web" } });
     }
 
     // Get message ids
@@ -771,7 +769,7 @@ var FigureView = widgets.DOMWidgetView.extend({
         // Emit event indicating that the widget has finished
         // rendering
         var event = new CustomEvent("plotlywidget-after-render", {
-          detail: {element: that.el, viewID: that.viewID},
+          detail: { element: that.el, viewID: that.viewID },
         });
 
         // Dispatch/Trigger/Fire the event
@@ -1180,8 +1178,7 @@ var FigureView = widgets.DOMWidgetView.extend({
    * Stub for future handling of plotly_doubleclick
    * @param data
    */
-  handle_plotly_doubleclick: function (data) {
-  },
+  handle_plotly_doubleclick: function (data) {},
 
   /**
    * Handle Plotly.addTraces request


### PR DESCRIPTION
This change addresses the selection behaviour of histograms with more than one trace and fixes a bug introduced in my last change #2711.

In the previous change, the point_indexes were sorted before being returned. This is not a problem when there is only one trace, however, with multiple traces, the indices of the values get mixed and result in incorrect behaviour.

So for example consider two traces with a random distribution and both traces are being selected. Firstly, all the indices are combined into one large array with the corresponding trace_indices [0,0,…,0,0,1,1 …,1,1].
Then the index-array is sorted and all the indices get reordered while the trace information is unchanged, which causes indices being assigned to the incorrect traces later on.

A quick solution is not sorting the array, which results in correct behaviour. This has the effect that the results are also not sorted in Python in each trace. Please let me know if this is an issue.

![Screenshot 2020-09-15 at 12 57 24](https://user-images.githubusercontent.com/37695050/93202529-1e3ecd80-f753-11ea-9043-7d528371d6e7.png)