### PR TITLE
FIX selector = 0 returns all traces in select_traces

### DIFF
--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -1139,7 +1139,7 @@ class BaseFigure(object):
             Generator that iterates through all of the traces that satisfy
             all of the specified selection criteria
         """
-        if not selector:
+        if not selector and not isinstance(selector, int):
             selector = {}
 
         if row is not None or col is not None or secondary_y is not None:

--- a/packages/python/plotly/plotly/tests/test_core/test_update_objects/test_update_traces.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_update_objects/test_update_traces.py
@@ -430,6 +430,7 @@ def select_traces_fixture():
 
 def test_select_traces_integer(select_traces_fixture):
     fig = select_traces_fixture
+    
     # check that selecting first trace does indeed only select the first
     tr = list(fig.select_traces(selector=0))
     assert len(tr) == 1

--- a/packages/python/plotly/plotly/tests/test_core/test_update_objects/test_update_traces.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_update_objects/test_update_traces.py
@@ -430,6 +430,10 @@ def select_traces_fixture():
 
 def test_select_traces_integer(select_traces_fixture):
     fig = select_traces_fixture
+    # check that selecting first trace does indeed only select the first
+    tr = list(fig.select_traces(selector=0))
+    assert len(tr) == 1
+    assert tr[0].y[1] == 0
     # check we can index last trace selected
     tr = list(fig.select_traces(selector=-1))[0]
     assert tr.y[1] == 20

--- a/packages/python/plotly/plotly/tests/test_core/test_update_objects/test_update_traces.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_update_objects/test_update_traces.py
@@ -430,7 +430,6 @@ def select_traces_fixture():
 
 def test_select_traces_integer(select_traces_fixture):
     fig = select_traces_fixture
-    
     # check that selecting first trace does indeed only select the first
     tr = list(fig.select_traces(selector=0))
     assert len(tr) == 1


### PR DESCRIPTION
Fix https://github.com/plotly/plotly.py/issues/3639 (`selector = 0` in `update_traces` selects all traces, not only the first one)

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
