### PR TITLE
Kaleido v5 updates

### DIFF
--- a/packages/python/plotly/plotly/io/_kaleido.py
+++ b/packages/python/plotly/plotly/io/_kaleido.py
@@ -14,7 +14,10 @@ try:
     root_dir = os.path.dirname(os.path.abspath(plotly.__file__))
     package_dir = os.path.join(root_dir, "package_data")
     scope.plotlyjs = os.path.join(package_dir, "plotly.min.js")
-    scope.mathjax = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js"
+    if scope.mathjax is None:
+        scope.mathjax = (
+            "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js"
+        )
 except ImportError:
     PlotlyScope = None
     scope = None

--- a/packages/python/plotly/plotly/io/_kaleido.py
+++ b/packages/python/plotly/plotly/io/_kaleido.py
@@ -92,9 +92,19 @@ def to_image(
     # -------------
     if engine == "auto":
         if scope is not None:
+            # Default to kaleido if available
             engine = "kaleido"
         else:
-            engine = "orca"
+            # See if orca is available
+            from ._orca import validate_executable
+
+            try:
+                validate_executable()
+                engine = "orca"
+            except:
+                # If orca not configured properly, make sure we display the error
+                # message advising the installation of kaleido
+                engine = "kaleido"
 
     if engine == "orca":
         # Fall back to legacy orca image export path


### PR DESCRIPTION
Two small kaleido updates that I'd like to get into v5

1) When neither kaleido nor orca is installed, display the kaleido installation instructions instead of orca. 92b8954

2) Don't override kaleido's MathJax path (with the CDN url) if kaleido was successful in autodetecting a local MathJax installation. Local MathJax support will be released in Kaleido 0.2 (See https://github.com/plotly/Kaleido/pull/75). 2b66c73