### PR TITLE
New features docs - Dec

### DIFF
--- a/doc/python/2D-Histogram.md
+++ b/doc/python/2D-Histogram.md
@@ -5,10 +5,10 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.2'
-      jupytext_version: 1.3.1
+      format_version: '1.3'
+      jupytext_version: 1.13.4
   kernelspec:
-    display_name: Python 3
+    display_name: Python 3 (ipykernel)
     language: python
     name: python3
   language_info:
@@ -20,7 +20,7 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.6.8
+    version: 3.7.11
   plotly:
     description: How to make 2D Histograms in Python with Plotly.
     display_as: statistical
@@ -231,6 +231,26 @@ fig.update_layout(
     hovermode='closest',
 
 )
+
+fig.show()
+```
+
+### Text on 2D Histogram Points
+
+
+In this example we add text to 2D-Histogram points. We use the values from the `z` attribute for the text, adding them following the format **%{variable}**.
+
+```python
+import plotly.graph_objects as go
+from plotly import data
+
+df = data.tips()
+
+fig = go.Figure(go.Histogram2d(
+        x=df.total_bill,
+        y=df.tip,
+        texttemplate= "%{z}"
+    ))
 
 fig.show()
 ```

--- a/doc/python/2D-Histogram.md
+++ b/doc/python/2D-Histogram.md
@@ -82,6 +82,17 @@ fig = px.density_heatmap(df, x="total_bill", y="tip", facet_row="sex", facet_col
 fig.show()
 ```
 
+You can add `z` as text to 2D Histogram points using `fig.update_traces(texttemplate="%{z}")`
+
+```python
+import plotly.express as px
+df = px.data.tips()
+
+fig = px.density_heatmap(df, x="total_bill", y="tip")
+fig.update_traces(texttemplate="%{z}") 
+fig.show()
+```
+
 ### Other aggregation functions than `count`
 
 By passing in a `z` value and a `histfunc`, density heatmaps can perform basic aggregation operations. Here we show average Sepal Length grouped by Petal Length and Petal Width for the Iris dataset.

--- a/doc/python/2D-Histogram.md
+++ b/doc/python/2D-Histogram.md
@@ -238,7 +238,7 @@ fig.show()
 ### Text on 2D Histogram Points
 
 
-In this example we add text to 2D-Histogram points. We use the values from the `z` attribute for the text, adding them following the format **%{variable}**.
+In this example we add text to 2D Histogram points. We use the values from the `z` attribute for the text.
 
 ```python
 import plotly.graph_objects as go

--- a/doc/python/2D-Histogram.md
+++ b/doc/python/2D-Histogram.md
@@ -248,7 +248,6 @@ fig.show()
 
 ### Text on 2D Histogram Points
 
-
 In this example we add text to 2D Histogram points. We use the values from the `z` attribute for the text.
 
 ```python

