### PR TITLE
Updating python dash snippets to heroku app links

### DIFF
--- a/doc/python/3d-mesh.md
+++ b/doc/python/3d-mesh.md
@@ -77,7 +77,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + '3d-mesh', width='100%', height=630)
 ```
 

--- a/doc/python/3d-scatter-plots.md
+++ b/doc/python/3d-scatter-plots.md
@@ -81,7 +81,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + '3d-scatter-plots', width='100%', height=630)
 ```
 

--- a/doc/python/animations.md
+++ b/doc/python/animations.md
@@ -56,7 +56,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'animations', width='100%', height=630)
 ```
 

--- a/doc/python/axes.md
+++ b/doc/python/axes.md
@@ -133,7 +133,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'axes', width='100%', height=630)
 ```
 

--- a/doc/python/bar-charts.md
+++ b/doc/python/bar-charts.md
@@ -96,7 +96,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'bar-charts', width='100%', height=630)
 ```
 

--- a/doc/python/bio-alignment-chart.md
+++ b/doc/python/bio-alignment-chart.md
@@ -58,6 +58,6 @@ fig.show()
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'bio-alignmentchart', width='100%', height=630)
 ```

--- a/doc/python/bio-clustergram.md
+++ b/doc/python/bio-clustergram.md
@@ -102,6 +102,6 @@ dash_bio.Clustergram(
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'bio-clustergram', width='100%', height=630)
 ```

--- a/doc/python/bio-manhattanplot.md
+++ b/doc/python/bio-manhattanplot.md
@@ -71,6 +71,6 @@ dash_bio.ManhattanPlot(
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'bio-manhattanplot', width='100%', height=630)
 ```

--- a/doc/python/bio-volcano-plot.md
+++ b/doc/python/bio-volcano-plot.md
@@ -71,6 +71,6 @@ dash_bio.VolcanoPlot(
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'bio-volcano', width='100%', height=630)
 ```

--- a/doc/python/box-plots.md
+++ b/doc/python/box-plots.md
@@ -73,7 +73,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'box-plots', width='100%', height=630)
 ```
 

--- a/doc/python/builtin-colorscales.md
+++ b/doc/python/builtin-colorscales.md
@@ -83,7 +83,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'builtin-colorscales', width='100%', height=630)
 ```
 

--- a/doc/python/candlestick-charts.md
+++ b/doc/python/candlestick-charts.md
@@ -83,7 +83,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'candlestick-charts', width='100%', height=630)
 ```
 

--- a/doc/python/choropleth-maps.md
+++ b/doc/python/choropleth-maps.md
@@ -151,7 +151,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'choropleth-maps', width='100%', height=630)
 ```
 

--- a/doc/python/colorscales.md
+++ b/doc/python/colorscales.md
@@ -99,7 +99,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'colorscales', width='100%', height=630)
 ```
 

--- a/doc/python/creating-and-updating-figures.md
+++ b/doc/python/creating-and-updating-figures.md
@@ -136,7 +136,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'figure-structure', width='100%', height=630)
 ```
 

--- a/doc/python/discrete-color.md
+++ b/doc/python/discrete-color.md
@@ -107,7 +107,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'discrete-color', width='100%', height=630)
 ```
 

--- a/doc/python/distplot.md
+++ b/doc/python/distplot.md
@@ -65,7 +65,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'distplot', width='100%', height=630)
 ```
 

--- a/doc/python/figure-labels.md
+++ b/doc/python/figure-labels.md
@@ -94,7 +94,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'figure-labels', width='100%', height=630)
 ```
 

--- a/doc/python/figure-structure.md
+++ b/doc/python/figure-structure.md
@@ -58,7 +58,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'figure-structure', width='100%', height=630)
 ```
 

--- a/doc/python/filled-area-plots.md
+++ b/doc/python/filled-area-plots.md
@@ -58,7 +58,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'filled-area-plots', width='100%', height=630)
 ```
 

--- a/doc/python/getting-started.md
+++ b/doc/python/getting-started.md
@@ -86,7 +86,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'getting-started', width='100%', height=630)
 ```
 

--- a/doc/python/heatmaps.md
+++ b/doc/python/heatmaps.md
@@ -102,7 +102,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'heatmaps', width='100%', height=630)
 ```
 

--- a/doc/python/histograms.md
+++ b/doc/python/histograms.md
@@ -109,7 +109,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'histograms', width='100%', height=630)
 ```
 

--- a/doc/python/horizontal-vertical-shapes.md
+++ b/doc/python/horizontal-vertical-shapes.md
@@ -76,7 +76,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'horizontal-vertical-shapes', width='100%', height=630)
 ```
 

--- a/doc/python/hover-text-and-formatting.md
+++ b/doc/python/hover-text-and-formatting.md
@@ -93,7 +93,7 @@ Change the hovermode below and try hovering over the points:
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'hover-text-and-formatting', width='100%', height=630)
 ```
 

--- a/doc/python/interactive-html-export.md
+++ b/doc/python/interactive-html-export.md
@@ -65,7 +65,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'interactive-html-export', width='100%', height=630)
 ```
 

