### PR TITLE
Update kaleido instructions to install from conda-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ $ pip install -U kaleido
 or conda.
 
 ```
-$ conda install -c plotly python-kaleido
+$ conda install -c conda-forge python-kaleido
 ```
 
 #### Orca

--- a/doc/python/static-image-export.md
+++ b/doc/python/static-image-export.md
@@ -50,7 +50,7 @@ $ pip install -U kaleido
 
 or conda.
 ```
-$ conda install -c plotly python-kaleido
+$ conda install -c conda-forge python-kaleido
 ```
 
 While Kaleido is now the recommended approach, image export can also be supported by the legacy [orca](https://github.com/plotly/orca) command line utility. See the [Orca Management](/python/orca-management/) section for instructions on installing, configuring, and troubleshooting orca.


### PR DESCRIPTION
Now that Kaliedo is on conda-forge, new versions will only be published there. This PR updates the installation instructions in the README and docs to install from conda-forge.

cc @nicolaskruchten because I don't remember the doc deployment sequence :slightly_smiling_face: 