### PR TITLE
Specify utf-8 in script tag

### DIFF
--- a/packages/python/plotly/plotly/io/_html.py
+++ b/packages/python/plotly/plotly/io/_html.py
@@ -272,7 +272,7 @@ def to_html(
     elif include_plotlyjs == "cdn":
         load_plotlyjs = """\
         {win_config}
-        <script src="{cdn_url}"></script>\
+        <script charset="utf-8" src="{cdn_url}"></script>\
     """.format(
             win_config=_window_plotly_config, cdn_url=plotly_cdn_url()
         )
@@ -280,7 +280,7 @@ def to_html(
     elif include_plotlyjs == "directory":
         load_plotlyjs = """\
         {win_config}
-        <script src="plotly.min.js"></script>\
+        <script charset="utf-8" src="plotly.min.js"></script>\
     """.format(
             win_config=_window_plotly_config
         )
@@ -288,7 +288,7 @@ def to_html(
     elif isinstance(include_plotlyjs, str) and include_plotlyjs.endswith(".js"):
         load_plotlyjs = """\
         {win_config}
-        <script src="{url}"></script>\
+        <script charset="utf-8" src="{url}"></script>\
     """.format(
             win_config=_window_plotly_config, url=include_plotlyjs_orig
         )

--- a/packages/python/plotly/plotly/tests/test_core/test_offline/test_offline.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_offline/test_offline.py
@@ -41,9 +41,11 @@ plotly_config_script = """\
 <script type="text/javascript">\
 window.PlotlyConfig = {MathJaxConfig: 'local'};</script>"""
 
-cdn_script = '<script src="{cdn_url}"></script>'.format(cdn_url=plotly_cdn_url())
+cdn_script = '<script charset="utf-8" src="{cdn_url}"></script>'.format(
+    cdn_url=plotly_cdn_url()
+)
 
-directory_script = '<script src="plotly.min.js"></script>'
+directory_script = '<script charset="utf-8" src="plotly.min.js"></script>'
 
 
 mathjax_cdn = "https://cdnjs.cloudflare.com" "/ajax/libs/mathjax/2.7.5/MathJax.js"

--- a/packages/python/plotly/plotly/tests/test_io/test_renderers.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_renderers.py
@@ -311,7 +311,9 @@ def test_repr_html(renderer):
     template = (
         '<div>                        <script type="text/javascript">'
         "window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n        "
-        '<script src="' + plotly_cdn_url() + '"></script>                '
+        '<script charset="utf-8" src="'
+        + plotly_cdn_url()
+        + '"></script>                '
         '<div id="cd462b94-79ce-42a2-887f-2650a761a144" class="plotly-graph-div" '
         'style="height:100%; width:100%;"></div>            <script type="text/javascript">'
         "                                    window.PLOTLYENV=window.PLOTLYENV || {};"


### PR DESCRIPTION
In our project ([Optuna](https://github.com/optuna/optuna)), plotly shows garbled text because of no specification for the encoding. This PR set charset to utf-8 in the script tag.


related issues:
- https://github.com/plotly/plotly.js/issues/5327
- https://github.com/plotly/plotly.js/issues/6491

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).
