### PR TITLE
Change URL from githubusercontent.com to github.io

### DIFF
--- a/doc/python/line-and-scatter.md
+++ b/doc/python/line-and-scatter.md
@@ -208,7 +208,7 @@ fig.show()
 import plotly.graph_objects as go
 import pandas as pd
 
-data= pd.read_csv("https://raw.githubusercontent.com/plotly/datasets/master/2014_usa_states.csv")
+data= pd.read_csv("https://plotly.github.io/datasets/2014_usa_states.csv")
 
 fig = go.Figure(data=go.Scatter(x=data['Postal'],
                                 y=data['Population'],


### PR DESCRIPTION
Before:
```python
data = pd.read_csv("https://raw.githubusercontent.com/plotly/datasets/master/2014_usa_states.csv")
```

After:
```python
data = pd.read_csv("https://plotly.github.io/datasets/2014_usa_states.csv")
```

If we can set the URL for `plotly.github.io/datasets` to `data.plotly.com`, we could have something like:
```python
data = pd.read_csv("https://data.plotly.com/2014_usa_states.csv")
```