### PR TITLE
Remove deprecated numpy types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - Introduce group attributes for `scatter` trace i.e. `alignmentgroup`, `offsetgroup`, `scattermode` and `scattergap` [[#6381](https://github.com/plotly/plotly.js/pull/6381)],
       this feature was anonymously sponsored: thank you to our sponsor!
     - Add `marker.cornerradius` attribute to `treemap` trace [[#6351](https://github.com/plotly/plotly.js/pull/6351)]
+### Fixed
+  - Fixed the usage of sume deprecated NumPy types which were removed in NumPy 1.24 [[#3997](https://github.com/plotly/plotly.py/pull/3997)]
 
 ## [5.11.0] - 2022-10-27
 

--- a/packages/python/plotly/_plotly_utils/tests/validators/test_integer_validator.py
+++ b/packages/python/plotly/_plotly_utils/tests/validators/test_integer_validator.py
@@ -58,7 +58,7 @@ def test_acceptance_min_max(val, validator_min_max):
 
 
 @pytest.mark.parametrize(
-    "val", [-1.01, -10, 2.1, 3, np.iinfo(np.int).max, np.iinfo(np.int).min]
+    "val", [-1.01, -10, 2.1, 3, np.iinfo(int).max, np.iinfo(int).min]
 )
 def test_rejection_min_max(val, validator_min_max):
     with pytest.raises(ValueError) as validation_failure:

--- a/packages/python/plotly/plotly/express/imshow_utils.py
+++ b/packages/python/plotly/plotly/express/imshow_utils.py
@@ -21,7 +21,6 @@ _integer_types = (
 _integer_ranges = {t: (np.iinfo(t).min, np.iinfo(t).max) for t in _integer_types}
 dtype_range = {
     np.bool_: (False, True),
-    np.bool8: (False, True),
     np.float16: (-1, 1),
     np.float32: (-1, 1),
     np.float64: (-1, 1),

--- a/packages/python/plotly/plotly/figure_factory/_streamline.py
+++ b/packages/python/plotly/plotly/figure_factory/_streamline.py
@@ -180,11 +180,11 @@ class _Streamline(object):
         Set up for RK4 function, based on Bokeh's streamline code
         """
         if isinstance(xi, np.ndarray):
-            self.x = xi.astype(np.int)
-            self.y = yi.astype(np.int)
+            self.x = xi.astype(int)
+            self.y = yi.astype(int)
         else:
-            self.val_x = np.int(xi)
-            self.val_y = np.int(yi)
+            self.val_x = int(xi)
+            self.val_y = int(yi)
         a00 = a[self.val_y, self.val_x]
         a01 = a[self.val_y, self.val_x + 1]
         a10 = a[self.val_y + 1, self.val_x]

--- a/packages/python/plotly/plotly/figure_factory/_violin.py
+++ b/packages/python/plotly/plotly/figure_factory/_violin.py
@@ -16,7 +16,7 @@ def calc_stats(data):
     """
     Calculate statistics for use in violin plot.
     """
-    x = np.asarray(data, np.float)
+    x = np.asarray(data, float)
     vals_min = np.min(x)
     vals_max = np.max(x)
     q2 = np.percentile(x, 50, interpolation="linear")
@@ -160,7 +160,7 @@ def violinplot(vals, fillcolor="#1f77b4", rugplot=True):
     """
     Refer to FigureFactory.create_violin() for docstring.
     """
-    vals = np.asarray(vals, np.float)
+    vals = np.asarray(vals, float)
     #  summary statistics
     vals_min = calc_stats(vals)["min"]
     vals_max = calc_stats(vals)["max"]
@@ -231,7 +231,7 @@ def violin_no_colorscale(
     )
     color_index = 0
     for k, gr in enumerate(group_name):
-        vals = np.asarray(gb.get_group(gr)[data_header], np.float)
+        vals = np.asarray(gb.get_group(gr)[data_header], float)
         if color_index >= len(colors):
             color_index = 0
         plot_data, plot_xrange = violinplot(
@@ -319,7 +319,7 @@ def violin_colorscale(
     min_value = min(group_stats_values)
 
     for k, gr in enumerate(group_name):
-        vals = np.asarray(gb.get_group(gr)[data_header], np.float)
+        vals = np.asarray(gb.get_group(gr)[data_header], float)
 
         # find intermediate color from colorscale
         intermed = (group_stats[gr] - min_value) / (max_value - min_value)
@@ -411,7 +411,7 @@ def violin_dict(
     )
 
     for k, gr in enumerate(group_name):
-        vals = np.asarray(gb.get_group(gr)[data_header], np.float)
+        vals = np.asarray(gb.get_group(gr)[data_header], float)
         plot_data, plot_xrange = violinplot(vals, fillcolor=colors[gr], rugplot=rugplot)
         layout = graph_objs.Layout()
 

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_imshow.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_imshow.py
@@ -9,7 +9,7 @@ import datetime
 from plotly.express.imshow_utils import rescale_intensity
 
 img_rgb = np.array([[[255, 0, 0], [0, 255, 0], [0, 0, 255]]], dtype=np.uint8)
-img_gray = np.arange(100, dtype=np.float).reshape((10, 10))
+img_gray = np.arange(100, dtype=float).reshape((10, 10))
 
 
 def decode_image_string(image_string):
@@ -47,7 +47,7 @@ def test_automatic_zmax_from_dtype():
     dtypes_dict = {
         np.uint8: 2**8 - 1,
         np.uint16: 2**16 - 1,
-        np.float: 1,
+        float: 1,
         bool: 255,
     }
     for key, val in dtypes_dict.items():

--- a/packages/python/plotly/plotly/tests/test_optional/test_utils/test_utils.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_utils/test_utils.py
@@ -414,8 +414,8 @@ class TestNumpyIntegerBaseType(TestCase):
         import plotly.graph_objects as go
         from plotly.subplots import make_subplots
 
-        indices_rows = np.array([1], dtype=np.int)
-        indices_cols = np.array([1], dtype=np.int)
+        indices_rows = np.array([1], dtype=int)
+        indices_cols = np.array([1], dtype=int)
         fig = make_subplots(rows=1, cols=1)
         fig.add_trace(go.Scatter(y=[1]), row=indices_rows[0], col=indices_cols[0])
 


### PR DESCRIPTION
# Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if ~~my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.~~
- [X] I have *modified* existing tests.
- [ ] ~~For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).~~
- [X] I have added a CHANGELOG entry if fixing/changing/adding anything substantial. 
- [ ] ~~For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).~~


Fixes #3989
Fixes #3991

NumPy deprecated these aliases in 1.20 and removed them in 1.24
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