--- a/doc/python/2D-Histogram.md
+++ b/doc/python/2D-Histogram.md
@@ -82,7 +82,7 @@ fig = px.density_heatmap(df, x="total_bill", y="tip", facet_row="sex", facet_col
 fig.show()
 ```
 
-You can add `z` as text to 2D Histogram points using `fig.update_traces(texttemplate="%{z}")`
+You can add the `z` values as text to 2D Histogram points using `fig.update_traces(texttemplate="%{z}")`
 
 ```python
 import plotly.express as px

--- a/doc/python/annotated-heatmap.md
+++ b/doc/python/annotated-heatmap.md
@@ -36,12 +36,10 @@ jupyter:
 
 ### Annotated Heatmaps with plotly.express and px.imshow
 
-
-These examples use [px.imshow](/python/imshow) to create Annotated Heatmaps. px.imshow is the best way creating heatmaps with z-annotations.
+These examples use [px.imshow](/python/imshow) to create Annotated Heatmaps. px.imshow is the recommended way to create heatmaps with z-annotations.
 
 
 #### Basic Annotated Heatmap for z-annotations
-
 
 After creating a figure with `px.imshow`, you can add z-annotations with `.update_traces(texttemplate="%{z}")`.
 
@@ -57,7 +55,6 @@ fig.show()
 ```
 
 #### Custom Font
-
 
 You can make changes to the font using `textfont`. Here we set the font size to 20.
 

--- a/doc/python/annotated-heatmap.md
+++ b/doc/python/annotated-heatmap.md
@@ -72,7 +72,6 @@ fig.show()
 
 ### Annotated Heatmaps with [figure factory](/python/figure-factories/). For more examples with Heatmaps, see [this page](/python/heatmaps/).
 
-
 The remaining examples show how to create Annotated Heatmaps with [figure factory](/python/figure-factories/). For more examples with Heatmaps, see [this page](/python/heatmaps/).
 
 
@@ -239,12 +238,6 @@ fig = ff.create_annotated_heatmap(z, annotation_text=symbol, text=hover,
                                  colorscale=colorscale, font_colors=['black'], hoverinfo='text')
 fig.update_layout(title_text='Periodic Table')
 fig.show()
-```
-
-#### Annotations with plotly.express
-
-```python
-
 ```
 
 #### Reference

--- a/doc/python/annotated-heatmap.md
+++ b/doc/python/annotated-heatmap.md
@@ -5,10 +5,10 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.1
+      format_version: '1.3'
+      jupytext_version: 1.13.4
   kernelspec:
-    display_name: Python 3
+    display_name: Python 3 (ipykernel)
     language: python
     name: python3
   language_info:
@@ -20,7 +20,7 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.6.7
+    version: 3.7.11
   plotly:
     description: How to make Annotated Heatmaps in Python with Plotly.
     display_as: scientific
@@ -34,9 +34,52 @@ jupyter:
     thumbnail: thumbnail/ann_heat.jpg
 ---
 
-#### Simple Annotated Heatmap
+### Annotated Heatmaps with plotly.express and px.imshow
 
-This page details the use of a [figure factory](/python/figure-factories/). For more examples with Heatmaps, see [this page](/python/heatmaps/).
+
+These examples use [px.imshow](/python/imshow) to create Annotated Heatmaps. px.imshow is the best way creating heatmaps with z-annotations.
+
+
+#### Basic Annotated Heatmap for z-annotations
+
+
+After creating a figure with `px.imshow`, you can add z-annotations with `.update_traces(texttemplate="%{z}")`.
+
+```python
+import plotly.express as px
+
+df = px.data.medals_wide(indexed=True)
+
+fig = px.imshow(df)
+fig.update_traces(texttemplate="%{z}")
+
+fig.show()
+```
+
+#### Custom Font
+
+
+You can make changes to the font using `textfont`. Here we set the font size to 20.
+
+```python
+import plotly.express as px
+
+df = px.data.medals_wide(indexed=True)
+
+fig = px.imshow(df)
+fig.update_traces(texttemplate="%{z}")
+fig.update_traces(textfont={"size":20})
+
+fig.show()
+```
+
+### Annotated Heatmaps with [figure factory](/python/figure-factories/). For more examples with Heatmaps, see [this page](/python/heatmaps/).
+
+
+The remaining examples show how to create Annotated Heatmaps with [figure factory](/python/figure-factories/). For more examples with Heatmaps, see [this page](/python/heatmaps/).
+
+
+#### Simple Annotated Heatmap
 
 ```python
 import plotly.figure_factory as ff
@@ -199,6 +242,12 @@ fig = ff.create_annotated_heatmap(z, annotation_text=symbol, text=hover,
                                  colorscale=colorscale, font_colors=['black'], hoverinfo='text')
 fig.update_layout(title_text='Periodic Table')
 fig.show()
+```
+
+#### Annotations with plotly.express
+
+```python
+
 ```
 
 #### Reference

--- a/doc/python/colorscales.md
+++ b/doc/python/colorscales.md
@@ -521,7 +521,7 @@ fig.show()
 ### Color Bar Displayed Horizontally
 
 
-By default, color bars are displayed vertically. You can change a color bar to be displayed horizontally by setting `orientation`=`h`.
+By default, color bars are displayed vertically. You can change a color bar to be displayed horizontally by setting the `colorbar` `orientation` attribute to `h`.
 
 ```python
 import plotly.graph_objects as go
@@ -539,17 +539,7 @@ fig = go.Figure()
 
 fig.add_trace(go.Heatmap(
     z=dataset["z"],
-    colorbar=dict(
-        title="Surface Heat",
-        titleside="top",
-        tickmode="array",
-        tickvals=[2, 50, 100],
-        ticktext=["Cool", "Mild", "Hot"],
-        ticks="outside",
-        orientation='h'
-        
-    )
-))
+    colorbar=dict(orientation='h')))
 
 fig.show()
 ```

--- a/doc/python/colorscales.md
+++ b/doc/python/colorscales.md
@@ -5,10 +5,10 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.2'
-      jupytext_version: 1.6.0
+      format_version: '1.3'
+      jupytext_version: 1.13.4
   kernelspec:
-    display_name: Python 3
+    display_name: Python 3 (ipykernel)
     language: python
     name: python3
   language_info:
@@ -20,10 +20,10 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.7.6
+    version: 3.7.11
   plotly:
-    description: How to set, create and control continuous color scales and color bars
-      in scatter, bar, map and heatmap figures.
+    description: How to set, create and control continuous color scales and color
+      bars in scatter, bar, map and heatmap figures.
     display_as: file_settings
     has_thumbnail: true
     ipynb: ~notebook_demo/187
@@ -512,6 +512,42 @@ fig.add_trace(go.Heatmap(
         tickvals=[2, 50, 100],
         ticktext=["Cool", "Mild", "Hot"],
         ticks="outside"
+    )
+))
+
+fig.show()
+```
+
+### Color Bar Displayed Horizontally
+
+
+By default, color bars are displayed vertically. You can change a color bar to be displayed horizontally by setting `orientation`=`h`.
+
+```python
+import plotly.graph_objects as go
+
+import six.moves.urllib
+import json
+
+# Load heatmap data
+response = six.moves.urllib.request.urlopen(
+    "https://raw.githubusercontent.com/plotly/datasets/master/custom_heatmap_colorscale.json")
+dataset = json.load(response)
+
+# Create and show figure
+fig = go.Figure()
+
+fig.add_trace(go.Heatmap(
+    z=dataset["z"],
+    colorbar=dict(
+        title="Surface Heat",
+        titleside="top",
+        tickmode="array",
+        tickvals=[2, 50, 100],
+        ticktext=["Cool", "Mild", "Hot"],
+        ticks="outside",
+        orientation='h'
+        
     )
 ))
 

--- a/doc/python/colorscales.md
+++ b/doc/python/colorscales.md
@@ -520,7 +520,6 @@ fig.show()
 
 ### Color Bar Displayed Horizontally
 
-
 By default, color bars are displayed vertically. You can change a color bar to be displayed horizontally by setting the `colorbar` `orientation` attribute to `h`.
 
 ```python

--- a/doc/python/heatmaps.md
+++ b/doc/python/heatmaps.md
@@ -204,15 +204,16 @@ In this example we add text to heatmap points. We use the values from the `text`
 
 ```python
 import plotly.graph_objects as go
-from plotly import data
 
-df = data.tips()
+fig = go.Figure(data=go.Heatmap(
+                    z=[[1, 20, 30],
+                      [20, 1, 60],
+                      [30, 60, 1]],
+                    text=[['one', 'twenty', 'thirty'],
+                          ['twenty', 'one', 'sixty'],
+                          ['thirty', 'sixty', 'one']],
+                    texttemplate="%{text}"))
 
-fig = go.Figure(go.Histogram2d(
-        x=df.total_bill,
-        y=df.tip,
-        texttemplate= "%{z}"
-    ))
 fig.show()
 ```
 

--- a/doc/python/heatmaps.md
+++ b/doc/python/heatmaps.md
@@ -88,7 +88,6 @@ fig.show()
 
 ### Adding and customizing text on points
 
-
 You can add text to heatmap points with `.update_traces(texttemplate="%{variable}")`. Here we use the values of the `z` attribute for `variable`. We also customize the font size with `textfont`.
 
 ```python
@@ -215,8 +214,7 @@ fig.show()
 
 ### Text on Heatmap Points
 
-
-In this example we add text to heatmap points using `texttemplate`. We use the values of the `text` attribute for the text. We also adjust the font size using `textfont`.
+In this example we add text to heatmap points using `texttemplate`. We use the values from the `text` attribute for the text. We also adjust the font size using `textfont`.
 
 ```python
 import plotly.graph_objects as go

--- a/doc/python/heatmaps.md
+++ b/doc/python/heatmaps.md
@@ -5,10 +5,10 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.2'
-      jupytext_version: 1.6.0
+      format_version: '1.3'
+      jupytext_version: 1.13.4
   kernelspec:
-    display_name: Python 3
+    display_name: Python 3 (ipykernel)
     language: python
     name: python3
   language_info:
@@ -20,7 +20,7 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.7.6
+    version: 3.7.11
   plotly:
     description: How to make Heatmaps in Python with Plotly.
     display_as: scientific
@@ -194,6 +194,25 @@ fig.update_layout(
     title='GitHub commits per day',
     xaxis_nticks=36)
 
+fig.show()
+```
+
+### Text on Heatmap Points
+
+
+In this example we add text to heatmap points. We use the values from the `text` attribute for the text.
+
+```python
+import plotly.graph_objects as go
+from plotly import data
+
+df = data.tips()
+
+fig = go.Figure(go.Histogram2d(
+        x=df.total_bill,
+        y=df.tip,
+        texttemplate= "%{z}"
+    ))
 fig.show()
 ```
 

--- a/doc/python/heatmaps.md
+++ b/doc/python/heatmaps.md
@@ -86,6 +86,22 @@ fig.update_xaxes(side="top")
 fig.show()
 ```
 
+### Adding and customizing text on points
+
+
+You can add text to heatmap points with `.update_traces(texttemplate="%{variable}")`. Here we use the values of the `z` attribute for `variable`. We also customize the font size with `textfont`.
+
+```python
+import plotly.express as px
+
+df = px.data.medals_wide(indexed=True)
+fig = px.imshow(df)
+fig.update_traces(texttemplate="%{z}")
+fig.update_traces(textfont={"size":20})
+
+fig.show()
+```
+
 ### Basic Heatmap with `plotly.graph_objects`
 
 If Plotly Express does not provide a good starting point, it is also possible to use [the more generic `go.Heatmap` class from `plotly.graph_objects`](/python/graph-objects/).
@@ -200,7 +216,7 @@ fig.show()
 ### Text on Heatmap Points
 
 
-In this example we add text to heatmap points. We use the values from the `text` attribute for the text.
+In this example we add text to heatmap points using `texttemplate`. We use the values from the `text` attribute for the text. We also adjust the font size using `textfont`.
 
 ```python
 import plotly.graph_objects as go
@@ -212,7 +228,8 @@ fig = go.Figure(data=go.Heatmap(
                     text=[['one', 'twenty', 'thirty'],
                           ['twenty', 'one', 'sixty'],
                           ['thirty', 'sixty', 'one']],
-                    texttemplate="%{text}"))
+                    texttemplate="%{text}",
+                    textfont={"size":20}))
 
 fig.show()
 ```

--- a/doc/python/heatmaps.md
+++ b/doc/python/heatmaps.md
@@ -216,7 +216,7 @@ fig.show()
 ### Text on Heatmap Points
 
 
-In this example we add text to heatmap points using `texttemplate`. We use the values from the `text` attribute for the text. We also adjust the font size using `textfont`.
+In this example we add text to heatmap points using `texttemplate`. We use the values of the `text` attribute for the text. We also adjust the font size using `textfont`.
 
 ```python
 import plotly.graph_objects as go

--- a/doc/python/histograms.md
+++ b/doc/python/histograms.md
@@ -210,7 +210,6 @@ fig.show()
 
 ### Adding bar text
 
-
 You can add text to histogram bars using `fig.update_traces(texttemplate="%{variable}")`, where `variable` is the text to add. In this example, we add the y-axis values to the bars. We get these values following the **Accessing the counts (y-axis) values** example above.
 
 ```python
@@ -360,7 +359,6 @@ fig.show()
 ```
 
 ### Histogram Bar Text
-
 
 You can add text to histogram bars using the `texttemplate` argument. In this example we add the x-axis values as text following the format `%{variable}`. We also adjust the size of the text using `textfont_size`.
 

