### PR TITLE
Implements getting a colorscale by name

### DIFF
--- a/packages/python/plotly/_plotly_utils/colors/__init__.py
+++ b/packages/python/plotly/_plotly_utils/colors/__init__.py
@@ -806,3 +806,30 @@ def named_colorscales():
     from _plotly_utils.basevalidators import ColorscaleValidator
 
     return [c for c in ColorscaleValidator("", "").named_colorscales]
+
+
+def get_colorscale(name):
+    """
+    Returns the colorscale for a given name. See `named_colorscales` for the
+    built-in colorscales.
+    """
+    from _plotly_utils.basevalidators import ColorscaleValidator
+
+    if not isinstance(name, str):
+        raise exceptions.PlotlyError("Name argument have to be a string.")
+
+    name = name.lower()
+    if name[-2:] == "_r":
+        should_reverse = True
+        name = name[:-2]
+    else:
+        should_reverse = False
+
+    if name in ColorscaleValidator("", "").named_colorscales:
+        colorscale = ColorscaleValidator("", "").named_colorscales[name]
+    else:
+        raise exceptions.PlotlyError(f"Colorscale {name} is not a built-in scale.")
+
+    if should_reverse:
+        return colorscale[::-1]
+    return colorscale

--- a/packages/python/plotly/plotly/colors/__init__.py
+++ b/packages/python/plotly/plotly/colors/__init__.py
@@ -45,4 +45,5 @@ __all__ = [
     "plotlyjs",
     "DEFAULT_PLOTLY_COLORS",
     "PLOTLY_SCALES",
+    "get_colorscale",
 ]

--- a/packages/python/plotly/plotly/tests/test_core/test_colors/test_colors.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_colors/test_colors.py
@@ -137,3 +137,30 @@ class TestColors(TestCase):
         self.assertRaisesRegexp(
             PlotlyError, pattern2, colors.make_colorscale, color_list2, scale
         )
+
+    def test_get_colorscale(self):
+
+        # test for incorrect input type
+        pattern = "Name argument have to be a string."
+        name = colors.sequential.haline
+
+        self.assertRaisesRegexp(PlotlyError, pattern, colors.get_colorscale, name)
+
+        # test for non-existing colorscale
+        pattern = r"Colorscale \S+ is not a built-in scale."
+        name = "foo"
+
+        self.assertRaisesRegex(PlotlyError, pattern, colors.get_colorscale, name)
+
+        # test non-capitalised access
+        self.assertEqual(colors.sequential.haline, colors.get_colorscale("haline"))
+        # test capitalised access
+        self.assertEqual(colors.diverging.Earth, colors.get_colorscale("Earth"))
+        # test accessing non-capitalised scale with capitalised name
+        self.assertEqual(colors.cyclical.mrybm, colors.get_colorscale("Mrybm"))
+        # test accessing capitalised scale with non-capitalised name
+        self.assertEqual(colors.sequential.Viridis, colors.get_colorscale("viridis"))
+        # test accessing reversed scale
+        self.assertEqual(
+            colors.diverging.Portland_r, colors.get_colorscale("portland_r")
+        )


### PR DESCRIPTION
A utility function to get a colorscale by name.
This follows the convention set by `plotly.colors.named_colorscales` and only gives access to scales defined in the `sequential`, `diverging` and `cyclical` namespaces.

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [x] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).
