### PR TITLE
Multiple plots in iframe renderer

### DIFF
--- a/packages/python/plotly/plotly/io/_base_renderers.py
+++ b/packages/python/plotly/plotly/io/_base_renderers.py
@@ -545,6 +545,8 @@ class IFrameRenderer(MimetypeRenderer):
         self.animation_opts = animation_opts
         self.include_plotlyjs = include_plotlyjs
         self.html_directory = html_directory
+        self.last_focus_cell = None
+        self.last_focus_cell_output_ct = 1
 
     def to_mimebundle(self, fig_dict):
         from plotly.io import write_html
@@ -608,8 +610,17 @@ class IFrameRenderer(MimetypeRenderer):
     def build_filename(self):
         ip = IPython.get_ipython() if IPython else None
         cell_number = list(ip.history_manager.get_tail(1))[0][1] + 1 if ip else 0
-        filename = "{dirname}/figure_{cell_number}.html".format(
-            dirname=self.html_directory, cell_number=cell_number
+        if self.last_focus_cell == cell_number:
+            output_ct_suffix = f"_{self.last_focus_cell_output_ct}"
+            self.last_focus_cell_output_ct += 1
+        else:
+            self.last_focus_cell = cell_number
+            self.last_focus_cell_output_ct = 1
+            output_ct_suffix = ""
+        filename = "{dirname}/figure_{cell_number}{output_ct_suffix}.html".format(
+            dirname=self.html_directory,
+            cell_number=cell_number,
+            output_ct_suffix=output_ct_suffix,
         )
         return filename
 

--- a/packages/python/plotly/plotly/io/_base_renderers.py
+++ b/packages/python/plotly/plotly/io/_base_renderers.py
@@ -524,7 +524,10 @@ class IFrameRenderer(MimetypeRenderer):
     Note that the HTML files in `iframe_figures/` are numbered according to
     the IPython cell execution count and so they will start being overwritten
     each time the kernel is restarted.  This directory may be deleted whenever
-    the kernel is restarted and it will be automatically recreated.
+    the kernel is restarted and it will be automatically recreated. If a cell
+    contains multiple plots, a second index is appended to the file name. For
+    example, figure_8_2.html would be the third figure in the eighth cell
+    executed.
 
     mime type: 'text/html'
     """


### PR DESCRIPTION

### Documentation PR

Only a couple sentences added to the documentation--no new examples.

- [x ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [N/A ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [N/A ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [N/A ] Every new/modified example is independently runnable
- [N/A ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [N/A ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [N/A ] The random seed is set if using randomly-generated data in new/modified examples
- [N/A ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [N/A ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [N/A ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [N/A ] Data frames are always called `df`
- [N/A ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [N/A ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [N/A ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [N/A ] `fig.show()` is at the end of each new/modified example
- [N/A ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [N/A ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [ x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [x ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

This is not a feature change, just a behavior change. It allows multiple outputs from a single jupyter cell to be stored and displayed when using the iframe renderer.

I ran relevant test files and all passed, but I didn't add any new tests since this is such a minor behavior change.

This is my first time contributed to any significant package on Github, so please let me know if I'm doing anything wrong.
