### PR TITLE
fix useless line in Quiver class definition

### DIFF
--- a/packages/python/plotly/plotly/figure_factory/_quiver.py
+++ b/packages/python/plotly/plotly/figure_factory/_quiver.py
@@ -254,11 +254,10 @@ class _Quiver(object):
         seg2_y = [i * j for i, j in zip(arrow_len, sin_ang2)]
 
         # Set coordinates to create arrow
-        for index in range(len(self.end_x)):
-            point1_x = [i - j * self.scaleratio for i, j in zip(self.end_x, seg1_x)]
-            point1_y = [i - j for i, j in zip(self.end_y, seg1_y)]
-            point2_x = [i - j * self.scaleratio for i, j in zip(self.end_x, seg2_x)]
-            point2_y = [i - j for i, j in zip(self.end_y, seg2_y)]
+        point1_x = [i - j * self.scaleratio for i, j in zip(self.end_x, seg1_x)]
+        point1_y = [i - j for i, j in zip(self.end_y, seg1_y)]
+        point2_x = [i - j * self.scaleratio for i, j in zip(self.end_x, seg2_x)]
+        point2_y = [i - j for i, j in zip(self.end_y, seg2_y)]
 
         # Combine lists to create arrow
         empty = [None] * len(self.end_x)


### PR DESCRIPTION
## Fixing #3490 issue
----
Deleted for loop and changed indentation as requested on issue.

- [X] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
