### PR TITLE
README: No relative links, no plot.ly

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <tr>
         <td>User forum</td>
         <td>
-            <a href="https://community.plot.ly"/>
+            <a href="https://community.plotly.com/"/>
             <img src="https://img.shields.io/badge/help_forum-discourse-blue.svg"/>
         </td>
     </tr>
@@ -43,34 +43,34 @@ fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
 fig.show()
 ```
 
-See the [Python documentation](https://plot.ly/python/) for more examples.
+See the [Python documentation](https://plotly.com/python/) for more examples.
 
 Read about what's new in [plotly.py v4](https://medium.com/plotly/plotly-py-4-0-is-here-offline-only-express-first-displayable-anywhere-fc444e5659ee)
 
 ## Overview
 
-[plotly.py](https://plot.ly/python) is an interactive, open-source, and browser-based graphing library for Python :sparkles:
+[plotly.py](https://plotly.com/python/) is an interactive, open-source, and browser-based graphing library for Python :sparkles:
 
 Built on top of [plotly.js](https://github.com/plotly/plotly.js), `plotly.py` is a high-level, declarative charting library. plotly.js ships with over 30 chart types, including scientific charts, 3D graphs, statistical charts, SVG maps, financial charts, and more.
 
-`plotly.py` is [MIT Licensed](packages/python/chart-studio/LICENSE.txt). Plotly graphs can be viewed in Jupyter notebooks, standalone HTML files, or hosted online using [Chart Studio Cloud](https://chart-studio.plot.ly/feed/).
+`plotly.py` is [MIT Licensed](https://github.com/plotly/plotly.py/blob/master/LICENSE.txt). Plotly graphs can be viewed in Jupyter notebooks, standalone HTML files, or hosted online using [Chart Studio Cloud](https://chart-studio.plotly.com/feed/).
 
-[Contact us](https://plot.ly/products/consulting-and-oem/) for consulting, dashboard development, application integration, and feature additions.
+[Contact us](https://plotly.com/consulting-and-oem/) for consulting, dashboard development, application integration, and feature additions.
 
 <p align="center">
-    <a href="https://plot.ly/python" target="_blank">
+    <a href="https://plotly.com/python/" target="_blank">
     <img src="https://raw.githubusercontent.com/cldougl/plot_images/add_r_img/plotly_2017.png">
 </a></p>
 
 ---
 
-- [Online Documentation](https://plot.ly/python)
-- [Contributing to plotly](contributing.md)
-- [Changelog](CHANGELOG.md)
-- [Code of Conduct](CODE_OF_CONDUCT.md)
-- [Version 4 Migration Guide](https://plot.ly/python/next/v4-migration/)
+- [Online Documentation](https://plotly.com/python/)
+- [Contributing to plotly](https://github.com/plotly/plotly.py/blob/master/contributing.md)
+- [Changelog](https://github.com/plotly/plotly.py/blob/master/CHANGELOG.md)
+- [Code of Conduct](https://github.com/plotly/plotly.py/blob/master/CODE_OF_CONDUCT.md)
+- [Version 4 Migration Guide](https://plotly.com/python/v4-migration/)
 - [New! Announcing Dash 1.0](https://medium.com/plotly/welcoming-dash-1-0-0-f3af4b84bae)
-- [Community forum](https://community.plot.ly/c/api/python)
+- [Community forum](https://community.plotly.com)
 
 ---
 
@@ -205,14 +205,14 @@ conda install -c plotly chart-studio=1.1.0
 
 ## Migration
 
-If you're migrating from plotly.py v3 to v4, please check out the [Version 4 migration guide](https://plot.ly/python/next/v4-migration/)
+If you're migrating from plotly.py v3 to v4, please check out the [Version 4 migration guide](https://plotly.com/python/v4-migration/)
 
-If you're migrating from plotly.py v2 to v3, please check out the [Version 3 migration guide](migration-guide.md)
+If you're migrating from plotly.py v2 to v3, please check out the [Version 3 migration guide](https://github.com/plotly/plotly.py/blob/master/migration-guide.md)
 
 ## Copyright and Licenses
 
 Code and documentation copyright 2019 Plotly, Inc.
 
-Code released under the [MIT license](packages/python/chart-studio/LICENSE.txt).
+Code released under the [MIT license](https://github.com/plotly/plotly.py/blob/master/LICENSE.txt).
 
 Docs released under the [Creative Commons license](https://github.com/plotly/documentation/blob/source/LICENSE).


### PR DESCRIPTION
@jim-mcintosh noticed some broken links on https://pypi.org/project/plotly/ - it's simply reusing this README so we can't use relative links. Also I cleaned up some old plot.ly references.