### PR TITLE
require package packaging

### DIFF
--- a/packages/python/plotly/setup.py
+++ b/packages/python/plotly/setup.py
@@ -556,7 +556,7 @@ setup(
     data_files=[
         ("etc/jupyter/nbconfig/notebook.d", ["jupyterlab-plotly.json"]),
     ],
-    install_requires=["tenacity>=6.2.0"],
+    install_requires=["tenacity>=6.2.0", "packaging"],
     zip_safe=False,
     cmdclass=dict(
         build_py=js_prerelease(versioneer_cmds["build_py"]),


### PR DESCRIPTION
Fix #4080

Seems `packaging` is implicitly included by another dep in py3.7+, but not in py3.6

It turns out it would be very hard to write a test for this. `packaging` is installed in the `circleci/python` base images via `pip install poetry` so it'll always be there from the start. Maybe when we upgrade to `cimg` images they're cleaner?