### PR TITLE
Compatibility with evolving PyData libraries

### DIFF
--- a/packages/python/plotly/_plotly_utils/utils.py
+++ b/packages/python/plotly/_plotly_utils/utils.py
@@ -167,15 +167,19 @@ class PlotlyJSONEncoder(_json.JSONEncoder):
 
     @staticmethod
     def encode_as_pandas(obj):
-        """Attempt to convert pandas.NaT"""
+        """Attempt to convert pandas.NaT / pandas.NA"""
         pandas = get_module("pandas", should_load=False)
         if not pandas:
             raise NotEncodable
 
         if obj is pandas.NaT:
             return None
-        else:
-            raise NotEncodable
+
+        # pandas.NA was introduced in pandas 1.0
+        if hasattr(pandas, "NA") and obj is pandas.NA:
+            return None
+
+        raise NotEncodable
 
     @staticmethod
     def encode_as_numpy(obj):

--- a/packages/python/plotly/plotly/express/_imshow.py
+++ b/packages/python/plotly/plotly/express/_imshow.py
@@ -50,7 +50,7 @@ def _infer_zmax_from_type(img):
         elif im_max <= 65535 * rtol:
             return 65535
         else:
-            return 2**32
+            return 2 ** 32
 
 
 def imshow(
@@ -351,7 +351,7 @@ def imshow(
         binary_string = img.ndim >= (3 + slice_dimensions) and not is_dataframe
 
     # Cast bools to uint8 (also one byte)
-    if img.dtype == np.bool:
+    if img.dtype == bool:
         img = 255 * img.astype(np.uint8)
 
     if range_color is not None:

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_imshow.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_imshow.py
@@ -45,17 +45,17 @@ def test_zmax():
 
 def test_automatic_zmax_from_dtype():
     dtypes_dict = {
-        np.uint8: 2**8 - 1,
-        np.uint16: 2**16 - 1,
+        np.uint8: 2 ** 8 - 1,
+        np.uint16: 2 ** 16 - 1,
         np.float: 1,
-        np.bool: 255,
+        bool: 255,
     }
     for key, val in dtypes_dict.items():
         img = np.array([0, 1], dtype=key)
         img = np.dstack((img,) * 3)
         fig = px.imshow(img, binary_string=False)
         # For uint8 in "infer" mode we don't pass zmin/zmax unless specified
-        if key in [np.uint8, np.bool]:
+        if key in [np.uint8, bool]:
             assert fig.data[0]["zmax"] is None
         else:
             assert fig.data[0]["zmax"] == (val, val, val, 255)
@@ -195,9 +195,7 @@ def test_imshow_xarray_slicethrough():
 
 
 def test_imshow_labels_and_ranges():
-    fig = px.imshow(
-        [[1, 2], [3, 4], [5, 6]],
-    )
+    fig = px.imshow([[1, 2], [3, 4], [5, 6]],)
     assert fig.layout.xaxis.title.text is None
     assert fig.layout.yaxis.title.text is None
     assert fig.layout.coloraxis.colorbar.title.text is None
@@ -386,11 +384,7 @@ def test_facet_col(facet_col, binary_string):
 @pytest.mark.parametrize("binary_string", [False, True])
 def test_animation_frame_grayscale(animation_frame, binary_string):
     img = np.random.randint(255, size=(10, 9, 8)).astype(np.uint8)
-    fig = px.imshow(
-        img,
-        animation_frame=animation_frame,
-        binary_string=binary_string,
-    )
+    fig = px.imshow(img, animation_frame=animation_frame, binary_string=binary_string,)
     nslices = img.shape[animation_frame]
     assert len(fig.frames) == nslices
 
@@ -399,11 +393,7 @@ def test_animation_frame_grayscale(animation_frame, binary_string):
 @pytest.mark.parametrize("binary_string", [False, True])
 def test_animation_frame_rgb(animation_frame, binary_string):
     img = np.random.randint(255, size=(10, 9, 8, 3)).astype(np.uint8)
-    fig = px.imshow(
-        img,
-        animation_frame=animation_frame,
-        binary_string=binary_string,
-    )
+    fig = px.imshow(img, animation_frame=animation_frame, binary_string=binary_string,)
     nslices = img.shape[animation_frame]
     assert len(fig.frames) == nslices
 


### PR DESCRIPTION
<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

-->
