### PR TITLE
Fix setup.py import of versioneer w/ PEP 517

### DIFF
--- a/packages/python/plotly/setup.py
+++ b/packages/python/plotly/setup.py
@@ -11,7 +11,7 @@ from distutils import log
 # ensure the current directory is on sys.path; so versioneer can be imported
 # when pip uses PEP 517/518 build rules.
 # https://github.com/python-versioneer/python-versioneer/issues/193
-sys.path.append(os.path.dirname(__file__))
+sys.path.insert(0, os.path.dirname(__file__))
 
 import versioneer
 


### PR DESCRIPTION
Same issue as https://github.com/dandi/dandi-cli/pull/998.

If versioneer is installed on the system, by appending our copy
to the import path, we're going to end up colliding and mixing-and-matching.

We always want to use the local copy vendored in tree.

Bug: https://bugs.gentoo.org/841002
Signed-off-by: Sam James <sam@gentoo.org>

## Code PR

- [X] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
