### PR TITLE
bug fix from matplotlib.collections api change

### DIFF
--- a/packages/python/plotly/plotly/matplotlylib/mplexporter/exporter.py
+++ b/packages/python/plotly/plotly/matplotlylib/mplexporter/exporter.py
@@ -286,7 +286,7 @@ class Exporter(object):
         }
 
         offset_dict = {"data": "before", "screen": "after"}
-        offset_order = offset_dict[collection.get_offset_position()]
+        offset_order = offset_dict[collection._offset_position]
 
         self.renderer.draw_path_collection(
             paths=processed_paths,


### PR DESCRIPTION
<!--

## Code PR

- [ x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ x] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ x] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ x] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).
-->

The matplotlib.collections.Collection object used to have offsets accessible via the get_offset_positions method, which was deprecated in favor of a hidden attribute _offset_position. There was a cold path in mplexported that used the old method and causes certain conversions to fail.