### PR TITLE
make moving-point-on-a-curve faster

### DIFF
--- a/doc/python/animations.md
+++ b/doc/python/animations.md
@@ -145,9 +145,7 @@ fig.show()
 
 ```python
 import plotly.graph_objects as go
-
 import numpy as np
-
 # Generate curve data
 t = np.linspace(-1, 1, 100)
 x = t + t ** 2
@@ -156,7 +154,7 @@ xm = np.min(x) - 1.5
 xM = np.max(x) + 1.5
 ym = np.min(y) - 1.5
 yM = np.max(y) + 1.5
-N = 50
+N = 25
 s = np.linspace(-1, 1, N)
 xx = s + s ** 2
 yy = s - s ** 2
@@ -167,26 +165,29 @@ fig = go.Figure(
     data=[go.Scatter(x=x, y=y,
                      mode="lines",
                      line=dict(width=2, color="blue")),
-          go.Scatter(x=x, y=y,
-                     mode="lines",
-                     line=dict(width=2, color="blue"))],
-    layout=go.Layout(
+          go.Scatter(x=[xx[0]], y=[yy[0]],
+                     mode="markers",
+                     marker=dict(color="red", size=10))])
+fig.update_layout(width=600, height=450,
         xaxis=dict(range=[xm, xM], autorange=False, zeroline=False),
         yaxis=dict(range=[ym, yM], autorange=False, zeroline=False),
-        title_text="Kinematic Generation of a Planar Curve", hovermode="closest",
-        updatemenus=[dict(type="buttons",
-                          buttons=[dict(label="Play",
-                                        method="animate",
-                                        args=[None])])]),
-    frames=[go.Frame(
-        data=[go.Scatter(
-            x=[xx[k]],
-            y=[yy[k]],
-            mode="markers",
-            marker=dict(color="red", size=10))])
-
-        for k in range(N)]
-)
+        title_text="Kinematic Generation of a Planar Curve", title_x=0.5, 
+        updatemenus = [dict(type = "buttons",
+        buttons = [
+            dict(
+                args = [None, {"frame": {"duration": 10, "redraw": False},
+                                "fromcurrent": True, "transition": {"duration": 10}}],
+                label = "Play",
+                method = "animate",
+                 
+                )])])
+       
+fig.update(frames=[go.Frame(
+                        data=[go.Scatter(
+                                   x=[xx[k]],
+                                   y=[yy[k]])],
+                        traces=[1]) # fig.data[1] is updated by each frame
+        for k in range(N)])
 
 fig.show()
 ```


### PR DESCRIPTION
proposed by empet [on the forum](https://community.plotly.com/t/faster-animation-than-with-duration-0/72083/2?u=adamschroeder). 

<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

-->
