### PR TITLE
Add tickmode="sync" example

### DIFF
--- a/doc/python/multiple-axes.md
+++ b/doc/python/multiple-axes.md
@@ -352,5 +352,67 @@ fig.show()
 
 ```
 
+### Sync Axes Ticks
+
+*New in 5.13*
+
+
+When you have multiple axes overlayed, each axis by default has its own number of ticks. You can sync the number of ticks on an axis overlayed on another axis by setting `tickmode="sync"`. In this example, we sync the ticks on the `"Total bill amount"` axis with the `"Total number of diners"` axis that it overlays. 
+
+```python
+import pandas as pd
+import plotly.graph_objects as go
+from plotly.data import tips
+
+df = tips()
+
+summed_values = df.groupby(by="day", as_index=False).sum(numeric_only=True)
+day_order_mapping = {"Thur": 0, "Fri": 1, "Sat": 2, "Sun": 3}
+summed_values["order"] = summed_values["day"].apply(lambda day: day_order_mapping[day])
+summed_values = summed_values.sort_values(by="order")
+
+days_of_week = summed_values["day"].values
+total_bills = summed_values["total_bill"].values
+number_of_diners = summed_values["size"].values
+
+
+fig = go.Figure(
+    data=go.Bar(
+        x=days_of_week,
+        y=number_of_diners,
+        name="Total number of diners",
+        marker=dict(color="paleturquoise"),
+    )
+)
+
+fig.add_trace(
+    go.Scatter(
+        x=days_of_week,
+        y=total_bills,
+        yaxis="y2",
+        name="Total bill amount",
+        marker=dict(color="crimson"),
+    )
+)
+
+fig.update_layout(
+    legend=dict(orientation="h"),
+    xaxis=dict(showgrid=True, ticklen=10, tickwidth=3),
+    yaxis=dict(
+        title=dict(text="Total number of diners"),
+        side="left",
+        range=[0, 250],
+    ),
+    yaxis2=dict(
+        title=dict(text="Total bill amount"),
+        side="right",
+        range=[0, 2000],
+        overlaying="y",
+        tickmode="auto",
+    ),
+)
+
+```
+
 #### Reference
 All of the y-axis properties are found here: https://plotly.com/python/reference/YAxis/.  For more information on creating subplots see the [Subplots in Python](/python/subplots/) section.

--- a/doc/python/multiple-axes.md
+++ b/doc/python/multiple-axes.md
@@ -396,7 +396,6 @@ fig.add_trace(
 
 fig.update_layout(
     legend=dict(orientation="h"),
-    xaxis=dict(showgrid=True, ticklen=10, tickwidth=3),
     yaxis=dict(
         title=dict(text="Total number of diners"),
         side="left",
@@ -410,6 +409,8 @@ fig.update_layout(
         tickmode="sync",
     ),
 )
+
+fig.show()
 
 ```
 

--- a/doc/python/multiple-axes.md
+++ b/doc/python/multiple-axes.md
@@ -354,10 +354,10 @@ fig.show()
 
 ### Sync Axes Ticks
 
+
 *New in 5.13*
 
-
-When you have multiple axes overlayed, each axis by default has its own number of ticks. You can sync the number of ticks on an axis overlayed on another axis by setting `tickmode="sync"`. In this example, we sync the ticks on the `"Total bill amount"` axis with the `"Total number of diners"` axis that it overlays. 
+With overlayed axes, each axis by default has its own number of ticks. You can sync the number of ticks on a cartesian axis with another one it overlays by setting `tickmode="sync"`. In this example, we sync the ticks on the `"Total bill amount"` axis with the `"Total number of diners"` axis that it overlays. 
 
 ```python
 import plotly.graph_objects as go

--- a/doc/python/multiple-axes.md
+++ b/doc/python/multiple-axes.md
@@ -360,7 +360,6 @@ fig.show()
 When you have multiple axes overlayed, each axis by default has its own number of ticks. You can sync the number of ticks on an axis overlayed on another axis by setting `tickmode="sync"`. In this example, we sync the ticks on the `"Total bill amount"` axis with the `"Total number of diners"` axis that it overlays. 
 
 ```python
-import pandas as pd
 import plotly.graph_objects as go
 from plotly.data import tips
 
@@ -408,7 +407,7 @@ fig.update_layout(
         side="right",
         range=[0, 2000],
         overlaying="y",
-        tickmode="auto",
+        tickmode="sync",
     ),
 )
 


### PR DESCRIPTION
Adds example for sync tickmode option from for Plotly.js 2.18.0 release:

https://github.com/plotly/plotly.js/releases/tag/v2.18.0

### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [x] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [x] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [x] Every new/modified example is independently runnable
- [x] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [x] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [x] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [x] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [x] `fig.show()` is at the end of each new/modified example
- [x] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [x] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)
