### PR TITLE
add note on jupyter multikernel

### DIFF
--- a/doc/python/getting-started.md
+++ b/doc/python/getting-started.md
@@ -174,7 +174,7 @@ fig = go.FigureWidget(data=go.Bar(y=[2, 3, 1]))
 fig
 ```
 
-Please check out our [Troubleshooting guide](/python/troubleshooting/) if you run into any problems with JupyterLab.
+Please check out our [Troubleshooting guide](/python/troubleshooting/) if you run into any problems with JupyterLab. Note that our documentation assumes that you will run plotly with the default jupyter kernel. If you are using multiple python kernels and run into problems, refer to the [Troubleshooting guide](/python/troubleshooting/) for help.
 
 <!-- #region -->
 

--- a/doc/python/troubleshooting.md
+++ b/doc/python/troubleshooting.md
@@ -82,6 +82,14 @@ $ jupyter labextension uninstall jupyterlab-plotly
 $ jupyter labextension uninstall plotlywidget
 ```
 
+The installation instructions in our documentation assume that you are running plotly in the default python kernel of jupyterlab. If you have installed [multiple python kernels](https://ipython.readthedocs.io/en/stable/install/kernel_install.html) you must ensure that the plotly jupyter labextension is installed for the default python kernel. That is, if you start jupyterlab from one python environment (the "server kernel") but then select a different python environment to run your notebooks (the "processing kernel"), then the "server kernel" must have the plotly jupyterlab extension installed, and the "processing kernel" must have plotly installed. In addition, the "processing kernel" must also have the [`nbformat`](https://nbformat.readthedocs.io/en/latest/) dependency installed to correctly render figures.
+
+If you forget to install the plotly jupyterlab extension for the "server kernel", then your plotly figures will display as blank spaces, even if the "processing kernel" is correctly installed. If you forget to add the `nbformat` dependency to the "processing kernel", you will receive an error message asking you to install it:
+
+```
+ValueError: Mime type rendering requires nbformat>=4.2.0 but it is not installed
+```
+
 If you run into "out of memory" problems while installing the extensions, try running these commands before running `jupyter labextension install`...
 
 ```bash


### PR DESCRIPTION
Very small doc change:
- explained that in multi-kernel jupyter setups, the default kernel needs plotly jupyterlab extension (as per existing docs), and the processing kernel needs plotly + nbformat
- noted two failure scenarios if this isn't done correctly (blank figure or error asking to install `nbformat`)