### PR TITLE
Fix an IndexError in .../figure_factory/_trisurf.py::map_face2color

### DIFF
--- a/packages/python/plotly/plotly/figure_factory/_trisurf.py
+++ b/packages/python/plotly/plotly/figure_factory/_trisurf.py
@@ -30,7 +30,11 @@ def map_face2color(face, colormap, scale, vmin, vmax):
         face_color = clrs.convert_to_RGB_255(face_color)
         face_color = clrs.label_rgb(face_color)
         return face_color
-    if face == vmax:
+
+    # find the normalized distance t of a triangle face between
+    # vmin and vmax where the distance is between 0 and 1
+    t = (face - vmin) / float((vmax - vmin))
+    if t == 1.0:
         # pick last color in colormap
         face_color = colormap[-1]
         face_color = clrs.convert_to_RGB_255(face_color)
@@ -38,9 +42,6 @@ def map_face2color(face, colormap, scale, vmin, vmax):
         return face_color
     else:
         if scale is None:
-            # find the normalized distance t of a triangle face between
-            # vmin and vmax where the distance is between 0 and 1
-            t = (face - vmin) / float((vmax - vmin))
             low_color_index = int(t / (1.0 / (len(colormap) - 1)))
 
             face_color = clrs.find_intermediate_color(
@@ -52,9 +53,6 @@ def map_face2color(face, colormap, scale, vmin, vmax):
             face_color = clrs.convert_to_RGB_255(face_color)
             face_color = clrs.label_rgb(face_color)
         else:
-            # find the face color for a non-linearly interpolated scale
-            t = (face - vmin) / float((vmax - vmin))
-
             low_color_index = 0
             for k in range(len(scale) - 1):
                 if scale[k] <= t < scale[k + 1]:


### PR DESCRIPTION
The function map_face2color in _trisurf.py compared face value (face) to max face value (vmax) and if equal did a quick exit by returning the last element in a list. Later it would compare normalized face value to indexed values. Because of floating point errors the normalized value could be 1.0 and lead to attempted look up at an index past the end of a list. This would raise an IndexError.

The essence of the problem is
```
def map_face2color(face, colormap, scale, vmin, vmax):
    if face == vmax: return colormap[-1];
    t = (face - vmin) / (vmax - vmin)  # normalized position
    # t can be equal to 1.0 even when face != vmax.
    # when t is equal to 1.0 finding first element past t in a list fails with IndexError
```

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

