### PR TITLE
Make pandas.NA JSON-serializable

### DIFF
--- a/packages/python/plotly/_plotly_utils/utils.py
+++ b/packages/python/plotly/_plotly_utils/utils.py
@@ -174,6 +174,8 @@ class PlotlyJSONEncoder(_json.JSONEncoder):
 
         if obj is pandas.NaT:
             return None
+        if obj is pandas.NA:
+            return None
         else:
             raise NotEncodable
 


### PR DESCRIPTION
When plotting mapbox from pandas dataframe, if `hover_data` contains `pandas.NA` values, it throws `Object of type NAType is not JSON serializable` error. However for `datetime64` objects it handles `pandas.NaT` values fine. I consider these cases to be similar and propose to make `NA` objects serializable the same way.
