### PR TITLE
Remove KeyError handling in _Dendrogram.get_color_dict

### DIFF
--- a/packages/python/plotly/plotly/figure_factory/_dendrogram.py
+++ b/packages/python/plotly/plotly/figure_factory/_dendrogram.py
@@ -223,10 +223,10 @@ class _Dendrogram(object):
         else:
             rgb_colorscale = colorscale
 
-        for i in range(len(default_colors.keys())):
-            k = list(default_colors.keys())[i]  # PY3 won't index keys
-            if i < len(rgb_colorscale):
-                default_colors[k] = rgb_colorscale[i]
+        for i, k in enumerate(default_colors.keys()):
+            if i >= len(rgb_colorscale):
+                break
+            default_colors[k] = rgb_colorscale[i]
 
         # add support for cyclic format colors as introduced in scipy===1.5.0
         # before this, the colors were named 'r', 'b', 'y' etc., now they are
@@ -248,13 +248,7 @@ class _Dendrogram(object):
             ("C9", "c"),
         ]
         for nc, oc in new_old_color_map:
-            try:
-                default_colors[nc] = default_colors[oc]
-            except KeyError:
-                # it could happen that the old color isn't found (if a custom
-                # colorscale was specified), in this case we set it to an
-                # arbitrary default.
-                default_colors[n] = "rgb(0,116,217)"
+            default_colors[nc] = default_colors[oc]
 
         return default_colors
 


### PR DESCRIPTION
`new_old_color_map` is hardcoded, and `default_colors` has a minimal key set that includes all the values.

Drive-by: simplify the overlay of `rgb_colorscale` onto `default_colors`.

Closes #2806

## Code PR

- [X] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
