### PR TITLE
Fix typo in the Scatter3D constructor documentation

### DIFF
--- a/packages/python/plotly/plotly/graph_objs/_scatter3d.py
+++ b/packages/python/plotly/plotly/graph_objs/_scatter3d.py
@@ -2292,7 +2292,7 @@ class Scatter3d(_BaseTraceType):
         legendrank
             Sets the legend rank for this trace. Items and groups
             with smaller ranks are presented on top/left side while
-            with `*reversed* `legend.traceorder` they are on
+            with *reversed* `legend.traceorder` they are on
             bottom/right side. The default legendrank is 1000, so
             that you can use ranks less than 1000 to place certain
             items before all unranked items, and ranks greater than


### PR DESCRIPTION
This is a documentation change in the code section, so I am not sure which of the following apply.

### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch


## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
