### PR TITLE
Add legend to dumbbell-plots

### DIFF
--- a/doc/python/dumbbell-plots.md
+++ b/doc/python/dumbbell-plots.md
@@ -109,7 +109,7 @@ fig.show()
 
 In this example, we add arrow markers to the plot. The first trace adds the lines connecting the data points and arrow markers.
 The second trace adds circle markers. On the first trace, we use `standoff=8` to position the arrow marker back from the data point.
-For the arrow marker to point directly at the circle marker, this value should be half the circle marker size.
+For the arrow marker to point directly at the circle marker, this value should be half the circle marker size, which is hardcoded to 16 here.
 
 ```python
 import pandas as pd

--- a/doc/python/dumbbell-plots.md
+++ b/doc/python/dumbbell-plots.md
@@ -55,39 +55,51 @@ countries = (
     .unique()
 )
 
-data = {"x": [], "y": [], "colors": [], "years": []}
+data = {"line_x": [], "line_y": [], "1952": [], "2002": [], "colors": [], "years": [], "countries": []}
 
 for country in countries:
-    data["x"].extend(
+    data["1952"].extend([df.loc[(df.year == 1952) & (df.country == country)]["lifeExp"].values[0]])
+    data["2002"].extend([df.loc[(df.year == 2002) & (df.country == country)]["lifeExp"].values[0]])
+    data["line_x"].extend(
         [
             df.loc[(df.year == 1952) & (df.country == country)]["lifeExp"].values[0],
             df.loc[(df.year == 2002) & (df.country == country)]["lifeExp"].values[0],
             None,
         ]
     )
-    data["y"].extend([country, country, None]),
-    data["colors"].extend(["green", "blue", "brown"]),
-    data["years"].extend(["1952", "2002", None])
+    data["line_y"].extend([country, country, None]),
 
 fig = go.Figure(
     data=[
         go.Scatter(
-            x=data["x"],
-            y=data["y"],
+            x=data["line_x"],
+            y=data["line_y"],
             mode="lines",
+            showlegend=False,
             marker=dict(
-                color="grey",
-            ),
+                color='grey'
+            )
         ),
         go.Scatter(
-            x=data["x"],
-            y=data["y"],
-            mode="markers+text",
+            x=data["1952"],
+            y=countries,
+            mode="markers",
+            name="1952",
             marker=dict(
-                color=data["colors"],
-                size=10,
-            ),
-            hovertemplate="""Country: %{y} <br> Life Expectancy: %{x} <br><extra></extra>""",
+                color="green",
+                size=10
+            )
+            
+        ),
+        go.Scatter(
+            x=data["2002"],
+            y=countries,
+            mode="markers",
+            name="2002",
+            marker=dict(
+                color="blue",
+                size=10
+            )   
         ),
     ]
 )
@@ -95,7 +107,7 @@ fig = go.Figure(
 fig.update_layout(
     title="Life Expectancy in Europe: 1952 and 2002",
     height=1000,
-    showlegend=False,
+    legend_itemclick=False
 )
 
 fig.show()
@@ -123,41 +135,56 @@ countries = (
     .sort_values(by=["lifeExp"], ascending=True)["country"]
     .unique()
 )
-
-data = {"x": [], "y": [], "colors": [], "years": []}
+    
+data = {"line_x": [], "line_y": [], "1952": [], "2002": [], "colors": [], "years": [], "countries": []}
 
 for country in countries:
-    data["x"].extend(
+    data["1952"].extend([df.loc[(df.year == 1952) & (df.country == country)]["lifeExp"].values[0]])
+    data["2002"].extend([df.loc[(df.year == 2002) & (df.country == country)]["lifeExp"].values[0]])
+    data["line_x"].extend(
         [
             df.loc[(df.year == 1952) & (df.country == country)]["lifeExp"].values[0],
             df.loc[(df.year == 2002) & (df.country == country)]["lifeExp"].values[0],
             None,
         ]
     )
-    data["y"].extend([country, country, None]),
-    data["colors"].extend(["silver", "lightskyblue", "white"]),
-    data["years"].extend(["1952", "2002", None])
+    data["line_y"].extend([country, country, None]),
+
 
 fig = go.Figure(
     data=[
         go.Scatter(
-            x=data["x"],
-            y=data["y"],
+            x=data["line_x"],
+            y=data["line_y"],
             mode="markers+lines",
+            showlegend=False,
             marker=dict(
-                symbol="arrow", color="black", size=16, angleref="previous", standoff=8
-            ),
+                symbol="arrow", 
+                color="black", 
+                size=16, 
+                angleref="previous", 
+                standoff=8
+            )
         ),
         go.Scatter(
-            x=data["x"],
-            y=data["y"],
-            text=data["years"],
+            x=data["1952"],
+            y=countries, 
+            name="1952",
             mode="markers",
             marker=dict(
-                color=data["colors"],
+                color="silver",
+                size=16,
+            )
+        ),
+        go.Scatter(
+            x=data["2002"],
+            y=countries,
+            name="2002",
+            mode="markers",
+            marker=dict(
+                color="lightskyblue",
                 size=16,
             ),
-            hovertemplate="""Country: %{y} <br> Life Expectancy: %{x} <br> Year: %{text} <br><extra></extra>""",
         ),
     ]
 )
@@ -165,7 +192,7 @@ fig = go.Figure(
 fig.update_layout(
     title="Life Expectancy in Europe: 1952 and 2002",
     height=1000,
-    showlegend=False,
+    legend_itemclick=False
 )
 
 

--- a/doc/python/dumbbell-plots.md
+++ b/doc/python/dumbbell-plots.md
@@ -135,7 +135,7 @@ countries = (
     .sort_values(by=["lifeExp"], ascending=True)["country"]
     .unique()
 )
-    
+
 data = {"line_x": [], "line_y": [], "1952": [], "2002": [], "colors": [], "years": [], "countries": []}
 
 for country in countries:
@@ -149,7 +149,6 @@ for country in countries:
         ]
     )
     data["line_y"].extend([country, country, None]),
-
 
 fig = go.Figure(
     data=[

--- a/doc/python/dumbbell-plots.md
+++ b/doc/python/dumbbell-plots.md
@@ -77,7 +77,7 @@ fig = go.Figure(
             mode="lines",
             showlegend=False,
             marker=dict(
-                color='grey'
+                color="grey"
             )
         ),
         go.Scatter(

--- a/doc/python/dumbbell-plots.md
+++ b/doc/python/dumbbell-plots.md
@@ -94,7 +94,6 @@ fig = go.Figure(
 
 fig.update_layout(
     title="Life Expectancy in Europe: 1952 and 2002",
-    width=1000,
     height=1000,
     showlegend=False,
 )
@@ -165,7 +164,6 @@ fig = go.Figure(
 
 fig.update_layout(
     title="Life Expectancy in Europe: 1952 and 2002",
-    width=1000,
     height=1000,
     showlegend=False,
 )


### PR DESCRIPTION
To display years on legend 

### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [x] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [x] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [x] Every new/modified example is independently runnable
- [x] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [x] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [x] The random seed is set if using randomly-generated data in new/modified examples
- [x] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [x] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [x] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [x] Data frames are always called `df`
- [x] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [x] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [x] `fig.show()` is at the end of each new/modified example
- [x] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [x] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

