### PR TITLE
fix small typo in histograms doc

### DIFF
--- a/doc/python/dumbbell-plots.md
+++ b/doc/python/dumbbell-plots.md
@@ -109,7 +109,7 @@ fig.show()
 
 In this example, we add arrow markers to the plot. The first trace adds the lines connecting the data points and arrow markers.
 The second trace adds circle markers. On the first trace, we use `standoff=8` to position the arrow marker back from the data point.
-For the arrow marker to point directly at the circle marker, this value should be half the circle marker size.
+For the arrow marker to point directly at the circle marker, this value should be half the circle marker size, which is hardcoded to 16 here.
 
 ```python
 import pandas as pd

--- a/doc/python/dumbbell-plots.md
+++ b/doc/python/dumbbell-plots.md
@@ -94,7 +94,6 @@ fig = go.Figure(
 
 fig.update_layout(
     title="Life Expectancy in Europe: 1952 and 2002",
-    width=1000,
     height=1000,
     showlegend=False,
 )
@@ -165,7 +164,6 @@ fig = go.Figure(
 
 fig.update_layout(
     title="Life Expectancy in Europe: 1952 and 2002",
-    width=1000,
     height=1000,
     showlegend=False,
 )

--- a/doc/python/histograms.md
+++ b/doc/python/histograms.md
@@ -40,7 +40,7 @@ jupyter:
 In statistics, a [histogram](https://en.wikipedia.org/wiki/Histogram) is representation of the distribution of numerical data, where the data are binned and the count for each bin is represented. More generally, in Plotly a histogram is an aggregated bar chart, with several possible aggregation functions (e.g. sum, average, count...) which can be used to visualize data on categorical and date axes as well as linear axes.
 
 
-Alternatives to violin plots for visualizing distributions include [violin plots](https://plotly.com/python/violin/), [box plots](https://plotly.com/python/box-plots/), [ECDF plots](https://plotly.com/python/ecdf-plots/) and [strip charts](https://plotly.com/python/strip-charts/).
+Alternatives to histogram plots for visualizing distributions include [violin plots](https://plotly.com/python/violin/), [box plots](https://plotly.com/python/box-plots/), [ECDF plots](https://plotly.com/python/ecdf-plots/) and [strip charts](https://plotly.com/python/strip-charts/).
 
 > If you're looking instead for bar charts, i.e. representing *raw, unaggregated* data with rectangular
 bar, go to the [Bar Chart tutorial](/python/bar-charts/).


### PR DESCRIPTION
I spotted a little typo where it was written `violin` instead of `histogram`.