### PR TITLE
Fix error in orjson engine when a dict has a non-string value as a key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [5.2.2] - ???
+
+### Fixed
+  - Fixed error when using the orjson engine with non-string keys  
+
 ## [5.2.1] - 2021-08-13
 
 ### Updated

--- a/packages/python/plotly/plotly/io/_json.py
+++ b/packages/python/plotly/plotly/io/_json.py
@@ -462,7 +462,7 @@ def clean_to_json_compatible(obj, **kwargs):
         return obj
 
     if isinstance(obj, dict):
-        return {k: clean_to_json_compatible(v, **kwargs) for k, v in obj.items()}
+        return {str(k): clean_to_json_compatible(v, **kwargs) for k, v in obj.items()}
     elif isinstance(obj, (list, tuple)):
         if obj:
             # Must process list recursively even though it may be slow

--- a/packages/python/plotly/plotly/tests/test_io/test_to_from_plotly_json.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_to_from_plotly_json.py
@@ -209,3 +209,9 @@ def test_object_array(engine, pretty):
     fig = px.scatter(px.data.tips(), x="total_bill", y="tip", custom_data=["sex"])
     result = fig.to_plotly_json()
     check_roundtrip(result, engine=engine, pretty=pretty)
+
+
+def test_nonstring_key(engine, pretty):
+    value = build_test_dict({0: 1})
+    result = pio.to_json_plotly(value, engine=engine)
+    check_roundtrip(result, engine=engine, pretty=pretty)


### PR DESCRIPTION
## Background
Python's built-in json library can handle encoding dictionaries with keys that aren't strings by coercing them to strings implicitly.  The orjson library requires the keys to be strings, otherwise an error is raised.

This would very rarely come up in plotly figures. But now that we're updating Dash (for Dash 2) to use the active plotly.py json engine, it comes up on occasion.

## Change
All dict keys are converted to strings during the existing cleaning pass that is used prior to orjson encoding.

## Tests
Test added that encodes a dict with integer keys.