### PR TITLE
Improve Type Checking Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+##  TBD
+
+### Fixed
+  - Improve support for type checking by bypassing lazy-loading when type checking.
 
 ##  [5.7.0] - 2022-04-05
 

--- a/packages/python/plotly/codegen/__init__.py
+++ b/packages/python/plotly/codegen/__init__.py
@@ -267,7 +267,7 @@ def perform_codegen():
         root_datatype_imports.append(f"._deprecations.{dep_clas}")
 
     optional_figure_widget_import = f"""
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     try:
         import ipywidgets as _ipywidgets
         from distutils.version import LooseVersion as _LooseVersion

--- a/packages/python/plotly/codegen/utils.py
+++ b/packages/python/plotly/codegen/utils.py
@@ -75,7 +75,8 @@ def build_from_imports_py(rel_modules=(), rel_classes=(), init_extra=""):
 
     result = f"""\
 import sys
-if sys.version_info < (3, 7):
+from typing import TYPE_CHECKING
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     {imports_str}
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/__init__.py
+++ b/packages/python/plotly/plotly/__init__.py
@@ -27,10 +27,11 @@ Modules:
 """
 from __future__ import absolute_import
 import sys
+from typing import TYPE_CHECKING
 from _plotly_utils.importers import relative_import
 
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from plotly import (
         graph_objs,
         tools,

--- a/packages/python/plotly/plotly/graph_objects/__init__.py
+++ b/packages/python/plotly/plotly/graph_objects/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ..graph_objs import Waterfall
     from ..graph_objs import Volume
     from ..graph_objs import Violin
@@ -263,7 +264,7 @@ else:
     )
 
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     try:
         import ipywidgets as _ipywidgets
         from distutils.version import LooseVersion as _LooseVersion

--- a/packages/python/plotly/plotly/graph_objs/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._bar import Bar
     from ._barpolar import Barpolar
     from ._box import Box
@@ -263,7 +264,7 @@ else:
     )
 
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     try:
         import ipywidgets as _ipywidgets
         from distutils.version import LooseVersion as _LooseVersion

--- a/packages/python/plotly/plotly/graph_objs/_carpet.py
+++ b/packages/python/plotly/plotly/graph_objs/_carpet.py
@@ -265,8 +265,8 @@ class Carpet(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -575,8 +575,8 @@ class Carpet(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/_choropleth.py
+++ b/packages/python/plotly/plotly/graph_objs/_choropleth.py
@@ -244,8 +244,8 @@ class Choropleth(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/_choroplethmapbox.py
+++ b/packages/python/plotly/plotly/graph_objs/_choroplethmapbox.py
@@ -268,8 +268,8 @@ class Choroplethmapbox(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/_cone.py
+++ b/packages/python/plotly/plotly/graph_objs/_cone.py
@@ -370,8 +370,8 @@ class Cone(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/_contour.py
+++ b/packages/python/plotly/plotly/graph_objs/_contour.py
@@ -291,8 +291,8 @@ class Contour(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -534,8 +534,8 @@ class Contour(_BaseTraceType):
                     Sets the contour label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat.
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format.
                 operation
                     Sets the constraint operation. "=" keeps
                     regions equal to `value` "<" and "<=" keep

--- a/packages/python/plotly/plotly/graph_objs/_contourcarpet.py
+++ b/packages/python/plotly/plotly/graph_objs/_contourcarpet.py
@@ -464,8 +464,8 @@ class Contourcarpet(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -684,8 +684,8 @@ class Contourcarpet(_BaseTraceType):
                     Sets the contour label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat.
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format.
                 operation
                     Sets the constraint operation. "=" keeps
                     regions equal to `value` "<" and "<=" keep

--- a/packages/python/plotly/plotly/graph_objs/_densitymapbox.py
+++ b/packages/python/plotly/plotly/graph_objs/_densitymapbox.py
@@ -267,8 +267,8 @@ class Densitymapbox(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/_heatmap.py
+++ b/packages/python/plotly/plotly/graph_objs/_heatmap.py
@@ -266,8 +266,8 @@ class Heatmap(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/_heatmapgl.py
+++ b/packages/python/plotly/plotly/graph_objs/_heatmapgl.py
@@ -243,8 +243,8 @@ class Heatmapgl(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/_histogram2d.py
+++ b/packages/python/plotly/plotly/graph_objs/_histogram2d.py
@@ -328,8 +328,8 @@ class Histogram2d(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/_histogram2dcontour.py
+++ b/packages/python/plotly/plotly/graph_objs/_histogram2dcontour.py
@@ -352,8 +352,8 @@ class Histogram2dContour(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -574,8 +574,8 @@ class Histogram2dContour(_BaseTraceType):
                     Sets the contour label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat.
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format.
                 operation
                     Sets the constraint operation. "=" keeps
                     regions equal to `value` "<" and "<=" keep

--- a/packages/python/plotly/plotly/graph_objs/_indicator.py
+++ b/packages/python/plotly/plotly/graph_objs/_indicator.py
@@ -135,8 +135,8 @@ class Indicator(_BaseTraceType):
                     Sets the value formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat.
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format.
 
         Returns
         -------
@@ -452,8 +452,8 @@ class Indicator(_BaseTraceType):
                     Sets the value formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat.
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format.
 
         Returns
         -------

--- a/packages/python/plotly/plotly/graph_objs/_isosurface.py
+++ b/packages/python/plotly/plotly/graph_objs/_isosurface.py
@@ -376,8 +376,8 @@ class Isosurface(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/_layout.py
+++ b/packages/python/plotly/plotly/graph_objs/_layout.py
@@ -3981,8 +3981,8 @@ class Layout(_BaseLayoutType):
                     Sets the hover text formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -4196,8 +4196,8 @@ class Layout(_BaseLayoutType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -4484,8 +4484,8 @@ class Layout(_BaseLayoutType):
                     Sets the hover text formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -4691,8 +4691,8 @@ class Layout(_BaseLayoutType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/_mesh3d.py
+++ b/packages/python/plotly/plotly/graph_objs/_mesh3d.py
@@ -452,8 +452,8 @@ class Mesh3d(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/_parcats.py
+++ b/packages/python/plotly/plotly/graph_objs/_parcats.py
@@ -535,8 +535,8 @@ class Parcats(_BaseTraceType):
                     only when this field is shown. Numbers are
                     formatted using d3-format's syntax
                     %{variable:d3-format}, for example "Price:
-                    %{y:$.2f}". https://github.com/d3/d3-format/tre
-                    e/v1.4.5#d3-format for details on the
+                    %{y:$.2f}". https://github.com/d3/d3-
+                    format/tree/v1.4.5#d3-format for details on the
                     formatting syntax. Dates are formatted using
                     d3-time-format's syntax %{variable|d3-time-
                     format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/graph_objs/_parcoords.py
+++ b/packages/python/plotly/plotly/graph_objs/_parcoords.py
@@ -136,8 +136,8 @@ class Parcoords(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/_sankey.py
+++ b/packages/python/plotly/plotly/graph_objs/_sankey.py
@@ -386,8 +386,8 @@ class Sankey(_BaseTraceType):
                     only when this field is shown. Numbers are
                     formatted using d3-format's syntax
                     %{variable:d3-format}, for example "Price:
-                    %{y:$.2f}". https://github.com/d3/d3-format/tre
-                    e/v1.4.5#d3-format for details on the
+                    %{y:$.2f}". https://github.com/d3/d3-
+                    format/tree/v1.4.5#d3-format for details on the
                     formatting syntax. Dates are formatted using
                     d3-time-format's syntax %{variable|d3-time-
                     format}, for example "Day: %{2019-01-01|%A}".
@@ -575,8 +575,8 @@ class Sankey(_BaseTraceType):
                     only when this field is shown. Numbers are
                     formatted using d3-format's syntax
                     %{variable:d3-format}, for example "Price:
-                    %{y:$.2f}". https://github.com/d3/d3-format/tre
-                    e/v1.4.5#d3-format for details on the
+                    %{y:$.2f}". https://github.com/d3/d3-
+                    format/tree/v1.4.5#d3-format for details on the
                     formatting syntax. Dates are formatted using
                     d3-time-format's syntax %{variable|d3-time-
                     format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/graph_objs/_streamtube.py
+++ b/packages/python/plotly/plotly/graph_objs/_streamtube.py
@@ -345,8 +345,8 @@ class Streamtube(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/_surface.py
+++ b/packages/python/plotly/plotly/graph_objs/_surface.py
@@ -344,8 +344,8 @@ class Surface(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/_table.py
+++ b/packages/python/plotly/plotly/graph_objs/_table.py
@@ -67,8 +67,8 @@ class Table(_BaseTraceType):
                     Sets the cell value formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat.
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format.
                 formatsrc
                     Sets the source reference on Chart Studio Cloud
                     for `format`.
@@ -307,8 +307,8 @@ class Table(_BaseTraceType):
                     Sets the cell value formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat.
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format.
                 formatsrc
                     Sets the source reference on Chart Studio Cloud
                     for `format`.

--- a/packages/python/plotly/plotly/graph_objs/_treemap.py
+++ b/packages/python/plotly/plotly/graph_objs/_treemap.py
@@ -1313,10 +1313,10 @@ class Treemap(_BaseTraceType):
                     Sets the inner padding (in px).
                 squarifyratio
                     When using "squarify" `packing` algorithm,
-                    according to https://github.com/d3/d3-hierarchy
-                    /blob/master/README.md#squarify_ratio this
-                    option specifies the desired aspect ratio of
-                    the generated rectangles. The ratio must be
+                    according to https://github.com/d3/d3-
+                    hierarchy/blob/master/README.md#squarify_ratio
+                    this option specifies the desired aspect ratio
+                    of the generated rectangles. The ratio must be
                     specified as a number greater than or equal to
                     one. Note that the orientation of the generated
                     rectangles (tall or wide) is not implied by the

--- a/packages/python/plotly/plotly/graph_objs/_volume.py
+++ b/packages/python/plotly/plotly/graph_objs/_volume.py
@@ -377,8 +377,8 @@ class Volume(_BaseTraceType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/bar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/bar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._error_x import ErrorX
     from ._error_y import ErrorY
     from ._hoverlabel import Hoverlabel

--- a/packages/python/plotly/plotly/graph_objs/bar/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/bar/_marker.py
@@ -374,8 +374,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/bar/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/bar/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/bar/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/bar/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/bar/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/bar/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._line import Line
     from ._pattern import Pattern

--- a/packages/python/plotly/plotly/graph_objs/bar/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/bar/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/bar/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/bar/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/bar/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/bar/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/bar/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/bar/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/barpolar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/barpolar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle
     from ._marker import Marker

--- a/packages/python/plotly/plotly/graph_objs/barpolar/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/barpolar/_marker.py
@@ -374,8 +374,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/barpolar/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/barpolar/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/barpolar/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/barpolar/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/barpolar/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/barpolar/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._line import Line
     from ._pattern import Pattern

--- a/packages/python/plotly/plotly/graph_objs/barpolar/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/barpolar/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/barpolar/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/barpolar/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/barpolar/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/barpolar/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/barpolar/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/barpolar/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/box/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/box/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/box/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/box/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/box/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/box/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/box/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/box/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/box/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/box/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/box/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/box/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/candlestick/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/candlestick/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._decreasing import Decreasing
     from ._hoverlabel import Hoverlabel
     from ._increasing import Increasing

--- a/packages/python/plotly/plotly/graph_objs/candlestick/decreasing/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/candlestick/decreasing/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/candlestick/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/candlestick/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/candlestick/increasing/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/candlestick/increasing/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/candlestick/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/candlestick/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/carpet/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/carpet/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._aaxis import Aaxis
     from ._baxis import Baxis
     from ._font import Font

--- a/packages/python/plotly/plotly/graph_objs/carpet/aaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/carpet/aaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/carpet/aaxis/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/carpet/aaxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/carpet/baxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/carpet/baxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/carpet/baxis/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/carpet/baxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/carpet/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/carpet/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/choropleth/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choropleth/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle

--- a/packages/python/plotly/plotly/graph_objs/choropleth/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choropleth/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/choropleth/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choropleth/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/choropleth/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choropleth/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/choropleth/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choropleth/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/choropleth/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choropleth/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/choropleth/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choropleth/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/choropleth/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choropleth/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/choroplethmapbox/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choroplethmapbox/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle

--- a/packages/python/plotly/plotly/graph_objs/choroplethmapbox/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choroplethmapbox/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/choroplethmapbox/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choroplethmapbox/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/choroplethmapbox/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choroplethmapbox/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/choroplethmapbox/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choroplethmapbox/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/choroplethmapbox/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choroplethmapbox/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/choroplethmapbox/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choroplethmapbox/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/choroplethmapbox/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/choroplethmapbox/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/cone/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/cone/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle

--- a/packages/python/plotly/plotly/graph_objs/cone/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/cone/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/cone/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/cone/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/cone/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/cone/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/cone/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/cone/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/contour/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/contour/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._contours import Contours
     from ._hoverlabel import Hoverlabel

--- a/packages/python/plotly/plotly/graph_objs/contour/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/contour/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/contour/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/contour/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/contour/contours/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/contour/contours/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._labelfont import Labelfont
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/contour/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/contour/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/contour/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/contour/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/contourcarpet/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/contourcarpet/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._contours import Contours
     from ._legendgrouptitle import Legendgrouptitle

--- a/packages/python/plotly/plotly/graph_objs/contourcarpet/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/contourcarpet/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/contourcarpet/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/contourcarpet/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/contourcarpet/contours/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/contourcarpet/contours/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._labelfont import Labelfont
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/contourcarpet/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/contourcarpet/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/densitymapbox/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/densitymapbox/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle

--- a/packages/python/plotly/plotly/graph_objs/densitymapbox/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/densitymapbox/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/densitymapbox/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/densitymapbox/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/densitymapbox/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/densitymapbox/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/densitymapbox/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/densitymapbox/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/funnel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/funnel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._connector import Connector
     from ._hoverlabel import Hoverlabel
     from ._insidetextfont import Insidetextfont

--- a/packages/python/plotly/plotly/graph_objs/funnel/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/funnel/_marker.py
@@ -373,8 +373,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/funnel/connector/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/funnel/connector/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/funnel/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/funnel/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/funnel/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/funnel/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/funnel/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/funnel/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._line import Line
     from . import colorbar

--- a/packages/python/plotly/plotly/graph_objs/funnel/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/funnel/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/funnel/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/funnel/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/funnelarea/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/funnelarea/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._domain import Domain
     from ._hoverlabel import Hoverlabel
     from ._insidetextfont import Insidetextfont

--- a/packages/python/plotly/plotly/graph_objs/funnelarea/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/funnelarea/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/funnelarea/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/funnelarea/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/funnelarea/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/funnelarea/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/funnelarea/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/funnelarea/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/heatmap/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/heatmap/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle

--- a/packages/python/plotly/plotly/graph_objs/heatmap/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/heatmap/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/heatmap/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/heatmap/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/heatmap/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/heatmap/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/heatmap/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/heatmap/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/heatmapgl/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/heatmapgl/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle

--- a/packages/python/plotly/plotly/graph_objs/heatmapgl/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/heatmapgl/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/heatmapgl/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/heatmapgl/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/heatmapgl/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/heatmapgl/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/heatmapgl/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/heatmapgl/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/histogram/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._cumulative import Cumulative
     from ._error_x import ErrorX
     from ._error_y import ErrorY

--- a/packages/python/plotly/plotly/graph_objs/histogram/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram/_marker.py
@@ -374,8 +374,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/histogram/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/histogram/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/histogram/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._line import Line
     from ._pattern import Pattern

--- a/packages/python/plotly/plotly/graph_objs/histogram/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/histogram/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/histogram/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/histogram/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/histogram2d/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram2d/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle

--- a/packages/python/plotly/plotly/graph_objs/histogram2d/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram2d/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/histogram2d/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram2d/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/histogram2d/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram2d/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/histogram2d/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram2d/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/histogram2dcontour/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram2dcontour/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._contours import Contours
     from ._hoverlabel import Hoverlabel

--- a/packages/python/plotly/plotly/graph_objs/histogram2dcontour/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram2dcontour/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/histogram2dcontour/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram2dcontour/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/histogram2dcontour/contours/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram2dcontour/contours/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._labelfont import Labelfont
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/histogram2dcontour/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram2dcontour/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/histogram2dcontour/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram2dcontour/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/icicle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/icicle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._domain import Domain
     from ._hoverlabel import Hoverlabel
     from ._insidetextfont import Insidetextfont

--- a/packages/python/plotly/plotly/graph_objs/icicle/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/icicle/_marker.py
@@ -303,8 +303,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/icicle/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/icicle/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/icicle/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/icicle/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/icicle/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/icicle/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._line import Line
     from . import colorbar

--- a/packages/python/plotly/plotly/graph_objs/icicle/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/icicle/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/icicle/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/icicle/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/icicle/pathbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/icicle/pathbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/image/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/image/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle
     from ._stream import Stream

--- a/packages/python/plotly/plotly/graph_objs/image/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/image/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/image/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/image/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/indicator/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/indicator/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._delta import Delta
     from ._domain import Domain
     from ._gauge import Gauge

--- a/packages/python/plotly/plotly/graph_objs/indicator/_gauge.py
+++ b/packages/python/plotly/plotly/graph_objs/indicator/_gauge.py
@@ -123,8 +123,8 @@ class Gauge(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/indicator/delta/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/indicator/delta/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._decreasing import Decreasing
     from ._font import Font
     from ._increasing import Increasing

--- a/packages/python/plotly/plotly/graph_objs/indicator/gauge/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/indicator/gauge/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._axis import Axis
     from ._bar import Bar
     from ._step import Step

--- a/packages/python/plotly/plotly/graph_objs/indicator/gauge/axis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/indicator/gauge/axis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
 else:

--- a/packages/python/plotly/plotly/graph_objs/indicator/gauge/bar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/indicator/gauge/bar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/indicator/gauge/step/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/indicator/gauge/step/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/indicator/gauge/threshold/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/indicator/gauge/threshold/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/indicator/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/indicator/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/indicator/number/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/indicator/number/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/indicator/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/indicator/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/isosurface/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/isosurface/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._caps import Caps
     from ._colorbar import ColorBar
     from ._contour import Contour

--- a/packages/python/plotly/plotly/graph_objs/isosurface/caps/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/isosurface/caps/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._x import X
     from ._y import Y
     from ._z import Z

--- a/packages/python/plotly/plotly/graph_objs/isosurface/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/isosurface/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/isosurface/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/isosurface/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/isosurface/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/isosurface/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/isosurface/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/isosurface/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/isosurface/slices/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/isosurface/slices/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._x import X
     from ._y import Y
     from ._z import Z

--- a/packages/python/plotly/plotly/graph_objs/layout/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._activeshape import Activeshape
     from ._annotation import Annotation
     from ._coloraxis import Coloraxis

--- a/packages/python/plotly/plotly/graph_objs/layout/_coloraxis.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/_coloraxis.py
@@ -269,8 +269,8 @@ class Coloraxis(_BaseLayoutHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/layout/_polar.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/_polar.py
@@ -120,8 +120,8 @@ class Polar(_BaseLayoutHierarchyType):
                     Sets the hover text formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -219,8 +219,8 @@ class Polar(_BaseLayoutHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -618,8 +618,8 @@ class Polar(_BaseLayoutHierarchyType):
                     Sets the hover text formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -723,8 +723,8 @@ class Polar(_BaseLayoutHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/layout/_scene.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/_scene.py
@@ -620,8 +620,8 @@ class Scene(_BaseLayoutHierarchyType):
                     Sets the hover text formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -738,8 +738,8 @@ class Scene(_BaseLayoutHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -944,8 +944,8 @@ class Scene(_BaseLayoutHierarchyType):
                     Sets the hover text formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -1062,8 +1062,8 @@ class Scene(_BaseLayoutHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -1268,8 +1268,8 @@ class Scene(_BaseLayoutHierarchyType):
                     Sets the hover text formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -1386,8 +1386,8 @@ class Scene(_BaseLayoutHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/layout/_smith.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/_smith.py
@@ -133,8 +133,8 @@ class Smith(_BaseLayoutHierarchyType):
                     Sets the hover text formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -182,8 +182,8 @@ class Smith(_BaseLayoutHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -255,8 +255,8 @@ class Smith(_BaseLayoutHierarchyType):
                     Sets the hover text formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -311,8 +311,8 @@ class Smith(_BaseLayoutHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/layout/_ternary.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/_ternary.py
@@ -72,8 +72,8 @@ class Ternary(_BaseLayoutHierarchyType):
                     Sets the hover text formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -160,8 +160,8 @@ class Ternary(_BaseLayoutHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -316,8 +316,8 @@ class Ternary(_BaseLayoutHierarchyType):
                     Sets the hover text formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -404,8 +404,8 @@ class Ternary(_BaseLayoutHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -619,8 +619,8 @@ class Ternary(_BaseLayoutHierarchyType):
                     Sets the hover text formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of
@@ -707,8 +707,8 @@ class Ternary(_BaseLayoutHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/layout/annotation/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/annotation/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
     from ._hoverlabel import Hoverlabel
     from . import hoverlabel

--- a/packages/python/plotly/plotly/graph_objs/layout/annotation/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/annotation/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/coloraxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/coloraxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from . import colorbar
 else:

--- a/packages/python/plotly/plotly/graph_objs/layout/coloraxis/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/coloraxis/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/layout/coloraxis/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/coloraxis/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/geo/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/geo/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._center import Center
     from ._domain import Domain
     from ._lataxis import Lataxis

--- a/packages/python/plotly/plotly/graph_objs/layout/geo/projection/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/geo/projection/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._rotation import Rotation
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/grid/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/grid/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._domain import Domain
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
     from ._grouptitlefont import Grouptitlefont
 else:

--- a/packages/python/plotly/plotly/graph_objs/layout/legend/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/legend/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
     from ._grouptitlefont import Grouptitlefont
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/layout/legend/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/legend/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/mapbox/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/mapbox/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._center import Center
     from ._domain import Domain
     from ._layer import Layer

--- a/packages/python/plotly/plotly/graph_objs/layout/mapbox/layer/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/mapbox/layer/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._circle import Circle
     from ._fill import Fill
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/layout/mapbox/layer/symbol/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/mapbox/layer/symbol/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/newshape/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/newshape/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/polar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/polar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._angularaxis import AngularAxis
     from ._domain import Domain
     from ._radialaxis import RadialAxis

--- a/packages/python/plotly/plotly/graph_objs/layout/polar/angularaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/polar/angularaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
 else:

--- a/packages/python/plotly/plotly/graph_objs/layout/polar/radialaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/polar/radialaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/layout/polar/radialaxis/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/polar/radialaxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._annotation import Annotation
     from ._aspectratio import Aspectratio
     from ._camera import Camera

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/annotation/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/annotation/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
     from ._hoverlabel import Hoverlabel
     from . import hoverlabel

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/annotation/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/annotation/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/camera/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/camera/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._center import Center
     from ._eye import Eye
     from ._projection import Projection

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/xaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/xaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/xaxis/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/xaxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/yaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/yaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/yaxis/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/yaxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/zaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/zaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/zaxis/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/zaxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/shape/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/shape/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/slider/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/slider/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._currentvalue import Currentvalue
     from ._font import Font
     from ._pad import Pad

--- a/packages/python/plotly/plotly/graph_objs/layout/slider/currentvalue/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/slider/currentvalue/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/smith/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/smith/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._domain import Domain
     from ._imaginaryaxis import Imaginaryaxis
     from ._realaxis import Realaxis

--- a/packages/python/plotly/plotly/graph_objs/layout/smith/imaginaryaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/smith/imaginaryaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/smith/realaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/smith/realaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/template/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/template/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._data import Data
     from ._layout import Layout
     from . import data

--- a/packages/python/plotly/plotly/graph_objs/layout/template/data/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/template/data/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._bar import Bar
     from ._barpolar import Barpolar
     from ._box import Box

--- a/packages/python/plotly/plotly/graph_objs/layout/ternary/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/ternary/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._aaxis import Aaxis
     from ._baxis import Baxis
     from ._caxis import Caxis

--- a/packages/python/plotly/plotly/graph_objs/layout/ternary/aaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/ternary/aaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/layout/ternary/aaxis/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/ternary/aaxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/ternary/baxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/ternary/baxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/layout/ternary/baxis/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/ternary/baxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/ternary/caxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/ternary/caxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/layout/ternary/caxis/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/ternary/caxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
     from ._pad import Pad
 else:

--- a/packages/python/plotly/plotly/graph_objs/layout/updatemenu/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/updatemenu/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._button import Button
     from ._font import Font
     from ._pad import Pad

--- a/packages/python/plotly/plotly/graph_objs/layout/xaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/xaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._rangebreak import Rangebreak
     from ._rangeselector import Rangeselector
     from ._rangeslider import Rangeslider

--- a/packages/python/plotly/plotly/graph_objs/layout/xaxis/rangeselector/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/xaxis/rangeselector/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._button import Button
     from ._font import Font
 else:

--- a/packages/python/plotly/plotly/graph_objs/layout/xaxis/rangeslider/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/xaxis/rangeslider/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._yaxis import YAxis
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/xaxis/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/xaxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/layout/yaxis/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/yaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._rangebreak import Rangebreak
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop

--- a/packages/python/plotly/plotly/graph_objs/layout/yaxis/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/yaxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/mesh3d/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/mesh3d/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._contour import Contour
     from ._hoverlabel import Hoverlabel

--- a/packages/python/plotly/plotly/graph_objs/mesh3d/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/mesh3d/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/mesh3d/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/mesh3d/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/mesh3d/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/mesh3d/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/mesh3d/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/mesh3d/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/ohlc/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/ohlc/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._decreasing import Decreasing
     from ._hoverlabel import Hoverlabel
     from ._increasing import Increasing

--- a/packages/python/plotly/plotly/graph_objs/ohlc/decreasing/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/ohlc/decreasing/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/ohlc/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/ohlc/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/ohlc/increasing/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/ohlc/increasing/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/ohlc/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/ohlc/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/parcats/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/parcats/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._dimension import Dimension
     from ._domain import Domain
     from ._labelfont import Labelfont

--- a/packages/python/plotly/plotly/graph_objs/parcats/_line.py
+++ b/packages/python/plotly/plotly/graph_objs/parcats/_line.py
@@ -371,8 +371,8 @@ class Line(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/parcats/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/parcats/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/parcats/line/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/parcats/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from . import colorbar
 else:

--- a/packages/python/plotly/plotly/graph_objs/parcats/line/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/parcats/line/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/parcats/line/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/parcats/line/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/parcoords/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/parcoords/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._dimension import Dimension
     from ._domain import Domain
     from ._labelfont import Labelfont

--- a/packages/python/plotly/plotly/graph_objs/parcoords/_line.py
+++ b/packages/python/plotly/plotly/graph_objs/parcoords/_line.py
@@ -369,8 +369,8 @@ class Line(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/parcoords/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/parcoords/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/parcoords/line/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/parcoords/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from . import colorbar
 else:

--- a/packages/python/plotly/plotly/graph_objs/parcoords/line/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/parcoords/line/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/parcoords/line/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/parcoords/line/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/pie/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/pie/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._domain import Domain
     from ._hoverlabel import Hoverlabel
     from ._insidetextfont import Insidetextfont

--- a/packages/python/plotly/plotly/graph_objs/pie/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/pie/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/pie/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/pie/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/pie/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/pie/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/pie/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/pie/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/pointcloud/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/pointcloud/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle
     from ._marker import Marker

--- a/packages/python/plotly/plotly/graph_objs/pointcloud/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/pointcloud/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/pointcloud/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/pointcloud/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/pointcloud/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/pointcloud/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._border import Border
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/sankey/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sankey/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._domain import Domain
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle

--- a/packages/python/plotly/plotly/graph_objs/sankey/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sankey/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/sankey/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sankey/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/sankey/link/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sankey/link/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorscale import Colorscale
     from ._hoverlabel import Hoverlabel
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/sankey/link/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sankey/link/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/sankey/node/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sankey/node/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._hoverlabel import Hoverlabel
     from ._line import Line
     from . import hoverlabel

--- a/packages/python/plotly/plotly/graph_objs/sankey/node/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sankey/node/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatter/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._error_x import ErrorX
     from ._error_y import ErrorY
     from ._fillpattern import Fillpattern

--- a/packages/python/plotly/plotly/graph_objs/scatter/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter/_marker.py
@@ -382,8 +382,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/scatter/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatter/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatter/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._gradient import Gradient
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/scatter/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/scatter/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatter/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/scatter/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._error_x import ErrorX
     from ._error_y import ErrorY
     from ._error_z import ErrorZ

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/_line.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/_line.py
@@ -371,8 +371,8 @@ class Line(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/_marker.py
@@ -379,8 +379,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/line/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from . import colorbar
 else:

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/line/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/line/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/line/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/line/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._line import Line
     from . import colorbar

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/projection/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/projection/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._x import X
     from ._y import Y
     from ._z import Z

--- a/packages/python/plotly/plotly/graph_objs/scattercarpet/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattercarpet/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/scattercarpet/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scattercarpet/_marker.py
@@ -382,8 +382,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/scattercarpet/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattercarpet/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scattercarpet/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattercarpet/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scattercarpet/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattercarpet/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._gradient import Gradient
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/scattercarpet/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattercarpet/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/scattercarpet/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattercarpet/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scattercarpet/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattercarpet/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/scattercarpet/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattercarpet/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/scattergeo/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergeo/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/scattergeo/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergeo/_marker.py
@@ -381,8 +381,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/scattergeo/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergeo/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scattergeo/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergeo/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scattergeo/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergeo/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._gradient import Gradient
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/scattergeo/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergeo/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/scattergeo/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergeo/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scattergeo/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergeo/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/scattergeo/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergeo/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/scattergl/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergl/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._error_x import ErrorX
     from ._error_y import ErrorY
     from ._hoverlabel import Hoverlabel

--- a/packages/python/plotly/plotly/graph_objs/scattergl/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergl/_marker.py
@@ -380,8 +380,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/scattergl/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergl/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scattergl/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergl/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scattergl/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergl/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._line import Line
     from . import colorbar

--- a/packages/python/plotly/plotly/graph_objs/scattergl/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergl/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/scattergl/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergl/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scattergl/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergl/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/scattergl/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergl/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/scattermapbox/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattermapbox/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/scattermapbox/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scattermapbox/_marker.py
@@ -446,8 +446,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/scattermapbox/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattermapbox/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scattermapbox/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattermapbox/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scattermapbox/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattermapbox/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from . import colorbar
 else:

--- a/packages/python/plotly/plotly/graph_objs/scattermapbox/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattermapbox/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/scattermapbox/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattermapbox/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scattermapbox/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattermapbox/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scattermapbox/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattermapbox/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatterpolar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/scatterpolar/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolar/_marker.py
@@ -382,8 +382,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/scatterpolar/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolar/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatterpolar/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolar/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatterpolar/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolar/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._gradient import Gradient
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/scatterpolar/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolar/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/scatterpolar/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolar/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatterpolar/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolar/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/scatterpolar/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolar/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/scatterpolargl/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolargl/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/scatterpolargl/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolargl/_marker.py
@@ -380,8 +380,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/scatterpolargl/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolargl/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatterpolargl/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolargl/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatterpolargl/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolargl/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._line import Line
     from . import colorbar

--- a/packages/python/plotly/plotly/graph_objs/scatterpolargl/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolargl/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/scatterpolargl/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolargl/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatterpolargl/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolargl/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/scatterpolargl/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolargl/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/scattersmith/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattersmith/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/scattersmith/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scattersmith/_marker.py
@@ -382,8 +382,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/scattersmith/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattersmith/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scattersmith/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattersmith/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scattersmith/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattersmith/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._gradient import Gradient
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/scattersmith/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattersmith/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/scattersmith/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattersmith/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scattersmith/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattersmith/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/scattersmith/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scattersmith/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/scatterternary/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterternary/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/scatterternary/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterternary/_marker.py
@@ -382,8 +382,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/scatterternary/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterternary/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatterternary/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterternary/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatterternary/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterternary/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._gradient import Gradient
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/scatterternary/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterternary/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/scatterternary/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterternary/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/scatterternary/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterternary/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/scatterternary/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterternary/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from ._textfont import Textfont
 else:

--- a/packages/python/plotly/plotly/graph_objs/splom/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/splom/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._diagonal import Diagonal
     from ._dimension import Dimension
     from ._hoverlabel import Hoverlabel

--- a/packages/python/plotly/plotly/graph_objs/splom/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/splom/_marker.py
@@ -380,8 +380,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/splom/dimension/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/splom/dimension/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._axis import Axis
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/splom/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/splom/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/splom/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/splom/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/splom/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/splom/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._line import Line
     from . import colorbar

--- a/packages/python/plotly/plotly/graph_objs/splom/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/splom/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/splom/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/splom/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/splom/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/splom/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/splom/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/splom/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/streamtube/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/streamtube/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle

--- a/packages/python/plotly/plotly/graph_objs/streamtube/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/streamtube/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/streamtube/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/streamtube/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/streamtube/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/streamtube/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/streamtube/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/streamtube/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/sunburst/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sunburst/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._domain import Domain
     from ._hoverlabel import Hoverlabel
     from ._insidetextfont import Insidetextfont

--- a/packages/python/plotly/plotly/graph_objs/sunburst/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/sunburst/_marker.py
@@ -303,8 +303,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/sunburst/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sunburst/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/sunburst/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sunburst/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/sunburst/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sunburst/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._line import Line
     from . import colorbar

--- a/packages/python/plotly/plotly/graph_objs/sunburst/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sunburst/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/sunburst/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/sunburst/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/surface/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/surface/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._contours import Contours
     from ._hoverlabel import Hoverlabel

--- a/packages/python/plotly/plotly/graph_objs/surface/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/surface/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/surface/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/surface/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/surface/contours/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/surface/contours/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._x import X
     from ._y import Y
     from ._z import Z

--- a/packages/python/plotly/plotly/graph_objs/surface/contours/x/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/surface/contours/x/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._project import Project
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/surface/contours/y/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/surface/contours/y/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._project import Project
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/surface/contours/z/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/surface/contours/z/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._project import Project
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/surface/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/surface/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/surface/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/surface/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/table/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/table/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._cells import Cells
     from ._domain import Domain
     from ._header import Header

--- a/packages/python/plotly/plotly/graph_objs/table/cells/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/table/cells/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._fill import Fill
     from ._font import Font
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/table/header/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/table/header/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._fill import Fill
     from ._font import Font
     from ._line import Line

--- a/packages/python/plotly/plotly/graph_objs/table/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/table/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/table/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/table/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/treemap/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/treemap/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._domain import Domain
     from ._hoverlabel import Hoverlabel
     from ._insidetextfont import Insidetextfont

--- a/packages/python/plotly/plotly/graph_objs/treemap/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/treemap/_marker.py
@@ -305,8 +305,8 @@ class Marker(_BaseTraceHierarchyType):
                     Sets the tick label formatting rule using d3
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see: h
-                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                    ormat. And for dates see:
+                    ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                    format. And for dates see:
                     https://github.com/d3/d3-time-
                     format/tree/v2.2.3#locale_format. We add two
                     items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/graph_objs/treemap/_tiling.py
+++ b/packages/python/plotly/plotly/graph_objs/treemap/_tiling.py
@@ -82,16 +82,17 @@ class Tiling(_BaseTraceHierarchyType):
     def squarifyratio(self):
         """
         When using "squarify" `packing` algorithm, according to https:/
