### PR TITLE
add optionial gzip compression in html export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [4.14.4] - unreleased
+
+### Added
+
+- `to_html()` and `write_html()` now allows data compression `compress` to reduce the html file size [3117](https://github.com/plotly/plotly.py/pull/3117)
+
 ## [4.14.3] - 2021-01-12
 
 ### Fixed

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -3672,6 +3672,10 @@ Invalid property path '{key_path_str}' for layout
         validate: bool (default True)
             True if the figure should be validated before being converted to
             JSON, False otherwise.
+        compress: bool (default False)
+            If True, the figure data is compressed reducing the total file size.
+            It adds an external compression library which requires an active 
+            internet connection.
         auto_open: bool (default True
             If True, open the saved file in a web browser after saving.
             This argument only applies if `full_html` is True.

--- a/packages/python/plotly/plotly/io/_html.py
+++ b/packages/python/plotly/plotly/io/_html.py
@@ -126,7 +126,7 @@ def to_html(
         JSON, False otherwise.
     compress: bool (default False)
         If True, the figure data is compressed reducing the total file size.
-        It adds an external compression library which requires an active 
+        It adds an external compression library which requires an active
         internet connection.
     Returns
     -------
@@ -240,7 +240,9 @@ def to_html(
     # Compress `jdata` via fflate, and replace `jdata` with a JavaScript variable
     script_compress = ""
     if compress:
-        compressed_data = base64.b64encode(gzip.compress(jdata.encode('utf-8'))).decode('ascii');
+        compressed_data = base64.b64encode(gzip.compress(jdata.encode("utf-8"))).decode(
+            "ascii"
+        )
         script_compress = """\
                 const data_compr_b64 = "{compressed_data}";
                 const data_raw = fflate.decompressSync(
@@ -248,11 +250,10 @@ def to_html(
                 );
                 const data = JSON.parse(fflate.strFromU8(data_raw));     
             """.format(
-                compressed_data=compressed_data
-            )
+            compressed_data=compressed_data
+        )
         # Replace the plotly data with the variable "data".
         jdata = "data"
-
 
     script = """\
                 if (document.getElementById("{id}")) {{\
@@ -329,8 +330,7 @@ def to_html(
     # Add compression library when compression is enabled
     load_fflatejs = ""
     if compress:
-        load_fflatejs = "<script src=\"https://cdn.jsdelivr.net/npm/fflate@0.6.7/umd/index.min.js\"></script>"
-
+        load_fflatejs = '<script src="https://cdn.jsdelivr.net/npm/fflate@0.6.7/umd/index.min.js"></script>'
 
     # ## Handle loading/initializing MathJax ##
     include_mathjax_orig = include_mathjax
@@ -532,7 +532,7 @@ def write_html(
         JSON, False otherwise.
     compress: bool (default False)
         If True, the figure data is compressed reducing the total file size.
-        It adds an external compression library which requires an active 
+        It adds an external compression library which requires an active
         internet connection.
     auto_open: bool (default True
         If True, open the saved file in a web browser after saving.


### PR DESCRIPTION
Exporting big 3d meshes resulted in huge files since the data is stored as plain text in the html file. By storing the data in compressed base64 the file size can be reduced by 85%.

Reduction Examples:
  96.8mb to 15.4mb
  42.2mb to   2.7mb
  27.6mb to   6.8mb

<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

-->

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [x] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [x] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

