### PR TITLE
fix issue #3403 deprecated numpy.bool

### DIFF
--- a/packages/python/plotly/plotly/express/_imshow.py
+++ b/packages/python/plotly/plotly/express/_imshow.py
@@ -346,7 +346,7 @@ def imshow(
         binary_string = img.ndim >= (3 + slice_dimensions) and not is_dataframe
 
     # Cast bools to uint8 (also one byte)
-    if img.dtype == np.bool:
+    if img.dtype == np.bool_:
         img = 255 * img.astype(np.uint8)
 
     if range_color is not None:


### PR DESCRIPTION
# Fix Issue #3403 changing deprecated numpy.bool too deprecated numpy.bool_

- [X] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
-->
