### PR TITLE
change plotly.js dependencie by plotly.js-dist

### DIFF
--- a/packages/javascript/jupyterlab-plotly/package.json
+++ b/packages/javascript/jupyterlab-plotly/package.json
@@ -65,7 +65,7 @@
     "@lumino/messaging": "^1.2.3",
     "@lumino/widgets": "^1.8.1",
     "lodash": "^4.17.4",
-    "plotly.js": "^2.4.2"
+    "plotly.js-dist": "^2.4.2"
   },
   "jupyterlab": {
     "extension": "lib/jupyterlab-plugin",


### PR DESCRIPTION
Hi,

This PR refers to this issue : https://github.com/plotly/plotly.js/issues/5966

We are facing trouble to build jupyterlab-plotly because of the box-intersect package, which is not accessible through our company CI network.