### PR TITLE
Update splom.md

### DIFF
--- a/doc/python/dumbbell-plots.md
+++ b/doc/python/dumbbell-plots.md
@@ -109,7 +109,7 @@ fig.show()
 
 In this example, we add arrow markers to the plot. The first trace adds the lines connecting the data points and arrow markers.
 The second trace adds circle markers. On the first trace, we use `standoff=8` to position the arrow marker back from the data point.
-For the arrow marker to point directly at the circle marker, this value should be half the circle marker size.
+For the arrow marker to point directly at the circle marker, this value should be half the circle marker size, which is hardcoded to 16 here.
 
 ```python
 import pandas as pd

--- a/doc/python/dumbbell-plots.md
+++ b/doc/python/dumbbell-plots.md
@@ -94,7 +94,6 @@ fig = go.Figure(
 
 fig.update_layout(
     title="Life Expectancy in Europe: 1952 and 2002",
-    width=1000,
     height=1000,
     showlegend=False,
 )
@@ -165,7 +164,6 @@ fig = go.Figure(
 
 fig.update_layout(
     title="Life Expectancy in Europe: 1952 and 2002",
-    width=1000,
     height=1000,
     showlegend=False,
 )

--- a/doc/python/splom.md
+++ b/doc/python/splom.md
@@ -56,7 +56,7 @@ Specify the columns to be represented with the `dimensions` argument, and set co
 import plotly.express as px
 df = px.data.iris()
 fig = px.scatter_matrix(df,
-    dimensions=["sepal_width", "sepal_length", "petal_width", "petal_length"],
+    dimensions=["sepal_length", "sepal_width", "petal_length", "petal_width"],
     color="species")
 fig.show()
 ```
@@ -69,7 +69,7 @@ The scatter matrix plot can be configured thanks to the parameters of `px.scatte
 import plotly.express as px
 df = px.data.iris()
 fig = px.scatter_matrix(df,
-    dimensions=["sepal_width", "sepal_length", "petal_width", "petal_length"],
+    dimensions=["sepal_length", "sepal_width", "petal_length", "petal_width"],
     color="species", symbol="species",
     title="Scatter matrix of iris data set",
     labels={col:col.replace('_', ' ') for col in df.columns}) # remove underscore


### PR DESCRIPTION
The dimensions in the scatter matrix is not mentioned according to the data order. It gets very confused to see the scatter matrix in that format. The other scatter matrix are in the correct order as the dataset columns. t took me some time to realize that when the scatter matrix's style changed, the labels were mentioned in a new way.
The columns in the iris data set are in the following order: "sepal length," "sepal width," "petal length," and "petal width."

<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

-->
