### PR TITLE
Use assertRaisesRegex instead of assertRaisesRegexp for Python 3.11 compatibility

### DIFF
--- a/packages/python/chart-studio/chart_studio/tests/test_optional/test_grid/test_grid.py
+++ b/packages/python/chart-studio/chart_studio/tests/test_optional/test_grid/test_grid.py
@@ -27,5 +27,5 @@ class TestDataframeToGrid(TestCase):
             'the column "{}" and try again.'.format("col_1")
         )
 
-        with self.assertRaisesRegexp(InputError, expected_message):
+        with self.assertRaisesRegex(InputError, expected_message):
             Grid(df)

--- a/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_dashboard/test_dashboard.py
+++ b/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_dashboard/test_dashboard.py
@@ -29,7 +29,7 @@ class TestDashboard(TestCase):
             "the strings 'first' and 'second'."
         )
 
-        self.assertRaisesRegexp(PlotlyError, message, dash._insert, my_box, "third")
+        self.assertRaisesRegex(PlotlyError, message, dash._insert, my_box, "third")
 
     def test_box_id_none(self):
 
@@ -49,9 +49,7 @@ class TestDashboard(TestCase):
             "one box in your dashboard."
         )
 
-        self.assertRaisesRegexp(
-            PlotlyError, message, dash.insert, my_box, "above", None
-        )
+        self.assertRaisesRegex(PlotlyError, message, dash.insert, my_box, "above", None)
 
     def test_id_not_valid(self):
         my_box = {
@@ -71,12 +69,12 @@ class TestDashboard(TestCase):
         dash.insert(my_box, "above", 1)
 
         # insert box
-        self.assertRaisesRegexp(PlotlyError, message, dash.insert, my_box, "above", 0)
+        self.assertRaisesRegex(PlotlyError, message, dash.insert, my_box, "above", 0)
         # get box by id
-        self.assertRaisesRegexp(PlotlyError, message, dash.get_box, 0)
+        self.assertRaisesRegex(PlotlyError, message, dash.get_box, 0)
 
         # remove box
-        self.assertRaisesRegexp(PlotlyError, message, dash.remove, 0)
+        self.assertRaisesRegex(PlotlyError, message, dash.remove, 0)
 
     def test_invalid_side(self):
         my_box = {
@@ -96,7 +94,7 @@ class TestDashboard(TestCase):
         dash = dashboard.Dashboard()
         dash.insert(my_box, "above", 0)
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, message, dash.insert, my_box, "somewhere", 1
         )
 

--- a/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_plotly/test_credentials.py
+++ b/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_plotly/test_credentials.py
@@ -78,7 +78,7 @@ class TestSignIn(PlotlyTestCase):
         self.users_current_mock.side_effect = exceptions.PlotlyRequestError(
             "msg", 400, "foobar"
         )
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             _plotly_utils.exceptions.PlotlyError, "Sign in failed"
         ):
             py.sign_in("foo", "bar")

--- a/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_plotly/test_plot.py
+++ b/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_plotly/test_plot.py
@@ -72,9 +72,7 @@ class TestPlot(PlotlyTestCase):
 
         kwargs = {"filename": "invalid-sharing-argument", "sharing": "privste"}
 
-        with self.assertRaisesRegexp(
-            PlotlyError, "The 'sharing' argument only accepts"
-        ):
+        with self.assertRaisesRegex(PlotlyError, "The 'sharing' argument only accepts"):
             py.plot(self.simple_figure, **kwargs)
 
     def test_plot_world_readable_sharing_conflict_1(self):
@@ -87,7 +85,7 @@ class TestPlot(PlotlyTestCase):
             "sharing": "public",
         }
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             PlotlyError, "setting your plot privacy to both public and private."
         ):
             py.plot(self.simple_figure, **kwargs)
@@ -102,7 +100,7 @@ class TestPlot(PlotlyTestCase):
             "sharing": "secret",
         }
 
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
             PlotlyError, "setting your plot privacy to both public and private."
         ):
             py.plot(self.simple_figure, **kwargs)

--- a/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_spectacle_presentation/test_spectacle_presentation.py
+++ b/packages/python/chart-studio/chart_studio/tests/test_plot_ly/test_spectacle_presentation/test_spectacle_presentation.py
@@ -19,7 +19,7 @@ class TestPresentation(TestCase):
         # one slide
         """
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             chart_studio.presentation_objs.presentation_objs.STYLE_ERROR,
             pres.Presentation,
@@ -36,7 +36,7 @@ class TestPresentation(TestCase):
         print x
         """
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             chart_studio.presentation_objs.presentation_objs.CODE_ENV_ERROR,
             pres.Presentation,
