### PR TITLE
refactor pandas df.append to pd.concat w/ asserts

### DIFF
--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1634,7 +1634,9 @@ def process_dataframe_hierarchy(args):
         df_tree["parent"] = df_tree["parent"].str.rstrip("/")
         if cols:
             df_tree[cols] = dfg[cols]
-        df_all_trees = df_all_trees.append(df_tree, ignore_index=True)
+        df_all_trees_old = df_all_trees.append(df_tree, ignore_index=True)
+        df_all_trees = pd.concat([df_all_trees, df_tree], ignore_index=True)
+        assert df_all_trees.equals(df_all_trees_old)
 
     # we want to make sure than (?) is the first color of the sequence
     if args["color"] and discrete_color:

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1634,9 +1634,7 @@ def process_dataframe_hierarchy(args):
         df_tree["parent"] = df_tree["parent"].str.rstrip("/")
         if cols:
             df_tree[cols] = dfg[cols]
-        df_all_trees_old = df_all_trees.append(df_tree, ignore_index=True)
         df_all_trees = df_all_trees.append(df_tree, ignore_index=True)
-        assert df_all_trees.equals(df_all_trees_old)
 
     # we want to make sure than (?) is the first color of the sequence
     if args["color"] and discrete_color:

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1634,7 +1634,9 @@ def process_dataframe_hierarchy(args):
         df_tree["parent"] = df_tree["parent"].str.rstrip("/")
         if cols:
             df_tree[cols] = dfg[cols]
+        df_all_trees_old = df_all_trees.append(df_tree, ignore_index=True)
         df_all_trees = df_all_trees.append(df_tree, ignore_index=True)
+        assert df_all_trees.equals(df_all_trees_old)
 
     # we want to make sure than (?) is the first color of the sequence
     if args["color"] and discrete_color:

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1634,9 +1634,7 @@ def process_dataframe_hierarchy(args):
         df_tree["parent"] = df_tree["parent"].str.rstrip("/")
         if cols:
             df_tree[cols] = dfg[cols]
-        df_all_trees_old = df_all_trees.append(df_tree, ignore_index=True)
         df_all_trees = pd.concat([df_all_trees, df_tree], ignore_index=True)
-        assert df_all_trees.equals(df_all_trees_old)
 
     # we want to make sure than (?) is the first color of the sequence
     if args["color"] and discrete_color:

--- a/packages/python/plotly/plotly/figure_factory/_county_choropleth.py
+++ b/packages/python/plotly/plotly/figure_factory/_county_choropleth.py
@@ -86,7 +86,9 @@ def _create_us_counties_df(st_to_state_name_dict, state_to_st_dict):
         columns=["State", "ST", "geometry", "FIPS", "STATEFP", "NAME"],
         index=[max(gdf.index) + 1],
     )
-    gdf = gdf.append(singlerow, sort=True)
+    gdf_old = gdf.append(singlerow, sort=True)
+    gdf = pd.concat([gdf, singlerow], sort=True)
+    assert gdf.equals(gdf_old)
 
     f = 51515
     singlerow = pd.DataFrame(
@@ -103,7 +105,9 @@ def _create_us_counties_df(st_to_state_name_dict, state_to_st_dict):
         columns=["State", "ST", "geometry", "FIPS", "STATEFP", "NAME"],
         index=[max(gdf.index) + 1],
     )
-    gdf = gdf.append(singlerow, sort=True)
+    gdf_old = gdf.append(singlerow, sort=True)
+    gdf = pd.concat([gdf, singlerow], sort=True)
+    assert gdf.equals(gdf_old)
 
     f = 2270
     singlerow = pd.DataFrame(
@@ -120,19 +124,25 @@ def _create_us_counties_df(st_to_state_name_dict, state_to_st_dict):
         columns=["State", "ST", "geometry", "FIPS", "STATEFP", "NAME"],
         index=[max(gdf.index) + 1],
     )
-    gdf = gdf.append(singlerow, sort=True)
+    gdf_old = gdf.append(singlerow, sort=True)
+    gdf = pd.concat([gdf, singlerow], sort=True)
+    assert gdf.equals(gdf_old)
 
     row_2198 = gdf[gdf["FIPS"] == 2198]
     row_2198.index = [max(gdf.index) + 1]
     row_2198.loc[row_2198.index[0], "FIPS"] = 2201
     row_2198.loc[row_2198.index[0], "STATEFP"] = "02"
