### PR TITLE
Fix typo: missing 'as'

### DIFF
--- a/doc/python/interactive-html-export.md
+++ b/doc/python/interactive-html-export.md
@@ -41,7 +41,7 @@ Plotly figures are interactive when viewed in a web browser: you can hover over 
 <!-- #region -->
 ### Saving to an HTML file
 
-Any figure can be saved an HTML file using the `write_html` method. These HTML files can be opened in any web browser to access the fully interactive figure.
+Any figure can be saved as an HTML file using the `write_html` method. These HTML files can be opened in any web browser to access the fully interactive figure.
 
 ```python
 import plotly.express as px


### PR DESCRIPTION
### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch

