### PR TITLE
px-first getting-started/readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Inside [Jupyter](https://jupyter.org/install) (installable with `pip install "ju
 
 ```python
 import plotly.express as px
-fig = px.bar(x=["a", "b", "c"], y=[1,2,3])
+fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
 fig.show()
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,8 @@
 Inside [Jupyter](https://jupyter.org/install) (installable with `pip install "jupyterlab>=3" "ipywidgets>=7.6"`):
 
 ```python
-import plotly.graph_objects as go
-fig = go.Figure()
-fig.add_trace(go.Scatter(y=[2, 1, 4, 3]))
-fig.add_trace(go.Bar(y=[1, 4, 3, 2]))
-fig.update_layout(title = 'Hello Figure')
+import plotly.express as px
+fig = px.bar(x=["a", "b", "c"], y=[1,2,3])
 fig.show()
 ```
 

--- a/doc/python/getting-started.md
+++ b/doc/python/getting-started.md
@@ -73,7 +73,7 @@ This package contains everything you need to write figures to standalone HTML fi
 
 ```python
 import plotly.express as px
-fig = px.bar(x=["a", "b", "c"], y=[1,2,3])
+fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
 fig.write_html('first_figure.html', auto_open=True)
 ```
 
@@ -129,7 +129,7 @@ and display plotly figures inline using the `plotly_mimetype` renderer...
 
 ```python
 import plotly.express as px
-fig = px.bar(x=["a", "b", "c"], y=[1,2,3])
+fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
 fig.show()
 ```
 
@@ -137,7 +137,7 @@ or using `FigureWidget` objects.
 
 ```python
 import plotly.express as px
-fig = px.bar(x=["a", "b", "c"], y=[1,2,3])
+fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
 
 import plotly.graph_objects as go
 fig_widget = go.FigureWidget(fig)
@@ -184,7 +184,7 @@ and display plotly figures inline using the notebook renderer...
 
 ```python
 import plotly.express as px
-fig = px.bar(x=["a", "b", "c"], y=[1,2,3])
+fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
 fig.show()
 ```
 
@@ -192,7 +192,7 @@ or using `FigureWidget` objects.
 
 ```python
 import plotly.express as px
-fig = px.bar(x=["a", "b", "c"], y=[1,2,3])
+fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
 
 import plotly.graph_objects as go
 fig_widget = go.FigureWidget(fig)

--- a/doc/python/getting-started.md
+++ b/doc/python/getting-started.md
@@ -72,8 +72,8 @@ This package contains everything you need to write figures to standalone HTML fi
 
 
 ```python
-import plotly.graph_objects as go
-fig = go.Figure(data=go.Bar(y=[2, 3, 1]))
+import plotly.express as px
+fig = px.bar(x=["a", "b", "c"], y=[1,2,3])
 fig.write_html('first_figure.html', auto_open=True)
 ```
 
@@ -128,17 +128,20 @@ $ jupyter lab
 and display plotly figures inline using the `plotly_mimetype` renderer...
 
 ```python
-import plotly.graph_objects as go
-fig = go.Figure(data=go.Bar(y=[2, 3, 1]))
+import plotly.express as px
+fig = px.bar(x=["a", "b", "c"], y=[1,2,3])
 fig.show()
 ```
 
 or using `FigureWidget` objects.
 
 ```python
+import plotly.express as px
+fig = px.bar(x=["a", "b", "c"], y=[1,2,3])
+
 import plotly.graph_objects as go
-fig = go.FigureWidget(data=go.Bar(y=[2, 3, 1]))
-fig
+fig_widget = go.FigureWidget(fig)
+fig_widget
 ```
 
 The instructions above apply to JupyterLab 3.x. **For JupyterLab 2 or earlier**, run the following commands to install the required JupyterLab extensions (note that this will require [`node`](https://nodejs.org/) to be installed):
@@ -180,17 +183,20 @@ and display plotly figures inline using the notebook renderer...
 
 
 ```python
-import plotly.graph_objects as go
-fig = go.Figure(data=go.Bar(y=[2, 3, 1]))
+import plotly.express as px
+fig = px.bar(x=["a", "b", "c"], y=[1,2,3])
 fig.show()
 ```
 
 or using `FigureWidget` objects.
 
 ```python
+import plotly.express as px
+fig = px.bar(x=["a", "b", "c"], y=[1,2,3])
+
 import plotly.graph_objects as go
-fig = go.FigureWidget(data=go.Bar(y=[2, 3, 1]))
-fig
+fig_widget = go.FigureWidget(fig)
+fig_widget
 ```
 
 See [_Displaying Figures in Python_](/python/renderers/) for more information on the renderers framework, and see [_Plotly FigureWidget Overview_](/python/figurewidget/) for more information on using `FigureWidget`.


### PR DESCRIPTION
<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

-->