-    gdf = gdf.append(row_2198, sort=True)
+    gdf_old = gdf.append(row_2198, sort=True)
+    gdf = pd.concat([gdf, row_2198], sort=True)
+    assert gdf.equals(gdf_old)
 
     row_2105 = gdf[gdf["FIPS"] == 2105]
     row_2105.index = [max(gdf.index) + 1]
     row_2105.loc[row_2105.index[0], "FIPS"] = 2232
     row_2105.loc[row_2105.index[0], "STATEFP"] = "02"
-    gdf = gdf.append(row_2105, sort=True)
+    gdf_old = gdf.append(row_2105, sort=True)
+    gdf = pd.concat([gdf, row_2105], sort=True)
+    assert gdf.equals(gdf_old)
     gdf = gdf.rename(columns={"NAME": "COUNTY_NAME"})
 
     gdf_reduced = gdf[["FIPS", "STATEFP", "COUNTY_NAME", "geometry"]]

--- a/packages/python/plotly/plotly/figure_factory/_county_choropleth.py
+++ b/packages/python/plotly/plotly/figure_factory/_county_choropleth.py
@@ -86,9 +86,7 @@ def _create_us_counties_df(st_to_state_name_dict, state_to_st_dict):
         columns=["State", "ST", "geometry", "FIPS", "STATEFP", "NAME"],
         index=[max(gdf.index) + 1],
     )
-    gdf_old = gdf.append(singlerow, sort=True)
     gdf = pd.concat([gdf, singlerow], sort=True)
-    assert gdf.equals(gdf_old)
 
     f = 51515
     singlerow = pd.DataFrame(
@@ -105,9 +103,7 @@ def _create_us_counties_df(st_to_state_name_dict, state_to_st_dict):
         columns=["State", "ST", "geometry", "FIPS", "STATEFP", "NAME"],
         index=[max(gdf.index) + 1],
     )
-    gdf_old = gdf.append(singlerow, sort=True)
     gdf = pd.concat([gdf, singlerow], sort=True)
-    assert gdf.equals(gdf_old)
 
     f = 2270
     singlerow = pd.DataFrame(
@@ -124,25 +120,19 @@ def _create_us_counties_df(st_to_state_name_dict, state_to_st_dict):
         columns=["State", "ST", "geometry", "FIPS", "STATEFP", "NAME"],
         index=[max(gdf.index) + 1],
     )
-    gdf_old = gdf.append(singlerow, sort=True)
     gdf = pd.concat([gdf, singlerow], sort=True)
-    assert gdf.equals(gdf_old)
 
     row_2198 = gdf[gdf["FIPS"] == 2198]
     row_2198.index = [max(gdf.index) + 1]
     row_2198.loc[row_2198.index[0], "FIPS"] = 2201
     row_2198.loc[row_2198.index[0], "STATEFP"] = "02"
-    gdf_old = gdf.append(row_2198, sort=True)
     gdf = pd.concat([gdf, row_2198], sort=True)
-    assert gdf.equals(gdf_old)
 
     row_2105 = gdf[gdf["FIPS"] == 2105]
     row_2105.index = [max(gdf.index) + 1]
     row_2105.loc[row_2105.index[0], "FIPS"] = 2232
     row_2105.loc[row_2105.index[0], "STATEFP"] = "02"
-    gdf_old = gdf.append(row_2105, sort=True)
     gdf = pd.concat([gdf, row_2105], sort=True)
-    assert gdf.equals(gdf_old)
     gdf = gdf.rename(columns={"NAME": "COUNTY_NAME"})
 
     gdf_reduced = gdf[["FIPS", "STATEFP", "COUNTY_NAME", "geometry"]]


### PR DESCRIPTION
This PR aims to resolve #3602 by replacing all pandas' `df.append()` calls by `pd.concat()` calls in alignment with [the corresponding 1.4.0 Release Notes](https://pandas.pydata.org/docs/whatsnew/v1.4.0.html#deprecated-dataframe-append-and-series-append). Since there should be no functionality affected, no bug fixed, no interface changed or similar whatsoever, we only changed the according calls in `plotly.express` and `plotly.figure_factory`. To make sure we did in fact not change the intermediate results of these calls, we temporarily kept the old calls in, and asserted them equaling our new calls to `pd.concat()`. Locally all tests passed and after successful pipeline runs we removed these assertions and the old calls, to finally get rid of the `FutureWarning`s.

This is my first contribution to Plot.ly, so please let me know, if I can improve anything.

As of now the `build-doc` job keeps failing although I have the impression, that  this is unrelated to my changes. Please let me know, if I can do anything to fix this.
 
## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).
