### PR TITLE
Remove default width/height for static image renderers

### DIFF
--- a/packages/python/plotly/plotly/io/_renderers.py
+++ b/packages/python/plotly/plotly/io/_renderers.py
@@ -428,13 +428,12 @@ renderers["databricks"] = DatabricksRenderer()
 renderers["json"] = JsonRenderer()
 
 # Static Image
-img_kwargs = dict(height=450, width=700)
-renderers["png"] = PngRenderer(**img_kwargs)
-jpeg_renderer = JpegRenderer(**img_kwargs)
+renderers["png"] = PngRenderer()
+jpeg_renderer = JpegRenderer()
 renderers["jpeg"] = jpeg_renderer
 renderers["jpg"] = jpeg_renderer
-renderers["svg"] = SvgRenderer(**img_kwargs)
-renderers["pdf"] = PdfRenderer(**img_kwargs)
+renderers["svg"] = SvgRenderer()
+renderers["pdf"] = PdfRenderer()
 
 # External
 renderers["browser"] = BrowserRenderer(config=config)

--- a/packages/python/plotly/plotly/tests/test_optional/test_kaleido/test_kaleido.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_kaleido/test_kaleido.py
@@ -99,9 +99,5 @@ def test_image_renderer():
 
     renderer = pio.renderers["svg"]
     scope.transform.assert_called_with(
-        fig,
-        format="svg",
-        width=renderer.width,
-        height=renderer.height,
-        scale=renderer.scale,
+        fig, format="svg", width=None, height=None, scale=renderer.scale,
     )


### PR DESCRIPTION
This takes care  of https://github.com/plotly/plotly.py/issues/2651.

Now the image size precedence is:
 - width/height provided to fig.show() (e.g. `fig.show(width=700, height=400))
 - width/height specified in figure (e.g. `px.scatter(..., width=800, height=500))
 - default_width/default_height specified in the kaleido scope (e.g. pio.kaleido.scope.default_width)