--- a/doc/python/legend.md
+++ b/doc/python/legend.md
@@ -159,7 +159,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'legend', width='100%', height=630)
 ```
 

--- a/doc/python/line-and-scatter.md
+++ b/doc/python/line-and-scatter.md
@@ -94,7 +94,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'line-and-scatter', width='100%', height=630)
 ```
 

--- a/doc/python/line-charts.md
+++ b/doc/python/line-charts.md
@@ -67,7 +67,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true tags=[]
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'line-charts', width='100%', height=630)
 ```
 

--- a/doc/python/mapbox-county-choropleth.md
+++ b/doc/python/mapbox-county-choropleth.md
@@ -116,7 +116,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'mapbox-county-choropleth', width='100%', height=630)
 ```
 

--- a/doc/python/marker-style.md
+++ b/doc/python/marker-style.md
@@ -116,7 +116,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'marker-style', width='100%', height=630)
 ```
 

--- a/doc/python/ml-knn.md
+++ b/doc/python/ml-knn.md
@@ -245,7 +245,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'knn-classification', width='100%', height=630)
 ```
 

--- a/doc/python/ml-pca.md
+++ b/doc/python/ml-pca.md
@@ -145,7 +145,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'pca-visualization', width='100%', height=630)
 ```
 

--- a/doc/python/ml-regression.md
+++ b/doc/python/ml-regression.md
@@ -100,7 +100,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'ml-regression', width='100%', height=630)
 ```
 

--- a/doc/python/ml-roc-pr.md
+++ b/doc/python/ml-roc-pr.md
@@ -128,7 +128,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'roc-and-pr-curves', width='100%', height=630)
 ```
 

--- a/doc/python/multiple-axes.md
+++ b/doc/python/multiple-axes.md
@@ -84,7 +84,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'multiple-axes', width='100%', height=630)
 ```
 

--- a/doc/python/network-graphs.md
+++ b/doc/python/network-graphs.md
@@ -154,7 +154,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'network-graphs', width='100%', height=630)
 ```
 

--- a/doc/python/pie-charts.md
+++ b/doc/python/pie-charts.md
@@ -72,7 +72,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'pie-charts', width='100%', height=630)
 ```
 

--- a/doc/python/plot-data-from-csv.md
+++ b/doc/python/plot-data-from-csv.md
@@ -65,7 +65,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'plot-data-from-csv', width='100%', height=630)
 ```
 

--- a/doc/python/plotly-express.md
+++ b/doc/python/plotly-express.md
@@ -95,7 +95,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'plotly-express', width='100%', height=630)
 ```
 

--- a/doc/python/renderers.md
+++ b/doc/python/renderers.md
@@ -239,7 +239,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'renderers', width='100%', height=630)
 ```
 

--- a/doc/python/sankey-diagram.md
+++ b/doc/python/sankey-diagram.md
@@ -113,7 +113,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'sankey-diagram', width='100%', height=630)
 ```
 

--- a/doc/python/setting-graph-size.md
+++ b/doc/python/setting-graph-size.md
@@ -59,7 +59,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'setting-graph-size', width='100%', height=630)
 ```
 

--- a/doc/python/shapes.md
+++ b/doc/python/shapes.md
@@ -78,7 +78,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'shapes', width='100%', height=630)
 ```
 

--- a/doc/python/static-image-export.md
+++ b/doc/python/static-image-export.md
@@ -158,7 +158,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'static-image-export', width='100%', height=630)
 ```
 

--- a/doc/python/subplots.md
+++ b/doc/python/subplots.md
@@ -220,7 +220,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'subplots', width='100%', height=630)
 ```
 

--- a/doc/python/table.md
+++ b/doc/python/table.md
@@ -98,7 +98,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'table', width='100%', height=630)
 ```
 

--- a/doc/python/text-and-annotations.md
+++ b/doc/python/text-and-annotations.md
@@ -112,7 +112,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'text-and-annotations', width='100%', height=630)
 ```
 

--- a/doc/python/tick-formatting.md
+++ b/doc/python/tick-formatting.md
@@ -89,7 +89,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'tick-formatting', width='100%', height=630)
 ```
 

--- a/doc/python/time-series.md
+++ b/doc/python/time-series.md
@@ -70,7 +70,7 @@ Get started  with [the official Dash docs](https://dash.plotly.com/installation)
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'time-series', width='100%', height=630)
 ```
 

--- a/doc/python/troubleshooting.md
+++ b/doc/python/troubleshooting.md
@@ -59,7 +59,7 @@ This is an example of a `plotly` graph correctly rendering inside `dash`:
 
 ```python hide_code=true
 from IPython.display import IFrame
-snippet_url = 'https://dash-gallery.plotly.host/python-docs-dash-snippets/'
+snippet_url = 'https://python-docs-dash-snippets.herokuapp.com/python-docs-dash-snippets/'
 IFrame(snippet_url + 'renderers', width='100%', height=630)
 ```
 


### PR DESCRIPTION
### Documentation PR

This PR changes the links for the embedded Dash example snippets from the `python-docs-dash-snippets` app to point to an instance of the app hosted on Heroku instead of the Dash App gallery. This would potentially address the GTM flagging problem raised in https://github.com/plotly/marketing-website/issues/460#. 