### PR TITLE
Fix test_offline's tearDown

### DIFF
--- a/packages/python/plotly/plotly/tests/test_core/test_offline/test_offline.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_offline/test_offline.py
@@ -81,6 +81,7 @@ class PlotlyOfflineTestCase(PlotlyOfflineBaseTestCase):
 
     def tearDown(self):
         pio.templates.default = "plotly"
+        super().tearDown()
 
     def _read_html(self, file_url):
         """Read and return the HTML contents from a file_url


### PR DESCRIPTION
While working on #3690 we discovered that subsequent runs of the test suite produced an error due to incorrect tear down behaviour in _test_offline.py_. At least this is, what we think is the cause and our fix solved the issue for us.

What had happened:

On 03.06.2019 John Mease introduced some chages in 2a44ce3b24f2cf5baef5b695d4ce1d73e68006a2 including [several new tearDown methods for instance for `class PlotlyOfflineTestCase(PlotlyOfflineBaseTestCase)`](https://github.com/plotly/plotly.py/commit/2a44ce3b24f2cf5baef5b695d4ce1d73e68006a2#diff-2fdbad55193be3908caa652c6c9dd3c8708f0401b8efdcfb10c7f51f4bbb7797R84-R85). The problem with this particular new `tearDown()` was, that since then it has overridden the [parent class tear down method, which was cleaning up after some of the tests](https://github.com/plotly/plotly.py/commit/2a44ce3b24f2cf5baef5b695d4ce1d73e68006a2#diff-2fdbad55193be3908caa652c6c9dd3c8708f0401b8efdcfb10c7f51f4bbb7797R68-R76). The residual files cause two failing tests on subsequent runs without the introduced patch, which now calls the parent class tearDown in John Mease's from 2019.

This is my second contribution to Plot.ly, so please let me know, if I can improve anything.

As of now the `build-doc` job keeps failing although I have the impression, that  this is unrelated to my changes. Please let me know, if I can do anything to fix this.
 
## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).
