### PR TITLE
angle can now be arrayOK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
   - Fixed the usage of some deprecated NumPy types which were removed in NumPy 1.24 [[#3997](https://github.com/plotly/plotly.py/pull/3997)]
   - Fixed bug for trendlines with datetime axes [[#3683](https://github.com/plotly/plotly.py/issues/3683)]
+  - `marker.angle` attribute now accepts iterables where appropriate [[#4013](https://github.com/plotly/plotly.py/issues/4013)]
 
 ## [5.11.0] - 2022-10-27
 

--- a/packages/python/plotly/_plotly_utils/basevalidators.py
+++ b/packages/python/plotly/_plotly_utils/basevalidators.py
@@ -1660,15 +1660,17 @@ class AngleValidator(BaseValidator):
         "description": "A number (in degree) between -180 and 180.",
         "requiredOpts": [],
         "otherOpts": [
-            "dflt"
+            "dflt",
+            "arrayOk"
         ]
     },
     """
 
-    def __init__(self, plotly_name, parent_name, **kwargs):
+    def __init__(self, plotly_name, parent_name, array_ok=False, **kwargs):
         super(AngleValidator, self).__init__(
             plotly_name=plotly_name, parent_name=parent_name, **kwargs
         )
+        self.array_ok = array_ok
 
     def description(self):
         desc = """\
@@ -1686,6 +1688,20 @@ class AngleValidator(BaseValidator):
         if v is None:
             # Pass None through
             pass
+        elif self.array_ok and is_homogeneous_array(v):
+            try:
+                v_array = copy_to_readonly_numpy_array(v, force_numeric=True)
+            except (ValueError, TypeError, OverflowError):
+                self.raise_invalid_val(v)
+            v = v_array  # Always numeric numpy array
+        elif self.array_ok and is_simple_array(v):
+            # Check numeric
+            invalid_els = [e for e in v if not isinstance(e, numbers.Number)]
+
+            if invalid_els:
+                self.raise_invalid_elements(invalid_els[:10])
+
+            v = to_scalar_or_list(v)
         elif not isinstance(v, numbers.Number):
             self.raise_invalid_val(v)
         else:

--- a/packages/python/plotly/_plotly_utils/basevalidators.py
+++ b/packages/python/plotly/_plotly_utils/basevalidators.py
@@ -1675,11 +1675,14 @@ class AngleValidator(BaseValidator):
     def description(self):
         desc = """\
     The '{plotly_name}' property is a angle (in degrees) that may be
-    specified as a number between -180 and 180. Numeric values outside this
-    range are converted to the equivalent value
+    specified as a number between -180 and 180{array_ok}.
+    Numeric values outside this range are converted to the equivalent value
     (e.g. 270 is converted to -90).
         """.format(
-            plotly_name=self.plotly_name
+            plotly_name=self.plotly_name,
+            array_ok=", or a list, numpy array or other iterable thereof"
+            if self.array_ok
+            else "",
         )
 
         return desc

--- a/packages/python/plotly/_plotly_utils/basevalidators.py
+++ b/packages/python/plotly/_plotly_utils/basevalidators.py
@@ -1694,6 +1694,8 @@ class AngleValidator(BaseValidator):
             except (ValueError, TypeError, OverflowError):
                 self.raise_invalid_val(v)
             v = v_array  # Always numeric numpy array
+            # Normalize v onto the interval [-180, 180)
+            v = (v + 180) % 360 - 180
         elif self.array_ok and is_simple_array(v):
             # Check numeric
             invalid_els = [e for e in v if not isinstance(e, numbers.Number)]
@@ -1701,7 +1703,7 @@ class AngleValidator(BaseValidator):
             if invalid_els:
                 self.raise_invalid_elements(invalid_els[:10])
 
-            v = to_scalar_or_list(v)
+            v = [(x + 180) % 360 - 180 for x in to_scalar_or_list(v)]
         elif not isinstance(v, numbers.Number):
             self.raise_invalid_val(v)
         else:

--- a/packages/python/plotly/_plotly_utils/tests/validators/test_angle_validator.py
+++ b/packages/python/plotly/_plotly_utils/tests/validators/test_angle_validator.py
@@ -7,9 +7,14 @@ import numpy as np
 
 # Fixtures
 # --------
-@pytest.fixture()
-def validator():
+@pytest.fixture
+def validator(request):
     return AngleValidator("prop", "parent")
+
+
+@pytest.fixture
+def validator_aok(request):
+    return AngleValidator("prop", "parent", array_ok=True)
 
 
 # Tests
@@ -36,3 +41,32 @@ def test_rejection(val, validator):
         validator.validate_coerce(val)
 
     assert "Invalid value" in str(validation_failure.value)
+
+
+# ### Test acceptance ###
+@pytest.mark.parametrize("val", [[0, 179, -179]])
+def test_aok_acceptance(val, validator_aok):
+    assert validator_aok.validate_coerce(val) == val
+    assert validator_aok.validate_coerce(tuple(val)) == val
+    assert np.array_equal(validator_aok.validate_coerce(np.array(val)), np.array(val))
+
+
+# ### Test coercion above 180 ###
+@pytest.mark.parametrize(
+    "val,expected",
+    [(180, -180), (181, -179), (-180.25, 179.75), (540, -180), (-541, 179)],
+)
+def test_aok_coercion(val, expected, validator_aok):
+    assert validator_aok.validate_coerce([val]) == [expected]
+    assert np.array_equal(
+        validator_aok.validate_coerce(np.array([val])), np.array([expected])
+    )
+
+
+# ### Test rejection ###
+@pytest.mark.parametrize("val", [["hello"], [()], [[]], [set()], ["34"]])
+def test_aok_rejection(val, validator_aok):
+    with pytest.raises(ValueError) as validation_failure:
+        validator_aok.validate_coerce(val)
+
+    assert "Invalid element(s)" in str(validation_failure.value)

--- a/packages/python/plotly/plotly/graph_objs/_bar.py
+++ b/packages/python/plotly/plotly/graph_objs/_bar.py
@@ -1374,8 +1374,8 @@ class Bar(_BaseTraceType):
         the maximum size in bars.
 
         The 'textangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/_funnel.py
+++ b/packages/python/plotly/plotly/graph_objs/_funnel.py
@@ -1150,8 +1150,8 @@ class Funnel(_BaseTraceType):
         the maximum size in bars.
 
         The 'textangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/_histogram.py
+++ b/packages/python/plotly/plotly/graph_objs/_histogram.py
@@ -1450,8 +1450,8 @@ class Histogram(_BaseTraceType):
         the maximum size in bars.
 
         The 'textangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/_parcoords.py
+++ b/packages/python/plotly/plotly/graph_objs/_parcoords.py
@@ -302,8 +302,8 @@ class Parcoords(_BaseTraceType):
         margins when `labelposition` is set to "bottom".
 
         The 'labelangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/_pie.py
+++ b/packages/python/plotly/plotly/graph_objs/_pie.py
@@ -970,8 +970,8 @@ class Pie(_BaseTraceType):
         some other angle.
 
         The 'rotation' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/_sunburst.py
+++ b/packages/python/plotly/plotly/graph_objs/_sunburst.py
@@ -1065,8 +1065,8 @@ class Sunburst(_BaseTraceType):
         default the first slice starts at 3 o'clock.
 
         The 'rotation' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/_waterfall.py
+++ b/packages/python/plotly/plotly/graph_objs/_waterfall.py
@@ -1173,8 +1173,8 @@ class Waterfall(_BaseTraceType):
         the maximum size in bars.
 
         The 'textangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/bar/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/bar/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/barpolar/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/barpolar/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/box/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/box/_marker.py
@@ -26,8 +26,8 @@ class Marker(_BaseTraceHierarchyType):
         Sets the marker angle in respect to `angleref`.
 
         The 'angle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/carpet/_aaxis.py
+++ b/packages/python/plotly/plotly/graph_objs/carpet/_aaxis.py
@@ -1253,8 +1253,8 @@ class Aaxis(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/carpet/_baxis.py
+++ b/packages/python/plotly/plotly/graph_objs/carpet/_baxis.py
@@ -1253,8 +1253,8 @@ class Baxis(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/choropleth/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/choropleth/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/choroplethmapbox/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/choroplethmapbox/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/cone/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/cone/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/contour/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/contour/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/contourcarpet/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/contourcarpet/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/densitymapbox/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/densitymapbox/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/funnel/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/funnel/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/heatmap/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/heatmap/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/heatmapgl/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/heatmapgl/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/histogram/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/histogram2d/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram2d/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/histogram2dcontour/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/histogram2dcontour/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/icicle/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/icicle/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/indicator/gauge/_axis.py
+++ b/packages/python/plotly/plotly/graph_objs/indicator/gauge/_axis.py
@@ -319,8 +319,8 @@ class Axis(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/isosurface/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/isosurface/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/layout/_annotation.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/_annotation.py
@@ -918,8 +918,8 @@ class Annotation(_BaseLayoutHierarchyType):
         horizontal.
 
         The 'textangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/layout/_xaxis.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/_xaxis.py
@@ -1859,8 +1859,8 @@ class XAxis(_BaseLayoutHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/layout/_yaxis.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/_yaxis.py
@@ -1782,8 +1782,8 @@ class YAxis(_BaseLayoutHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/layout/coloraxis/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/coloraxis/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseLayoutHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/layout/polar/_angularaxis.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/polar/_angularaxis.py
@@ -631,8 +631,8 @@ class AngularAxis(_BaseLayoutHierarchyType):
         corresponds to due North (like on a compass),
 
         The 'rotation' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns
@@ -854,8 +854,8 @@ class AngularAxis(_BaseLayoutHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/layout/polar/_radialaxis.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/polar/_radialaxis.py
@@ -75,8 +75,8 @@ class RadialAxis(_BaseLayoutHierarchyType):
         angle.
 
         The 'angle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns
@@ -920,8 +920,8 @@ class RadialAxis(_BaseLayoutHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/_annotation.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/_annotation.py
@@ -790,8 +790,8 @@ class Annotation(_BaseLayoutHierarchyType):
         horizontal.
 
         The 'textangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/_xaxis.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/_xaxis.py
@@ -1071,8 +1071,8 @@ class XAxis(_BaseLayoutHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/_yaxis.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/_yaxis.py
@@ -1071,8 +1071,8 @@ class YAxis(_BaseLayoutHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/layout/scene/_zaxis.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/scene/_zaxis.py
@@ -1071,8 +1071,8 @@ class ZAxis(_BaseLayoutHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/layout/smith/_realaxis.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/smith/_realaxis.py
@@ -477,8 +477,8 @@ class Realaxis(_BaseLayoutHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/layout/ternary/_aaxis.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/ternary/_aaxis.py
@@ -671,8 +671,8 @@ class Aaxis(_BaseLayoutHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/layout/ternary/_baxis.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/ternary/_baxis.py
@@ -671,8 +671,8 @@ class Baxis(_BaseLayoutHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/layout/ternary/_caxis.py
+++ b/packages/python/plotly/plotly/graph_objs/layout/ternary/_caxis.py
@@ -671,8 +671,8 @@ class Caxis(_BaseLayoutHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/mesh3d/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/mesh3d/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/parcats/line/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/parcats/line/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/parcoords/line/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/parcoords/line/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scatter/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter/_marker.py
@@ -48,8 +48,8 @@ class Marker(_BaseTraceHierarchyType):
         Sets the marker angle in respect to `angleref`.
 
         The 'angle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180, or a list, numpy array or other iterable thereof.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scatter/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/line/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/line/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scatter3d/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/scatter3d/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scattercarpet/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scattercarpet/_marker.py
@@ -48,8 +48,8 @@ class Marker(_BaseTraceHierarchyType):
         Sets the marker angle in respect to `angleref`.
 
         The 'angle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180, or a list, numpy array or other iterable thereof.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scattercarpet/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/scattercarpet/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scattergeo/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergeo/_marker.py
@@ -47,8 +47,8 @@ class Marker(_BaseTraceHierarchyType):
         Sets the marker angle in respect to `angleref`.
 
         The 'angle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180, or a list, numpy array or other iterable thereof.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scattergeo/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergeo/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scattergl/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergl/_marker.py
@@ -43,8 +43,8 @@ class Marker(_BaseTraceHierarchyType):
         Sets the marker angle in respect to `angleref`.
 
         The 'angle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180, or a list, numpy array or other iterable thereof.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scattergl/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/scattergl/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scattermapbox/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/scattermapbox/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scatterpolar/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolar/_marker.py
@@ -48,8 +48,8 @@ class Marker(_BaseTraceHierarchyType):
         Sets the marker angle in respect to `angleref`.
 
         The 'angle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180, or a list, numpy array or other iterable thereof.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scatterpolar/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolar/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scatterpolargl/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolargl/_marker.py
@@ -43,8 +43,8 @@ class Marker(_BaseTraceHierarchyType):
         Sets the marker angle in respect to `angleref`.
 
         The 'angle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180, or a list, numpy array or other iterable thereof.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scatterpolargl/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterpolargl/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scattersmith/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scattersmith/_marker.py
@@ -48,8 +48,8 @@ class Marker(_BaseTraceHierarchyType):
         Sets the marker angle in respect to `angleref`.
 
         The 'angle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180, or a list, numpy array or other iterable thereof.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scattersmith/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/scattersmith/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scatterternary/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterternary/_marker.py
@@ -48,8 +48,8 @@ class Marker(_BaseTraceHierarchyType):
         Sets the marker angle in respect to `angleref`.
 
         The 'angle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180, or a list, numpy array or other iterable thereof.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/scatterternary/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/scatterternary/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/splom/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/splom/_marker.py
@@ -43,8 +43,8 @@ class Marker(_BaseTraceHierarchyType):
         Sets the marker angle in respect to `angleref`.
 
         The 'angle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180, or a list, numpy array or other iterable thereof.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/splom/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/splom/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/streamtube/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/streamtube/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/sunburst/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/sunburst/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/surface/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/surface/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/treemap/marker/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/treemap/marker/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/violin/_marker.py
+++ b/packages/python/plotly/plotly/graph_objs/violin/_marker.py
@@ -26,8 +26,8 @@ class Marker(_BaseTraceHierarchyType):
         Sets the marker angle in respect to `angleref`.
 
         The 'angle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns

--- a/packages/python/plotly/plotly/graph_objs/volume/_colorbar.py
+++ b/packages/python/plotly/plotly/graph_objs/volume/_colorbar.py
@@ -640,8 +640,8 @@ class ColorBar(_BaseTraceHierarchyType):
         labels vertically.
 
         The 'tickangle' property is a angle (in degrees) that may be
-        specified as a number between -180 and 180. Numeric values outside this
-        range are converted to the equivalent value
+        specified as a number between -180 and 180.
+        Numeric values outside this range are converted to the equivalent value
         (e.g. 270 is converted to -90).
 
         Returns


### PR DESCRIPTION
<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

-->
