### PR TITLE
honor zmin/zmid/zmax in annotated_heatmap font colors

### DIFF
--- a/packages/python/plotly/plotly/figure_factory/_annotated_heatmap.py
+++ b/packages/python/plotly/plotly/figure_factory/_annotated_heatmap.py
@@ -196,14 +196,14 @@ class _AnnotatedHeatmap(object):
             self.zmin = min([v for row in self.z for v in row])
             self.zmax = max([v for row in self.z for v in row])
 
-        if "zmin" in kwargs:
+        if kwargs.get("zmin", None) is not None:
             self.zmin = kwargs["zmin"]
-        if "zmax" in kwargs:
+        if kwargs.get("zmax", None) is not None:
             self.zmax = kwargs["zmax"]
 
         self.zmid = (self.zmax + self.zmin) / 2
 
-        if "zmid" in kwargs:
+        if kwargs.get("zmid", None) is not None:
             self.zmin = kwargs["zmid"]
 
     def get_text_color(self):

--- a/packages/python/plotly/plotly/figure_factory/_annotated_heatmap.py
+++ b/packages/python/plotly/plotly/figure_factory/_annotated_heatmap.py
@@ -204,7 +204,7 @@ class _AnnotatedHeatmap(object):
         self.zmid = (self.zmax + self.zmin) / 2
 
         if kwargs.get("zmid", None) is not None:
-            self.zmin = kwargs["zmid"]
+            self.zmid = kwargs["zmid"]
 
     def get_text_color(self):
         """

--- a/packages/python/plotly/plotly/figure_factory/_annotated_heatmap.py
+++ b/packages/python/plotly/plotly/figure_factory/_annotated_heatmap.py
@@ -189,6 +189,23 @@ class _AnnotatedHeatmap(object):
         self.reversescale = reversescale
         self.font_colors = font_colors
 
+        if np and isinstance(self.z, np.ndarray):
+            self.zmin = np.amin(self.z)
+            self.zmax = np.amax(self.z)
+        else:
+            self.zmin = min([v for row in self.z for v in row])
+            self.zmax = max([v for row in self.z for v in row])
+
+        if "zmin" in kwargs:
+            self.zmin = kwargs["zmin"]
+        if "zmax" in kwargs:
+            self.zmax = kwargs["zmax"]
+
+        self.zmid = (self.zmax + self.zmin) / 2
+
+        if "zmid" in kwargs:
+            self.zmin = kwargs["zmid"]
+
     def get_text_color(self):
         """
         Get font color for annotations.
@@ -264,21 +281,6 @@ class _AnnotatedHeatmap(object):
             max_text_color = black
         return min_text_color, max_text_color
 
-    def get_z_mid(self):
-        """
-        Get the mid value of z matrix
-
-        :rtype (float) z_avg: average val from z matrix
-        """
-        if np and isinstance(self.z, np.ndarray):
-            z_min = np.amin(self.z)
-            z_max = np.amax(self.z)
-        else:
-            z_min = min([v for row in self.z for v in row])
-            z_max = max([v for row in self.z for v in row])
-        z_mid = (z_max + z_min) / 2
-        return z_mid
-
     def make_annotations(self):
         """
         Get annotations for each cell of the heatmap with graph_objs.Annotation
@@ -287,11 +289,10 @@ class _AnnotatedHeatmap(object):
             the heatmap
         """
         min_text_color, max_text_color = _AnnotatedHeatmap.get_text_color(self)
-        z_mid = _AnnotatedHeatmap.get_z_mid(self)
         annotations = []
         for n, row in enumerate(self.z):
             for m, val in enumerate(row):
-                font_color = min_text_color if val < z_mid else max_text_color
+                font_color = min_text_color if val < self.zmid else max_text_color
                 annotations.append(
                     graph_objs.layout.Annotation(
                         text=str(self.annotation_text[n][m]),


### PR DESCRIPTION
Alternative to https://github.com/plotly/plotly.py/pull/2892 to close https://github.com/plotly/plotly.py/issues/2187, cc @bensdm.

This is a more targeted fix for the zmin/zmax problem specifically, and doesn't address the difficulty of light colors in the middle range of a diverging colorscale.