### PR TITLE
:recycle: check for all same groups

### DIFF
--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1916,10 +1916,17 @@ def get_orderings(args, grouper, grouped, all_same_group):
     of a single dimension-group
     """
     orders = {} if "category_orders" not in args else args["category_orders"].copy()
+    sorted_group_names = []
 
     if all_same_group:
-        sorted_group_names = [("",) * len(grouper)]
-        return orders, sorted_group_names
+        for col in grouper:
+            if col != one_group:
+                single_val = args["data_frame"][col].iloc[0]
+                sorted_group_names.append(single_val)
+                orders[col] = [single_val]
+            else:
+                sorted_group_names.append("")
+        return orders, [tuple(sorted_group_names)]
 
     for col in grouper:
         if col != one_group:
@@ -1929,7 +1936,6 @@ def get_orderings(args, grouper, grouped, all_same_group):
             else:
                 orders[col] = list(OrderedDict.fromkeys(list(orders[col]) + uniques))
 
-    sorted_group_names = []
     for group_name in grouped.groups:
         if len(grouper) == 1:
             group_name = (group_name,)

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1904,7 +1904,7 @@ def infer_config(args, constructor, trace_patch, layout_patch):
     return trace_specs, grouped_mappings, sizeref, show_colorbar
 
 
-def get_orderings(args, grouper, grouped):
+def get_orderings(args, grouper, grouped, all_same_group):
     """
     `orders` is the user-supplied ordering with the remaining data-frame-supplied
     ordering appended if the column is used for grouping. It includes anything the user
@@ -1917,7 +1917,7 @@ def get_orderings(args, grouper, grouped):
     """
     orders = {} if "category_orders" not in args else args["category_orders"].copy()
 
-    if _all_one_group(grouper):
+    if all_same_group:
         sorted_group_names = [("",) * len(grouper)]
         return orders, sorted_group_names
 
@@ -1944,10 +1944,12 @@ def get_orderings(args, grouper, grouped):
     return orders, sorted_group_names
 
 
-def _all_one_group(grouper):
-    for g in grouper:
+def _all_same_group(args, grouper):
+    for g in set(grouper):
         if g != one_group:
-            return False
+            arr = args["data_frame"][g].values
+            if not (arr[0] == arr).all(axis=0):
+                return False
     return True
 
 
@@ -1968,10 +1970,11 @@ def make_figure(args, constructor, trace_patch=None, layout_patch=None):
     )
     grouper = [x.grouper or one_group for x in grouped_mappings] or [one_group]
     grouped = None
-    if not _all_one_group(grouper):
+    all_same_group = _all_same_group(args, grouper)
+    if not all_same_group:
         grouped = args["data_frame"].groupby(grouper, sort=False)
 
-    orders, sorted_group_names = get_orderings(args, grouper, grouped)
+    orders, sorted_group_names = get_orderings(args, grouper, grouped, all_same_group)
 
     col_labels = []
     row_labels = []


### PR DESCRIPTION
Check for all same group instead of checking for all one group (see #3765)

<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

-->
