### PR TITLE
Include Jupyter Lab directive to render

### DIFF
--- a/doc/python/getting-started.md
+++ b/doc/python/getting-started.md
@@ -132,6 +132,13 @@ $ jupyter lab
 and display plotly figures inline using the `plotly_mimetype` renderer...
 
 ```python
+import plotly.io as pio
+pio.renderers.default='iframe'
+```
+
+then 
+
+```python
 import plotly.express as px
 fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
 fig.show()


### PR DESCRIPTION
I am using Jupyter Lab 3.0.1. I followed the instructions here using plotly 5.13.0 but I was getting a blank white output. as below. Adding the directive mentioned made it render.
![image](https://user-images.githubusercontent.com/74888616/220406265-1f1fb1e2-d42d-4e73-9d2d-1874302d5faf.png)



### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [x] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [x] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [x] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [x] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [x] The random seed is set if using randomly-generated data in new/modified examples
- [x] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [x] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [x] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [x] Data frames are always called `df`
- [x] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [x] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [x] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [x] `fig.show()` is at the end of each new/modified example
- [x] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [x] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