-        /github.com/d3/d3-hierarchy/blob/master/README.md#squarify_rati
-        o this option specifies the desired aspect ratio of the
-        generated rectangles. The ratio must be specified as a number
-        greater than or equal to one. Note that the orientation of the
-        generated rectangles (tall or wide) is not implied by the
-        ratio; for example, a ratio of two will attempt to produce a
-        mixture of rectangles whose width:height ratio is either 2:1 or
-        1:2. When using "squarify", unlike d3 which uses the Golden
-        Ratio i.e. 1.618034, Plotly applies 1 to increase squares in
-        treemap layouts.
+        /github.com/d3/d3-
+        hierarchy/blob/master/README.md#squarify_ratio this option
+        specifies the desired aspect ratio of the generated rectangles.
+        The ratio must be specified as a number greater than or equal
+        to one. Note that the orientation of the generated rectangles
+        (tall or wide) is not implied by the ratio; for example, a
+        ratio of two will attempt to produce a mixture of rectangles
+        whose width:height ratio is either 2:1 or 1:2. When using
+        "squarify", unlike d3 which uses the Golden Ratio i.e.
+        1.618034, Plotly applies 1 to increase squares in treemap
+        layouts.
 
         The 'squarifyratio' property is a number and may be specified as:
           - An int or float in the interval [1, inf]
