### PR TITLE
Prevent swallowing of ValueError in core.py

### DIFF
--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2368,6 +2368,7 @@ Use the {facet_arg} argument to adjust this spacing.""".format(
     except ValueError as e:
         _spacing_error_translator(e, "Horizontal", "facet_col_spacing")
         _spacing_error_translator(e, "Vertical", "facet_row_spacing")
+        raise
 
     # Remove explicit font size of row/col titles so template can take over
     for annot in fig.layout.annotations:


### PR DESCRIPTION
Traceback that this leads to:
```
File .../python3.9/site-packages/plotly/express/_core.py:2226, in make_figure(args, constructor, trace_patch, layout_patch)
   2223 if args.get("marginal_y") is not None:
   2224     ncols += 1
-> 2226 fig = init_figure(
   2227     args, subplot_type, frame_list, nrows, ncols, col_labels, row_labels
   2228 )
   2230 # Position traces in subplots
   2231 for frame in frame_list:

File .../python3.9/site-packages/plotly/express/_core.py:2373, in init_figure(args, subplot_type, frame_list, nrows, ncols, col_labels, row_labels)
   2370     _spacing_error_translator(e, "Vertical", "facet_row_spacing")
   2372 # Remove explicit font size of row/col titles so template can take over
-> 2373 for annot in fig.layout.annotations:
   2374     annot.update(font=None)
   2376 return fig

UnboundLocalError: local variable 'fig' referenced before assignment
```

<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

-->