@@ -52,7 +52,7 @@ class TestPresentation(TestCase):
         ```
         """
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             chart_studio.presentation_objs.presentation_objs.LANG_ERROR,
             pres.Presentation,

--- a/packages/python/plotly/plotly/tests/test_core/test_colors/test_colors.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_colors/test_colors.py
@@ -16,7 +16,7 @@ class TestColors(TestCase):
             "Plotly scale, an rgb color or a hex color."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, colors.validate_colors, color_string
         )
 
@@ -27,7 +27,7 @@ class TestColors(TestCase):
             "Whoops! The elements in your rgb colors tuples cannot " "exceed 255.0."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern2, colors.validate_colors, color_string2
         )
 
@@ -36,7 +36,7 @@ class TestColors(TestCase):
 
         pattern3 = "Whoops! The elements in your colors tuples cannot " "exceed 1.0."
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern3, colors.validate_colors, color_tuple
         )
 
@@ -56,7 +56,7 @@ class TestColors(TestCase):
 
         pattern2 = "You must select either rgb or tuple for your colortype " "variable."
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern2,
             colors.convert_colors_to_same_type,
@@ -72,7 +72,7 @@ class TestColors(TestCase):
 
         pattern = "You must select either rgb or tuple for your colortype " "variable."
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern,
             colors.convert_dict_colors_to_same_type,
@@ -89,7 +89,7 @@ class TestColors(TestCase):
             "You must input a list of scale values that has at least " "two values."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, colors.validate_scale_values, scale
         )
 
@@ -101,7 +101,7 @@ class TestColors(TestCase):
             "1.0 respectively."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, colors.validate_scale_values, scale
         )
 
@@ -113,7 +113,7 @@ class TestColors(TestCase):
             "increasing sequence of numbers."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, colors.validate_scale_values, scale
         )
 
@@ -124,9 +124,7 @@ class TestColors(TestCase):
 
         pattern = "You must input a list of colors that has at least two colors."
 
-        self.assertRaisesRegexp(
-            PlotlyError, pattern, colors.make_colorscale, color_list
-        )
+        self.assertRaisesRegex(PlotlyError, pattern, colors.make_colorscale, color_list)
 
         # test length of colors and scale
         color_list2 = [(0, 0, 0), (1, 1, 1)]
@@ -134,7 +132,7 @@ class TestColors(TestCase):
 
         pattern2 = "The length of colors and scale must be the same."
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern2, colors.make_colorscale, color_list2, scale
         )
 
@@ -144,7 +142,7 @@ class TestColors(TestCase):
         pattern = "Name argument have to be a string."
         name = colors.sequential.haline
 
-        self.assertRaisesRegexp(PlotlyError, pattern, colors.get_colorscale, name)
+        self.assertRaisesRegex(PlotlyError, pattern, colors.get_colorscale, name)
 
         # test for non-existing colorscale
         pattern = r"Colorscale \S+ is not a built-in scale."

--- a/packages/python/plotly/plotly/tests/test_core/test_graph_objs/test_figure.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_graph_objs/test_figure.py
@@ -28,13 +28,13 @@ class FigureTest(TestCaseNoTemplate):
         self.assertEqual(go.Figure().frames, ())
 
     def test_nested_frames(self):
-        with self.assertRaisesRegexp(ValueError, "frames"):
+        with self.assertRaisesRegex(ValueError, "frames"):
             go.Figure({"frames": [{"frames": []}]})
 
         figure = go.Figure()
         figure.frames = [{}]
 
-        with self.assertRaisesRegexp(ValueError, "frames"):
+        with self.assertRaisesRegex(ValueError, "frames"):
             figure.to_plotly_json()["frames"][0]["frames"] = []
             figure.frames[0].frames = []
 

--- a/packages/python/plotly/plotly/tests/test_core/test_update_objects/test_update_annotations.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_update_objects/test_update_annotations.py
@@ -84,7 +84,7 @@ class TestSelectForEachUpdateAnnotations(TestCase):
         self.assertEqual(annot.yref, "paper")
 
         # Not valid to add annotation by row/col
-        with self.assertRaisesRegexp(Exception, "make_subplots"):
+        with self.assertRaisesRegex(Exception, "make_subplots"):
             fig.add_annotation(text="B", row=1, col=1)
 
     def test_add_annotations(self):
@@ -124,7 +124,7 @@ class TestSelectForEachUpdateAnnotations(TestCase):
         self.assertEqual(annot.yref, "y4")
 
         # Try to add to (2, 2), which not a valid
-        with self.assertRaisesRegexp(ValueError, "of type polar"):
+        with self.assertRaisesRegex(ValueError, "of type polar"):
             self.fig.add_annotation(text="D", row=2, col=2)
 
     def test_select_annotations_no_grid(self):

--- a/packages/python/plotly/plotly/tests/test_optional/test_figure_factory/test_figure_factory.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_figure_factory/test_figure_factory.py
@@ -29,7 +29,7 @@ class TestDistplot(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "group_labels": ["group"],
             "curve_type": "curve",
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             "curve_type must be defined as " "'kde' or 'normal'",
             ff.create_distplot,
@@ -1288,7 +1288,7 @@ class TestTrisurf(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "be bigger than or equal to the value of vmax."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, ff.create_trisurf, x, y, z, simplices
         )
 
@@ -1316,7 +1316,7 @@ class TestTrisurf(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "an rgb color or a hex color."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, ff.create_trisurf, x, y, z, simplices, colormap="foo"
         )
 
@@ -1327,7 +1327,7 @@ class TestTrisurf(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "Whoops! The elements in your rgb colors tuples " "cannot exceed 255.0."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern2,
             ff.create_trisurf,
@@ -1343,7 +1343,7 @@ class TestTrisurf(NumpyTestUtilsMixin, TestCaseNoTemplate):
 
         pattern3 = "Whoops! The elements in your colors tuples cannot exceed 1.0."
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern3,
             ff.create_trisurf,
@@ -1615,7 +1615,7 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "a scatterplot matrix."
         )
 
-        self.assertRaisesRegexp(PlotlyError, pattern, ff.create_scatterplotmatrix, df)
+        self.assertRaisesRegex(PlotlyError, pattern, ff.create_scatterplotmatrix, df)
 
     def test_one_column_dataframe(self):
 
@@ -1627,7 +1627,7 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "use at least 2 columns."
         )
 
-        self.assertRaisesRegexp(PlotlyError, pattern, ff.create_scatterplotmatrix, df)
+        self.assertRaisesRegex(PlotlyError, pattern, ff.create_scatterplotmatrix, df)
 
     def test_valid_diag_choice(self):
 
@@ -1650,7 +1650,7 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "'color' and 'colorscale are set internally."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, ff.create_scatterplotmatrix, df, **kwargs
         )
 
@@ -1664,7 +1664,7 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "names of your dataframe."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, ff.create_scatterplotmatrix, df, index="grape"
         )
 
@@ -1678,11 +1678,11 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "either numbers or strings."
         )
 
-        self.assertRaisesRegexp(PlotlyError, pattern, ff.create_scatterplotmatrix, df)
+        self.assertRaisesRegex(PlotlyError, pattern, ff.create_scatterplotmatrix, df)
 
         df = pd.DataFrame([[1, 2], ["a", 4]])
 
-        self.assertRaisesRegexp(PlotlyError, pattern, ff.create_scatterplotmatrix, df)
+        self.assertRaisesRegex(PlotlyError, pattern, ff.create_scatterplotmatrix, df)
 
     def test_same_data_in_index(self):
 
@@ -1694,13 +1694,13 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "are all numbers or all strings."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, ff.create_scatterplotmatrix, df, index="apple"
         )
 
         df = pd.DataFrame([[1, 2], ["a", 4]], columns=["apple", "pear"])
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, ff.create_scatterplotmatrix, df, index="apple"
         )
 
@@ -1723,7 +1723,7 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
         # check: proper 'rgb' color
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern_rgb,
             ff.create_scatterplotmatrix,
@@ -1732,7 +1732,7 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
             index="c",
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern_rgb,
             ff.create_scatterplotmatrix,
@@ -1746,7 +1746,7 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
         # check: proper color tuple
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern_tuple,
             ff.create_scatterplotmatrix,
@@ -1755,7 +1755,7 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
             index="c",
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern_tuple,
             ff.create_scatterplotmatrix,
@@ -1774,7 +1774,7 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "sequence of increasing numbers."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern,
             ff.create_scatterplotmatrix,
@@ -1785,7 +1785,7 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
         # check: the endpts are a list of numbers
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern,
             ff.create_scatterplotmatrix,
@@ -1796,7 +1796,7 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
         )
 
         # check: endpts is a list of INCREASING numbers
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern,
             ff.create_scatterplotmatrix,
@@ -1820,7 +1820,7 @@ class TestScatterPlotMatrix(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "If colormap is a dictionary, all the names in the index " "must be keys."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern,
             ff.create_scatterplotmatrix,
@@ -2170,15 +2170,15 @@ class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "Whoops! The elements in your rgb colors tuples cannot " "exceed 255.0."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, ff.create_violin, data, colors="rgb(300, 2, 3)"
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, ff.create_violin, data, colors=["rgb(300, 2, 3)"]
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern,
             ff.create_violin,
@@ -2188,15 +2188,15 @@ class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
 
         pattern2 = "Whoops! The elements in your colors tuples cannot " "exceed 1.0."
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern2, ff.create_violin, data, colors=(1.1, 1, 1)
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern2, ff.create_violin, data, colors=[(1.1, 1, 1)]
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern2, ff.create_violin, data, colors={"apple": (1.1, 1, 1)}
         )
 
@@ -2214,7 +2214,7 @@ class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "numeric data for the violin plot."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern,
             ff.create_violin,
@@ -2234,13 +2234,13 @@ class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "either numbers or dictionaries."
         )
 
-        self.assertRaisesRegexp(PlotlyError, pattern, ff.create_violin, data)
+        self.assertRaisesRegex(PlotlyError, pattern, ff.create_violin, data)
 
         data = [1, "foo"]
 
         pattern2 = "If data is a list, it must contain only numbers."
 
-        self.assertRaisesRegexp(PlotlyError, pattern2, ff.create_violin, data)
+        self.assertRaisesRegex(PlotlyError, pattern2, ff.create_violin, data)
 
     def test_dataframe_input(self):
 
@@ -2252,7 +2252,7 @@ class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "Error. You must use a pandas DataFrame if you are using " "a group header."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, ff.create_violin, data, group_header=True
         )
 
@@ -2266,7 +2266,7 @@ class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "The colors param cannot be a dictionary if you are " "using a colorscale."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern,
             ff.create_violin,
@@ -2284,7 +2284,7 @@ class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "appear as keys in colors."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern2,
             ff.create_violin,
@@ -2306,7 +2306,7 @@ class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "scale is allowed."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern,
             ff.create_violin,
@@ -2325,7 +2325,7 @@ class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
 
         pattern = "Your group_stats param must be a dictionary."
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern,
             ff.create_violin,
@@ -2344,7 +2344,7 @@ class TestViolin(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "represented as a key in group_stats."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern2,
             ff.create_violin,
@@ -3086,7 +3086,7 @@ class TestFacetGrid(NumpyTestUtilsMixin, TestCaseNoTemplate):
 
         pattern = "You must input a pandas DataFrame."
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, ff.create_facet_grid, data, "a", "b"
         )
 
@@ -3098,7 +3098,7 @@ class TestFacetGrid(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "trace_type of 'scatter' or 'scattergl'."
         )
 
-        self.assertRaisesRegexp(PlotlyError, pattern, ff.create_facet_grid, data, "a")
+        self.assertRaisesRegex(PlotlyError, pattern, ff.create_facet_grid, data, "a")
 
     def test_valid_col_selection(self):
         data = pd.DataFrame([[0, 0], [1, 1]], columns=["a", "b"])
@@ -3108,7 +3108,7 @@ class TestFacetGrid(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "dataframe."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, ff.create_facet_grid, data, "a", "c"
         )
 
@@ -3124,7 +3124,7 @@ class TestFacetGrid(NumpyTestUtilsMixin, TestCaseNoTemplate):
 
         pattern = "'scales' must be set to 'fixed', 'free_x', 'free_y' and 'free'."
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern,
             ff.create_facet_grid,
@@ -3181,7 +3181,7 @@ class TestFacetGrid(NumpyTestUtilsMixin, TestCaseNoTemplate):
 
         color_dict = {"bar": "#ffffff"}
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern,
             ff.create_facet_grid,
@@ -3420,13 +3420,13 @@ class TestBullet(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "Every entry of the data argument (list, tuple, etc) must "
             "be a dictionary."
         )
-        self.assertRaisesRegexp(PlotlyError, pattern, ff.create_bullet, df)
+        self.assertRaisesRegex(PlotlyError, pattern, ff.create_bullet, df)
 
     def test_not_df_or_list(self):
         df = "foo"
 
         pattern = "You must input a pandas DataFrame, or a list of dictionaries."
-        self.assertRaisesRegexp(PlotlyError, pattern, ff.create_bullet, df)
+        self.assertRaisesRegex(PlotlyError, pattern, ff.create_bullet, df)
 
     def test_valid_color_lists_of_2_rgb_colors(self):
         df = [{"title": "Revenue"}]
@@ -3438,11 +3438,11 @@ class TestBullet(NumpyTestUtilsMixin, TestCaseNoTemplate):
             "Both 'range_colors' or 'measure_colors' must be a list "
             "of two valid colors."
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, ff.create_bullet, df, range_colors=range_colors
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, ff.create_bullet, df, measure_colors=measure_colors
         )
 
@@ -4061,7 +4061,7 @@ class TestChoropleth(NumpyTestUtilsMixin, TestCaseNoTemplate):
 
         def test_fips_values_same_length(self):
             pattern = "fips and values must be the same length"
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 PlotlyError,
                 pattern,
                 ff.create_choropleth,
@@ -4076,7 +4076,7 @@ class TestChoropleth(NumpyTestUtilsMixin, TestCaseNoTemplate):
                 "in your order and have no duplicate items"
             )
 
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 PlotlyError,
                 pattern,
                 ff.create_choropleth,
@@ -4098,7 +4098,7 @@ class TestChoropleth(NumpyTestUtilsMixin, TestCaseNoTemplate):
 
             pattern = "'scope' must be a list/tuple/sequence"
 
-            self.assertRaisesRegexp(
+            self.assertRaisesRegex(
                 PlotlyError,
                 pattern,
                 ff.create_choropleth,

--- a/packages/python/plotly/plotly/tests/test_optional/test_tools/test_figure_factory.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_tools/test_figure_factory.py
@@ -165,13 +165,13 @@ class TestFinanceCharts(TestCaseNoTemplate, NumpyTestUtilsMixin):
             "close": [1, 2],
             "direction": ["inc"],
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             "direction must be defined as " "'increasing', 'decreasing', or 'both'",
             ff.create_ohlc,
             **kwargs
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             "direction must be defined as " "'increasing', 'decreasing', or 'both'",
             ff.create_candlestick,
@@ -185,13 +185,13 @@ class TestFinanceCharts(TestCaseNoTemplate, NumpyTestUtilsMixin):
             "close": [1, 2],
             "direction": ["d"],
         }
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             "direction must be defined as " "'increasing', 'decreasing', or 'both'",
             ff.create_ohlc,
             **kwargs
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             "direction must be defined as " "'increasing', 'decreasing', or 'both'",
             ff.create_candlestick,
@@ -205,7 +205,7 @@ class TestFinanceCharts(TestCaseNoTemplate, NumpyTestUtilsMixin):
         # highest (or equal) then the data may have been entered incorrectly.
 
         kwargs = {"open": [2, 3], "high": [4, 2], "low": [1, 1], "close": [1, 2]}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             "Oops! Looks like some of "
             "your high values are less "
@@ -216,7 +216,7 @@ class TestFinanceCharts(TestCaseNoTemplate, NumpyTestUtilsMixin):
             ff.create_ohlc,
             **kwargs
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             "Oops! Looks like some of "
             "your high values are less "
@@ -237,7 +237,7 @@ class TestFinanceCharts(TestCaseNoTemplate, NumpyTestUtilsMixin):
 
         # create_ohlc_increase
         kwargs = {"open": [2, 3], "high": [4, 6], "low": [3, 1], "close": [1, 2]}
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             "Oops! Looks like some of "
             "your low values are greater "
@@ -248,7 +248,7 @@ class TestFinanceCharts(TestCaseNoTemplate, NumpyTestUtilsMixin):
             ff.create_ohlc,
             **kwargs
         )
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             "Oops! Looks like some of "
             "your low values are greater "
@@ -1575,7 +1575,7 @@ class TestGantt(TestCaseNoTemplate, NumpyTestUtilsMixin):
             "dictionaries is being used."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern2, ff.create_gantt, df, index_col="foo"
         )
 
@@ -1583,19 +1583,19 @@ class TestGantt(TestCaseNoTemplate, NumpyTestUtilsMixin):
 
         pattern3 = "You must input either a dataframe or a list of " "dictionaries."
 
-        self.assertRaisesRegexp(PlotlyError, pattern3, ff.create_gantt, df)
+        self.assertRaisesRegex(PlotlyError, pattern3, ff.create_gantt, df)
 
         df = []
 
         pattern4 = "Your list is empty. It must contain at least one " "dictionary."
 
-        self.assertRaisesRegexp(PlotlyError, pattern4, ff.create_gantt, df)
+        self.assertRaisesRegex(PlotlyError, pattern4, ff.create_gantt, df)
 
         df = ["foo"]
 
         pattern5 = "Your list must only include dictionaries."
 
-        self.assertRaisesRegexp(PlotlyError, pattern5, ff.create_gantt, df)
+        self.assertRaisesRegex(PlotlyError, pattern5, ff.create_gantt, df)
 
     def test_gantt_index(self):
 
@@ -1617,7 +1617,7 @@ class TestGantt(TestCaseNoTemplate, NumpyTestUtilsMixin):
             "dictionaries is being used."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern, ff.create_gantt, df, index_col="foo"
         )
 
@@ -1641,7 +1641,7 @@ class TestGantt(TestCaseNoTemplate, NumpyTestUtilsMixin):
             "column are all numbers or all strings."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern2, ff.create_gantt, df, index_col="Complete"
         )
 
@@ -1670,7 +1670,7 @@ class TestGantt(TestCaseNoTemplate, NumpyTestUtilsMixin):
             "Whoops! The elements in your rgb colors tuples cannot " "exceed 255.0."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern,
             ff.create_gantt,
@@ -1685,7 +1685,7 @@ class TestGantt(TestCaseNoTemplate, NumpyTestUtilsMixin):
 
         pattern2 = "Whoops! The elements in your colors tuples cannot " "exceed 1.0."
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern2,
             ff.create_gantt,
@@ -1703,7 +1703,7 @@ class TestGantt(TestCaseNoTemplate, NumpyTestUtilsMixin):
             "keys must be all the values in the index column."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern3,
             ff.create_gantt,
@@ -1721,7 +1721,7 @@ class TestGantt(TestCaseNoTemplate, NumpyTestUtilsMixin):
             "assigning colors to particular values in a dictionary."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError, pattern4, ff.create_gantt, df, colors=colors_dict_good
         )
 
@@ -1733,7 +1733,7 @@ class TestGantt(TestCaseNoTemplate, NumpyTestUtilsMixin):
             "column."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern5,
             ff.create_gantt,
@@ -1750,7 +1750,7 @@ class TestGantt(TestCaseNoTemplate, NumpyTestUtilsMixin):
             "bounds on the colormap."
         )
 
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             PlotlyError,
             pattern6,
             ff.create_gantt,
@@ -2138,7 +2138,7 @@ class Test2D_Density(TestCaseNoTemplate, NumpyTestUtilsMixin):
 
         pattern = "All elements of your 'x' and 'y' lists must be numbers."
 
-        self.assertRaisesRegexp(PlotlyError, pattern, ff.create_2d_density, x, y)
+        self.assertRaisesRegex(PlotlyError, pattern, ff.create_2d_density, x, y)
 
         # validate that x and y are the same length
         x2 = [1]
@@ -2146,7 +2146,7 @@ class Test2D_Density(TestCaseNoTemplate, NumpyTestUtilsMixin):
 
         pattern2 = "Both lists 'x' and 'y' must be the same length."
 
-        self.assertRaisesRegexp(PlotlyError, pattern2, ff.create_2d_density, x2, y2)
+        self.assertRaisesRegex(PlotlyError, pattern2, ff.create_2d_density, x2, y2)
 
     def test_2D_density_all_args(self):
 


### PR DESCRIPTION
## Code PR

The deprecated aliases were removed in Python 3.11 in python/cpython#28268 . So this PR replaces `assertRaisesRegexp` with `assertRaisesRegex` for Python 3.11 compatibility.

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).


Command to identify deprecated aliases : 

```
 rg -t py 'assertEquals|assertNotEquals|assertAlmostEquals|assertNotAlmostEquals|assertRegexpMatches|assertNotRegexpMatches|assertRaisesRegexp|failUnlessEqual|failIfEqual|failUnlessAlmostEqual|failUnless|failUnlessRaises|failIf|assertDictContainsSubset|_TextTestResult' 
```