@@ -122,17 +123,18 @@ class Tiling(_BaseTraceHierarchyType):
             Sets the inner padding (in px).
         squarifyratio
             When using "squarify" `packing` algorithm, according to
-            https://github.com/d3/d3-hierarchy/blob/master/README.m
-            d#squarify_ratio this option specifies the desired
-            aspect ratio of the generated rectangles. The ratio
-            must be specified as a number greater than or equal to
-            one. Note that the orientation of the generated
-            rectangles (tall or wide) is not implied by the ratio;
-            for example, a ratio of two will attempt to produce a
-            mixture of rectangles whose width:height ratio is
-            either 2:1 or 1:2. When using "squarify", unlike d3
-            which uses the Golden Ratio i.e. 1.618034, Plotly
-            applies 1 to increase squares in treemap layouts.
+            https://github.com/d3/d3-
+            hierarchy/blob/master/README.md#squarify_ratio this
+            option specifies the desired aspect ratio of the
+            generated rectangles. The ratio must be specified as a
+            number greater than or equal to one. Note that the
+            orientation of the generated rectangles (tall or wide)
+            is not implied by the ratio; for example, a ratio of
+            two will attempt to produce a mixture of rectangles
+            whose width:height ratio is either 2:1 or 1:2. When
+            using "squarify", unlike d3 which uses the Golden Ratio
+            i.e. 1.618034, Plotly applies 1 to increase squares in
+            treemap layouts.
         """
 
     def __init__(
@@ -158,17 +160,18 @@ class Tiling(_BaseTraceHierarchyType):
             Sets the inner padding (in px).
         squarifyratio
             When using "squarify" `packing` algorithm, according to
-            https://github.com/d3/d3-hierarchy/blob/master/README.m
-            d#squarify_ratio this option specifies the desired
-            aspect ratio of the generated rectangles. The ratio
-            must be specified as a number greater than or equal to
-            one. Note that the orientation of the generated
-            rectangles (tall or wide) is not implied by the ratio;
-            for example, a ratio of two will attempt to produce a
-            mixture of rectangles whose width:height ratio is
-            either 2:1 or 1:2. When using "squarify", unlike d3
-            which uses the Golden Ratio i.e. 1.618034, Plotly
-            applies 1 to increase squares in treemap layouts.
+            https://github.com/d3/d3-
+            hierarchy/blob/master/README.md#squarify_ratio this
+            option specifies the desired aspect ratio of the
+            generated rectangles. The ratio must be specified as a
+            number greater than or equal to one. Note that the
+            orientation of the generated rectangles (tall or wide)
+            is not implied by the ratio; for example, a ratio of
+            two will attempt to produce a mixture of rectangles
+            whose width:height ratio is either 2:1 or 1:2. When
+            using "squarify", unlike d3 which uses the Golden Ratio
+            i.e. 1.618034, Plotly applies 1 to increase squares in
+            treemap layouts.
 
         Returns
         -------

--- a/packages/python/plotly/plotly/graph_objs/treemap/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/treemap/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/treemap/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/treemap/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/treemap/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/treemap/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorbar import ColorBar
     from ._line import Line
     from ._pad import Pad

--- a/packages/python/plotly/plotly/graph_objs/treemap/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/treemap/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/treemap/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/treemap/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/treemap/pathbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/treemap/pathbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import Textfont
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/violin/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/violin/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._box import Box
     from ._hoverlabel import Hoverlabel
     from ._legendgrouptitle import Legendgrouptitle

--- a/packages/python/plotly/plotly/graph_objs/violin/box/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/violin/box/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/violin/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/violin/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/violin/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/violin/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/violin/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/violin/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/violin/selected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/violin/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/violin/unselected/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/violin/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/volume/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/volume/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._caps import Caps
     from ._colorbar import ColorBar
     from ._contour import Contour

--- a/packages/python/plotly/plotly/graph_objs/volume/caps/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/volume/caps/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._x import X
     from ._y import Y
     from ._z import Z

--- a/packages/python/plotly/plotly/graph_objs/volume/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/volume/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tickfont import Tickfont
     from ._tickformatstop import Tickformatstop
     from ._title import Title

--- a/packages/python/plotly/plotly/graph_objs/volume/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/volume/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/volume/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/volume/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/volume/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/volume/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/volume/slices/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/volume/slices/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._x import X
     from ._y import Y
     from ._z import Z

--- a/packages/python/plotly/plotly/graph_objs/waterfall/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/waterfall/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._connector import Connector
     from ._decreasing import Decreasing
     from ._hoverlabel import Hoverlabel

--- a/packages/python/plotly/plotly/graph_objs/waterfall/connector/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/waterfall/connector/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/waterfall/decreasing/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/waterfall/decreasing/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from . import marker
 else:

--- a/packages/python/plotly/plotly/graph_objs/waterfall/decreasing/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/waterfall/decreasing/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/waterfall/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/waterfall/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/waterfall/increasing/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/waterfall/increasing/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from . import marker
 else:

--- a/packages/python/plotly/plotly/graph_objs/waterfall/increasing/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/waterfall/increasing/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/waterfall/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/waterfall/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import Font
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/graph_objs/waterfall/totals/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/waterfall/totals/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import Marker
     from . import marker
 else:

--- a/packages/python/plotly/plotly/graph_objs/waterfall/totals/marker/__init__.py
+++ b/packages/python/plotly/plotly/graph_objs/waterfall/totals/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import Line
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/io/__init__.py
+++ b/packages/python/plotly/plotly/io/__init__.py
@@ -1,7 +1,8 @@
 from _plotly_utils.importers import relative_import
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._kaleido import to_image, write_image, full_figure_for_development
     from . import orca, kaleido
     from . import json

--- a/packages/python/plotly/plotly/validators/__init__.py
+++ b/packages/python/plotly/plotly/validators/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._waterfall import WaterfallValidator
     from ._volume import VolumeValidator
     from ._violin import ViolinValidator

--- a/packages/python/plotly/plotly/validators/_bar.py
+++ b/packages/python/plotly/plotly/validators/_bar.py
@@ -80,8 +80,8 @@ class BarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -249,8 +249,8 @@ class BarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -321,9 +321,9 @@ class BarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -373,9 +373,9 @@ class BarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/_barpolar.py
+++ b/packages/python/plotly/plotly/validators/_barpolar.py
@@ -59,8 +59,8 @@ class BarpolarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_box.py
+++ b/packages/python/plotly/plotly/validators/_box.py
@@ -85,8 +85,8 @@ class BoxValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -390,9 +390,9 @@ class BoxValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -444,9 +444,9 @@ class BoxValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/_candlestick.py
+++ b/packages/python/plotly/plotly/validators/_candlestick.py
@@ -191,9 +191,9 @@ class CandlestickValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -234,9 +234,9 @@ class CandlestickValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/_choropleth.py
+++ b/packages/python/plotly/plotly/validators/_choropleth.py
@@ -101,8 +101,8 @@ class ChoroplethValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_choroplethmapbox.py
+++ b/packages/python/plotly/plotly/validators/_choroplethmapbox.py
@@ -100,8 +100,8 @@ class ChoroplethmapboxValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_cone.py
+++ b/packages/python/plotly/plotly/validators/_cone.py
@@ -104,8 +104,8 @@ class ConeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -248,9 +248,10 @@ class ConeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `u`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format.By default the values are formatted
-                using generic number format.
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format.By default the
+                values are formatted using generic number
+                format.
             uid
                 Assign an id to this trace, Use this to provide
                 object constancy between traces during
@@ -286,9 +287,10 @@ class ConeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `v`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format.By default the values are formatted
-                using generic number format.
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format.By default the
+                values are formatted using generic number
+                format.
             visible
                 Determines whether or not this trace is
                 visible. If "legendonly", the trace is not
@@ -303,9 +305,10 @@ class ConeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `w`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format.By default the values are formatted
-                using generic number format.
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format.By default the
+                values are formatted using generic number
+                format.
             wsrc
                 Sets the source reference on Chart Studio Cloud
                 for `w`.
@@ -316,9 +319,9 @@ class ConeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -337,9 +340,9 @@ class ConeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -358,9 +361,9 @@ class ConeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `z`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/_contour.py
+++ b/packages/python/plotly/plotly/validators/_contour.py
@@ -109,8 +109,8 @@ class ContourValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -227,8 +227,8 @@ class ContourValidator(_plotly_utils.basevalidators.CompoundValidator):
                 %{variable}, for example "y: %{y}". Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -290,9 +290,9 @@ class ContourValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -348,9 +348,9 @@ class ContourValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -399,9 +399,10 @@ class ContourValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `z`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format.By default the values are formatted
-                using generic number format.
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format.By default the
+                values are formatted using generic number
+                format.
             zmax
                 Sets the upper bound of the color domain. Value
                 should have the same units as in `z` and if

--- a/packages/python/plotly/plotly/validators/_densitymapbox.py
+++ b/packages/python/plotly/plotly/validators/_densitymapbox.py
@@ -88,8 +88,8 @@ class DensitymapboxValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_funnel.py
+++ b/packages/python/plotly/plotly/validators/_funnel.py
@@ -69,8 +69,8 @@ class FunnelValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -243,8 +243,8 @@ class FunnelValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -307,9 +307,9 @@ class FunnelValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -356,9 +356,9 @@ class FunnelValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/_funnelarea.py
+++ b/packages/python/plotly/plotly/validators/_funnelarea.py
@@ -57,8 +57,8 @@ class FunnelareaValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -196,8 +196,8 @@ class FunnelareaValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_heatmap.py
+++ b/packages/python/plotly/plotly/validators/_heatmap.py
@@ -95,8 +95,8 @@ class HeatmapValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -199,8 +199,8 @@ class HeatmapValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -265,9 +265,9 @@ class HeatmapValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -326,9 +326,9 @@ class HeatmapValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -377,9 +377,10 @@ class HeatmapValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `z`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format.By default the values are formatted
-                using generic number format.
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format.By default the
+                values are formatted using generic number
+                format.
             zmax
                 Sets the upper bound of the color domain. Value
                 should have the same units as in `z` and if

--- a/packages/python/plotly/plotly/validators/_histogram.py
+++ b/packages/python/plotly/plotly/validators/_histogram.py
@@ -119,8 +119,8 @@ class HistogramValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -281,8 +281,8 @@ class HistogramValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -345,9 +345,9 @@ class HistogramValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -378,9 +378,9 @@ class HistogramValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/_histogram2d.py
+++ b/packages/python/plotly/plotly/validators/_histogram2d.py
@@ -124,8 +124,8 @@ class Histogram2DValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -232,8 +232,8 @@ class Histogram2DValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -304,9 +304,9 @@ class Histogram2DValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -348,9 +348,9 @@ class Histogram2DValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -374,9 +374,10 @@ class Histogram2DValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `z`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format.By default the values are formatted
-                using generic number format.
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format.By default the
+                values are formatted using generic number
+                format.
             zmax
                 Sets the upper bound of the color domain. Value
                 should have the same units as in `z` and if

--- a/packages/python/plotly/plotly/validators/_histogram2dcontour.py
+++ b/packages/python/plotly/plotly/validators/_histogram2dcontour.py
@@ -135,8 +135,8 @@ class Histogram2DcontourValidator(_plotly_utils.basevalidators.CompoundValidator
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -260,8 +260,8 @@ class Histogram2DcontourValidator(_plotly_utils.basevalidators.CompoundValidator
                 %{variable}, for example "y: %{y}". Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -330,9 +330,9 @@ class Histogram2DcontourValidator(_plotly_utils.basevalidators.CompoundValidator
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -372,9 +372,9 @@ class Histogram2DcontourValidator(_plotly_utils.basevalidators.CompoundValidator
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -398,9 +398,10 @@ class Histogram2DcontourValidator(_plotly_utils.basevalidators.CompoundValidator
                 Sets the hover text formatting rulefor `z`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format.By default the values are formatted
-                using generic number format.
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format.By default the
+                values are formatted using generic number
+                format.
             zmax
                 Sets the upper bound of the color domain. Value
                 should have the same units as in `z` and if

--- a/packages/python/plotly/plotly/validators/_icicle.py
+++ b/packages/python/plotly/plotly/validators/_icicle.py
@@ -60,8 +60,8 @@ class IcicleValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -216,8 +216,8 @@ class IcicleValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_image.py
+++ b/packages/python/plotly/plotly/validators/_image.py
@@ -55,8 +55,8 @@ class ImageValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_isosurface.py
+++ b/packages/python/plotly/plotly/validators/_isosurface.py
@@ -110,8 +110,8 @@ class IsosurfaceValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -274,9 +274,10 @@ class IsosurfaceValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `value`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format.By default the values are formatted
-                using generic number format.
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format.By default the
+                values are formatted using generic number
+                format.
             valuesrc
                 Sets the source reference on Chart Studio Cloud
                 for `value`.
@@ -292,9 +293,9 @@ class IsosurfaceValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -313,9 +314,9 @@ class IsosurfaceValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -334,9 +335,9 @@ class IsosurfaceValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `z`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/_mesh3d.py
+++ b/packages/python/plotly/plotly/validators/_mesh3d.py
@@ -142,8 +142,8 @@ class Mesh3DValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -361,9 +361,9 @@ class Mesh3DValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -387,9 +387,9 @@ class Mesh3DValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -413,9 +413,9 @@ class Mesh3DValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `z`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/_ohlc.py
+++ b/packages/python/plotly/plotly/validators/_ohlc.py
@@ -187,9 +187,9 @@ class OhlcValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -230,9 +230,9 @@ class OhlcValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/_parcats.py
+++ b/packages/python/plotly/plotly/validators/_parcats.py
@@ -66,8 +66,8 @@ class ParcatsValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_pie.py
+++ b/packages/python/plotly/plotly/validators/_pie.py
@@ -60,8 +60,8 @@ class PieValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -227,8 +227,8 @@ class PieValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_sankey.py
+++ b/packages/python/plotly/plotly/validators/_sankey.py
@@ -135,8 +135,8 @@ class SankeyValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the value formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat.
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format.
             valuesuffix
                 Adds a unit to follow the value in the hover
                 tooltip. Add a space if a separation is

--- a/packages/python/plotly/plotly/validators/_scatter.py
+++ b/packages/python/plotly/plotly/validators/_scatter.py
@@ -121,8 +121,8 @@ class ScatterValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -298,8 +298,8 @@ class ScatterValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -364,9 +364,9 @@ class ScatterValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -416,9 +416,9 @@ class ScatterValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/_scatter3d.py
+++ b/packages/python/plotly/plotly/validators/_scatter3d.py
@@ -58,8 +58,8 @@ class Scatter3DValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -203,8 +203,8 @@ class Scatter3DValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -256,9 +256,9 @@ class Scatter3DValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -279,9 +279,9 @@ class Scatter3DValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -302,9 +302,9 @@ class Scatter3DValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `z`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/_scattercarpet.py
+++ b/packages/python/plotly/plotly/validators/_scattercarpet.py
@@ -88,8 +88,8 @@ class ScattercarpetValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -228,8 +228,8 @@ class ScattercarpetValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_scattergeo.py
+++ b/packages/python/plotly/plotly/validators/_scattergeo.py
@@ -82,8 +82,8 @@ class ScattergeoValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -252,8 +252,8 @@ class ScattergeoValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_scattergl.py
+++ b/packages/python/plotly/plotly/validators/_scattergl.py
@@ -92,8 +92,8 @@ class ScatterglValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -226,8 +226,8 @@ class ScatterglValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -292,9 +292,9 @@ class ScatterglValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -344,9 +344,9 @@ class ScatterglValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/_scattermapbox.py
+++ b/packages/python/plotly/plotly/validators/_scattermapbox.py
@@ -68,8 +68,8 @@ class ScattermapboxValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -225,8 +225,8 @@ class ScattermapboxValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_scatterpolar.py
+++ b/packages/python/plotly/plotly/validators/_scatterpolar.py
@@ -86,8 +86,8 @@ class ScatterpolarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -241,8 +241,8 @@ class ScatterpolarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_scatterpolargl.py
+++ b/packages/python/plotly/plotly/validators/_scatterpolargl.py
@@ -87,8 +87,8 @@ class ScatterpolarglValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -244,8 +244,8 @@ class ScatterpolarglValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_scattersmith.py
+++ b/packages/python/plotly/plotly/validators/_scattersmith.py
@@ -80,8 +80,8 @@ class ScattersmithValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -240,8 +240,8 @@ class ScattersmithValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_scatterternary.py
+++ b/packages/python/plotly/plotly/validators/_scatterternary.py
@@ -110,8 +110,8 @@ class ScatterternaryValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -265,8 +265,8 @@ class ScatterternaryValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_splom.py
+++ b/packages/python/plotly/plotly/validators/_splom.py
@@ -57,8 +57,8 @@ class SplomValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -216,9 +216,9 @@ class SplomValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -240,9 +240,9 @@ class SplomValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/_streamtube.py
+++ b/packages/python/plotly/plotly/validators/_streamtube.py
@@ -100,8 +100,8 @@ class StreamtubeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -232,9 +232,10 @@ class StreamtubeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `u`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format.By default the values are formatted
-                using generic number format.
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format.By default the
+                values are formatted using generic number
+                format.
             uid
                 Assign an id to this trace, Use this to provide
                 object constancy between traces during
@@ -270,9 +271,10 @@ class StreamtubeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `v`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format.By default the values are formatted
-                using generic number format.
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format.By default the
+                values are formatted using generic number
+                format.
             visible
                 Determines whether or not this trace is
                 visible. If "legendonly", the trace is not
@@ -287,9 +289,10 @@ class StreamtubeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `w`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format.By default the values are formatted
-                using generic number format.
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format.By default the
+                values are formatted using generic number
+                format.
             wsrc
                 Sets the source reference on Chart Studio Cloud
                 for `w`.
@@ -299,9 +302,9 @@ class StreamtubeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -319,9 +322,9 @@ class StreamtubeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -339,9 +342,9 @@ class StreamtubeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `z`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/_sunburst.py
+++ b/packages/python/plotly/plotly/validators/_sunburst.py
@@ -60,8 +60,8 @@ class SunburstValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -226,8 +226,8 @@ class SunburstValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_surface.py
+++ b/packages/python/plotly/plotly/validators/_surface.py
@@ -110,8 +110,8 @@ class SurfaceValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -287,9 +287,9 @@ class SurfaceValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -310,9 +310,9 @@ class SurfaceValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -333,9 +333,9 @@ class SurfaceValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `z`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/_treemap.py
+++ b/packages/python/plotly/plotly/validators/_treemap.py
@@ -60,8 +60,8 @@ class TreemapValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -213,8 +213,8 @@ class TreemapValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/_violin.py
+++ b/packages/python/plotly/plotly/validators/_violin.py
@@ -67,8 +67,8 @@ class ViolinValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -315,9 +315,9 @@ class ViolinValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -347,9 +347,9 @@ class ViolinValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/_volume.py
+++ b/packages/python/plotly/plotly/validators/_volume.py
@@ -109,8 +109,8 @@ class VolumeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -284,9 +284,10 @@ class VolumeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `value`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format.By default the values are formatted
-                using generic number format.
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format.By default the
+                values are formatted using generic number
+                format.
             valuesrc
                 Sets the source reference on Chart Studio Cloud
                 for `value`.
@@ -302,9 +303,9 @@ class VolumeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -323,9 +324,9 @@ class VolumeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -344,9 +345,9 @@ class VolumeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `z`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/_waterfall.py
+++ b/packages/python/plotly/plotly/validators/_waterfall.py
@@ -75,8 +75,8 @@ class WaterfallValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -257,8 +257,8 @@ class WaterfallValidator(_plotly_utils.basevalidators.CompoundValidator):
                 are inserted using %{variable}, for example "y:
                 %{y}". Numbers are formatted using d3-format's
                 syntax %{variable:d3-format}, for example
-                "Price: %{y:$.2f}". https://github.com/d3/d3-fo
-                rmat/tree/v1.4.5#d3-format for details on the
+                "Price: %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".
@@ -326,9 +326,9 @@ class WaterfallValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `x`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"
@@ -375,9 +375,9 @@ class WaterfallValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rulefor `y`
                 using d3 formatting mini-languages which are
                 very similar to those in Python. For numbers,
-                see: https://github.com/d3/d3-format/tree/v1.4.
-                5#d3-format. And for dates see:
-                https://github.com/d3/d3-time-
+                see: https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format. And for dates
+                see: https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
                 the year as a decimal number as well as "%{n}f"

--- a/packages/python/plotly/plotly/validators/bar/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ysrc import YsrcValidator
     from ._yperiodalignment import YperiodalignmentValidator
     from ._yperiod0 import Yperiod0Validator

--- a/packages/python/plotly/plotly/validators/bar/error_x/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/error_x/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._visible import VisibleValidator
     from ._valueminus import ValueminusValidator

--- a/packages/python/plotly/plotly/validators/bar/error_y/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/error_y/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._visible import VisibleValidator
     from ._valueminus import ValueminusValidator

--- a/packages/python/plotly/plotly/validators/bar/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/bar/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/bar/insidetextfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/insidetextfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/bar/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/bar/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/bar/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._showscale import ShowscaleValidator
     from ._reversescale import ReversescaleValidator
     from ._pattern import PatternValidator

--- a/packages/python/plotly/plotly/validators/bar/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/bar/marker/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/bar/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/bar/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/bar/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/bar/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/bar/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/bar/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._reversescale import ReversescaleValidator

--- a/packages/python/plotly/plotly/validators/bar/marker/pattern/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/marker/pattern/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._soliditysrc import SoliditysrcValidator
     from ._solidity import SolidityValidator
     from ._sizesrc import SizesrcValidator

--- a/packages/python/plotly/plotly/validators/bar/outsidetextfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/outsidetextfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/bar/selected/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/bar/selected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/selected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._opacity import OpacityValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/bar/selected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/selected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/bar/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/bar/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/bar/unselected/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/bar/unselected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/unselected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._opacity import OpacityValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/bar/unselected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/bar/unselected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/barpolar/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._visible import VisibleValidator

--- a/packages/python/plotly/plotly/validators/barpolar/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/barpolar/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/barpolar/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/barpolar/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/barpolar/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._showscale import ShowscaleValidator
     from ._reversescale import ReversescaleValidator
     from ._pattern import PatternValidator

--- a/packages/python/plotly/plotly/validators/barpolar/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/barpolar/marker/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/barpolar/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/barpolar/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/barpolar/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/barpolar/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/barpolar/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/barpolar/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._reversescale import ReversescaleValidator

--- a/packages/python/plotly/plotly/validators/barpolar/marker/pattern/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/marker/pattern/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._soliditysrc import SoliditysrcValidator
     from ._solidity import SolidityValidator
     from ._sizesrc import SizesrcValidator

--- a/packages/python/plotly/plotly/validators/barpolar/selected/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/barpolar/selected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/selected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._opacity import OpacityValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/barpolar/selected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/selected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/barpolar/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/barpolar/unselected/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/barpolar/unselected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/unselected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._opacity import OpacityValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/barpolar/unselected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/barpolar/unselected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/box/__init__.py
+++ b/packages/python/plotly/plotly/validators/box/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ysrc import YsrcValidator
     from ._yperiodalignment import YperiodalignmentValidator
     from ._yperiod0 import Yperiod0Validator

--- a/packages/python/plotly/plotly/validators/box/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/box/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/box/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/box/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/box/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/box/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/box/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/box/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/box/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/box/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/box/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/box/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._symbol import SymbolValidator
     from ._size import SizeValidator
     from ._outliercolor import OutliercolorValidator

--- a/packages/python/plotly/plotly/validators/box/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/box/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._outlierwidth import OutlierwidthValidator
     from ._outliercolor import OutliercolorValidator

--- a/packages/python/plotly/plotly/validators/box/selected/__init__.py
+++ b/packages/python/plotly/plotly/validators/box/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import MarkerValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/box/selected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/box/selected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/box/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/box/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/box/unselected/__init__.py
+++ b/packages/python/plotly/plotly/validators/box/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import MarkerValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/box/unselected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/box/unselected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/candlestick/__init__.py
+++ b/packages/python/plotly/plotly/validators/candlestick/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._yhoverformat import YhoverformatValidator
     from ._yaxis import YaxisValidator
     from ._xsrc import XsrcValidator

--- a/packages/python/plotly/plotly/validators/candlestick/decreasing/__init__.py
+++ b/packages/python/plotly/plotly/validators/candlestick/decreasing/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import LineValidator
     from ._fillcolor import FillcolorValidator
 else:

--- a/packages/python/plotly/plotly/validators/candlestick/decreasing/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/candlestick/decreasing/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/candlestick/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/candlestick/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._split import SplitValidator
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator

--- a/packages/python/plotly/plotly/validators/candlestick/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/candlestick/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/candlestick/increasing/__init__.py
+++ b/packages/python/plotly/plotly/validators/candlestick/increasing/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import LineValidator
     from ._fillcolor import FillcolorValidator
 else:

--- a/packages/python/plotly/plotly/validators/candlestick/increasing/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/candlestick/increasing/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/candlestick/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/candlestick/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/candlestick/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/candlestick/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/candlestick/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/candlestick/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/candlestick/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/candlestick/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/carpet/__init__.py
+++ b/packages/python/plotly/plotly/validators/carpet/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ysrc import YsrcValidator
     from ._yaxis import YaxisValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/carpet/_aaxis.py
+++ b/packages/python/plotly/plotly/validators/carpet/_aaxis.py
@@ -174,8 +174,8 @@ class AaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/carpet/_baxis.py
+++ b/packages/python/plotly/plotly/validators/carpet/_baxis.py
@@ -174,8 +174,8 @@ class BaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/carpet/aaxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/carpet/aaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._type import TypeValidator
     from ._title import TitleValidator
     from ._tickvalssrc import TickvalssrcValidator

--- a/packages/python/plotly/plotly/validators/carpet/aaxis/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/carpet/aaxis/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/carpet/aaxis/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/carpet/aaxis/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/carpet/aaxis/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/carpet/aaxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._offset import OffsetValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/carpet/aaxis/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/carpet/aaxis/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/carpet/baxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/carpet/baxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._type import TypeValidator
     from ._title import TitleValidator
     from ._tickvalssrc import TickvalssrcValidator

--- a/packages/python/plotly/plotly/validators/carpet/baxis/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/carpet/baxis/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/carpet/baxis/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/carpet/baxis/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/carpet/baxis/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/carpet/baxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._offset import OffsetValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/carpet/baxis/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/carpet/baxis/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/carpet/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/carpet/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/carpet/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/carpet/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/carpet/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/carpet/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/carpet/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/carpet/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/choropleth/__init__.py
+++ b/packages/python/plotly/plotly/validators/choropleth/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._zmin import ZminValidator
     from ._zmid import ZmidValidator

--- a/packages/python/plotly/plotly/validators/choropleth/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/choropleth/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/choropleth/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/choropleth/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/choropleth/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/choropleth/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/choropleth/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/choropleth/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/choropleth/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/choropleth/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/choropleth/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/choropleth/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/choropleth/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/choropleth/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/choropleth/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/choropleth/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/choropleth/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/choropleth/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/choropleth/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/choropleth/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/choropleth/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/choropleth/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._opacitysrc import OpacitysrcValidator
     from ._opacity import OpacityValidator
     from ._line import LineValidator

--- a/packages/python/plotly/plotly/validators/choropleth/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/choropleth/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/choropleth/selected/__init__.py
+++ b/packages/python/plotly/plotly/validators/choropleth/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import MarkerValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/choropleth/selected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/choropleth/selected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._opacity import OpacityValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/choropleth/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/choropleth/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/choropleth/unselected/__init__.py
+++ b/packages/python/plotly/plotly/validators/choropleth/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import MarkerValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/choropleth/unselected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/choropleth/unselected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._opacity import OpacityValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/__init__.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._zmin import ZminValidator
     from ._zmid import ZmidValidator

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/_colorbar.py
@@ -133,8 +133,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._opacitysrc import OpacitysrcValidator
     from ._opacity import OpacityValidator
     from ._line import LineValidator

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/selected/__init__.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import MarkerValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/selected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/selected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._opacity import OpacityValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/unselected/__init__.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import MarkerValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/choroplethmapbox/unselected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/choroplethmapbox/unselected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._opacity import OpacityValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/cone/__init__.py
+++ b/packages/python/plotly/plotly/validators/cone/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._zhoverformat import ZhoverformatValidator
     from ._z import ZValidator

--- a/packages/python/plotly/plotly/validators/cone/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/cone/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/cone/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/cone/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/cone/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/cone/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/cone/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/cone/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/cone/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/cone/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/cone/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/cone/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/cone/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/cone/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/cone/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/cone/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/cone/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/cone/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/cone/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/cone/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/cone/lighting/__init__.py
+++ b/packages/python/plotly/plotly/validators/cone/lighting/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._vertexnormalsepsilon import VertexnormalsepsilonValidator
     from ._specular import SpecularValidator
     from ._roughness import RoughnessValidator

--- a/packages/python/plotly/plotly/validators/cone/lightposition/__init__.py
+++ b/packages/python/plotly/plotly/validators/cone/lightposition/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/cone/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/cone/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/contour/__init__.py
+++ b/packages/python/plotly/plotly/validators/contour/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._zmin import ZminValidator
     from ._zmid import ZmidValidator

--- a/packages/python/plotly/plotly/validators/contour/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/contour/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/contour/_contours.py
+++ b/packages/python/plotly/plotly/validators/contour/_contours.py
@@ -30,8 +30,8 @@ class ContoursValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the contour label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat.
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format.
             operation
                 Sets the constraint operation. "=" keeps
                 regions equal to `value` "<" and "<=" keep

--- a/packages/python/plotly/plotly/validators/contour/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/contour/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/contour/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/contour/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/contour/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/contour/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/contour/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/contour/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/contour/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/contour/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/contour/contours/__init__.py
+++ b/packages/python/plotly/plotly/validators/contour/contours/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._type import TypeValidator
     from ._start import StartValidator

--- a/packages/python/plotly/plotly/validators/contour/contours/labelfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/contour/contours/labelfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/contour/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/contour/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/contour/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/contour/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/contour/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/contour/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/contour/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/contour/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/contour/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/contour/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._smoothing import SmoothingValidator
     from ._dash import DashValidator

--- a/packages/python/plotly/plotly/validators/contour/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/contour/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/contour/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/contour/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/contourcarpet/__init__.py
+++ b/packages/python/plotly/plotly/validators/contourcarpet/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._zmin import ZminValidator
     from ._zmid import ZmidValidator

--- a/packages/python/plotly/plotly/validators/contourcarpet/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/contourcarpet/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/contourcarpet/_contours.py
+++ b/packages/python/plotly/plotly/validators/contourcarpet/_contours.py
@@ -28,8 +28,8 @@ class ContoursValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the contour label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat.
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format.
             operation
                 Sets the constraint operation. "=" keeps
                 regions equal to `value` "<" and "<=" keep

--- a/packages/python/plotly/plotly/validators/contourcarpet/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/contourcarpet/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/contourcarpet/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/contourcarpet/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/contourcarpet/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/contourcarpet/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/contourcarpet/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/contourcarpet/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/contourcarpet/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/contourcarpet/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/contourcarpet/contours/__init__.py
+++ b/packages/python/plotly/plotly/validators/contourcarpet/contours/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._type import TypeValidator
     from ._start import StartValidator

--- a/packages/python/plotly/plotly/validators/contourcarpet/contours/labelfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/contourcarpet/contours/labelfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/contourcarpet/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/contourcarpet/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/contourcarpet/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/contourcarpet/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/contourcarpet/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/contourcarpet/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._smoothing import SmoothingValidator
     from ._dash import DashValidator

--- a/packages/python/plotly/plotly/validators/contourcarpet/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/contourcarpet/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/densitymapbox/__init__.py
+++ b/packages/python/plotly/plotly/validators/densitymapbox/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._zmin import ZminValidator
     from ._zmid import ZmidValidator

--- a/packages/python/plotly/plotly/validators/densitymapbox/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/densitymapbox/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/densitymapbox/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/densitymapbox/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/densitymapbox/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/densitymapbox/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/densitymapbox/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/densitymapbox/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/densitymapbox/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/densitymapbox/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/densitymapbox/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/densitymapbox/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/densitymapbox/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/densitymapbox/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/densitymapbox/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/densitymapbox/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/densitymapbox/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/densitymapbox/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/densitymapbox/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/densitymapbox/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/densitymapbox/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/densitymapbox/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/frame/__init__.py
+++ b/packages/python/plotly/plotly/validators/frame/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._traces import TracesValidator
     from ._name import NameValidator
     from ._layout import LayoutValidator

--- a/packages/python/plotly/plotly/validators/funnel/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ysrc import YsrcValidator
     from ._yperiodalignment import YperiodalignmentValidator
     from ._yperiod0 import Yperiod0Validator

--- a/packages/python/plotly/plotly/validators/funnel/connector/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/connector/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._line import LineValidator
     from ._fillcolor import FillcolorValidator

--- a/packages/python/plotly/plotly/validators/funnel/connector/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/connector/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._dash import DashValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/funnel/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/funnel/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/funnel/insidetextfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/insidetextfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/funnel/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/funnel/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/funnel/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._showscale import ShowscaleValidator
     from ._reversescale import ReversescaleValidator
     from ._opacitysrc import OpacitysrcValidator

--- a/packages/python/plotly/plotly/validators/funnel/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/funnel/marker/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/funnel/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/funnel/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/funnel/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/funnel/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/funnel/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/funnel/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._reversescale import ReversescaleValidator

--- a/packages/python/plotly/plotly/validators/funnel/outsidetextfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/outsidetextfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/funnel/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/funnel/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnel/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/funnelarea/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnelarea/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._valuessrc import ValuessrcValidator
     from ._values import ValuesValidator

--- a/packages/python/plotly/plotly/validators/funnelarea/domain/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnelarea/domain/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._y import YValidator
     from ._x import XValidator
     from ._row import RowValidator

--- a/packages/python/plotly/plotly/validators/funnelarea/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnelarea/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/funnelarea/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnelarea/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/funnelarea/insidetextfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnelarea/insidetextfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/funnelarea/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnelarea/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/funnelarea/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnelarea/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/funnelarea/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnelarea/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import LineValidator
     from ._colorssrc import ColorssrcValidator
     from ._colors import ColorsValidator

--- a/packages/python/plotly/plotly/validators/funnelarea/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnelarea/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/funnelarea/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnelarea/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/funnelarea/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnelarea/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/funnelarea/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnelarea/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._position import PositionValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/funnelarea/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/funnelarea/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/heatmap/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmap/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._zsmooth import ZsmoothValidator
     from ._zmin import ZminValidator

--- a/packages/python/plotly/plotly/validators/heatmap/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/heatmap/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/heatmap/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmap/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/heatmap/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmap/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/heatmap/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmap/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/heatmap/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmap/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/heatmap/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmap/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/heatmap/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmap/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/heatmap/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmap/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/heatmap/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmap/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/heatmap/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmap/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/heatmap/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmap/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/heatmap/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmap/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/heatmapgl/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmapgl/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._zsmooth import ZsmoothValidator
     from ._zmin import ZminValidator

--- a/packages/python/plotly/plotly/validators/heatmapgl/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/heatmapgl/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/heatmapgl/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmapgl/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/heatmapgl/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmapgl/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/heatmapgl/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmapgl/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/heatmapgl/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmapgl/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/heatmapgl/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmapgl/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/heatmapgl/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmapgl/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/heatmapgl/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmapgl/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/heatmapgl/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmapgl/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/heatmapgl/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmapgl/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/heatmapgl/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/heatmapgl/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/histogram/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ysrc import YsrcValidator
     from ._yhoverformat import YhoverformatValidator
     from ._ycalendar import YcalendarValidator

--- a/packages/python/plotly/plotly/validators/histogram/cumulative/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/cumulative/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._enabled import EnabledValidator
     from ._direction import DirectionValidator
     from ._currentbin import CurrentbinValidator

--- a/packages/python/plotly/plotly/validators/histogram/error_x/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/error_x/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._visible import VisibleValidator
     from ._valueminus import ValueminusValidator

--- a/packages/python/plotly/plotly/validators/histogram/error_y/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/error_y/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._visible import VisibleValidator
     from ._valueminus import ValueminusValidator

--- a/packages/python/plotly/plotly/validators/histogram/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/histogram/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/histogram/insidetextfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/insidetextfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/histogram/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/histogram/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/histogram/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._showscale import ShowscaleValidator
     from ._reversescale import ReversescaleValidator
     from ._pattern import PatternValidator

--- a/packages/python/plotly/plotly/validators/histogram/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/histogram/marker/_colorbar.py
@@ -133,8 +133,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/histogram/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/histogram/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/histogram/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/histogram/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/histogram/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/histogram/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._reversescale import ReversescaleValidator

--- a/packages/python/plotly/plotly/validators/histogram/marker/pattern/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/marker/pattern/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._soliditysrc import SoliditysrcValidator
     from ._solidity import SolidityValidator
     from ._sizesrc import SizesrcValidator

--- a/packages/python/plotly/plotly/validators/histogram/outsidetextfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/outsidetextfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/histogram/selected/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/histogram/selected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/selected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._opacity import OpacityValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/histogram/selected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/selected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/histogram/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/histogram/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/histogram/unselected/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/histogram/unselected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/unselected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._opacity import OpacityValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/histogram/unselected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/unselected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/histogram/xbins/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/xbins/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._start import StartValidator
     from ._size import SizeValidator
     from ._end import EndValidator

--- a/packages/python/plotly/plotly/validators/histogram/ybins/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram/ybins/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._start import StartValidator
     from ._size import SizeValidator
     from ._end import EndValidator

--- a/packages/python/plotly/plotly/validators/histogram2d/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2d/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._zsmooth import ZsmoothValidator
     from ._zmin import ZminValidator

--- a/packages/python/plotly/plotly/validators/histogram2d/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/histogram2d/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/histogram2d/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2d/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/histogram2d/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2d/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/histogram2d/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2d/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/histogram2d/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2d/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/histogram2d/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2d/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/histogram2d/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2d/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/histogram2d/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2d/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/histogram2d/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2d/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/histogram2d/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2d/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/histogram2d/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2d/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorsrc import ColorsrcValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/histogram2d/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2d/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/histogram2d/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2d/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/histogram2d/xbins/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2d/xbins/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._start import StartValidator
     from ._size import SizeValidator
     from ._end import EndValidator

--- a/packages/python/plotly/plotly/validators/histogram2d/ybins/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2d/ybins/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._start import StartValidator
     from ._size import SizeValidator
     from ._end import EndValidator

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._zmin import ZminValidator
     from ._zmid import ZmidValidator

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/_colorbar.py
@@ -133,8 +133,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/_contours.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/_contours.py
@@ -32,8 +32,8 @@ class ContoursValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the contour label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat.
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format.
             operation
                 Sets the constraint operation. "=" keeps
                 regions equal to `value` "<" and "<=" keep

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/contours/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/contours/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._type import TypeValidator
     from ._start import StartValidator

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/contours/labelfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/contours/labelfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._smoothing import SmoothingValidator
     from ._dash import DashValidator

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorsrc import ColorsrcValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/xbins/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/xbins/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._start import StartValidator
     from ._size import SizeValidator
     from ._end import EndValidator

--- a/packages/python/plotly/plotly/validators/histogram2dcontour/ybins/__init__.py
+++ b/packages/python/plotly/plotly/validators/histogram2dcontour/ybins/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._start import StartValidator
     from ._size import SizeValidator
     from ._end import EndValidator

--- a/packages/python/plotly/plotly/validators/icicle/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._valuessrc import ValuessrcValidator
     from ._values import ValuesValidator

--- a/packages/python/plotly/plotly/validators/icicle/domain/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/domain/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._y import YValidator
     from ._x import XValidator
     from ._row import RowValidator

--- a/packages/python/plotly/plotly/validators/icicle/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/icicle/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/icicle/insidetextfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/insidetextfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/icicle/leaf/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/leaf/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._opacity import OpacityValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/icicle/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/icicle/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/icicle/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._showscale import ShowscaleValidator
     from ._reversescale import ReversescaleValidator
     from ._line import LineValidator

--- a/packages/python/plotly/plotly/validators/icicle/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/icicle/marker/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/icicle/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/icicle/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/icicle/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/icicle/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/icicle/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/icicle/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/icicle/outsidetextfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/outsidetextfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/icicle/pathbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/pathbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._thickness import ThicknessValidator
     from ._textfont import TextfontValidator

--- a/packages/python/plotly/plotly/validators/icicle/pathbar/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/pathbar/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/icicle/root/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/root/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/icicle/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/icicle/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/icicle/tiling/__init__.py
+++ b/packages/python/plotly/plotly/validators/icicle/tiling/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._pad import PadValidator
     from ._orientation import OrientationValidator
     from ._flip import FlipValidator

--- a/packages/python/plotly/plotly/validators/image/__init__.py
+++ b/packages/python/plotly/plotly/validators/image/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._zsmooth import ZsmoothValidator
     from ._zmin import ZminValidator

--- a/packages/python/plotly/plotly/validators/image/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/image/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/image/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/image/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/image/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/image/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/image/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/image/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/image/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/image/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/indicator/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._value import ValueValidator
     from ._uirevision import UirevisionValidator

--- a/packages/python/plotly/plotly/validators/indicator/_delta.py
+++ b/packages/python/plotly/plotly/validators/indicator/_delta.py
@@ -32,8 +32,8 @@ class DeltaValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the value formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat.
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format.
 """,
             ),
             **kwargs,

