### PR TITLE
fix SyntaxWarning for comparing with a literal

### DIFF
--- a/packages/python/chart-studio/chart_studio/tools.py
+++ b/packages/python/chart-studio/chart_studio/tools.py
@@ -287,7 +287,7 @@ def _get_embed_url(file_owner_or_url, file_id=None):
             "The 'file_id' argument must be a non-negative number."
         )
 
-    if share_key is "":
+    if share_key == "":
         return "{plotly_rest_url}/~{file_owner}/{file_id}.embed".format(
             plotly_rest_url=plotly_rest_url, file_owner=file_owner, file_id=file_id
         )


### PR DESCRIPTION
## Summary

This fixes the following warning we get for `chart_studio`:

```
/opt/conda/lib/python3.8/site-packages/chart_studio/tools.py:290: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if share_key is "":
```

We should be comparing the values for literals. Alternatively we can write this comparison as 

```python
    if not share_key:
        return "{plotly_rest_url}/~{file_owner}/{file_id}.embed".format(
            plotly_rest_url=plotly_rest_url, file_owner=file_owner, file_id=file_id
        )
```

### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).




