### PR TITLE
Update sankey-diagram.md: fix reference link

### DIFF
--- a/doc/python/sankey-diagram.md
+++ b/doc/python/sankey-diagram.md
@@ -199,4 +199,4 @@ fig.show()
 
 ### Reference
 
-See [https://plotly.com/python/reference/sankey](https://plotly/.com/python/reference/sankey/) for more information and options!
+See [https://plotly.com/python/reference/sankey](https://plotly.com/python/reference/sankey/) for more information and options!


### PR DESCRIPTION
Hi! This is just fixing a broken link from a typo with an extra `/`.