--- a/doc/python/histograms.md
+++ b/doc/python/histograms.md
@@ -208,6 +208,25 @@ fig = px.histogram(df, x="total_bill", color="sex", marginal="rug", # can be `bo
 fig.show()
 ```
 
+### Adding bar text
+
+
+You can add text to histogram bars using `fig.update_traces(texttemplate="%{variable}")`, where `variable` is the text to add. In this example, we add the y-axis values to the bars. We get these values following the **Accessing the counts (y-axis) values** example above.
+
+```python
+import plotly.express as px
+import numpy as np
+
+df = px.data.tips()
+
+counts, bins = np.histogram(df.total_bill, bins=range(0, 60, 5))
+bins = 0.5 * (bins[:-1] + bins[1:])
+
+fig = px.bar(x=bins, y=counts, labels={'x':'total_bill', 'y':'count'})
+fig.update_traces(texttemplate="%{y}")
+fig.show()
+```
+
 ## Histograms with go.Histogram
 
 If Plotly Express does not provide a good starting point, it is also possible to use [the more generic `go.Histogram` class from `plotly.graph_objects`](/python/graph-objects/). All of the available histogram options are described in the histogram section of the reference page: https://plotly.com/python/reference#histogram.

--- a/doc/python/histograms.md
+++ b/doc/python/histograms.md
@@ -210,18 +210,12 @@ fig.show()
 
 ### Adding bar text
 
-You can add text to histogram bars using `fig.update_traces(texttemplate="%{variable}")`, where `variable` is the text to add. In this example, we add the y-axis values to the bars. We get these values following the **Accessing the counts (y-axis) values** example above.
+You can add text to histogram bars using `fig.update_traces(texttemplate="%{variable}")`, where `variable` is the text to add. In this example, we add the y-axis values to the bars. 
 
 ```python
 import plotly.express as px
-import numpy as np
-
 df = px.data.tips()
-
-counts, bins = np.histogram(df.total_bill, bins=range(0, 60, 5))
-bins = 0.5 * (bins[:-1] + bins[1:])
-
-fig = px.bar(x=bins, y=counts, labels={'x':'total_bill', 'y':'count'})
+fig = px.histogram(df, x="total_bill", y="tip", histfunc='avg', nbins=8)
 fig.update_traces(texttemplate="%{y}")
 fig.show()
 ```

--- a/doc/python/histograms.md
+++ b/doc/python/histograms.md
@@ -5,10 +5,10 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.2'
-      jupytext_version: 1.4.2
+      format_version: '1.3'
+      jupytext_version: 1.13.4
   kernelspec:
-    display_name: Python 3
+    display_name: Python 3 (ipykernel)
     language: python
     name: python3
   language_info:
@@ -20,7 +20,7 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.7.7
+    version: 3.7.11
   plotly:
     description: How to make Histograms in Python with Plotly.
     display_as: statistical
@@ -336,6 +336,24 @@ fig.update_layout(
     bargap=0.2, # gap between bars of adjacent location coordinates
     bargroupgap=0.1 # gap between bars of the same location coordinates
 )
+
+fig.show()
+```
+
+### Histogram Bar Text
+
+
+You can add text to histogram bars using the `texttemplate` argument. In this example we add the x-axis values as  text following the format `%{variable}`. We also adjust the size of the text using `textfont_size`.
+
+
+
+```python
+import plotly.graph_objects as go
+
+numbers = ["5", "10", "3", "10", "5", "8", "5", "5"]
+
+fig = go.Figure()
+fig.add_trace(go.Histogram(x=numbers, name="count", texttemplate="%{x}", textfont_size=20))
 
 fig.show()
 ```

--- a/doc/python/histograms.md
+++ b/doc/python/histograms.md
@@ -362,9 +362,7 @@ fig.show()
 ### Histogram Bar Text
 
 
-You can add text to histogram bars using the `texttemplate` argument. In this example we add the x-axis values as  text following the format `%{variable}`. We also adjust the size of the text using `textfont_size`.
-
-
+You can add text to histogram bars using the `texttemplate` argument. In this example we add the x-axis values as text following the format `%{variable}`. We also adjust the size of the text using `textfont_size`.
 
 ```python
 import plotly.graph_objects as go

--- a/doc/python/imshow.md
+++ b/doc/python/imshow.md
@@ -5,10 +5,10 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.2'
-      jupytext_version: 1.4.2
+      format_version: '1.3'
+      jupytext_version: 1.13.4
   kernelspec:
-    display_name: Python 3
+    display_name: Python 3 (ipykernel)
     language: python
     name: python3
   language_info:
@@ -20,7 +20,7 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.7.7
+    version: 3.7.11
   plotly:
     description: How to display image data in Python with Plotly.
     display_as: scientific

--- a/doc/python/imshow.md
+++ b/doc/python/imshow.md
@@ -5,10 +5,10 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.3'
-      jupytext_version: 1.13.4
+      format_version: '1.2'
+      jupytext_version: 1.4.2
   kernelspec:
-    display_name: Python 3 (ipykernel)
+    display_name: Python 3
     language: python
     name: python3
   language_info:
@@ -20,7 +20,7 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.7.11
+    version: 3.7.7
   plotly:
     description: How to display image data in Python with Plotly.
     display_as: scientific


### PR DESCRIPTION
This PR adds examples to the docs for:

- Text on 2D histograms, histograms and heatmaps
- Horizontal color bars
- Annotated heatmaps

---


### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [x] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [x] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [x] Every new/modified example is independently runnable
- [x] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [x] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [x] The random seed is set if using randomly-generated data in new/modified examples
- [x] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [x] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [x] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [x] Data frames are always called `df`
- [x] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [x] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [x] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [x] `fig.show()` is at the end of each new/modified example
- [x] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [x] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)