### PR TITLE
Add missing whitespaces in ImportError message.

### DIFF
--- a/packages/python/plotly/plotly/io/_base_renderers.py
+++ b/packages/python/plotly/plotly/io/_base_renderers.py
@@ -867,8 +867,8 @@ class SphinxGalleryOrcaRenderer(ExternalRenderer):
         except (ValueError, ImportError):
             raise ImportError(
                 "orca and psutil are required to use the `sphinx-gallery-orca` renderer. "
-                "See https://plotly.com/python/static-image-export/ for instructions on"
-                "how to install orca. Alternatively, you can use the `sphinx-gallery`"
-                "renderer (note that png thumbnails can only be generated with"
+                "See https://plotly.com/python/static-image-export/ for instructions on "
+                "how to install orca. Alternatively, you can use the `sphinx-gallery` "
+                "renderer (note that png thumbnails can only be generated with "
                 "the `sphinx-gallery-orca` renderer)."
             )


### PR DESCRIPTION
## Minor PR

I stumbled across the error myself and it read "ImportError: orca and psutil are required to use the `sphinx-gallery-orca` renderer. See https://plotly.com/python/static-image-export/ for instructions **onhow** to install orca. Alternatively, you can use the **`sphinx-gallery`renderer** (note that png thumbnails can only be generated **withthe** `sphinx-gallery-orca` renderer)."