### PR TITLE
correct misspells, fix #3074

### DIFF
--- a/packages/python/plotly/_plotly_utils/colors/__init__.py
+++ b/packages/python/plotly/_plotly_utils/colors/__init__.py
@@ -377,7 +377,7 @@ def validate_colors(colors, colortype="tuple"):
 
 def validate_colors_dict(colors, colortype="tuple"):
     """
-    Validates dictioanry of color(s)
+    Validates dictionary of color(s)
     """
     # validate each color element in the dictionary
     for key in colors:
@@ -491,15 +491,15 @@ def convert_colors_to_same_type(
         return (colors_list, scale)
     else:
         raise exceptions.PlotlyError(
-            "You must select either rgb or tuple " "for your colortype variable."
+            "You must select either rgb or tuple for your colortype variable."
         )
 
 
 def convert_dict_colors_to_same_type(colors_dict, colortype="rgb"):
     """
-    Converts a colors in a dictioanry of colors to the specified color type
+    Converts a colors in a dictionary of colors to the specified color type
 
-    :param (dict) colors_dict: a dictioanry whose values are single colors
+    :param (dict) colors_dict: a dictionary whose values are single colors
     """
     for key in colors_dict:
         if "#" in colors_dict[key]:
@@ -519,7 +519,7 @@ def convert_dict_colors_to_same_type(colors_dict, colortype="rgb"):
         return colors_dict
     else:
         raise exceptions.PlotlyError(
-            "You must select either rgb or tuple " "for your colortype variable."
+            "You must select either rgb or tuple for your colortype variable."
         )
 
 
@@ -536,7 +536,7 @@ def validate_scale_values(scale):
     """
     if len(scale) < 2:
         raise exceptions.PlotlyError(
-            "You must input a list of scale values " "that has at least two values."
+            "You must input a list of scale values that has at least two values."
         )
 
     if (scale[0] != 0) or (scale[-1] != 1):
@@ -584,7 +584,7 @@ def make_colorscale(colors, scale=None):
     # validate minimum colors length of 2
     if len(colors) < 2:
         raise exceptions.PlotlyError(
-            "You must input a list of colors that " "has at least two colors."
+            "You must input a list of colors that has at least two colors."
         )
 
     if scale is None:
@@ -594,7 +594,7 @@ def make_colorscale(colors, scale=None):
     else:
         if len(colors) != len(scale):
             raise exceptions.PlotlyError(
-                "The length of colors and scale " "must be the same."
+                "The length of colors and scale must be the same."
             )
 
         validate_scale_values(scale)

--- a/packages/python/plotly/plotly/figure_factory/_gantt.py
+++ b/packages/python/plotly/plotly/figure_factory/_gantt.py
@@ -973,7 +973,7 @@ def create_gantt(
             raise exceptions.PlotlyError(
                 "Error. You have set colors to a dictionary but have not "
                 "picked an index. An index is required if you are "
-                "assigning colors to particular values in a dictioanry."
+                "assigning colors to particular values in a dictionary."
             )
         fig = gantt(
             chart,

--- a/packages/python/plotly/plotly/figure_factory/_violin.py
+++ b/packages/python/plotly/plotly/figure_factory/_violin.py
@@ -475,7 +475,7 @@ def create_violin(
         of param colors. This means colors must be a list with at least 2
         colors in it (Plotly colorscales are accepted since they map to a
         list of two rgb colors). Default = False
-    :param (dict) group_stats: a dictioanry where each key is a unique
+    :param (dict) group_stats: a dictionary where each key is a unique
         value from the group_header column in data. Each value must be a
         number and will be used to color the violin plots if a colorscale
         is being used.

--- a/packages/python/plotly/plotly/tests/test_optional/optional_utils.py
+++ b/packages/python/plotly/plotly/tests/test_optional/optional_utils.py
@@ -37,7 +37,7 @@ class NumpyTestUtilsMixin(object):
         """
         Helper function for assert_dict_equal
 
-        By defualt removes uid from d1 and/or d2 if present
+        By default removes uid from d1 and/or d2 if present
         then calls assert_dict_equal.
 
         :param (list|tuple) ignore: sequence of key names as

--- a/packages/python/plotly/plotly/tests/test_optional/test_tools/test_figure_factory.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_tools/test_figure_factory.py
@@ -1718,7 +1718,7 @@ class TestGantt(TestCaseNoTemplate, NumpyTestUtilsMixin):
         pattern4 = (
             "Error. You have set colors to a dictionary but have not "
             "picked an index. An index is required if you are "
-            "assigning colors to particular values in a dictioanry."
+            "assigning colors to particular values in a dictionary."
         )
 
         self.assertRaisesRegexp(


### PR DESCRIPTION
### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

