### PR TITLE
Update grouped bar and scatter chart

### DIFF
--- a/doc/python/graphing-multiple-chart-types.md
+++ b/doc/python/graphing-multiple-chart-types.md
@@ -82,26 +82,49 @@ non_smoker_mean = mean_values_df[mean_values_df.smoker == "No"].sort_values(
 smoker = df[df.smoker == "Yes"].sort_values(by="tip", ascending=False)
 non_smoker = df[df.smoker == "No"].sort_values(by="tip", ascending=False)
 
-fig = go.Figure()
+fig = go.Figure(
+    layout=dict(
+        xaxis=dict(categoryorder="category descending"),
+        yaxis=dict(range=[0, 7]),
+        scattermode="group",
+        legend=dict(groupclick="toggleitem"),
+    )
+)
 
 fig.add_trace(
     go.Bar(
         x=smoker_mean.sex,
         y=smoker_mean.tip,
-        name="Average (Smoker)",
+        name="Average",
         marker_color="IndianRed",
         offsetgroup="smoker",
+        legendgroup="smoker",
+        legendgrouptitle_text="Smoker",
     )
 )
 
 
 fig.add_trace(
+    go.Scatter(
+        x=smoker.sex,
+        y=smoker.tip,
+        mode="markers",
+        name="Individual tips",
+        marker=dict(color="LightSlateGrey", size=5),
+        offsetgroup="smoker",
+        legendgroup="smoker",
+    )
+)
+
+fig.add_trace(
     go.Bar(
         x=non_smoker_mean.sex,
         y=non_smoker_mean.tip,
-        name="Average (Non-Smoker)",
+        name="Average",
         marker_color="LightSalmon",
         offsetgroup="non-smoker",
+        legendgroup="non-smoker",
+        legendgrouptitle_text="Non-Smoker",
     )
 )
 
@@ -111,27 +134,14 @@ fig.add_trace(
         x=non_smoker.sex,
         y=non_smoker.tip,
         mode="markers",
-        name="Individual tips (Non-Smoker)",
+        name="Individual tips",
         marker=dict(color="LightSteelBlue", size=5),
         offsetgroup="non-smoker",
+        legendgroup="non-smoker",
     )
 )
-
-fig.add_trace(
-    go.Scatter(
-        x=smoker.sex,
-        y=smoker.tip,
-        mode="markers",
-        name="Individual tips (Smoker)",
-        marker=dict(color="LightSlateGrey", size=5),
-        offsetgroup="smoker",
-    )
-)
-
-fig.update_layout(scattermode="group")
 
 fig.show()
-
 ```
 
 #### Line Chart and a Bar Chart


### PR DESCRIPTION
With the current example, the order of the bar groups changes if you deselect the scatter traces.
This PR sets a category_order to keep them consistent, a range to keep the range of the y axis consistent, and groups the Smoker/non-smoker traces together in the legend. 

### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [x] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [x] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [x] Every new/modified example is independently runnable
- [x] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [x] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [] The random seed is set if using randomly-generated data in new/modified examples
- [x] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [x] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [x] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [x] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [x] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [x] `fig.show()` is at the end of each new/modified example
- [x] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [x] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)
