### PR TITLE
Update the basewidget.py with the more recent ipywidgets8 compatible …

### DIFF
--- a/packages/python/plotly/plotly/basewidget.py
+++ b/packages/python/plotly/plotly/basewidget.py
@@ -733,12 +733,11 @@ class BaseFigureWidget(BaseFigure, widgets.DOMWidget):
 
     # Display
     # -------
-    def _ipython_display_(self):
+    def _repr_mimebundle_(self, include=None, exclude=None, validate=True, **kwargs):
         """
         Handle rich display of figures in ipython contexts
         """
-        # Override BaseFigure's display to make sure we display the widget version
-        widgets.DOMWidget._ipython_display_(self)
+        widgets.DOMWidget._repr_mimebundle_(self)
 
     # Callbacks
     # ---------


### PR DESCRIPTION
This PR fixes the issue https://github.com/plotly/plotly.py/issues/3686 which had made plotly incompatible with ipywidgets 8.

Confirmed that the FigureWidget is working on Python 3.8.x and `ipywidgets` 8 with this fix.


c.f. https://github.com/jupyter-widgets/ipywidgets/pull/2021 and https://github.com/jupyter-widgets/ipywidgets/issues/3552#issuecomment-1220997361