--- a/packages/python/plotly/plotly/validators/indicator/_number.py
+++ b/packages/python/plotly/plotly/validators/indicator/_number.py
@@ -20,8 +20,8 @@ class NumberValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the value formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat.
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format.
 """,
             ),
             **kwargs,

--- a/packages/python/plotly/plotly/validators/indicator/delta/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/delta/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._valueformat import ValueformatValidator
     from ._relative import RelativeValidator
     from ._reference import ReferenceValidator

--- a/packages/python/plotly/plotly/validators/indicator/delta/decreasing/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/delta/decreasing/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._symbol import SymbolValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/indicator/delta/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/delta/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/indicator/delta/increasing/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/delta/increasing/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._symbol import SymbolValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/indicator/domain/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/domain/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._y import YValidator
     from ._x import XValidator
     from ._row import RowValidator

--- a/packages/python/plotly/plotly/validators/indicator/gauge/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/gauge/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._threshold import ThresholdValidator
     from ._stepdefaults import StepdefaultsValidator
     from ._steps import StepsValidator

--- a/packages/python/plotly/plotly/validators/indicator/gauge/_axis.py
+++ b/packages/python/plotly/plotly/validators/indicator/gauge/_axis.py
@@ -100,8 +100,8 @@ class AxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/indicator/gauge/axis/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/gauge/axis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._tickwidth import TickwidthValidator
     from ._tickvalssrc import TickvalssrcValidator

--- a/packages/python/plotly/plotly/validators/indicator/gauge/axis/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/gauge/axis/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/indicator/gauge/axis/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/gauge/axis/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/indicator/gauge/bar/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/gauge/bar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._thickness import ThicknessValidator
     from ._line import LineValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/indicator/gauge/bar/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/gauge/bar/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/indicator/gauge/step/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/gauge/step/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._thickness import ThicknessValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._range import RangeValidator

--- a/packages/python/plotly/plotly/validators/indicator/gauge/step/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/gauge/step/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/indicator/gauge/threshold/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/gauge/threshold/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._thickness import ThicknessValidator
     from ._line import LineValidator

--- a/packages/python/plotly/plotly/validators/indicator/gauge/threshold/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/gauge/threshold/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/indicator/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/indicator/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/indicator/number/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/number/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._valueformat import ValueformatValidator
     from ._suffix import SuffixValidator
     from ._prefix import PrefixValidator

--- a/packages/python/plotly/plotly/validators/indicator/number/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/number/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/indicator/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/indicator/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
     from ._align import AlignValidator

--- a/packages/python/plotly/plotly/validators/indicator/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/indicator/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/isosurface/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._zhoverformat import ZhoverformatValidator
     from ._z import ZValidator

--- a/packages/python/plotly/plotly/validators/isosurface/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/isosurface/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/isosurface/caps/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/caps/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/isosurface/caps/x/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/caps/x/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._fill import FillValidator
 else:

--- a/packages/python/plotly/plotly/validators/isosurface/caps/y/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/caps/y/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._fill import FillValidator
 else:

--- a/packages/python/plotly/plotly/validators/isosurface/caps/z/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/caps/z/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._fill import FillValidator
 else:

--- a/packages/python/plotly/plotly/validators/isosurface/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/isosurface/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/isosurface/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/isosurface/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/isosurface/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/isosurface/contour/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/contour/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._show import ShowValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/isosurface/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/isosurface/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/isosurface/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/isosurface/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/isosurface/lighting/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/lighting/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._vertexnormalsepsilon import VertexnormalsepsilonValidator
     from ._specular import SpecularValidator
     from ._roughness import RoughnessValidator

--- a/packages/python/plotly/plotly/validators/isosurface/lightposition/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/lightposition/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/isosurface/slices/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/slices/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/isosurface/slices/x/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/slices/x/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._locationssrc import LocationssrcValidator
     from ._locations import LocationsValidator

--- a/packages/python/plotly/plotly/validators/isosurface/slices/y/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/slices/y/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._locationssrc import LocationssrcValidator
     from ._locations import LocationsValidator

--- a/packages/python/plotly/plotly/validators/isosurface/slices/z/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/slices/z/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._locationssrc import LocationssrcValidator
     from ._locations import LocationsValidator

--- a/packages/python/plotly/plotly/validators/isosurface/spaceframe/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/spaceframe/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._fill import FillValidator
 else:

--- a/packages/python/plotly/plotly/validators/isosurface/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/isosurface/surface/__init__.py
+++ b/packages/python/plotly/plotly/validators/isosurface/surface/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._pattern import PatternValidator
     from ._fill import FillValidator

--- a/packages/python/plotly/plotly/validators/layout/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._yaxis import YaxisValidator
     from ._xaxis import XaxisValidator
     from ._width import WidthValidator

--- a/packages/python/plotly/plotly/validators/layout/_xaxis.py
+++ b/packages/python/plotly/plotly/validators/layout/_xaxis.py
@@ -141,8 +141,8 @@ class XaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
@@ -356,8 +356,8 @@ class XaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/layout/_yaxis.py
+++ b/packages/python/plotly/plotly/validators/layout/_yaxis.py
@@ -141,8 +141,8 @@ class YaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
@@ -348,8 +348,8 @@ class YaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/layout/activeshape/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/activeshape/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._opacity import OpacityValidator
     from ._fillcolor import FillcolorValidator
 else:

--- a/packages/python/plotly/plotly/validators/layout/annotation/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/annotation/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._yshift import YshiftValidator
     from ._yref import YrefValidator
     from ._yclick import YclickValidator

--- a/packages/python/plotly/plotly/validators/layout/annotation/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/annotation/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/annotation/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/annotation/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import FontValidator
     from ._bordercolor import BordercolorValidator
     from ._bgcolor import BgcolorValidator

--- a/packages/python/plotly/plotly/validators/layout/annotation/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/annotation/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/coloraxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/coloraxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._showscale import ShowscaleValidator
     from ._reversescale import ReversescaleValidator
     from ._colorscale import ColorscaleValidator

--- a/packages/python/plotly/plotly/validators/layout/coloraxis/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/layout/coloraxis/_colorbar.py
@@ -133,8 +133,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/layout/coloraxis/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/coloraxis/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/layout/coloraxis/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/coloraxis/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/coloraxis/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/coloraxis/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/layout/coloraxis/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/coloraxis/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/layout/coloraxis/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/coloraxis/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/colorscale/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/colorscale/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sequentialminus import SequentialminusValidator
     from ._sequential import SequentialValidator
     from ._diverging import DivergingValidator

--- a/packages/python/plotly/plotly/validators/layout/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/geo/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/geo/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._uirevision import UirevisionValidator
     from ._subunitwidth import SubunitwidthValidator

--- a/packages/python/plotly/plotly/validators/layout/geo/center/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/geo/center/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._lon import LonValidator
     from ._lat import LatValidator
 else:

--- a/packages/python/plotly/plotly/validators/layout/geo/domain/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/geo/domain/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._y import YValidator
     from ._x import XValidator
     from ._row import RowValidator

--- a/packages/python/plotly/plotly/validators/layout/geo/lataxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/geo/lataxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tick0 import Tick0Validator
     from ._showgrid import ShowgridValidator
     from ._range import RangeValidator

--- a/packages/python/plotly/plotly/validators/layout/geo/lonaxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/geo/lonaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._tick0 import Tick0Validator
     from ._showgrid import ShowgridValidator
     from ._range import RangeValidator

--- a/packages/python/plotly/plotly/validators/layout/geo/projection/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/geo/projection/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._type import TypeValidator
     from ._tilt import TiltValidator
     from ._scale import ScaleValidator

--- a/packages/python/plotly/plotly/validators/layout/geo/projection/rotation/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/geo/projection/rotation/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._roll import RollValidator
     from ._lon import LonValidator
     from ._lat import LatValidator

--- a/packages/python/plotly/plotly/validators/layout/grid/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/grid/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._yside import YsideValidator
     from ._ygap import YgapValidator
     from ._yaxes import YaxesValidator

--- a/packages/python/plotly/plotly/validators/layout/grid/domain/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/grid/domain/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._y import YValidator
     from ._x import XValidator
 else:

--- a/packages/python/plotly/plotly/validators/layout/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelength import NamelengthValidator
     from ._grouptitlefont import GrouptitlefontValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/layout/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/hoverlabel/grouptitlefont/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/hoverlabel/grouptitlefont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/image/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/image/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._yref import YrefValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/layout/legend/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/legend/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._yanchor import YanchorValidator
     from ._y import YValidator
     from ._xanchor import XanchorValidator

--- a/packages/python/plotly/plotly/validators/layout/legend/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/legend/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/legend/grouptitlefont/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/legend/grouptitlefont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/legend/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/legend/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/layout/legend/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/legend/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/mapbox/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/mapbox/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zoom import ZoomValidator
     from ._uirevision import UirevisionValidator
     from ._style import StyleValidator

--- a/packages/python/plotly/plotly/validators/layout/mapbox/center/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/mapbox/center/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._lon import LonValidator
     from ._lat import LatValidator
 else:

--- a/packages/python/plotly/plotly/validators/layout/mapbox/domain/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/mapbox/domain/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._y import YValidator
     from ._x import XValidator
     from ._row import RowValidator

--- a/packages/python/plotly/plotly/validators/layout/mapbox/layer/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/mapbox/layer/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._type import TypeValidator
     from ._templateitemname import TemplateitemnameValidator

--- a/packages/python/plotly/plotly/validators/layout/mapbox/layer/circle/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/mapbox/layer/circle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._radius import RadiusValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/layout/mapbox/layer/fill/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/mapbox/layer/fill/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._outlinecolor import OutlinecolorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/layout/mapbox/layer/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/mapbox/layer/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._dashsrc import DashsrcValidator
     from ._dash import DashValidator

--- a/packages/python/plotly/plotly/validators/layout/mapbox/layer/symbol/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/mapbox/layer/symbol/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textposition import TextpositionValidator
     from ._textfont import TextfontValidator
     from ._text import TextValidator

--- a/packages/python/plotly/plotly/validators/layout/mapbox/layer/symbol/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/mapbox/layer/symbol/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/margin/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/margin/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._t import TValidator
     from ._r import RValidator
     from ._pad import PadValidator

--- a/packages/python/plotly/plotly/validators/layout/modebar/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/modebar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._uirevision import UirevisionValidator
     from ._removesrc import RemovesrcValidator
     from ._remove import RemoveValidator

--- a/packages/python/plotly/plotly/validators/layout/newshape/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/newshape/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._opacity import OpacityValidator
     from ._line import LineValidator
     from ._layer import LayerValidator

--- a/packages/python/plotly/plotly/validators/layout/newshape/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/newshape/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._dash import DashValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/polar/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/polar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._uirevision import UirevisionValidator
     from ._sector import SectorValidator
     from ._radialaxis import RadialaxisValidator

--- a/packages/python/plotly/plotly/validators/layout/polar/_angularaxis.py
+++ b/packages/python/plotly/plotly/validators/layout/polar/_angularaxis.py
@@ -96,8 +96,8 @@ class AngularaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
@@ -195,8 +195,8 @@ class AngularaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/layout/polar/_radialaxis.py
+++ b/packages/python/plotly/plotly/validators/layout/polar/_radialaxis.py
@@ -111,8 +111,8 @@ class RadialaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
@@ -216,8 +216,8 @@ class RadialaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/layout/polar/angularaxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/polar/angularaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._uirevision import UirevisionValidator
     from ._type import TypeValidator

--- a/packages/python/plotly/plotly/validators/layout/polar/angularaxis/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/polar/angularaxis/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/polar/angularaxis/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/polar/angularaxis/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/layout/polar/domain/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/polar/domain/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._y import YValidator
     from ._x import XValidator
     from ._row import RowValidator

--- a/packages/python/plotly/plotly/validators/layout/polar/radialaxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/polar/radialaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._uirevision import UirevisionValidator
     from ._type import TypeValidator

--- a/packages/python/plotly/plotly/validators/layout/polar/radialaxis/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/polar/radialaxis/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/polar/radialaxis/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/polar/radialaxis/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/layout/polar/radialaxis/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/polar/radialaxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/layout/polar/radialaxis/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/polar/radialaxis/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zaxis import ZaxisValidator
     from ._yaxis import YaxisValidator
     from ._xaxis import XaxisValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/_xaxis.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/_xaxis.py
@@ -106,8 +106,8 @@ class XaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
@@ -224,8 +224,8 @@ class XaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/layout/scene/_yaxis.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/_yaxis.py
@@ -106,8 +106,8 @@ class YaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
@@ -224,8 +224,8 @@ class YaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/layout/scene/_zaxis.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/_zaxis.py
@@ -106,8 +106,8 @@ class ZaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
@@ -224,8 +224,8 @@ class ZaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/layout/scene/annotation/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/annotation/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._yshift import YshiftValidator
     from ._yanchor import YanchorValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/annotation/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/annotation/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/annotation/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/annotation/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._font import FontValidator
     from ._bordercolor import BordercolorValidator
     from ._bgcolor import BgcolorValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/annotation/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/annotation/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/aspectratio/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/aspectratio/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/camera/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/camera/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._up import UpValidator
     from ._projection import ProjectionValidator
     from ._eye import EyeValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/camera/center/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/camera/center/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/camera/eye/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/camera/eye/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/camera/projection/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/camera/projection/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._type import TypeValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/layout/scene/camera/up/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/camera/up/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/domain/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/domain/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._y import YValidator
     from ._x import XValidator
     from ._row import RowValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/xaxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/xaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zerolinewidth import ZerolinewidthValidator
     from ._zerolinecolor import ZerolinecolorValidator
     from ._zeroline import ZerolineValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/xaxis/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/xaxis/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/xaxis/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/xaxis/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/xaxis/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/xaxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/layout/scene/xaxis/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/xaxis/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/yaxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/yaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zerolinewidth import ZerolinewidthValidator
     from ._zerolinecolor import ZerolinecolorValidator
     from ._zeroline import ZerolineValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/yaxis/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/yaxis/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/yaxis/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/yaxis/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/yaxis/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/yaxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/layout/scene/yaxis/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/yaxis/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/zaxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/zaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zerolinewidth import ZerolinewidthValidator
     from ._zerolinecolor import ZerolinecolorValidator
     from ._zeroline import ZerolineValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/zaxis/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/zaxis/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/zaxis/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/zaxis/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/layout/scene/zaxis/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/zaxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/layout/scene/zaxis/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/scene/zaxis/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/shape/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/shape/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ysizemode import YsizemodeValidator
     from ._yref import YrefValidator
     from ._yanchor import YanchorValidator

--- a/packages/python/plotly/plotly/validators/layout/shape/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/shape/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._dash import DashValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/slider/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/slider/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._yanchor import YanchorValidator
     from ._y import YValidator
     from ._xanchor import XanchorValidator

--- a/packages/python/plotly/plotly/validators/layout/slider/currentvalue/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/slider/currentvalue/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._xanchor import XanchorValidator
     from ._visible import VisibleValidator
     from ._suffix import SuffixValidator

--- a/packages/python/plotly/plotly/validators/layout/slider/currentvalue/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/slider/currentvalue/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/slider/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/slider/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/slider/pad/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/slider/pad/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._t import TValidator
     from ._r import RValidator
     from ._l import LValidator

--- a/packages/python/plotly/plotly/validators/layout/slider/step/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/slider/step/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator

--- a/packages/python/plotly/plotly/validators/layout/slider/transition/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/slider/transition/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._easing import EasingValidator
     from ._duration import DurationValidator
 else:

--- a/packages/python/plotly/plotly/validators/layout/smith/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/smith/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._realaxis import RealaxisValidator
     from ._imaginaryaxis import ImaginaryaxisValidator
     from ._domain import DomainValidator

--- a/packages/python/plotly/plotly/validators/layout/smith/_imaginaryaxis.py
+++ b/packages/python/plotly/plotly/validators/layout/smith/_imaginaryaxis.py
@@ -26,8 +26,8 @@ class ImaginaryaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
@@ -75,8 +75,8 @@ class ImaginaryaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/layout/smith/_realaxis.py
+++ b/packages/python/plotly/plotly/validators/layout/smith/_realaxis.py
@@ -24,8 +24,8 @@ class RealaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
@@ -80,8 +80,8 @@ class RealaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/layout/smith/domain/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/smith/domain/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._y import YValidator
     from ._x import XValidator
     from ._row import RowValidator

--- a/packages/python/plotly/plotly/validators/layout/smith/imaginaryaxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/smith/imaginaryaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._tickwidth import TickwidthValidator
     from ._tickvalssrc import TickvalssrcValidator

--- a/packages/python/plotly/plotly/validators/layout/smith/imaginaryaxis/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/smith/imaginaryaxis/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/smith/realaxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/smith/realaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._tickwidth import TickwidthValidator
     from ._tickvalssrc import TickvalssrcValidator

--- a/packages/python/plotly/plotly/validators/layout/smith/realaxis/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/smith/realaxis/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/template/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/template/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._layout import LayoutValidator
     from ._data import DataValidator
 else:

--- a/packages/python/plotly/plotly/validators/layout/template/data/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/template/data/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._waterfall import WaterfallValidator
     from ._volume import VolumeValidator
     from ._violin import ViolinValidator

--- a/packages/python/plotly/plotly/validators/layout/ternary/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._uirevision import UirevisionValidator
     from ._sum import SumValidator
     from ._domain import DomainValidator

--- a/packages/python/plotly/plotly/validators/layout/ternary/_aaxis.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/_aaxis.py
@@ -59,8 +59,8 @@ class AaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
@@ -147,8 +147,8 @@ class AaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/layout/ternary/_baxis.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/_baxis.py
@@ -59,8 +59,8 @@ class BaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
@@ -147,8 +147,8 @@ class BaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/layout/ternary/_caxis.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/_caxis.py
@@ -59,8 +59,8 @@ class CaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the hover text formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of
@@ -147,8 +147,8 @@ class CaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/layout/ternary/aaxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/aaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._uirevision import UirevisionValidator
     from ._title import TitleValidator
     from ._tickwidth import TickwidthValidator

--- a/packages/python/plotly/plotly/validators/layout/ternary/aaxis/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/aaxis/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/ternary/aaxis/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/aaxis/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/layout/ternary/aaxis/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/aaxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/layout/ternary/aaxis/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/aaxis/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/ternary/baxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/baxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._uirevision import UirevisionValidator
     from ._title import TitleValidator
     from ._tickwidth import TickwidthValidator

--- a/packages/python/plotly/plotly/validators/layout/ternary/baxis/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/baxis/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/ternary/baxis/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/baxis/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/layout/ternary/baxis/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/baxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/layout/ternary/baxis/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/baxis/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/ternary/caxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/caxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._uirevision import UirevisionValidator
     from ._title import TitleValidator
     from ._tickwidth import TickwidthValidator

--- a/packages/python/plotly/plotly/validators/layout/ternary/caxis/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/caxis/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/ternary/caxis/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/caxis/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/layout/ternary/caxis/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/caxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/layout/ternary/caxis/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/caxis/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/ternary/domain/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/ternary/domain/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._y import YValidator
     from ._x import XValidator
     from ._row import RowValidator

--- a/packages/python/plotly/plotly/validators/layout/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._yref import YrefValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/layout/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/title/pad/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/title/pad/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._t import TValidator
     from ._r import RValidator
     from ._l import LValidator

--- a/packages/python/plotly/plotly/validators/layout/transition/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/transition/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ordering import OrderingValidator
     from ._easing import EasingValidator
     from ._duration import DurationValidator

--- a/packages/python/plotly/plotly/validators/layout/uniformtext/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/uniformtext/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._mode import ModeValidator
     from ._minsize import MinsizeValidator
 else:

--- a/packages/python/plotly/plotly/validators/layout/updatemenu/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/updatemenu/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._yanchor import YanchorValidator
     from ._y import YValidator
     from ._xanchor import XanchorValidator

--- a/packages/python/plotly/plotly/validators/layout/updatemenu/button/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/updatemenu/button/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/layout/updatemenu/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/updatemenu/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/updatemenu/pad/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/updatemenu/pad/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._t import TValidator
     from ._r import RValidator
     from ._l import LValidator

--- a/packages/python/plotly/plotly/validators/layout/xaxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/xaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zerolinewidth import ZerolinewidthValidator
     from ._zerolinecolor import ZerolinecolorValidator
     from ._zeroline import ZerolineValidator

--- a/packages/python/plotly/plotly/validators/layout/xaxis/rangebreak/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/xaxis/rangebreak/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._values import ValuesValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._pattern import PatternValidator

--- a/packages/python/plotly/plotly/validators/layout/xaxis/rangeselector/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/xaxis/rangeselector/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._yanchor import YanchorValidator
     from ._y import YValidator
     from ._xanchor import XanchorValidator

--- a/packages/python/plotly/plotly/validators/layout/xaxis/rangeselector/button/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/xaxis/rangeselector/button/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._stepmode import StepmodeValidator

--- a/packages/python/plotly/plotly/validators/layout/xaxis/rangeselector/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/xaxis/rangeselector/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/xaxis/rangeslider/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/xaxis/rangeslider/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._yaxis import YaxisValidator
     from ._visible import VisibleValidator
     from ._thickness import ThicknessValidator

--- a/packages/python/plotly/plotly/validators/layout/xaxis/rangeslider/yaxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/xaxis/rangeslider/yaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._rangemode import RangemodeValidator
     from ._range import RangeValidator
 else:

--- a/packages/python/plotly/plotly/validators/layout/xaxis/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/xaxis/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/xaxis/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/xaxis/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/layout/xaxis/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/xaxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._standoff import StandoffValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/layout/xaxis/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/xaxis/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/yaxis/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/yaxis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zerolinewidth import ZerolinewidthValidator
     from ._zerolinecolor import ZerolinecolorValidator
     from ._zeroline import ZerolineValidator

--- a/packages/python/plotly/plotly/validators/layout/yaxis/rangebreak/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/yaxis/rangebreak/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._values import ValuesValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._pattern import PatternValidator

--- a/packages/python/plotly/plotly/validators/layout/yaxis/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/yaxis/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/layout/yaxis/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/yaxis/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/layout/yaxis/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/yaxis/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._standoff import StandoffValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/layout/yaxis/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/layout/yaxis/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/mesh3d/__init__.py
+++ b/packages/python/plotly/plotly/validators/mesh3d/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._zhoverformat import ZhoverformatValidator
     from ._zcalendar import ZcalendarValidator

--- a/packages/python/plotly/plotly/validators/mesh3d/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/mesh3d/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/mesh3d/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/mesh3d/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/mesh3d/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/mesh3d/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/mesh3d/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/mesh3d/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/mesh3d/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/mesh3d/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/mesh3d/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/mesh3d/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/mesh3d/contour/__init__.py
+++ b/packages/python/plotly/plotly/validators/mesh3d/contour/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._show import ShowValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/mesh3d/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/mesh3d/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/mesh3d/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/mesh3d/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/mesh3d/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/mesh3d/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/mesh3d/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/mesh3d/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/mesh3d/lighting/__init__.py
+++ b/packages/python/plotly/plotly/validators/mesh3d/lighting/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._vertexnormalsepsilon import VertexnormalsepsilonValidator
     from ._specular import SpecularValidator
     from ._roughness import RoughnessValidator

--- a/packages/python/plotly/plotly/validators/mesh3d/lightposition/__init__.py
+++ b/packages/python/plotly/plotly/validators/mesh3d/lightposition/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/mesh3d/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/mesh3d/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/ohlc/__init__.py
+++ b/packages/python/plotly/plotly/validators/ohlc/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._yhoverformat import YhoverformatValidator
     from ._yaxis import YaxisValidator
     from ._xsrc import XsrcValidator

--- a/packages/python/plotly/plotly/validators/ohlc/decreasing/__init__.py
+++ b/packages/python/plotly/plotly/validators/ohlc/decreasing/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import LineValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/ohlc/decreasing/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/ohlc/decreasing/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._dash import DashValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/ohlc/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/ohlc/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._split import SplitValidator
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator

--- a/packages/python/plotly/plotly/validators/ohlc/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/ohlc/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/ohlc/increasing/__init__.py
+++ b/packages/python/plotly/plotly/validators/ohlc/increasing/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import LineValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/ohlc/increasing/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/ohlc/increasing/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._dash import DashValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/ohlc/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/ohlc/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/ohlc/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/ohlc/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/ohlc/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/ohlc/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._dash import DashValidator
 else:

--- a/packages/python/plotly/plotly/validators/ohlc/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/ohlc/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/parcats/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcats/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._uirevision import UirevisionValidator
     from ._uid import UidValidator

--- a/packages/python/plotly/plotly/validators/parcats/_line.py
+++ b/packages/python/plotly/plotly/validators/parcats/_line.py
@@ -100,8 +100,8 @@ class LineValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/parcats/dimension/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcats/dimension/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._valuessrc import ValuessrcValidator
     from ._values import ValuesValidator

--- a/packages/python/plotly/plotly/validators/parcats/domain/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcats/domain/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._y import YValidator
     from ._x import XValidator
     from ._row import RowValidator

--- a/packages/python/plotly/plotly/validators/parcats/labelfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcats/labelfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/parcats/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcats/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/parcats/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcats/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/parcats/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcats/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._showscale import ShowscaleValidator
     from ._shape import ShapeValidator
     from ._reversescale import ReversescaleValidator

--- a/packages/python/plotly/plotly/validators/parcats/line/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/parcats/line/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/parcats/line/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcats/line/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/parcats/line/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcats/line/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/parcats/line/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcats/line/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/parcats/line/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcats/line/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/parcats/line/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcats/line/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/parcats/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcats/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/parcats/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcats/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/parcoords/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcoords/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._uirevision import UirevisionValidator
     from ._uid import UidValidator

--- a/packages/python/plotly/plotly/validators/parcoords/_dimensions.py
+++ b/packages/python/plotly/plotly/validators/parcoords/_dimensions.py
@@ -52,8 +52,8 @@ class DimensionsValidator(_plotly_utils.basevalidators.CompoundArrayValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/parcoords/dimension/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcoords/dimension/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._valuessrc import ValuessrcValidator
     from ._values import ValuesValidator

--- a/packages/python/plotly/plotly/validators/parcoords/domain/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcoords/domain/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._y import YValidator
     from ._x import XValidator
     from ._row import RowValidator

--- a/packages/python/plotly/plotly/validators/parcoords/labelfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcoords/labelfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/parcoords/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcoords/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/parcoords/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcoords/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/parcoords/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcoords/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._showscale import ShowscaleValidator
     from ._reversescale import ReversescaleValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/parcoords/line/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/parcoords/line/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/parcoords/line/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcoords/line/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/parcoords/line/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcoords/line/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/parcoords/line/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcoords/line/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/parcoords/line/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcoords/line/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/parcoords/line/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcoords/line/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/parcoords/rangefont/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcoords/rangefont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/parcoords/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcoords/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/parcoords/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/parcoords/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/pie/__init__.py
+++ b/packages/python/plotly/plotly/validators/pie/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._valuessrc import ValuessrcValidator
     from ._values import ValuesValidator

--- a/packages/python/plotly/plotly/validators/pie/domain/__init__.py
+++ b/packages/python/plotly/plotly/validators/pie/domain/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._y import YValidator
     from ._x import XValidator
     from ._row import RowValidator

--- a/packages/python/plotly/plotly/validators/pie/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/pie/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/pie/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/pie/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/pie/insidetextfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/pie/insidetextfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/pie/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/pie/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/pie/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/pie/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/pie/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/pie/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import LineValidator
     from ._colorssrc import ColorssrcValidator
     from ._colors import ColorsValidator

--- a/packages/python/plotly/plotly/validators/pie/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/pie/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/pie/outsidetextfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/pie/outsidetextfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/pie/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/pie/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/pie/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/pie/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/pie/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/pie/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._position import PositionValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/pie/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/pie/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/pointcloud/__init__.py
+++ b/packages/python/plotly/plotly/validators/pointcloud/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ysrc import YsrcValidator
     from ._yboundssrc import YboundssrcValidator
     from ._ybounds import YboundsValidator

--- a/packages/python/plotly/plotly/validators/pointcloud/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/pointcloud/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/pointcloud/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/pointcloud/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/pointcloud/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/pointcloud/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/pointcloud/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/pointcloud/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/pointcloud/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/pointcloud/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizemin import SizeminValidator
     from ._sizemax import SizemaxValidator
     from ._opacity import OpacityValidator

--- a/packages/python/plotly/plotly/validators/pointcloud/marker/border/__init__.py
+++ b/packages/python/plotly/plotly/validators/pointcloud/marker/border/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
     from ._arearatio import ArearatioValidator
 else:

--- a/packages/python/plotly/plotly/validators/pointcloud/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/pointcloud/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/sankey/__init__.py
+++ b/packages/python/plotly/plotly/validators/sankey/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._valuesuffix import ValuesuffixValidator
     from ._valueformat import ValueformatValidator

--- a/packages/python/plotly/plotly/validators/sankey/_link.py
+++ b/packages/python/plotly/plotly/validators/sankey/_link.py
@@ -57,8 +57,8 @@ class LinkValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/sankey/_node.py
+++ b/packages/python/plotly/plotly/validators/sankey/_node.py
@@ -54,8 +54,8 @@ class NodeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 only when this field is shown. Numbers are
                 formatted using d3-format's syntax
                 %{variable:d3-format}, for example "Price:
-                %{y:$.2f}". https://github.com/d3/d3-format/tre
-                e/v1.4.5#d3-format for details on the
+                %{y:$.2f}". https://github.com/d3/d3-
+                format/tree/v1.4.5#d3-format for details on the
                 formatting syntax. Dates are formatted using
                 d3-time-format's syntax %{variable|d3-time-
                 format}, for example "Day: %{2019-01-01|%A}".

--- a/packages/python/plotly/plotly/validators/sankey/domain/__init__.py
+++ b/packages/python/plotly/plotly/validators/sankey/domain/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._y import YValidator
     from ._x import XValidator
     from ._row import RowValidator

--- a/packages/python/plotly/plotly/validators/sankey/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/sankey/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/sankey/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/sankey/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/sankey/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/sankey/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/sankey/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/sankey/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/sankey/link/__init__.py
+++ b/packages/python/plotly/plotly/validators/sankey/link/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._valuesrc import ValuesrcValidator
     from ._value import ValueValidator
     from ._targetsrc import TargetsrcValidator

--- a/packages/python/plotly/plotly/validators/sankey/link/colorscale/__init__.py
+++ b/packages/python/plotly/plotly/validators/sankey/link/colorscale/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator
     from ._label import LabelValidator

--- a/packages/python/plotly/plotly/validators/sankey/link/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/sankey/link/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/sankey/link/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/sankey/link/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/sankey/link/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/sankey/link/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/sankey/node/__init__.py
+++ b/packages/python/plotly/plotly/validators/sankey/node/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ysrc import YsrcValidator
     from ._y import YValidator
     from ._xsrc import XsrcValidator

--- a/packages/python/plotly/plotly/validators/sankey/node/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/sankey/node/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/sankey/node/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/sankey/node/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/sankey/node/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/sankey/node/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/sankey/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/sankey/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/sankey/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/sankey/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatter/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ysrc import YsrcValidator
     from ._yperiodalignment import YperiodalignmentValidator
     from ._yperiod0 import Yperiod0Validator

--- a/packages/python/plotly/plotly/validators/scatter/error_x/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/error_x/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._visible import VisibleValidator
     from ._valueminus import ValueminusValidator

--- a/packages/python/plotly/plotly/validators/scatter/error_y/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/error_y/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._visible import VisibleValidator
     from ._valueminus import ValueminusValidator

--- a/packages/python/plotly/plotly/validators/scatter/fillpattern/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/fillpattern/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._soliditysrc import SoliditysrcValidator
     from ._solidity import SolidityValidator
     from ._sizesrc import SizesrcValidator

--- a/packages/python/plotly/plotly/validators/scatter/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scatter/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scatter/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatter/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatter/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._smoothing import SmoothingValidator
     from ._simplify import SimplifyValidator

--- a/packages/python/plotly/plotly/validators/scatter/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._symbolsrc import SymbolsrcValidator
     from ._symbol import SymbolValidator
     from ._sizesrc import SizesrcValidator

--- a/packages/python/plotly/plotly/validators/scatter/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/scatter/marker/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/scatter/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/scatter/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatter/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/scatter/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scatter/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatter/marker/gradient/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/marker/gradient/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._typesrc import TypesrcValidator
     from ._type import TypeValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/scatter/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._reversescale import ReversescaleValidator

--- a/packages/python/plotly/plotly/validators/scatter/selected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatter/selected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/selected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatter/selected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/selected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/scatter/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatter/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scatter/unselected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatter/unselected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/unselected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatter/unselected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter/unselected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/scatter3d/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._zhoverformat import ZhoverformatValidator
     from ._zcalendar import ZcalendarValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/error_x/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/error_x/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._visible import VisibleValidator
     from ._valueminus import ValueminusValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/error_y/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/error_y/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._visible import VisibleValidator
     from ._valueminus import ValueminusValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/error_z/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/error_z/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._visible import VisibleValidator
     from ._valueminus import ValueminusValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatter3d/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._showscale import ShowscaleValidator
     from ._reversescale import ReversescaleValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/line/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/line/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/scatter3d/line/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/line/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/line/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/line/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/line/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/line/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/line/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/line/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/line/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/line/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._symbolsrc import SymbolsrcValidator
     from ._symbol import SymbolValidator
     from ._sizesrc import SizesrcValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/marker/_colorbar.py
@@ -133,8 +133,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/scatter3d/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._reversescale import ReversescaleValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/projection/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/projection/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/projection/x/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/projection/x/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._scale import ScaleValidator
     from ._opacity import OpacityValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/projection/y/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/projection/y/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._scale import ScaleValidator
     from ._opacity import OpacityValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/projection/z/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/projection/z/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._scale import ScaleValidator
     from ._opacity import OpacityValidator

--- a/packages/python/plotly/plotly/validators/scatter3d/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatter3d/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatter3d/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._family import FamilyValidator

--- a/packages/python/plotly/plotly/validators/scattercarpet/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._yaxis import YaxisValidator
     from ._xaxis import XaxisValidator
     from ._visible import VisibleValidator

--- a/packages/python/plotly/plotly/validators/scattercarpet/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scattercarpet/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scattercarpet/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattercarpet/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattercarpet/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._smoothing import SmoothingValidator
     from ._shape import ShapeValidator

--- a/packages/python/plotly/plotly/validators/scattercarpet/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._symbolsrc import SymbolsrcValidator
     from ._symbol import SymbolValidator
     from ._sizesrc import SizesrcValidator

--- a/packages/python/plotly/plotly/validators/scattercarpet/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/marker/_colorbar.py
@@ -133,8 +133,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/scattercarpet/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/scattercarpet/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattercarpet/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/scattercarpet/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scattercarpet/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattercarpet/marker/gradient/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/marker/gradient/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._typesrc import TypesrcValidator
     from ._type import TypeValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/scattercarpet/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._reversescale import ReversescaleValidator

--- a/packages/python/plotly/plotly/validators/scattercarpet/selected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattercarpet/selected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/selected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattercarpet/selected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/selected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/scattercarpet/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattercarpet/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scattercarpet/unselected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattercarpet/unselected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/unselected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattercarpet/unselected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattercarpet/unselected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/scattergeo/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._unselected import UnselectedValidator
     from ._uirevision import UirevisionValidator

--- a/packages/python/plotly/plotly/validators/scattergeo/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scattergeo/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scattergeo/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattergeo/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattergeo/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._dash import DashValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattergeo/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._symbolsrc import SymbolsrcValidator
     from ._symbol import SymbolValidator
     from ._sizesrc import SizesrcValidator

--- a/packages/python/plotly/plotly/validators/scattergeo/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/marker/_colorbar.py
@@ -133,8 +133,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/scattergeo/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/scattergeo/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattergeo/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/scattergeo/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scattergeo/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattergeo/marker/gradient/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/marker/gradient/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._typesrc import TypesrcValidator
     from ._type import TypeValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/scattergeo/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._reversescale import ReversescaleValidator

--- a/packages/python/plotly/plotly/validators/scattergeo/selected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattergeo/selected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/selected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattergeo/selected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/selected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/scattergeo/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattergeo/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scattergeo/unselected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattergeo/unselected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/unselected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattergeo/unselected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergeo/unselected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/scattergl/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ysrc import YsrcValidator
     from ._yperiodalignment import YperiodalignmentValidator
     from ._yperiod0 import Yperiod0Validator

--- a/packages/python/plotly/plotly/validators/scattergl/error_x/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/error_x/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._visible import VisibleValidator
     from ._valueminus import ValueminusValidator

--- a/packages/python/plotly/plotly/validators/scattergl/error_y/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/error_y/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._visible import VisibleValidator
     from ._valueminus import ValueminusValidator

--- a/packages/python/plotly/plotly/validators/scattergl/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scattergl/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scattergl/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattergl/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattergl/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._shape import ShapeValidator
     from ._dash import DashValidator

--- a/packages/python/plotly/plotly/validators/scattergl/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._symbolsrc import SymbolsrcValidator
     from ._symbol import SymbolValidator
     from ._sizesrc import SizesrcValidator

--- a/packages/python/plotly/plotly/validators/scattergl/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/scattergl/marker/_colorbar.py
@@ -133,8 +133,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/scattergl/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/scattergl/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattergl/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/scattergl/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scattergl/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattergl/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._reversescale import ReversescaleValidator

--- a/packages/python/plotly/plotly/validators/scattergl/selected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattergl/selected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/selected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattergl/selected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/selected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/scattergl/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattergl/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scattergl/unselected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattergl/unselected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/unselected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattergl/unselected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattergl/unselected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/scattermapbox/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._unselected import UnselectedValidator
     from ._uirevision import UirevisionValidator

--- a/packages/python/plotly/plotly/validators/scattermapbox/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scattermapbox/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scattermapbox/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattermapbox/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattermapbox/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattermapbox/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._symbolsrc import SymbolsrcValidator
     from ._symbol import SymbolValidator
     from ._sizesrc import SizesrcValidator

--- a/packages/python/plotly/plotly/validators/scattermapbox/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/marker/_colorbar.py
@@ -133,8 +133,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/scattermapbox/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/scattermapbox/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattermapbox/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/scattermapbox/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scattermapbox/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattermapbox/selected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import MarkerValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/scattermapbox/selected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/selected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattermapbox/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattermapbox/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattermapbox/unselected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import MarkerValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/scattermapbox/unselected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattermapbox/unselected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatterpolar/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._unselected import UnselectedValidator
     from ._uirevision import UirevisionValidator

--- a/packages/python/plotly/plotly/validators/scatterpolar/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scatterpolar/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scatterpolar/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatterpolar/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatterpolar/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._smoothing import SmoothingValidator
     from ._shape import ShapeValidator

--- a/packages/python/plotly/plotly/validators/scatterpolar/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._symbolsrc import SymbolsrcValidator
     from ._symbol import SymbolValidator
     from ._sizesrc import SizesrcValidator

--- a/packages/python/plotly/plotly/validators/scatterpolar/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/marker/_colorbar.py
@@ -133,8 +133,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/scatterpolar/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/scatterpolar/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatterpolar/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/scatterpolar/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scatterpolar/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatterpolar/marker/gradient/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/marker/gradient/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._typesrc import TypesrcValidator
     from ._type import TypeValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/scatterpolar/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._reversescale import ReversescaleValidator

--- a/packages/python/plotly/plotly/validators/scatterpolar/selected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatterpolar/selected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/selected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatterpolar/selected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/selected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/scatterpolar/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatterpolar/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scatterpolar/unselected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatterpolar/unselected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/unselected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatterpolar/unselected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolar/unselected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/scatterpolargl/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._unselected import UnselectedValidator
     from ._uirevision import UirevisionValidator

--- a/packages/python/plotly/plotly/validators/scatterpolargl/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scatterpolargl/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scatterpolargl/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatterpolargl/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatterpolargl/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._shape import ShapeValidator
     from ._dash import DashValidator

--- a/packages/python/plotly/plotly/validators/scatterpolargl/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._symbolsrc import SymbolsrcValidator
     from ._symbol import SymbolValidator
     from ._sizesrc import SizesrcValidator

--- a/packages/python/plotly/plotly/validators/scatterpolargl/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/marker/_colorbar.py
@@ -133,8 +133,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/scatterpolargl/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/scatterpolargl/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatterpolargl/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/scatterpolargl/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scatterpolargl/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatterpolargl/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._reversescale import ReversescaleValidator

--- a/packages/python/plotly/plotly/validators/scatterpolargl/selected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatterpolargl/selected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/selected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatterpolargl/selected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/selected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/scatterpolargl/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatterpolargl/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scatterpolargl/unselected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatterpolargl/unselected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/unselected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatterpolargl/unselected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterpolargl/unselected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/scattersmith/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._unselected import UnselectedValidator
     from ._uirevision import UirevisionValidator

--- a/packages/python/plotly/plotly/validators/scattersmith/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scattersmith/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scattersmith/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattersmith/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattersmith/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._smoothing import SmoothingValidator
     from ._shape import ShapeValidator

--- a/packages/python/plotly/plotly/validators/scattersmith/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._symbolsrc import SymbolsrcValidator
     from ._symbol import SymbolValidator
     from ._sizesrc import SizesrcValidator

--- a/packages/python/plotly/plotly/validators/scattersmith/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/marker/_colorbar.py
@@ -133,8 +133,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/scattersmith/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/scattersmith/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattersmith/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/scattersmith/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scattersmith/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattersmith/marker/gradient/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/marker/gradient/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._typesrc import TypesrcValidator
     from ._type import TypeValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/scattersmith/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._reversescale import ReversescaleValidator

--- a/packages/python/plotly/plotly/validators/scattersmith/selected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattersmith/selected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/selected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattersmith/selected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/selected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/scattersmith/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattersmith/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scattersmith/unselected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/scattersmith/unselected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/unselected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scattersmith/unselected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scattersmith/unselected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/scatterternary/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._unselected import UnselectedValidator
     from ._uirevision import UirevisionValidator

--- a/packages/python/plotly/plotly/validators/scatterternary/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scatterternary/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scatterternary/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatterternary/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatterternary/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._smoothing import SmoothingValidator
     from ._shape import ShapeValidator

--- a/packages/python/plotly/plotly/validators/scatterternary/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._symbolsrc import SymbolsrcValidator
     from ._symbol import SymbolValidator
     from ._sizesrc import SizesrcValidator

--- a/packages/python/plotly/plotly/validators/scatterternary/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/marker/_colorbar.py
@@ -133,8 +133,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/scatterternary/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/scatterternary/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatterternary/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/scatterternary/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/scatterternary/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatterternary/marker/gradient/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/marker/gradient/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._typesrc import TypesrcValidator
     from ._type import TypeValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/scatterternary/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._reversescale import ReversescaleValidator

--- a/packages/python/plotly/plotly/validators/scatterternary/selected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatterternary/selected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/selected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatterternary/selected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/selected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/scatterternary/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatterternary/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/scatterternary/unselected/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._textfont import TextfontValidator
     from ._marker import MarkerValidator
 else:

--- a/packages/python/plotly/plotly/validators/scatterternary/unselected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/unselected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/scatterternary/unselected/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/scatterternary/unselected/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/splom/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._yhoverformat import YhoverformatValidator
     from ._yaxes import YaxesValidator
     from ._xhoverformat import XhoverformatValidator

--- a/packages/python/plotly/plotly/validators/splom/diagonal/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/diagonal/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/splom/dimension/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/dimension/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._valuessrc import ValuessrcValidator
     from ._values import ValuesValidator

--- a/packages/python/plotly/plotly/validators/splom/dimension/axis/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/dimension/axis/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._type import TypeValidator
     from ._matches import MatchesValidator
 else:

--- a/packages/python/plotly/plotly/validators/splom/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/splom/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/splom/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/splom/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/splom/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._symbolsrc import SymbolsrcValidator
     from ._symbol import SymbolValidator
     from ._sizesrc import SizesrcValidator

--- a/packages/python/plotly/plotly/validators/splom/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/splom/marker/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/splom/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/splom/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/splom/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/splom/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/splom/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/splom/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._reversescale import ReversescaleValidator

--- a/packages/python/plotly/plotly/validators/splom/selected/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import MarkerValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/splom/selected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/selected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/splom/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/splom/unselected/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import MarkerValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/splom/unselected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/splom/unselected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/streamtube/__init__.py
+++ b/packages/python/plotly/plotly/validators/streamtube/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._zhoverformat import ZhoverformatValidator
     from ._z import ZValidator

--- a/packages/python/plotly/plotly/validators/streamtube/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/streamtube/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/streamtube/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/streamtube/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/streamtube/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/streamtube/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/streamtube/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/streamtube/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/streamtube/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/streamtube/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/streamtube/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/streamtube/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/streamtube/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/streamtube/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/streamtube/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/streamtube/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/streamtube/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/streamtube/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/streamtube/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/streamtube/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/streamtube/lighting/__init__.py
+++ b/packages/python/plotly/plotly/validators/streamtube/lighting/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._vertexnormalsepsilon import VertexnormalsepsilonValidator
     from ._specular import SpecularValidator
     from ._roughness import RoughnessValidator

--- a/packages/python/plotly/plotly/validators/streamtube/lightposition/__init__.py
+++ b/packages/python/plotly/plotly/validators/streamtube/lightposition/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/streamtube/starts/__init__.py
+++ b/packages/python/plotly/plotly/validators/streamtube/starts/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._z import ZValidator
     from ._ysrc import YsrcValidator

--- a/packages/python/plotly/plotly/validators/streamtube/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/streamtube/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/sunburst/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._valuessrc import ValuessrcValidator
     from ._values import ValuesValidator

--- a/packages/python/plotly/plotly/validators/sunburst/domain/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/domain/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._y import YValidator
     from ._x import XValidator
     from ._row import RowValidator

--- a/packages/python/plotly/plotly/validators/sunburst/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/sunburst/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/sunburst/insidetextfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/insidetextfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/sunburst/leaf/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/leaf/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._opacity import OpacityValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/sunburst/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/sunburst/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/sunburst/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._showscale import ShowscaleValidator
     from ._reversescale import ReversescaleValidator
     from ._line import LineValidator

--- a/packages/python/plotly/plotly/validators/sunburst/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/sunburst/marker/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/sunburst/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/sunburst/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/sunburst/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/sunburst/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/sunburst/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/sunburst/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/sunburst/outsidetextfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/outsidetextfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/sunburst/root/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/root/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/sunburst/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/sunburst/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/sunburst/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/surface/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._zhoverformat import ZhoverformatValidator
     from ._zcalendar import ZcalendarValidator

--- a/packages/python/plotly/plotly/validators/surface/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/surface/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/surface/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/surface/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/surface/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/surface/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/surface/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/surface/contours/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/contours/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/surface/contours/x/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/contours/x/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._usecolormap import UsecolormapValidator
     from ._start import StartValidator

--- a/packages/python/plotly/plotly/validators/surface/contours/x/project/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/contours/x/project/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/surface/contours/y/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/contours/y/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._usecolormap import UsecolormapValidator
     from ._start import StartValidator

--- a/packages/python/plotly/plotly/validators/surface/contours/y/project/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/contours/y/project/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/surface/contours/z/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/contours/z/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._usecolormap import UsecolormapValidator
     from ._start import StartValidator

--- a/packages/python/plotly/plotly/validators/surface/contours/z/project/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/contours/z/project/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/surface/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/surface/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/surface/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/surface/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/surface/lighting/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/lighting/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._specular import SpecularValidator
     from ._roughness import RoughnessValidator
     from ._fresnel import FresnelValidator

--- a/packages/python/plotly/plotly/validators/surface/lightposition/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/lightposition/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/surface/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/surface/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/table/__init__.py
+++ b/packages/python/plotly/plotly/validators/table/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._uirevision import UirevisionValidator
     from ._uid import UidValidator

--- a/packages/python/plotly/plotly/validators/table/_cells.py
+++ b/packages/python/plotly/plotly/validators/table/_cells.py
@@ -29,8 +29,8 @@ class CellsValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the cell value formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat.
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format.
             formatsrc
                 Sets the source reference on Chart Studio Cloud
                 for `format`.

--- a/packages/python/plotly/plotly/validators/table/_header.py
+++ b/packages/python/plotly/plotly/validators/table/_header.py
@@ -29,8 +29,8 @@ class HeaderValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the cell value formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat.
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format.
             formatsrc
                 Sets the source reference on Chart Studio Cloud
                 for `format`.

--- a/packages/python/plotly/plotly/validators/table/cells/__init__.py
+++ b/packages/python/plotly/plotly/validators/table/cells/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._valuessrc import ValuessrcValidator
     from ._values import ValuesValidator
     from ._suffixsrc import SuffixsrcValidator

--- a/packages/python/plotly/plotly/validators/table/cells/fill/__init__.py
+++ b/packages/python/plotly/plotly/validators/table/cells/fill/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorsrc import ColorsrcValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/table/cells/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/table/cells/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/table/cells/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/table/cells/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/table/domain/__init__.py
+++ b/packages/python/plotly/plotly/validators/table/domain/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._y import YValidator
     from ._x import XValidator
     from ._row import RowValidator

--- a/packages/python/plotly/plotly/validators/table/header/__init__.py
+++ b/packages/python/plotly/plotly/validators/table/header/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._valuessrc import ValuessrcValidator
     from ._values import ValuesValidator
     from ._suffixsrc import SuffixsrcValidator

--- a/packages/python/plotly/plotly/validators/table/header/fill/__init__.py
+++ b/packages/python/plotly/plotly/validators/table/header/fill/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._colorsrc import ColorsrcValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/table/header/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/table/header/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/table/header/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/table/header/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/table/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/table/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/table/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/table/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/table/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/table/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/table/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/table/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/table/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/table/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/treemap/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._valuessrc import ValuessrcValidator
     from ._values import ValuesValidator

--- a/packages/python/plotly/plotly/validators/treemap/_tiling.py
+++ b/packages/python/plotly/plotly/validators/treemap/_tiling.py
@@ -22,10 +22,10 @@ class TilingValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the inner padding (in px).
             squarifyratio
                 When using "squarify" `packing` algorithm,
-                according to https://github.com/d3/d3-hierarchy
-                /blob/master/README.md#squarify_ratio this
-                option specifies the desired aspect ratio of
-                the generated rectangles. The ratio must be
+                according to https://github.com/d3/d3-
+                hierarchy/blob/master/README.md#squarify_ratio
+                this option specifies the desired aspect ratio
+                of the generated rectangles. The ratio must be
                 specified as a number greater than or equal to
                 one. Note that the orientation of the generated
                 rectangles (tall or wide) is not implied by the

--- a/packages/python/plotly/plotly/validators/treemap/domain/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/domain/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._y import YValidator
     from ._x import XValidator
     from ._row import RowValidator

--- a/packages/python/plotly/plotly/validators/treemap/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/treemap/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/treemap/insidetextfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/insidetextfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/treemap/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/treemap/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/treemap/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._showscale import ShowscaleValidator
     from ._reversescale import ReversescaleValidator
     from ._pad import PadValidator

--- a/packages/python/plotly/plotly/validators/treemap/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/treemap/marker/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/treemap/marker/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/marker/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/treemap/marker/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/marker/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/treemap/marker/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/marker/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/treemap/marker/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/marker/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/treemap/marker/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/marker/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/treemap/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._widthsrc import WidthsrcValidator
     from ._width import WidthValidator
     from ._colorsrc import ColorsrcValidator

--- a/packages/python/plotly/plotly/validators/treemap/marker/pad/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/marker/pad/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._t import TValidator
     from ._r import RValidator
     from ._l import LValidator

--- a/packages/python/plotly/plotly/validators/treemap/outsidetextfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/outsidetextfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/treemap/pathbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/pathbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._thickness import ThicknessValidator
     from ._textfont import TextfontValidator

--- a/packages/python/plotly/plotly/validators/treemap/pathbar/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/pathbar/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/treemap/root/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/root/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._color import ColorValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/treemap/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/treemap/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/treemap/tiling/__init__.py
+++ b/packages/python/plotly/plotly/validators/treemap/tiling/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._squarifyratio import SquarifyratioValidator
     from ._pad import PadValidator
     from ._packing import PackingValidator

--- a/packages/python/plotly/plotly/validators/violin/__init__.py
+++ b/packages/python/plotly/plotly/validators/violin/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ysrc import YsrcValidator
     from ._yhoverformat import YhoverformatValidator
     from ._yaxis import YaxisValidator

--- a/packages/python/plotly/plotly/validators/violin/box/__init__.py
+++ b/packages/python/plotly/plotly/validators/violin/box/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._visible import VisibleValidator
     from ._line import LineValidator

--- a/packages/python/plotly/plotly/validators/violin/box/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/violin/box/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/violin/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/violin/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/violin/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/violin/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/violin/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/violin/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/violin/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/violin/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/violin/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/violin/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/violin/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/violin/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._symbol import SymbolValidator
     from ._size import SizeValidator
     from ._outliercolor import OutliercolorValidator

--- a/packages/python/plotly/plotly/validators/violin/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/violin/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._outlierwidth import OutlierwidthValidator
     from ._outliercolor import OutliercolorValidator

--- a/packages/python/plotly/plotly/validators/violin/meanline/__init__.py
+++ b/packages/python/plotly/plotly/validators/violin/meanline/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._visible import VisibleValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/violin/selected/__init__.py
+++ b/packages/python/plotly/plotly/validators/violin/selected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import MarkerValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/violin/selected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/violin/selected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/violin/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/violin/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/violin/unselected/__init__.py
+++ b/packages/python/plotly/plotly/validators/violin/unselected/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import MarkerValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/violin/unselected/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/violin/unselected/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._opacity import OpacityValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/volume/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._zsrc import ZsrcValidator
     from ._zhoverformat import ZhoverformatValidator
     from ._z import ZValidator

--- a/packages/python/plotly/plotly/validators/volume/_colorbar.py
+++ b/packages/python/plotly/plotly/validators/volume/_colorbar.py
@@ -131,8 +131,8 @@ class ColorbarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 Sets the tick label formatting rule using d3
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see: h
-                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-f
-                ormat. And for dates see:
+                ttps://github.com/d3/d3-format/tree/v1.4.5#d3-
+                format. And for dates see:
                 https://github.com/d3/d3-time-
                 format/tree/v2.2.3#locale_format. We add two
                 items to d3's date formatter: "%h" for half of

--- a/packages/python/plotly/plotly/validators/volume/caps/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/caps/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/volume/caps/x/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/caps/x/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._fill import FillValidator
 else:

--- a/packages/python/plotly/plotly/validators/volume/caps/y/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/caps/y/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._fill import FillValidator
 else:

--- a/packages/python/plotly/plotly/validators/volume/caps/z/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/caps/z/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._fill import FillValidator
 else:

--- a/packages/python/plotly/plotly/validators/volume/colorbar/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/colorbar/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ypad import YpadValidator
     from ._yanchor import YanchorValidator
     from ._y import YValidator

--- a/packages/python/plotly/plotly/validators/volume/colorbar/tickfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/colorbar/tickfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/volume/colorbar/tickformatstop/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/colorbar/tickformatstop/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._value import ValueValidator
     from ._templateitemname import TemplateitemnameValidator
     from ._name import NameValidator

--- a/packages/python/plotly/plotly/validators/volume/colorbar/title/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/colorbar/title/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._side import SideValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/volume/colorbar/title/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/colorbar/title/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/volume/contour/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/contour/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._show import ShowValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/volume/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/volume/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/volume/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/volume/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/volume/lighting/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/lighting/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._vertexnormalsepsilon import VertexnormalsepsilonValidator
     from ._specular import SpecularValidator
     from ._roughness import RoughnessValidator

--- a/packages/python/plotly/plotly/validators/volume/lightposition/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/lightposition/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/volume/slices/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/slices/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._z import ZValidator
     from ._y import YValidator
     from ._x import XValidator

--- a/packages/python/plotly/plotly/validators/volume/slices/x/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/slices/x/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._locationssrc import LocationssrcValidator
     from ._locations import LocationsValidator

--- a/packages/python/plotly/plotly/validators/volume/slices/y/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/slices/y/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._locationssrc import LocationssrcValidator
     from ._locations import LocationsValidator

--- a/packages/python/plotly/plotly/validators/volume/slices/z/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/slices/z/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._locationssrc import LocationssrcValidator
     from ._locations import LocationsValidator

--- a/packages/python/plotly/plotly/validators/volume/spaceframe/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/spaceframe/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._fill import FillValidator
 else:

--- a/packages/python/plotly/plotly/validators/volume/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/volume/surface/__init__.py
+++ b/packages/python/plotly/plotly/validators/volume/surface/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._show import ShowValidator
     from ._pattern import PatternValidator
     from ._fill import FillValidator

--- a/packages/python/plotly/plotly/validators/waterfall/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._ysrc import YsrcValidator
     from ._yperiodalignment import YperiodalignmentValidator
     from ._yperiod0 import Yperiod0Validator

--- a/packages/python/plotly/plotly/validators/waterfall/connector/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/connector/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._visible import VisibleValidator
     from ._mode import ModeValidator
     from ._line import LineValidator

--- a/packages/python/plotly/plotly/validators/waterfall/connector/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/connector/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._dash import DashValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/waterfall/decreasing/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/decreasing/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import MarkerValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/waterfall/decreasing/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/decreasing/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import LineValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/waterfall/decreasing/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/decreasing/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/waterfall/hoverlabel/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/hoverlabel/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._namelengthsrc import NamelengthsrcValidator
     from ._namelength import NamelengthValidator
     from ._font import FontValidator

--- a/packages/python/plotly/plotly/validators/waterfall/hoverlabel/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/hoverlabel/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/waterfall/increasing/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/increasing/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import MarkerValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/waterfall/increasing/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/increasing/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import LineValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/waterfall/increasing/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/increasing/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/waterfall/insidetextfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/insidetextfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/waterfall/legendgrouptitle/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/legendgrouptitle/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._text import TextValidator
     from ._font import FontValidator
 else:

--- a/packages/python/plotly/plotly/validators/waterfall/legendgrouptitle/font/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/legendgrouptitle/font/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._size import SizeValidator
     from ._family import FamilyValidator
     from ._color import ColorValidator

--- a/packages/python/plotly/plotly/validators/waterfall/outsidetextfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/outsidetextfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/waterfall/stream/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/stream/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._token import TokenValidator
     from ._maxpoints import MaxpointsValidator
 else:

--- a/packages/python/plotly/plotly/validators/waterfall/textfont/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/textfont/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._sizesrc import SizesrcValidator
     from ._size import SizeValidator
     from ._familysrc import FamilysrcValidator

--- a/packages/python/plotly/plotly/validators/waterfall/totals/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/totals/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._marker import MarkerValidator
 else:
     from _plotly_utils.importers import relative_import

--- a/packages/python/plotly/plotly/validators/waterfall/totals/marker/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/totals/marker/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._line import LineValidator
     from ._color import ColorValidator
 else:

--- a/packages/python/plotly/plotly/validators/waterfall/totals/marker/line/__init__.py
+++ b/packages/python/plotly/plotly/validators/waterfall/totals/marker/line/__init__.py
@@ -1,6 +1,7 @@
 import sys
+from typing import TYPE_CHECKING
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 7) or TYPE_CHECKING:
     from ._width import WidthValidator
     from ._color import ColorValidator
 else:


### PR DESCRIPTION
<details>
<summary>Code PR Checklist</summary>

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [x] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [x] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

</details>

Prevent lazy import when type checking

This checks whether type checking is being done, and if so, disables the lazy import as this is generally not supported by type checkers.  This should not have any impact on the runtime performance as the lazy import should still be used at runtime.

This is achieved by inspecting the [`TYPE_CHECKING`](https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING) variable.

This should resolve issue #1682 and provide a temporary workaround for issue #1103.  In the latter case, the addition of stubs would probably still be an improvement as I believe this would be faster.