### PR TITLE
Doc - Configuration-options - improvement propositions

### DIFF
--- a/doc/python/configuration-options.md
+++ b/doc/python/configuration-options.md
@@ -53,7 +53,7 @@ import plotly.graph_objects as go
 
 fig = go.Figure()
 
-config = dict({'scrollZoom': True})
+config = {'scrollZoom': True}
 
 fig.add_trace(
     go.Scatter(
@@ -244,6 +244,8 @@ fig.add_trace(
         y=[1, 3, 1]))
 
 fig.update_layout(modebar_remove=['zoom', 'pan'])
+
+fig.show()
 ```
 
 ### Add optional shape-drawing buttons to modebar
@@ -253,16 +255,19 @@ fig.update_layout(modebar_remove=['zoom', 'pan'])
 Some modebar buttons of Cartesian plots are optional and have to be added explicitly, using the `modeBarButtonsToAdd` config attribute. These buttons are used for drawing or erasing shapes. See [the tutorial on shapes and shape drawing](python/shapes#drawing-shapes-on-cartesian-plots) for more details.
 
 ```python
-import plotly.graph_objects as go
 import plotly.express as px
+
 df = px.data.iris()
+
 fig = px.scatter(df, x='petal_width', y='sepal_length', color='species')
+
 fig.update_layout(
     dragmode='drawopenpath',
     newshape_line_color='cyan',
     title_text='Draw a path to separate versicolor and virginica'
 )
-fig.show(config={'modeBarButtonsToAdd':['drawline',
+
+fig.show(config={'modeBarButtonsToAdd': ['drawline',
                                         'drawopenpath',
                                         'drawclosedpath',
                                         'drawcircle',
@@ -276,10 +281,12 @@ fig.show(config={'modeBarButtonsToAdd':['drawline',
 The `layout.modebar.add` attribute can be used instead of the approach used above:
 
 ```python
-import plotly.graph_objects as go
 import plotly.express as px
+
 df = px.data.iris()
+
 fig = px.scatter(df, x='petal_width', y='sepal_length', color='species')
+
 fig.update_layout(
     dragmode='drawopenpath',
     newshape_line_color='cyan',
@@ -292,6 +299,8 @@ fig.update_layout(
         'eraseshape'
        ]
 )
+
+fig.show()
 ```
 
 ### Double-Click Delay
@@ -304,12 +313,12 @@ import plotly.graph_objects as go
 config = {'doubleClickDelay': 1000}
 
 fig = go.Figure(go.Bar(
-    y = [3, 5, 3, 2],
-    x = ["2019-09-02", "2019-10-10", "2019-11-12", "2019-12-22"],
-    texttemplate = "%{label}",
-    textposition = "inside"))
+    y=[3, 5, 3, 2],
+    x=["2019-09-02", "2019-10-10", "2019-11-12", "2019-12-22"],
+    texttemplate="%{label}",
+    textposition="inside"))
 
-fig.update_layout(xaxis = {'type': 'date'})
+fig.update_layout(xaxis={'type': 'date'})
 
 fig.show(config=config)
 ```
@@ -320,4 +329,4 @@ The same configuration dictionary that you pass to the `config` parameter of the
 
 #### Reference
 
-See config options at https://github.com/plotly/plotly.js/blob/master/src/plot_api/plot_config.js#L6
+See config options at https://github.com/plotly/plotly.js/blob/master/src/plot_api/plot_config.js


### PR DESCRIPTION
Here some improvement propositions as I am going through the docs:

- Add missing `fig.show()` in second exemple of [**Removing Modebar Buttons**](https://plotly.com/python/configuration-options/#removing-modebar-buttons) and [**Add optional shape-drawing buttons to modebar**](https://plotly.com/python/configuration-options/#add-optional-shapedrawing-buttons-to-modebar)
- Modify `config = dict({'scrollZoom': True})` to `config = {'scrollZoom': True}` in [**Enabling Scroll Zoom**](https://plotly.com/python/configuration-options/#enabling-scroll-zoom)
- Remove unused `import plotly.graph_objects as go` in the two examples in [**Add optional shape-drawing buttons to modebar**](https://plotly.com/python/configuration-options/#add-optional-shapedrawing-buttons-to-modebar)
- Remove #L6 from hyperlink https://github.com/plotly/plotly.js/blob/master/src/plot_api/plot_config.js#L6 in [**Reference**](https://plotly.com/python/configuration-options/#reference)

  (nothing special on line 6)
- Add/remove spaces and new lines for syntax and consistency

### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [x] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [x] Every new/modified example is independently runnable
- [x] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [x] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [x] Data frames are always called `df`
- [x] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [x] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [x] `fig.show()` is at the end of each new/modified example
- [x] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

