### PR TITLE
support dataframe protocol (tested with Vaex)

### DIFF
--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1304,14 +1304,17 @@ def build_dataframe(args, constructor):
     df_provided = args["data_frame"] is not None
     if df_provided and not isinstance(args["data_frame"], pd.DataFrame):
         if hasattr(args["data_frame"], "__dataframe__"):
-            # Pandas does not implement a `from_dataframe` yet
-            # $ wget https://raw.githubusercontent.com/data-apis/dataframe-api/main/protocol/pandas_implementation.py
-            # $ export PYTHONPATH=`pwd`
-            import pandas_implementation
-
-            args["data_frame"] = pandas_implementation.from_dataframe(
-                args["data_frame"]
-            )
+            try:
+                import pandas.api.interchange
+            except ModuleNotFoundError:
+                raise NotImplementedError(
+                    "The dataframe you provided supports the dataframe interchange"
+                    "protocol, "
+                    "but pandas 1.5.0 or greater is required to consume it."
+                )
+            df_not_pandas = args["data_frame"]
+            df_pandas = pandas.api.interchange.from_dataframe(df_not_pandas)
+            args["data_frame"] = df_pandas
         else:
             args["data_frame"] = pd.DataFrame(args["data_frame"])
     df_input = args["data_frame"]

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1303,7 +1303,17 @@ def build_dataframe(args, constructor):
     # Cast data_frame argument to DataFrame (it could be a numpy array, dict etc.)
     df_provided = args["data_frame"] is not None
     if df_provided and not isinstance(args["data_frame"], pd.DataFrame):
-        args["data_frame"] = pd.DataFrame(args["data_frame"])
+        if hasattr(args["data_frame"], "__dataframe__"):
+            # Pandas does not implement a `from_dataframe` yet
+            # $ wget https://raw.githubusercontent.com/data-apis/dataframe-api/main/protocol/pandas_implementation.py
+            # $ export PYTHONPATH=`pwd`
+            import pandas_implementation
+
+            args["data_frame"] = pandas_implementation.from_dataframe(
+                args["data_frame"]
+            )
+        else:
+            args["data_frame"] = pd.DataFrame(args["data_frame"])
     df_input = args["data_frame"]
 
     # now we handle special cases like wide-mode or x-xor-y specification

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_input.py
@@ -233,6 +233,19 @@ def test_build_df_with_index():
     assert_frame_equal(tips.reset_index()[out["data_frame"].columns], out["data_frame"])
 
 
+def test_build_df_protocol():
+    import vaex
+
+    # take out the 'species' columns since the vaex implementation does not cover strings yet
+    iris_pandas = px.data.iris()[["petal_width", "sepal_length"]]
+    iris_vaex = vaex.from_pandas(iris_pandas)
+    args = dict(data_frame=iris_vaex, x="petal_width", y="sepal_length")
+    out = build_dataframe(args, go.Scatter)
+    assert_frame_equal(
+        iris_pandas.reset_index()[out["data_frame"].columns], out["data_frame"]
+    )
+
+
 def test_timezones():
     df = pd.DataFrame({"date": ["2015-04-04 19:31:30+1:00"], "value": [3]})
     df["date"] = pd.to_datetime(df["date"])

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_input.py
@@ -236,7 +236,7 @@ def test_build_df_with_index():
 def test_build_df_protocol():
     import vaex
 
-    # take out the 'species' columns since the vaex implementation does not cover strings yet
+    # take out the 'species' columns since there are still some issues with strings
     iris_pandas = px.data.iris()[["petal_width", "sepal_length"]]
     iris_vaex = vaex.from_pandas(iris_pandas)
     args = dict(data_frame=iris_vaex, x="petal_width", y="sepal_length")


### PR DESCRIPTION
This allows plotly express to take in any dataframe that supports
the dataframe protocol, see:
https://data-apis.org/blog/dataframe_protocol_rfc/
https://data-apis.org/dataframe-protocol/latest/index.html

Test includes an example with vaex, which should work with
https://github.com/vaexio/vaex/pull/1509/
(not yet released)

This is only a POC, I think this needs to wait till Pandas implemented the `from_dataframe`, and if you'd like to keep this test, would require a Vaex version with above mentioned PR merged and released.

Usage:
![image](https://user-images.githubusercontent.com/1765949/133602057-fb0d59a4-070b-4d41-b652-876af0e2662e.png)

Note that this does not speed up any aggregation/processing, although reading from hdf5/arrow/parquet might be faster.
