### PR TITLE
Fix dropdowns.md example

### DIFF
--- a/doc/python/dropdowns.md
+++ b/doc/python/dropdowns.md
@@ -5,10 +5,10 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.2'
-      jupytext_version: 1.3.2
+      format_version: '1.3'
+      jupytext_version: 1.14.1
   kernelspec:
-    display_name: Python 3
+    display_name: Python 3 (ipykernel)
     language: python
     name: python3
   language_info:
@@ -20,7 +20,7 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.7.3
+    version: 3.8.0
   plotly:
     description: How to add dropdowns to update Plotly chart attributes in Python.
     display_as: controls
@@ -362,26 +362,26 @@ fig = go.Figure()
 # Add Traces
 
 fig.add_trace(
-    go.Scatter(x=list(df.index),
+    go.Scatter(x=list(df.Date),
                y=list(df.High),
                name="High",
                line=dict(color="#33CFA5")))
 
 fig.add_trace(
-    go.Scatter(x=list(df.index),
+    go.Scatter(x=list(df.Date),
                y=[df.High.mean()] * len(df.index),
                name="High Average",
                visible=False,
                line=dict(color="#33CFA5", dash="dash")))
 
 fig.add_trace(
-    go.Scatter(x=list(df.index),
+    go.Scatter(x=list(df.Date),
                y=list(df.Low),
                name="Low",
                line=dict(color="#F06A6A")))
 
 fig.add_trace(
-    go.Scatter(x=list(df.index),
+    go.Scatter(x=list(df.Date),
                y=[df.Low.mean()] * len(df.index),
                name="Low Average",
                visible=False,
@@ -393,17 +393,17 @@ high_annotations = [dict(x="2016-03-01",
                          xref="x", yref="y",
                          text="High Average:<br> %.3f" % df.High.mean(),
                          ax=0, ay=-40),
-                    dict(x=df.High.idxmax(),
+                    dict(x=df.Date[df.High.idxmax()],
                          y=df.High.max(),
                          xref="x", yref="y",
                          text="High Max:<br> %.3f" % df.High.max(),
-                         ax=0, ay=-40)]
+                         ax=-40, ay=-40)]
 low_annotations = [dict(x="2015-05-01",
                         y=df.Low.mean(),
                         xref="x", yref="y",
                         text="Low Average:<br> %.3f" % df.Low.mean(),
                         ax=0, ay=40),
-                   dict(x=df.High.idxmin(),
+                   dict(x=df.Date[df.High.idxmin()],
                         y=df.Low.min(),
                         xref="x", yref="y",
                         text="Low Min:<br> %.3f" % df.Low.min(),


### PR DESCRIPTION
The example in its current form doesn't work as documented (which traces are visible change)

This PR updates the x axes values for the annotations so they are all dates.

----

### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [x] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [x] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [x] Every new/modified example is independently runnable
- [x] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [x] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [x] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [x] Data frames are always called `df`
- [x] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [x] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [x] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [x] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

