### PR TITLE
Small fix in documentation: date-index mismatch in "Update Dropdown"

### DIFF
--- a/doc/python/dropdowns.md
+++ b/doc/python/dropdowns.md
@@ -353,7 +353,8 @@ import pandas as pd
 
 # Load dataset
 df = pd.read_csv(
-    "https://raw.githubusercontent.com/plotly/datasets/master/finance-charts-apple.csv")
+    "https://raw.githubusercontent.com/plotly/datasets/master/finance-charts-apple.csv",
+    index_col=0)
 df.columns = [col.replace("AAPL.", "") for col in df.columns]
 
 # Initialize figure


### PR DESCRIPTION
Code in this example assumed the index to be the date stamp. However, the file is read from CSV and does not take the 0 col ('Date') as the index for the pd.DataFrame. A simple "index_col=0" argument fixed this. Without this fix the chart does not display the expected behavior. 


### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch


## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
