### PR TITLE
Add license trove classifier

### DIFF
--- a/packages/python/plotly/setup.py
+++ b/packages/python/plotly/setup.py
@@ -512,6 +512,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering :: Visualization",
+        "License :: OSI Approved :: MIT License",
     ],
     python_requires=">=3.6",
     license="MIT",


### PR DESCRIPTION
Add a proper license [Trove classifier](https://pypi.org/classifiers/).

This is used by tools such as [`pip-licenses`](https://github.com/raimon49/pip-licenses) to provide a license report for users.