### PR TITLE
Fix Issue 2966 px.pie has no legend title

### DIFF
--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2146,6 +2146,9 @@ def make_figure(args, constructor, trace_patch=None, layout_patch=None):
     layout_patch["legend"] = dict(tracegroupgap=0)
     if trace_name_labels:
         layout_patch["legend"]["title_text"] = ", ".join(trace_name_labels)
+    elif('showlegend' in trace_patch.keys()):
+        if(trace_patch['showlegend'] and constructor == go.Pie):
+            layout_patch["legend"]["title_text"] = args['names']
     if args["title"]:
         layout_patch["title_text"] = args["title"]
     elif args["template"].layout.margin.t is None:

--- a/packages/python/plotly/plotly/tests/test_core/test_graph_objs/test_pie.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_graph_objs/test_pie.py
@@ -1,0 +1,24 @@
+import plotly.express as px
+import plotly.graph_objects as go
+from numpy.testing import assert_equal
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def _compare_legend_to_column_name(name_column, name_from_fig):
+    """Compare legend title name to the name given to it 
+    in "names" value to see if is equal to it and not None.
+    """
+    assert_equal(name_from_fig, name_column)
+    assert name_from_fig
+
+
+def test_pie_like_px():
+    # Pie
+    data_name = 'col1'
+    names_name = 'col2'
+    df = pd.DataFrame(data={data_name: [3, 2, 1], names_name: [1, 2, 4]})
+    fig = px.pie(df, values=data_name, names=names_name,
+                 title='Population of European continent')
+    _compare_legend_to_column_name(names_name, fig.layout.legend.title.text)


### PR DESCRIPTION

## Code PR

- [X] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [X] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.


Fixes #2966 issue and adds a new testing file to test changes asserting that the name in the parameter "names" is the same as fig.layout.legend.title.text in the fig variable.

## Example
Code:
```python
import plotly.express as px
df = px.data.gapminder().query("year == 2007").query("continent == 'Europe'")
df.loc[df['pop'] < 2.e6, 'country'] = 'Other countries' # Represent only large countries
fig = px.pie(df, values='pop', names='country', title='Population of European continent')
fig.show()
```
### Results
Before:
![image](https://user-images.githubusercontent.com/26484691/145315384-0cf4f4c7-c642-4e24-b546-194f211d0cc9.png)

After:
![image](https://user-images.githubusercontent.com/26484691/145315416-4c64417f-f97d-46bb-bfc0-c0c9761fc860.png)


