### PR TITLE
document corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,7 +135,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   faster image rendering and smaller figure size. Additional optional arguments
   `binary_backend`, `binary_format` and `binary_compression_level` control
   how to generate the b64 string ([#2691](https://github.com/plotly/plotly.py/pull/2691)
-- `px.imshow` has a new `constrast_rescaling` argument in order to choose how
+- `px.imshow` has a new `contrast_rescaling` argument in order to choose how
   to set data values corresponding to the bounds of the color range
   ([#2691](https://github.com/plotly/plotly.py/pull/2691)
 
@@ -239,7 +239,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- The `hover_data` parameter of `px` functions can now be a dictionary. This makes it possible to skip hover information for some arguments or to change the formatting of hover informatiom [#2377](https://github.com/plotly/plotly.py/pull/2377).
+- The `hover_data` parameter of `px` functions can now be a dictionary. This makes it possible to skip hover information for some arguments or to change the formatting of hover information [#2377](https://github.com/plotly/plotly.py/pull/2377).
 - It's now possible to build a development version of Plotly.py against the build artifacts from a non-`master` branch of Plotly.js, which makes for faster QA and development cycles [#2349](https://github.com/plotly/plotly.py/pull/2349). Thanks [@zouhairm](https://github.com/zouhairm) for this Pull Request!
 
 ### Fixed
@@ -252,7 +252,7 @@ This version includes several performance improvements ([#2368](https://github.c
 
  - Child graph objects (e.g. `figure.layout.xaxis`) are no longer created eagerly during graph object construction. Instead, they are created lazily the first time the property is accessed.
  - Property validation is now disabled for select internal operations.
- - When used with Python 3.7 and above, ploty.py now takes advantage of [PEP-562](https://www.python.org/dev/peps/pep-0562/) to perform submodule imports lazily.  This dramatically improves import times.
+ - When used with Python 3.7 and above, plotly.py now takes advantage of [PEP-562](https://www.python.org/dev/peps/pep-0562/) to perform submodule imports lazily.  This dramatically improves import times.
 
 ## [4.6.0] - 2020-03-31
 
@@ -290,7 +290,7 @@ This version includes several performance improvements ([#2368](https://github.c
 
 - Jupyterlab extension now compatible with both Jupyterlab 1.2 and 2.0 [#2261](https://github.com/plotly/plotly.py/pull/2261) with thanks to [@consideRatio](https://github.com/consideRatio) for the contribution!
 - Fixed a bug when using boolean values for the color argument of px functions [#2127](https://github.com/plotly/plotly.py/pull/2127)
-- Corrected import bug which was occuring with old versions of ipywidgets [#2265](https://github.com/plotly/plotly.py/pull/2265)
+- Corrected import bug which was occurring with old versions of ipywidgets [#2265](https://github.com/plotly/plotly.py/pull/2265)
 - Fixed python 3.8 syntax warning [#2262](https://github.com/plotly/plotly.py/pull/2262), with thanks to [@sgn](https://github.com/sgn) for the contribution!
 
 ## [4.5.3] - 2020-03-05
@@ -365,7 +365,7 @@ This version includes several performance improvements ([#2368](https://github.c
  for more information
  - The tutorials of the [plotly.py documentation](https://plot.ly/python/) are
    now in the main [plotly.py Github repository](https://github.com/plotly/plotly.py). Contributions in order to improve or extend the documentation are very welcome!
- - `plotly.express` generated plots no longer have a default height of 600 pixels, instead they inherit the default height of regular figures [#1990](https://github.com/plotly/plotly.py/pull/1990). To restore the old behavior, set `px.defaults.height=600` once per session, or set the `height` keyword arguement to any `px.function()` to 600.
+ - `plotly.express` generated plots no longer have a default height of 600 pixels, instead they inherit the default height of regular figures [#1990](https://github.com/plotly/plotly.py/pull/1990). To restore the old behavior, set `px.defaults.height=600` once per session, or set the `height` keyword argument to any `px.function()` to 600.
 
 ### Fixed
 
@@ -439,7 +439,7 @@ section [#1969](https://github.com/plotly/plotly.py/pull/1969).
  - The width of a figure produced by the `create_gantt` figure factory now resizes responsively ([#1724](https://github.com/plotly/plotly.py/pull/1724))
 
 ### Fixed
- - The name of the steps property of `graph_objects.indicator.Guage` has been renamed from `stepss` to `steps`
+ - The name of the steps property of `graph_objects.indicator.Gauge` has been renamed from `stepss` to `steps`
  - Avoid crash in iframe renderers when running outside iPython ([#1723](https://github.com/plotly/plotly.py/pull/1723))
 
 ## [4.1.0] - 2019-08-06
@@ -491,7 +491,7 @@ This is a major release that includes many new features, and a few breaking chan
  - Added support for all trace types in `make_subplots` ([#1528](https://github.com/plotly/plotly.py/pull/1528))
  - Added support for secondary y-axes in `make_subplots` ([#1564](https://github.com/plotly/plotly.py/pull/1564))
  - Support passing a scalar trace object (rather than a list or tuple of trace objects) as the `data` property to the `Figure` constructor ([#1614](https://github.com/plotly/plotly.py/pull/1614))
- - Added dictionary-stule `.pop` method to graph object classes ([#1614](https://github.com/plotly/plotly.py/pull/1614))
+ - Added dictionary-style `.pop` method to graph object classes ([#1614](https://github.com/plotly/plotly.py/pull/1614))
  - New `jupyterlab-plotly` JupyterLab extension for rendering figures in JupyterLab. Replaces the `@jupyterlab/plotly-extension` extension, and includes JupyterLab 1.0 support.
  - Added new suite of built-in colorscales to the `plotly.colors` module, and support for specifying this wide range of colorscales by name. Also added support for specifying colorscales as a list of colors, in which case the color spacing is assumed to be uniform ([#1647](https://github.com/plotly/plotly.py/pull/1647)).
  - Added `sphinx-gallery` renderer for embedding plotly figures in [Sphinx-Gallery](https://sphinx-gallery.github.io/) ([#1577](https://github.com/plotly/plotly.py/pull/1577), [plotly/plotly-sphinx-gallery](https://github.com/plotly/plotly-sphinx-gallery)).
@@ -1096,7 +1096,7 @@ must be installed:
   properties are ignored rather than causing an exception.
  - A `to_ordered_dict` method has been added to the `Figure` and `FigureWidget`
   classes. This method returns a representation of the figure as a nested
-  structure of `OrdererdDict` and `list` instances where the keys in each
+  structure of `OrderedDict` and `list` instances where the keys in each
   `OrderedDict` are sorted alphabetically.  This method replaces the
   `get_ordered` method that was available in version 2, and makes it possible
   to traverse the nested structure of a figure in a deterministic order.
@@ -1517,7 +1517,7 @@ gone.
 ## [1.12.10] - 2016-11-28
 ### Updated
 - `FF.create_violin` and `FF.create_scatterplotmatrix` now by default do not print subplot grid information in output
-- Removed alert that occured when downloading plot images offline. Please note: for higher resolution images and more export options, consider making requests to our image servers. See: `help(py.image)` for more details.
+- Removed alert that occurred when downloading plot images offline. Please note: for higher resolution images and more export options, consider making requests to our image servers. See: `help(py.image)` for more details.
 
 ### Added
 - Plot configuration options for offline plots. See the list of [configuration options](https://github.com/Rikorose/plotly.py/blob/master/plotly/offline/offline.py#L189) and [examples](https://plot.ly/javascript/configuration-options/) for more information.

--- a/build_for_conda.md
+++ b/build_for_conda.md
@@ -16,4 +16,4 @@ Finally, build and test the created version:
 
 `conda build plotly`
 
-Currently, the updated (version 1.12.4) conda package sits at https://anaconda.org/chohner/plotly. There seems to be an old offial package at https://anaconda.org/plotly/plotly.
+Currently, the updated (version 1.12.4) conda package sits at https://anaconda.org/chohner/plotly. There seems to be an old official package at https://anaconda.org/plotly/plotly.

--- a/doc/python/3d-mesh.md
+++ b/doc/python/3d-mesh.md
@@ -83,7 +83,7 @@ IFrame(snippet_url + '3d-mesh', width='100%', height=630)
 
 ### Mesh Tetrahedron
 
-In this example we use the `ì`, `j` and `k` parameters to specify manually the geometry of the triangles of the mesh.
+In this example we use the `i`, `j` and `k` parameters to specify manually the geometry of the triangles of the mesh.
 
 ```python
 import plotly.graph_objects as go

--- a/doc/python/imshow.md
+++ b/doc/python/imshow.md
@@ -231,7 +231,7 @@ fig.show()
 
 ### Automatic contrast rescaling in `px.imshow`
 
-When `zmin` and `zmax` are not specified, the `contrast_rescaling` arguments determines how `zmin` and `zmax` are computed. For `contrast_rescaling='minmax'`, the extrema of the data range are used. For `contrast_rescaling='infer'`, a heuristic based on the data type is used:
+When `zmin` and `zmax` are not specified, the `contrast_rescaling` arguments determines how `zmin` and `zmax` are computed. For `contrast_rescaling='minmax'`, the extreme of the data range are used. For `contrast_rescaling='infer'`, a heuristic based on the data type is used:
 - for integer data types, `zmin` and `zmax` correspond to the extreme values of the data type, for example 0 and 255 for `uint8`, 0 and 65535 for `uint16`, etc.
 - for float numbers, the maximum value of the data is computed, and zmax is 1 if the max is smaller than 1, 255 if the max is smaller than 255, etc. (with higher thresholds 2**16 - 1 and 2**32 -1).
 

--- a/doc/python/linear-fits.md
+++ b/doc/python/linear-fits.md
@@ -23,7 +23,7 @@ jupyter:
     version: 3.6.8
   plotly:
     description: Add linear Ordinary Least Squares (OLS) regression trendlines or
-      non-linear Locally Weighted Scatterplot Smoothing (LOEWSS) trendlines to scatterplots
+      non-linear Locally Weighted Scatterplot Smoothing (LOWESS) trendlines to scatterplots
       in Python.
     display_as: statistical
     language: python

--- a/doc/python/sliders.md
+++ b/doc/python/sliders.md
@@ -90,7 +90,7 @@ The method determines which [plotly.js function](https://plot.ly/javascript/plot
 
 
 ### Sliders in Plotly Express
-Plotly Express provide sliders, but with implicit animation using the `"animate"` method described above. The animation play button can be omited by removing `updatemenus` in the `layout`:
+Plotly Express provide sliders, but with implicit animation using the `"animate"` method described above. The animation play button can be omitted by removing `updatemenus` in the `layout`:
 
 ```python
 import plotly.express as px

--- a/doc/python/ternary-plots.md
+++ b/doc/python/ternary-plots.md
@@ -41,7 +41,7 @@ A ternary plot depicts the ratios of three variables as positions in an equilate
 
 [Plotly Express](/python/plotly-express/) is the easy-to-use, high-level interface to Plotly, which [operates on a variety of types of data](/python/px-arguments/) and produces [easy-to-style figures](/python/styling-plotly-express/).
 
-Here we use `px.scatter_ternary` to visualize thre three-way split between the three major candidates in a municipal election.
+Here we use `px.scatter_ternary` to visualize the three-way split between the three major candidates in a municipal election.
 
 ```python
 import plotly.express as px

--- a/doc/unconverted/python/amazon-redshift.md
+++ b/doc/unconverted/python/amazon-redshift.md
@@ -68,7 +68,7 @@ port = 5439
 dbname = 'dev'
 ```
 
-As I mentioned there are numerous ways to connect to a Redshift databause and I've included two below. We can use either the SQLAlchemy package or we can use the psycopg2 package for a more direct access.
+As I mentioned there are numerous ways to connect to a Redshift database and I've included two below. We can use either the SQLAlchemy package or we can use the psycopg2 package for a more direct access.
 
 Both will allow us to execute SQL queries and get results however the SQLAlchemy engine makes it a bit easier to directly return our data as a dataframe using pandas. Plotly has a tight integration with pandas as well, making it extremely easy to make interactive graphs to share with your company.
 

--- a/doc/unconverted/python/filled-chord-diagram.md
+++ b/doc/unconverted/python/filled-chord-diagram.md
@@ -28,7 +28,7 @@ jupyter:
 
 Circular layout or [Chord diagram](https://en.wikipedia.org/wiki/Chord_diagram) is a method of visualizing  data that describe relationships. It was intensively promoted  through [Circos](http://circos.ca/), a software package in Perl that  was initially designed for displaying genomic data.
 
-M Bostock developed reusable charts  for [chord diagrams](http://bl.ocks.org/mbostock/4062006) in d3.js. Two years ago on [stackoverflow](http://stackoverflow.com/questions/19105801/chord-diagram-in-python), the exsistence of a Python package for plotting chord diagrams was adressed, but the question was closed due to being *off topic*.<br> Here we show that a chord diagram can be generated in Python with Plotly. We illustrate the method of generating a chord diagram from data recorded in a square matrix. The rows and columns represent the same entities.
+M Bostock developed reusable charts  for [chord diagrams](http://bl.ocks.org/mbostock/4062006) in d3.js. Two years ago on [stackoverflow](http://stackoverflow.com/questions/19105801/chord-diagram-in-python), the existence of a Python package for plotting chord diagrams was addressed, but the question was closed due to being *off topic*.<br> Here we show that a chord diagram can be generated in Python with Plotly. We illustrate the method of generating a chord diagram from data recorded in a square matrix. The rows and columns represent the same entities.
 
 This example considers a community of 5 friends on Facebook. We record the number of comments posted by each member on the other friends' walls. The data table is given in the next cell:
 

--- a/doc/unconverted/python/gapminder-example.md
+++ b/doc/unconverted/python/gapminder-example.md
@@ -62,7 +62,7 @@ py.iplot(table, filename='animations-gapminder-data-preview')
 #### Make the Grid
 Since we are using the v2 api for animations in Plotly, we need to first make a `grid`. You can learn more in the [introduction to animation doc](https://plot.ly/python/animations/).
 
-We will first define a list of _string_ years which will represent the values that our `slider` will take on. Going through the dataset, we will take out all the unique continents from the column `continent` and store them as well. Finally, we make a grid with each column representing a slice of the dataframe by _year_, _continent_ and _column name_, making sure to name each column uniquly by these variables:
+We will first define a list of _string_ years which will represent the values that our `slider` will take on. Going through the dataset, we will take out all the unique continents from the column `continent` and store them as well. Finally, we make a grid with each column representing a slice of the dataframe by _year_, _continent_ and _column name_, making sure to name each column uniquely by these variables:
 
 ```python
 years_from_col = set(dataset['year'])
@@ -259,7 +259,7 @@ Finally we make our `frames`. Here we are running again through the years and co
 ```
 frame = {'data': [], 'name': value-name}
 ```
-We add a dictionary of data to this list and at the end of each loop, we ensure to add the `steps` dictionary to the steps list. At the end, we attatch the `sliders` dictionary to the figure via:
+We add a dictionary of data to this list and at the end of each loop, we ensure to add the `steps` dictionary to the steps list. At the end, we attach the `sliders` dictionary to the figure via:
 
 ```
 figure['layout']['sliders'] = [sliders_dict]

--- a/doc/unconverted/python/interpolation-and-extrapolation-in-1d.md
+++ b/doc/unconverted/python/interpolation-and-extrapolation-in-1d.md
@@ -99,7 +99,7 @@ py.iplot(fig, filename='interpolation-and-extrapolation')
 ```
 
 #### Interpolation and Extrapolation of Y From X
-Interpolation and Extrapolation of (x, y) points with pre-existant points and an array of specific x values.
+Interpolation and Extrapolation of (x, y) points with pre-existent points and an array of specific x values.
 
 ```python
 points = np.array([(1, 1), (2, 4), (3, 1), (9, 3)])

--- a/doc/unconverted/python/linear-gauge-chart.md
+++ b/doc/unconverted/python/linear-gauge-chart.md
@@ -12,7 +12,7 @@ jupyter:
     language: python
     name: python2
   plotly:
-    description: How to make interactive linear-guage charts in Python with Plotly.
+    description: How to make interactive linear-gauge charts in Python with Plotly.
     display_as: basic
     language: python
     layout: base

--- a/doc/unconverted/python/normality-test.md
+++ b/doc/unconverted/python/normality-test.md
@@ -361,7 +361,7 @@ We have covered a few normality tests, but this is not all of the tests that exi
    - Start looking into the use of nonparametric statistical methods instead of the parametric methods.
    - If some of the methods suggest that the sample is Gaussian and some not, then perhaps take this as an indication that your data is Gaussian-like.
 
-_This tuorial is inspired from ["A Gentle Introduction to Normality Tests"](https://machinelearningmastery.com/a-gentle-introduction-to-normality-tests-in-python/)_
+_This tutorial is inspired from ["A Gentle Introduction to Normality Tests"](https://machinelearningmastery.com/a-gentle-introduction-to-normality-tests-in-python/)_
 <!-- #endregion -->
 
 ```python

--- a/doc/unconverted/python/peak-integration.md
+++ b/doc/unconverted/python/peak-integration.md
@@ -12,7 +12,7 @@ jupyter:
     language: python
     name: python2
   plotly:
-    description: Learn how to integrate the area between peaks and bassline in Python.
+    description: Learn how to integrate the area between peaks and baseline in Python.
     display_as: peak-analysis
     has_thumbnail: false
     language: python

--- a/doc/unconverted/python/streaming-tutorial.md
+++ b/doc/unconverted/python/streaming-tutorial.md
@@ -74,7 +74,7 @@ The `Stream Id Object` comes bundled in the `graph_objs` package. We can then ca
 help(go.Stream)
 ```
 
-As we can see, the `Stream Id Object` is a dictionary-like object that takes two parameters, and has all the methods that are assoicated with dictionaries.
+As we can see, the `Stream Id Object` is a dictionary-like object that takes two parameters, and has all the methods that are associated with dictionaries.
 We will need one of these objects for each of trace that we wish to stream data to.
 We'll now create a single stream token for our streaming example, which will include one scatter trace.
 
@@ -89,7 +89,7 @@ stream_1 = go.Stream(
 )
 ```
 
-The `'maxpoints'` key sets the maxiumum number of points to keep on the plotting surface at any given time.
+The `'maxpoints'` key sets the maximum number of points to keep on the plotting surface at any given time.
 More over, if you want to avoid the use of these `Stream Id Objects`, you can just create a dictionary with at least the token parameter defined, for example:
 
 ```python

--- a/doc/unconverted/python/t-test.md
+++ b/doc/unconverted/python/t-test.md
@@ -46,7 +46,7 @@ import scipy
 #### Generate Data
 
 
-Let us generate some random data from the `Normal Distriubtion`. We will sample 50 points from a normal distribution with mean $\mu = 0$ and variance $\sigma^2 = 1$ and from another with mean $\mu = 2$ and variance $\sigma^2 = 1$.
+Let us generate some random data from the `Normal Distribution`. We will sample 50 points from a normal distribution with mean $\mu = 0$ and variance $\sigma^2 = 1$ and from another with mean $\mu = 2$ and variance $\sigma^2 = 1$.
 
 ```python
 data1 = np.random.normal(0, 1, size=50)
@@ -82,7 +82,7 @@ py.iplot(data, filename='normal-dists-plot')
 #### One Sample T Test
 
 
-A `One Sample T-Test` is a statistical test used to evaluate the null hypothesis that the mean $m$ of a 1D sample dataset of independant observations is equal to the true mean $\mu$ of the population from which the data is sampled. In other words, our null hypothesis is that
+A `One Sample T-Test` is a statistical test used to evaluate the null hypothesis that the mean $m$ of a 1D sample dataset of independent observations is equal to the true mean $\mu$ of the population from which the data is sampled. In other words, our null hypothesis is that
 
 $$
 \begin{align*}

--- a/doc/unconverted/python/tesla-supercharging-stations.md
+++ b/doc/unconverted/python/tesla-supercharging-stations.md
@@ -12,7 +12,7 @@ jupyter:
     language: python
     name: python2
   plotly:
-    description: How to plot car-travel routes between USA and Canada Telsa Supercharging
+    description: How to plot car-travel routes between USA and Canada Tesla Supercharging
       Stations in Python.
     display_as: maps
     language: python

--- a/packages/python/chart-studio/specs/gridspec.md
+++ b/packages/python/chart-studio/specs/gridspec.md
@@ -192,7 +192,7 @@ Type checking boiler plate
 A `PlotlyRequestError` that prints a useful error message from the server:
 1. Print `response.detail` if provided (Plotly error message)
 2. Otherwise, print `response.body` if the response is plain-text
-3. Otherwise, print the original `requests.expceptions.HTTPError` error message.
+3. Otherwise, print the original `requests.exceptions.HTTPError` error message.
 
 Also, store the status code.
 

--- a/packages/python/plotly/plotly/figure_factory/README.md
+++ b/packages/python/plotly/plotly/figure_factory/README.md
@@ -4,7 +4,7 @@
 In the Python Plotly Library:
 
 We have basic plot types that are created using the `plotly.graph_objs` module.
-These plot types include Scatter, Box and Bar types. For a complete list see the [graph_objs file](https://github.com/plotly/plotly.py/blob/master/plotly/graph_objs/graph_objs.py). They are the basis of the plots and charts instatiated by Plotly.
+These plot types include Scatter, Box and Bar types. For a complete list see the [graph_objs file](https://github.com/plotly/plotly.py/blob/master/plotly/graph_objs/graph_objs.py). They are the basis of the plots and charts instantiated by Plotly.
 
 To create a basic chart like this, first we create the `data` using the tools in `plotly.graph_objs` and then we plot it. For example:
 
@@ -25,7 +25,7 @@ py.iplot(data, filename='new-scatter-plot')
 
 There is another type of chart which uses these basic plot types to make other types of graphs, and these are the figure factories. These are wrappers that utilize the code from `plotly.graph_objs` to build charts that can use their structures. A good example of a figure factory is the [Scatterplot Matrix](https://plot.ly/python/scatterplot-matrix/) as it utilizes `go.Scatter`, `go.Box` and `go.Histogram`.
 
-So if you have ever wanted to contribute to the Plotly Python Library by adding a new chart type we don't have, now you can! This README will help you get started by cloning the plotly.py repo, forking a new branch, creating a new figure factory, and creatng a new Pull Request to get feedback for merging. Just follow all these steps and you'll be ready to go.
+So if you have ever wanted to contribute to the Plotly Python Library by adding a new chart type we don't have, now you can! This README will help you get started by cloning the plotly.py repo, forking a new branch, creating a new figure factory, and creating a new Pull Request to get feedback for merging. Just follow all these steps and you'll be ready to go.
 
 ## Getting Started:
 1. In the Terminal, clone the `plotly.py` repo locally and then check out the master branch.
@@ -45,7 +45,7 @@ $ git checkout -b "add-ff-type"
 ## Create a figure_factory File
 1. Creating python file
 
-Move to the `plotly/figure_factory` directory in the `plotly.py` repo. To do this, open up the Terminal and excute the command:
+Move to the `plotly/figure_factory` directory in the `plotly.py` repo. To do this, open up the Terminal and execute the command:
 
 ```
 cd plotly/figure_factory
@@ -138,7 +138,7 @@ The figure `fig` must be a Plotly Figure, meaning it must have the form `fig = g
 
 5. Useful Tips
 
-It is often not a good idea to put all your code into your `create_foo()` function. It is best practice to not repeat yourself and this requires taking repeated blocks of code and puting them into a seperate function.
+It is often not a good idea to put all your code into your `create_foo()` function. It is best practice to not repeat yourself and this requires taking repeated blocks of code and putting them into a separate function.
 
 It is best to make all other functions besides `create_foo()` secret so a user cannot access them. This is done by placing a `_` before the name of the function, so `_aux_func()` for example.
 
@@ -161,7 +161,7 @@ and commit these changes and write a commit message.
 $ git commit -m "this is the work that I did"
 ```
 
-After you have added and commited all of your changes to the local branch, it is time to create your PR for the Plotly team to review.
+After you have added and committed all of your changes to the local branch, it is time to create your PR for the Plotly team to review.
 
 ```
 $ git push origin add-ff-type

--- a/release.md
+++ b/release.md
@@ -24,7 +24,7 @@ with the expected publication date.
 Use the `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, and `Security`
 labels for all changes to plotly.py.  If the version of plotly.js has
 been updated, include this as the first `Updated` entry. Call out any
-noteable changes as sub-bullets (new trace types in particular), and provide
+notable changes as sub-bullets (new trace types in particular), and provide
 a link to the plotly.js CHANGELOG.
 
 ### Finalize versions
@@ -213,7 +213,7 @@ npm run build && npm publish --access public --tag next
 ```
 
 The `--tag next` part ensures that users won't install this version unless
-they explicitly ask for the version or for the version wtih the `next` tag.
+they explicitly ask for the version or for the version with the `next` tag.
 
 Do the same in the `jupyterlab-plotly` directory.
 
@@ -302,7 +302,7 @@ Publish the final version to PyPI
 
 ### Publish to plotly anaconda channel
 
-From `packages/python/plotly-geo`, build the conda packge
+From `packages/python/plotly-geo`, build the conda package
 ```bash
 (plotly_dev) $ conda build recipe/
 ```
@@ -351,7 +351,7 @@ Publish the final version to PyPI
 
 ### Publish to plotly anaconda channel
 
-From `packages/python/plotly-geo`, build the conda packge
+From `packages/python/plotly-geo`, build the conda package
 ```bash
 (plotly_dev) $ conda build recipe/
 ```


### PR DESCRIPTION
In continuation with the previous pull request https://github.com/plotly/plotly.py/pull/3073, I have fixed the iteration logic of my "spelling mistakes detection" script to iterate over all directories and its subdirectories. Fixing a few more documents which were missed in the previous sweep. I guess all documents are completely covered.

For my next step I'm modifying my script to fix docstrings within python files. The regex to extract comments between """ """ is in place but not for ''' ''' and # ...

Let me know if the pull request for docstring correction within python files goes to ```doc-prod``` or ```master```