### PR TITLE
Fixing the browser rendering issue for chrome and chromium browsers

### DIFF
--- a/packages/python/plotly/plotly/io/_base_renderers.py
+++ b/packages/python/plotly/plotly/io/_base_renderers.py
@@ -666,6 +666,9 @@ def open_html_in_browser(html, using=None, new=0, autoraise=True):
     if isinstance(html, six.string_types):
         html = html.encode("utf8")
 
+    if isinstance(using, tuple):
+        using = [i for i in webbrowser._browsers.keys() if any(j in i for j in using)][0]
+
     class OneShotRequestHandler(BaseHTTPRequestHandler):
         def do_GET(self):
             self.send_response(200)

--- a/packages/python/plotly/plotly/io/_base_renderers.py
+++ b/packages/python/plotly/plotly/io/_base_renderers.py
@@ -667,7 +667,9 @@ def open_html_in_browser(html, using=None, new=0, autoraise=True):
         html = html.encode("utf8")
 
     if isinstance(using, tuple):
-        using = [i for i in webbrowser._browsers.keys() if any(j in i for j in using)][0]
+        using = [i for i in webbrowser._browsers.keys() if any(j in i for j in using)]
+        if using:
+            using = using[0]
 
     class OneShotRequestHandler(BaseHTTPRequestHandler):
         def do_GET(self):

--- a/packages/python/plotly/plotly/io/_renderers.py
+++ b/packages/python/plotly/plotly/io/_renderers.py
@@ -438,9 +438,10 @@ renderers["pdf"] = PdfRenderer(**img_kwargs)
 
 # External
 renderers["browser"] = BrowserRenderer(config=config)
-renderers["firefox"] = BrowserRenderer(config=config, using="firefox")
-renderers["chrome"] = BrowserRenderer(config=config, using="chrome")
-renderers["chromium"] = BrowserRenderer(config=config, using="chromium")
+renderers["firefox"] = BrowserRenderer(config=config, using=("firefox"))
+renderers["chrome"] = BrowserRenderer(config=config, using=("chrome", "google-chrome"))
+renderers["chromium"] = BrowserRenderer(config=config, using=("chromium", "chromium-browser"))
+renderers["opera"] = BrowserRenderer(config=config, using=("opera"))
 renderers["iframe"] = IFrameRenderer(config=config, include_plotlyjs=True)
 renderers["iframe_connected"] = IFrameRenderer(config=config, include_plotlyjs="cdn")
 renderers["sphinx_gallery"] = SphinxGalleryHtmlRenderer()


### PR DESCRIPTION
... by modifying the "using" argument passed to open_html_in_browser method to be a tuple of strings.

This PR is to resolve this issue https://github.com/plotly/plotly.py/issues/2348.

File changes include
plotly.py/packages/python/plotly/plotly/io/_base_renderers.py
plotly.py/packages/python/plotly/plotly/io/_renderers.py

There would be no changes to documentation as the existing examples and tests would still apply, just the underlying implementation was changed to perform string matching.