### PR TITLE
Fix typo

### DIFF
--- a/doc/python/dumbbell-plots.md
+++ b/doc/python/dumbbell-plots.md
@@ -36,7 +36,7 @@ jupyter:
 ## Basic Dumbbell Plot
 
 
-Dumbbell plots are useful for demonstrating change between two sets of data points, for example, the population change for a selection of countries for two different years
+Dumbbell plots are useful for demonstrating change between two sets of data points, for example, the population change for a selection of countries for two different years.
 
 In this example, we compare life expectancy in 1952 with life expectancy in 2002 for countries in Europe.
 
@@ -107,9 +107,9 @@ fig.show()
 
 *Note: The `arrow`, `angleref`, and `standoff` properties used on the `marker` in this example are new in 5.11*
 
-In this example, we add arrow markers to the plot. The first trace adds the lines connecting the data points and arrow markers. 
+In this example, we add arrow markers to the plot. The first trace adds the lines connecting the data points and arrow markers.
 The second trace adds circle markers. On the first trace, we use `standoff=8` to position the arrow marker back from the data point.
-For the arrow marker to point directly at the circle marker, this value should be half the circle marker size. 
+For the arrow marker to point directly at the circle marker, this value should be half the circle marker size.
 
 ```python
 import pandas as pd

--- a/doc/python/legend.md
+++ b/doc/python/legend.md
@@ -193,7 +193,7 @@ fig.show()
 
 *New in 5.11*
 
-Set the width of hozitonal legend entries by setting `entrywidth`. Here we set it to `70` pixels. Pixels is the default unit for `entrywidth`, but you can set it to be a fraction of the plot width using `entrywidthmode='fraction`.
+Set the width of horizontal legend entries by setting `entrywidth`. Here we set it to `70` pixels. Pixels is the default unit for `entrywidth`, but you can set it to be a fraction of the plot width using `entrywidthmode='fraction`.
 
 ```python
 import plotly.express as px

--- a/doc/python/scattermapbox.md
+++ b/doc/python/scattermapbox.md
@@ -249,7 +249,7 @@ fig.show()
 
 *New in 5.11*
 
-Display clusters of data points by setting `cluster`. Here, we enable clusters with `enabled=True`. You can also enable clusters by setting other `cluster` properties. Other available properties include `color` (for setting the color of the clusters), `size` (for setting the size of a cluster step), and `step` (for configuring how many points it takes to create a cluster or advance to the next cluster step.
+Display clusters of data points by setting `cluster`. Here, we enable clusters with `enabled=True`. You can also enable clusters by setting other `cluster` properties. Other available properties include `color` (for setting the color of the clusters), `size` (for setting the size of a cluster step), and `step` (for configuring how many points it takes to create a cluster or advance to the next cluster step).
 
 ```python
 import plotly.express as px


### PR DESCRIPTION
Just noticed a few small issues in the new examples.
Can also merge to doc-prod instead after the release if that's easier.