### PR TITLE
Fix make_subplots documentation of print_grid's default

### DIFF
--- a/packages/python/plotly/plotly/subplots.py
+++ b/packages/python/plotly/plotly/subplots.py
@@ -98,7 +98,7 @@ def make_subplots(
           - 'bottom-left': Subplots are numbererd with (1, 1) in the bottom
                            left corner
 
-    print_grid: boolean (default True):
+    print_grid: boolean (default False):
         If True, prints a string representation of the plot grid.  Grid may
         also be printed using the `Figure.print_grid()` method on the
         resulting figure.

--- a/packages/python/plotly/plotly/tools.py
+++ b/packages/python/plotly/plotly/tools.py
@@ -241,7 +241,7 @@ def make_subplots(
     shared_xaxes=False,
     shared_yaxes=False,
     start_cell="top-left",
-    print_grid=None,
+    print_grid=False,
     **kwargs
 ):
     """Return an instance of plotly.graph_objs.Figure
@@ -354,7 +354,7 @@ def make_subplots(
         Choose the starting cell in the subplot grid used to set the
         domains of the subplots.
 
-    print_grid (kwarg, boolean, default=True):
+    print_grid (kwarg, boolean, default=False):
         If True, prints a tab-delimited string representation of
         your plot grid.
 


### PR DESCRIPTION
Fixes small inconsistency pointed out in https://github.com/plotly/plotly.py/issues/3234 in the API reference documentation.
This makes the API reference match the code for the default value of `print_grid` in `make_subplots`

### Documentation PR

- [X] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [X] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch

## Code PR

- [X] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
