### PR TITLE
Dont precalculate key error

### DIFF
--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -4777,7 +4777,7 @@ class BasePlotlyType(object):
                 else:
                     return False
             else:
-                if obj is not None and p in obj._valid_props:
+                if hasattr(obj, '_valid_props') and p in obj._valid_props:
                     obj = obj[p]
                 else:
                     return False

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -3863,7 +3863,7 @@ Invalid property path '{key_path_str}' for layout
             # >>> layout.update(xaxis2={'title': 'xaxis 2'})
             for key in update_obj:
                 # special handling for missing keys that match _subplot_re_match
-                if not key in plotly_obj and isinstance(plotly_obj, BaseLayoutType):
+                if key not in plotly_obj and isinstance(plotly_obj, BaseLayoutType):
                     # try _subplot_re_match
                     match = plotly_obj._subplot_re_match(key)
                     if match:

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -3862,18 +3862,17 @@ Invalid property path '{key_path_str}' for layout
             # This should be valid even if xaxis2 hasn't been initialized:
             # >>> layout.update(xaxis2={'title': 'xaxis 2'})
             for key in update_obj:
+                # special handling for missing keys that match _subplot_re_match
+                if not key in plotly_obj and isinstance(plotly_obj, BaseLayoutType):
+                    # try _subplot_re_match
+                    match = plotly_obj._subplot_re_match(key)
+                    if match:
+                        # We need to create a subplotid object
+                        plotly_obj[key] = {}
+                        continue
+
                 err = _check_path_in_prop_tree(plotly_obj, key, error_cast=ValueError)
                 if err is not None:
-                    if isinstance(plotly_obj, BaseLayoutType):
-                        # try _subplot_re_match
-                        match = plotly_obj._subplot_re_match(key)
-                        if match:
-                            # We need to create a subplotid object
-                            plotly_obj[key] = {}
-                            continue
-                    # If no match, raise the error, which should already
-                    # contain the _raise_on_invalid_property_error
-                    # generated message
                     raise err
 
             # Convert update_obj to dict

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -4777,7 +4777,7 @@ class BasePlotlyType(object):
                 else:
                     return False
             else:
-                if hasattr(obj, '_valid_props') and p in obj._valid_props:
+                if hasattr(obj, "_valid_props") and p in obj._valid_props:
                     obj = obj[p]
                 else:
                     return False


### PR DESCRIPTION
## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [x] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

This PR is intended to address #4100 (adding many subplots takes a long time because of precalculating error string for new keys with Levenshtein distance to existing keys, even when that error is caught and discarded during normal operation of `update`)

I checked that the same tests pass with or without this PR applied, on `master`