### PR TITLE
Add support for truncate_mode to figure factory dendrogram

### DIFF
--- a/packages/python/plotly/plotly/figure_factory/_dendrogram.py
+++ b/packages/python/plotly/plotly/figure_factory/_dendrogram.py
@@ -21,8 +21,13 @@ def create_dendrogram(
     colorscale=None,
     distfun=None,
     linkagefun=lambda x: sch.linkage(x, "complete"),
+    truncate_mode=None,
     hovertext=None,
     color_threshold=None,
+    show_leaf_counts=None,
+    show_contracted=None,
+    leaf_rotation=None,
+    leaf_font_size=None
 ):
     """
     Function that returns a dendrogram Plotly figure object. This is a thin
@@ -59,7 +64,7 @@ def create_dendrogram(
     >>> fig.show()
 
     Example 2: Dendrogram to put on the left of the heatmap
-
+    
     >>> from plotly.figure_factory import create_dendrogram
 
     >>> import numpy as np
@@ -71,7 +76,7 @@ def create_dendrogram(
     >>> dendro.show()
 
     Example 3: Dendrogram with Pandas
-
+    
     >>> from plotly.figure_factory import create_dendrogram
 
     >>> import numpy as np
@@ -104,6 +109,11 @@ def create_dendrogram(
         linkagefun=linkagefun,
         hovertext=hovertext,
         color_threshold=color_threshold,
+        truncate_mode=truncate_mode,
+        show_leaf_counts=show_leaf_counts,
+        show_contracted=show_contracted,
+        leaf_rotation=leaf_rotation,
+        leaf_font_size=leaf_font_size
     )
 
     return graph_objs.Figure(data=dendrogram.data, layout=dendrogram.layout)
@@ -126,6 +136,11 @@ class _Dendrogram(object):
         linkagefun=lambda x: sch.linkage(x, "complete"),
         hovertext=None,
         color_threshold=None,
+        truncate_mode=None,
+        show_leaf_counts=None,
+        show_contracted=None,
+        leaf_rotation=None,
+        leaf_font_size=None
     ):
         self.orientation = orientation
         self.labels = labels
@@ -135,6 +150,11 @@ class _Dendrogram(object):
         self.leaves = []
         self.sign = {self.xaxis: 1, self.yaxis: 1}
         self.layout = {self.xaxis: {}, self.yaxis: {}}
+        self.truncate_mode = truncate_mode
+        self.show_leaf_counts= show_leaf_counts
+        self.show_contracted= show_contracted
+        self.leaf_rotation= leaf_rotation
+        self.leaf_font_size = leaf_font_size
 
         if self.orientation in ["left", "bottom"]:
             self.sign[self.xaxis] = 1
@@ -271,7 +291,7 @@ class _Dendrogram(object):
             "ticks": "outside",
             "mirror": "allticks",
             "rangemode": "tozero",
-            "showticklabels": True,
+            "showticklabels": False if self.truncate_mode != None else True,
             "zeroline": False,
             "showgrid": False,
             "showline": True,
@@ -344,7 +364,12 @@ class _Dendrogram(object):
             orientation=self.orientation,
             labels=self.labels,
             no_plot=True,
+            truncate_mode=self.truncate_mode,
             color_threshold=color_threshold,
+            show_leaf_counts=self.show_leaf_counts,
+            show_contracted=self.show_contracted,
+            leaf_rotation=self.leaf_rotation,
+            leaf_font_size=self.leaf_font_size
         )
 
         icoord = scp.array(P["icoord"])


### PR DESCRIPTION
 Now the user can specify via an argument if they want this mode and they can also specify hovertext, color_threshold, show_leaf_counts, show_contracted, leaf_rotation, leaf_font_size. If the truncate mode is on, then showticklabels will be set to False, else, it will remain True.

The end result looks like this:

![example_dendrogram_truncated](https://user-images.githubusercontent.com/10984467/175716347-7f1b5d82-5402-4219-803e-0e5efa47809a.png)


## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

-->
