### PR TITLE
Fix #4019

### DIFF
--- a/packages/python/plotly/plotly/io/_html.py
+++ b/packages/python/plotly/plotly/io/_html.py
@@ -542,7 +542,7 @@ def write_html(
         bundle_path = path.parent / "plotly.min.js"
 
         if not bundle_path.exists():
-            bundle_path.write_text(get_plotlyjs())
+            bundle_path.write_text(get_plotlyjs(), encoding="utf-8")
 
     # Handle auto_open
     if path is not None and full_html and auto_open:


### PR DESCRIPTION
Explicitly encode plotly.min.js content as utf-8, since get_plotlyjs returns utf-8 decoded content.
