### PR TITLE
docs: fix simple typo, specfic -> specific

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -280,7 +280,7 @@ pytest  packages/python/plotly/plotly/tests/test_core/
 pytest plotly/tests/test_plotly/test_plot.py
 ```
 
-or for a specfic test function
+or for a specific test function
 
 ```bash
 pytest plotly/tests/test_plotly/test_plot.py::test_function


### PR DESCRIPTION
There is a small typo in contributing.md.

Should read `specific` rather than `specfic`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md