### PR TITLE
Remove errroneous comma in SVG path

### DIFF
--- a/doc/python/shapes.md
+++ b/doc/python/shapes.md
@@ -565,7 +565,7 @@ fig.update_layout(
         # filled Polygon
         dict(
             type="path",
-            path=" M 3,7 L2,8 L2,9 L3,10, L4,10 L5,9 L5,8 L4,7 Z",
+            path=" M 3,7 L2,8 L2,9 L3,10 L4,10 L5,9 L5,8 L4,7 Z",
             fillcolor="PaleTurquoise",
             line_color="LightSeaGreen",
         ),


### PR DESCRIPTION
This is only a minor mistake, but slightly misleading because one may think that this is an example of how to draw partial edges.
