### PR TITLE
Fix make_trace_kwargs error due to deprecated append method

### DIFF
--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -268,7 +268,7 @@ def make_trace_kwargs(args, trace_spec, trace_data, mapping_labels, sizeref):
         fit information to be used for trendlines
     """
     if "line_close" in args and args["line_close"]:
-        trace_data = trace_data.append(trace_data.iloc[0])
+        trace_data = pd.concat([trace_data, pd.DataFrame(trace_data.iloc[0]).T], axis=0)
     trace_patch = trace_spec.trace_patch.copy() or {}
     fit_results = None
     hover_header = ""


### PR DESCRIPTION
Very small update to [core.py](https://github.com/plotly/plotly.py/blob/master/packages/python/plotly/plotly/express/_core.py). Pandas has moved to 2.0, so `pd.DataFrame.append` is now deprecated and `make_trace_kwargs` throws an error.

Resolves #4025 and #4065
#4025 : concat is not a method of pd.DataFrame -- need to use pd.concat instead.
#4065: does not produce the desired output, as per example below:
```{python}
import numpy as np
import pandas as pd

# Create random 3x3 dataframe
df = pd.DataFrame(
    np.random.randint(0, 10, size=(3, 3)), 
    columns=['col1', 'col2', 'col3']
)

df_1 = pd.concat([df, df.iloc[0]], axis=0)
print(df_1)

>>>      col1  col2  col3    0
0      6.0   4.0   7.0  NaN
1      4.0   6.0   8.0  NaN
2      9.0   1.0   3.0  NaN
col1   NaN   NaN   NaN  6.0
col2   NaN   NaN   NaN  4.0
col3   NaN   NaN   NaN  7.0

df_2 = pd.concat([df, pd.DataFrame(df.iloc[0]).T], axis=0)
print(df_2)

>>>    col1  col2  col3
0     6     4     7
1     4     6     8
2     9     1     3
0     6     4     7
```
df_2 matches the behaviour of the old append method.


### Documentation PR

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).


