### PR TITLE
improve browser error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
   - Fixed regression introduced in version 5.0.0 where pandas/numpy arrays with `dtype` of Object were being converted to `list` values when added to a Figure ([#3292](https://github.com/plotly/plotly.py/issues/3292), [#3293](https://github.com/plotly/plotly.py/pull/3293))
+  - Better detection of Chrome and Chromium browsers in the Renderers framework, especially on Linux ([#3278](https://github.com/plotly/plotly.py/pull/3278)) with thanks to [@c-chaitanya](https://github.com/c-chaitanya) for the contribution
 
 ## [5.1.0] - 2021-06-28
 

--- a/packages/python/plotly/plotly/io/_base_renderers.py
+++ b/packages/python/plotly/plotly/io/_base_renderers.py
@@ -669,15 +669,21 @@ def open_html_in_browser(html, using=None, new=0, autoraise=True):
     if isinstance(html, six.string_types):
         html = html.encode("utf8")
 
-    if isinstance(using, tuple):
-        try:
-            using = [i for i in webbrowser._browsers.keys() if i in using][0]
-        except IndexError:
-            raise ValueError(
-                """
-Unable to find the given browser.
-Try one among the following 'chrome', 'chromium', 'firefox' or 'default' """
-            )
+    browser = None
+
+    if using is None:
+        browser = webbrowser.get()
+    else:
+        if not isinstance(using, tuple):
+            using = (using,)
+        for browser_key in using:
+            try:
+                browser = webbrowser.get(browser_key)
+            except webbrowser.Error:
+                pass
+
+        if browser is None:
+            raise ValueError("Can't locate a browser with key in " + str(using))
 
     class OneShotRequestHandler(BaseHTTPRequestHandler):
         def do_GET(self):
@@ -694,7 +700,7 @@ Try one among the following 'chrome', 'chromium', 'firefox' or 'default' """
             pass
 
     server = HTTPServer(("127.0.0.1", 0), OneShotRequestHandler)
-    webbrowser.get(using).open(
+    browser.open(
         "http://127.0.0.1:%s" % server.server_port, new=new, autoraise=autoraise
     )
 

--- a/packages/python/plotly/plotly/io/_base_renderers.py
+++ b/packages/python/plotly/plotly/io/_base_renderers.py
@@ -672,7 +672,7 @@ def open_html_in_browser(html, using=None, new=0, autoraise=True):
     browser = None
 
     if using is None:
-        browser = webbrowser.get()
+        browser = webbrowser.get(None)
     else:
         if not isinstance(using, tuple):
             using = (using,)

--- a/packages/python/plotly/plotly/io/_base_renderers.py
+++ b/packages/python/plotly/plotly/io/_base_renderers.py
@@ -679,6 +679,8 @@ def open_html_in_browser(html, using=None, new=0, autoraise=True):
         for browser_key in using:
             try:
                 browser = webbrowser.get(browser_key)
+                if browser is not None:
+                    break
             except webbrowser.Error:
                 pass
 

--- a/packages/python/plotly/plotly/tests/test_io/test_renderers.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_renderers.py
@@ -249,7 +249,11 @@ def test_browser_renderer_show(fig1, renderer):
         pio.show(fig1)
 
     # check get args
-    mock_get.assert_called_once_with(renderer_obj.using)
+    if isinstance(renderer_obj.using, tuple):
+        for using in renderer_obj.using:
+            mock_get.assert_called_with(using)
+    else:
+        mock_get.assert_called_once_with(renderer_obj.using)
 
     # check open args
     mock_call_args = mock_browser.open.call_args

--- a/packages/python/plotly/plotly/tests/test_io/test_renderers.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_renderers.py
@@ -221,10 +221,14 @@ def test_notebook_connected_show(fig1, name, connected):
 
 # Browser
 # -------
-@pytest.mark.parametrize("renderer", ["browser", "chrome", "firefox"])
+@pytest.mark.parametrize("renderer", ["browser", "chrome", "chromium", "firefox"])
 def test_browser_renderer_show(fig1, renderer):
     pio.renderers.default = renderer
     renderer_obj = pio.renderers[renderer]
+    using = renderer_obj.using
+    if isinstance(renderer_obj.using, tuple):
+        using = renderer_obj.using[0]
+        renderer_obj.using = using
 
     # Setup mocks
     mock_get = MagicMock(name="test get")
@@ -249,11 +253,7 @@ def test_browser_renderer_show(fig1, renderer):
         pio.show(fig1)
 
     # check get args
-    if isinstance(renderer_obj.using, tuple):
-        for using in renderer_obj.using:
-            mock_get.assert_called_with(using)
-    else:
-        mock_get.assert_called_once_with(renderer_obj.using)
+    mock_get.assert_called_once_with(using)
 
     # check open args
     mock_call_args = mock_browser.open.call_args

--- a/packages/python/plotly/plotly/tests/test_io/test_renderers.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_renderers.py
@@ -226,9 +226,8 @@ def test_browser_renderer_show(fig1, renderer):
     pio.renderers.default = renderer
     renderer_obj = pio.renderers[renderer]
     using = renderer_obj.using
-    if isinstance(renderer_obj.using, tuple):
-        using = renderer_obj.using[0]
-        renderer_obj.using = using
+    if not isinstance(renderer_obj.using, tuple):
+        using = (using,)
 
     # Setup mocks
     mock_get = MagicMock(name="test get")
@@ -253,7 +252,7 @@ def test_browser_renderer_show(fig1, renderer):
         pio.show(fig1)
 
     # check get args
-    mock_get.assert_called_once_with(using)
+    mock_get.assert_any_call(using[0])
 
     # check open args
     mock_call_args = mock_browser.open.call_args

--- a/packages/python/plotly/plotly/tests/test_io/test_renderers.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_renderers.py
@@ -225,8 +225,6 @@ def test_notebook_connected_show(fig1, name, connected):
 def test_browser_renderer_show(fig1, renderer):
     pio.renderers.default = renderer
     renderer_obj = pio.renderers[renderer]
-    # scan through webbrowser._browsers.keys() and assign the browser name registered with os
-    renderer_obj.using = [i for i in webbrowser._browsers.keys() if renderer in i][0]
 
     # Setup mocks
     mock_get = MagicMock(name="test get")


### PR DESCRIPTION
Followup to https://github.com/plotly/plotly.py/pull/3278 because `webbrowser._browsers` is an unreliable private object.