### PR TITLE
Draw PCA loadings as arrows

### DIFF
--- a/doc/python/dumbbell-plots.md
+++ b/doc/python/dumbbell-plots.md
@@ -109,7 +109,7 @@ fig.show()
 
 In this example, we add arrow markers to the plot. The first trace adds the lines connecting the data points and arrow markers.
 The second trace adds circle markers. On the first trace, we use `standoff=8` to position the arrow marker back from the data point.
-For the arrow marker to point directly at the circle marker, this value should be half the circle marker size.
+For the arrow marker to point directly at the circle marker, this value should be half the circle marker size, which is hardcoded to 16 here.
 
 ```python
 import pandas as pd

--- a/doc/python/dumbbell-plots.md
+++ b/doc/python/dumbbell-plots.md
@@ -94,7 +94,6 @@ fig = go.Figure(
 
 fig.update_layout(
     title="Life Expectancy in Europe: 1952 and 2002",
-    width=1000,
     height=1000,
     showlegend=False,
 )
@@ -165,7 +164,6 @@ fig = go.Figure(
 
 fig.update_layout(
     title="Life Expectancy in Europe: 1952 and 2002",
-    width=1000,
     height=1000,
     showlegend=False,
 )

--- a/doc/python/ml-pca.md
+++ b/doc/python/ml-pca.md
@@ -250,11 +250,16 @@ loadings = pca.components_.T * np.sqrt(pca.explained_variance_)
 fig = px.scatter(components, x=0, y=1, color=df['species'])
 
 for i, feature in enumerate(features):
-    fig.add_shape(
-        type='line',
-        x0=0, y0=0,
-        x1=loadings[i, 0],
-        y1=loadings[i, 1]
+    fig.add_annotation(
+        ax=0, ay=0,
+        axref="x", ayref="y",
+        x=loadings[i, 0],
+        y=loadings[i, 1],
+        showarrow=True,
+        arrowsize=2,
+        arrowhead=2,
+        xanchor="right",
+        yanchor="top"
     )
     fig.add_annotation(
         x=loadings[i, 0],
@@ -263,6 +268,7 @@ for i, feature in enumerate(features):
         xanchor="center",
         yanchor="bottom",
         text=feature,
+        yshift=5,
     )
 fig.show()
 ```


### PR DESCRIPTION
Current example draws loadings as straight lines. A more common way is to represent them as arrows.



If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [x] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [x] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [x] Every new/modified example is independently runnable
- [x] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [x] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [x] The random seed is set if using randomly-generated data in new/modified examples
- [x] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [x] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [x] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [x] Data frames are always called `df`
- [x] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go. Figure`)
- [x] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [x] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [x] `fig.show()` is at the end of each new/modified example
- [x] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [x] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)
