### PR TITLE
substituted deprecated numpy types and matplotlib arguments

### DIFF
--- a/packages/python/plotly/plotly/express/_imshow.py
+++ b/packages/python/plotly/plotly/express/_imshow.py
@@ -346,7 +346,7 @@ def imshow(
         binary_string = img.ndim >= (3 + slice_dimensions) and not is_dataframe
 
     # Cast bools to uint8 (also one byte)
-    if img.dtype == np.bool:
+    if img.dtype == bool:
         img = 255 * img.astype(np.uint8)
 
     if range_color is not None:

--- a/packages/python/plotly/plotly/figure_factory/_streamline.py
+++ b/packages/python/plotly/plotly/figure_factory/_streamline.py
@@ -183,8 +183,8 @@ class _Streamline(object):
             self.x = xi.astype(np.int)
             self.y = yi.astype(np.int)
         else:
-            self.val_x = np.int(xi)
-            self.val_y = np.int(yi)
+            self.val_x = int(xi)
+            self.val_y = int(yi)
         a00 = a[self.val_y, self.val_x]
         a01 = a[self.val_y, self.val_x + 1]
         a10 = a[self.val_y + 1, self.val_x]

--- a/packages/python/plotly/plotly/figure_factory/_violin.py
+++ b/packages/python/plotly/plotly/figure_factory/_violin.py
@@ -16,7 +16,7 @@ def calc_stats(data):
     """
     Calculate statistics for use in violin plot.
     """
-    x = np.asarray(data, np.float)
+    x = np.asarray(data, dtype=float)
     vals_min = np.min(x)
     vals_max = np.max(x)
     q2 = np.percentile(x, 50, interpolation="linear")
@@ -160,7 +160,7 @@ def violinplot(vals, fillcolor="#1f77b4", rugplot=True):
     """
     Refer to FigureFactory.create_violin() for docstring.
     """
-    vals = np.asarray(vals, np.float)
+    vals = np.asarray(vals, dtype=float)
     #  summary statistics
     vals_min = calc_stats(vals)["min"]
     vals_max = calc_stats(vals)["max"]
@@ -231,7 +231,7 @@ def violin_no_colorscale(
     )
     color_index = 0
     for k, gr in enumerate(group_name):
-        vals = np.asarray(gb.get_group(gr)[data_header], np.float)
+        vals = np.asarray(gb.get_group(gr)[data_header], dtype=float)
         if color_index >= len(colors):
             color_index = 0
         plot_data, plot_xrange = violinplot(
@@ -319,7 +319,7 @@ def violin_colorscale(
     min_value = min(group_stats_values)
 
     for k, gr in enumerate(group_name):
-        vals = np.asarray(gb.get_group(gr)[data_header], np.float)
+        vals = np.asarray(gb.get_group(gr)[data_header], dtype=float)
 
         # find intermediate color from colorscale
         intermed = (group_stats[gr] - min_value) / (max_value - min_value)
@@ -411,7 +411,7 @@ def violin_dict(
     )
 
     for k, gr in enumerate(group_name):
-        vals = np.asarray(gb.get_group(gr)[data_header], np.float)
+        vals = np.asarray(gb.get_group(gr)[data_header], dtype=float)
         plot_data, plot_xrange = violinplot(vals, fillcolor=colors[gr], rugplot=rugplot)
         layout = graph_objs.Layout()
 

--- a/packages/python/plotly/plotly/tests/test_optional/test_matplotlylib/test_bars.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_matplotlylib/test_bars.py
@@ -15,7 +15,7 @@ if matplotlylib:
 @pytest.mark.matplotlib
 def test_vertical_bar():
     fig, ax = plt.subplots()
-    ax.bar(left=D["left"], height=D["height"])
+    ax.bar(x=D["left"], height=D["height"])
     renderer = run_fig(fig)
 
     for data_no, data_dict in enumerate(renderer.plotly_fig["data"]):
@@ -35,7 +35,7 @@ def test_vertical_bar():
 @pytest.mark.matplotlib
 def test_horizontal_bar():
     fig, ax = plt.subplots()
-    ax.barh(bottom=D["bottom"], width=D["width"])
+    ax.barh(y=D["bottom"], width=D["width"])
     renderer = run_fig(fig)
 
     for data_no, data_dict in enumerate(renderer.plotly_fig["data"]):
@@ -56,7 +56,7 @@ def test_horizontal_bar():
 def test_h_and_v_bars():
     fig, ax = plt.subplots()
     ax.bar(
-        left=D["multi_left"],
+        x=D["multi_left"],
         height=D["multi_height"],
         width=10,
         color="green",
@@ -64,7 +64,7 @@ def test_h_and_v_bars():
     )
     # changing height 10 -> 14 because ValueError if bargap not in [0, 1]
     ax.barh(
-        bottom=D["multi_bottom"],
+        y=D["multi_bottom"],
         width=D["multi_width"],
         height=14,
         color="red",

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_imshow.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_imshow.py
@@ -9,7 +9,7 @@ import datetime
 from plotly.express.imshow_utils import rescale_intensity
 
 img_rgb = np.array([[[255, 0, 0], [0, 255, 0], [0, 0, 255]]], dtype=np.uint8)
-img_gray = np.arange(100, dtype=np.float).reshape((10, 10))
+img_gray = np.arange(100, dtype=float).reshape((10, 10))
 
 
 def decode_image_string(image_string):
@@ -47,15 +47,15 @@ def test_automatic_zmax_from_dtype():
     dtypes_dict = {
         np.uint8: 2 ** 8 - 1,
         np.uint16: 2 ** 16 - 1,
-        np.float: 1,
-        np.bool: 255,
+        float: 1,
+        bool: 255,
     }
     for key, val in dtypes_dict.items():
         img = np.array([0, 1], dtype=key)
         img = np.dstack((img,) * 3)
         fig = px.imshow(img, binary_string=False)
         # For uint8 in "infer" mode we don't pass zmin/zmax unless specified
-        if key in [np.uint8, np.bool]:
+        if key in [np.uint8, bool]:
             assert fig.data[0]["zmax"] is None
         else:
             assert fig.data[0]["zmax"] == (val, val, val, 255)

--- a/packages/python/plotly/plotly/tests/test_optional/test_utils/test_utils.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_utils/test_utils.py
@@ -411,8 +411,8 @@ class TestNumpyIntegerBaseType(TestCase):
         import plotly.graph_objects as go
         from plotly.subplots import make_subplots
 
-        indices_rows = np.array([1], dtype=np.int)
-        indices_cols = np.array([1], dtype=np.int)
+        indices_rows = np.array([1], dtype=int)
+        indices_cols = np.array([1], dtype=int)
         fig = make_subplots(rows=1, cols=1)
         fig.add_trace(go.Scatter(y=[1]), row=indices_rows[0], col=indices_cols[0])
 


### PR DESCRIPTION
Replaced deprecated numpy.dtypes

  * `np.bool` ==> `bool`
  *  `np.int` ==> `int`
  *  `np.float` ==> `float`

Replaced deprecated Matplotlib bar arguments

  * `left` ==> `x`
  *  `bottom` ==> `y`


## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).


