### PR TITLE
Px pandas2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,6 +275,8 @@ jobs:
             npx percy snapshot -c test/percy/snapshots.yml test/percy/
             rm test/percy/*.html
             rm -rf test/percy/pandas2
+      - store_artifacts:
+          path: test/percy
 
   # Chart studio
   python_37_chart_studio:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,15 +268,13 @@ jobs:
             pip install "pandas==1.1.5"
             python test/percy/plotly-express.py
             python test/percy/compare-pandas.py
+            rm -rf test/percy/pandas2
       - run:
           name: Run percy snapshots
           command: |
             npm i @percy/cli
             npx percy snapshot -c test/percy/snapshots.yml test/percy/
             rm test/percy/*.html
-            rm -rf test/percy/pandas2
-      - store_artifacts:
-          path: test/percy
 
   # Chart studio
   python_37_chart_studio:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,21 @@ commands:
             cd packages/python/plotly
             . venv/bin/activate
             pytest -x test_init/test_lazy_imports.py
-
+      - run:
+          name: Test PX if Pandas 2
+          command: |
+            if [ "<<parameters.py>>" == "39_pandas_2" ]; then
+              . packages/python/plotly/venv/bin/activate
+              pip install -e ./packages/python/plotly
+              pip install -e ./packages/python/plotly-geo
+              python test/percy/plotly-express.py
+              mkdir test/percy/pandas2
+              mv test/percy/*.html test/percy/pandas2/
+              # 1.1 is the earliest minor with Py3.9 wheels
+              pip install "pandas==1.1.5"
+              python test/percy/plotly-express.py
+              python test/percy/compare-pandas.py
+            fi
   test_orca:
     parameters:
       py:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,21 +92,6 @@ commands:
             cd packages/python/plotly
             . venv/bin/activate
             pytest -x test_init/test_lazy_imports.py
-      - run:
-          name: Test PX if Pandas 2
-          command: |
-            if [ "<<parameters.py>>" == "39_pandas_2" ]; then
-              . packages/python/plotly/venv/bin/activate
-              pip install -e ./packages/python/plotly
-              pip install -e ./packages/python/plotly-geo
-              python test/percy/plotly-express.py
-              mkdir test/percy/pandas2
-              mv test/percy/*.html test/percy/pandas2/
-              # 1.1 is the earliest minor with Py3.9 wheels
-              pip install "pandas==1.1.5"
-              python test/percy/plotly-express.py
-              python test/percy/compare-pandas.py
-            fi
   test_orca:
     parameters:
       py:
@@ -245,7 +230,7 @@ jobs:
   # Percy
   python_37_percy:
     docker:
-      - image: cimg/python:3.7-browsers
+      - image: cimg/python:3.9-browsers
         environment:
           PERCY_ENABLED: True
           PERCY_PROJECT: plotly/plotly.py
@@ -267,18 +252,29 @@ jobs:
             pip install --upgrade pip wheel
             pip install -e ./packages/python/plotly
             pip install -e ./packages/python/plotly-geo
-            pip install -r ./packages/python/plotly/test_requirements/requirements_37_optional.txt
+            pip install -r ./packages/python/plotly/test_requirements/requirements_39_pandas_2_optional.txt
       - run:
-          name: Build html figures
+          name: Build html figures (Pandas 2)
           command: |
             . venv/bin/activate
             python test/percy/plotly-express.py
+      - run:
+          name: Build html figures (Pandas 1) and compare
+          command: |
+            . venv/bin/activate
+            mkdir test/percy/pandas2
+            mv test/percy/*.html test/percy/pandas2/
+            # 1.1 is the earliest minor with Py3.9 wheels
+            pip install "pandas==1.1.5"
+            python test/percy/plotly-express.py
+            python test/percy/compare-pandas.py
       - run:
           name: Run percy snapshots
           command: |
             npm i @percy/cli
             npx percy snapshot -c test/percy/snapshots.yml test/percy/
             rm test/percy/*.html
+            rm -rf test/percy/pandas2
 
   # Chart studio
   python_37_chart_studio:

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ packages/python/plotly/jupyterlab_plotly/labextension/
 packages/python/plotly/jupyterlab_plotly/nbextension/index.js*
 
 test/percy/*.html
+test/percy/pandas2/*.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED]
+
+### Fixed
+  - Fixed another compatibility issue with Pandas 2.0, just affecting `px.*(line_close=True)` [[#4190](https://github.com/plotly/plotly.py/pull/4190)]
+
 ## [5.14.1] - 2023-04-05
 
 ### Fixed

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -268,7 +268,7 @@ def make_trace_kwargs(args, trace_spec, trace_data, mapping_labels, sizeref):
         fit information to be used for trendlines
     """
     if "line_close" in args and args["line_close"]:
-        trace_data = trace_data.append(trace_data.iloc[0])
+        trace_data = pd.concat([trace_data, trace_data.iloc[:1]])
     trace_patch = trace_spec.trace_patch.copy() or {}
     fit_results = None
     hover_header = ""

--- a/packages/python/plotly/test_requirements/requirements_39_pandas_2_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_39_pandas_2_optional.txt
@@ -1,6 +1,6 @@
 requests==2.25.1
 tenacity==6.2.0
-pandas==2.0.0
+pandas==2.0.1
 numpy==1.20.3
 xarray==0.17.0
 statsmodels

--- a/test/percy/compare-pandas.py
+++ b/test/percy/compare-pandas.py
@@ -4,17 +4,20 @@ import os
 
 os.chdir(os.path.dirname(__file__))
 
+
 def clean_float(numstr):
     # round numbers to 3 digits, to remove floating-point differences
     return round(float(numstr), 3)
 
+
 def get_fig(html):
     # strip off all the rest of the html and js
-    fig_str = html[html.index('[{', html.rindex('Plotly.newPlot(')):]
-    fig_str = fig_str[:fig_str.index('}    ') + 1]
-    data, layout, config = json.loads(f'[{fig_str}]', parse_float=clean_float)
+    fig_str = html[html.index("[{", html.rindex("Plotly.newPlot(")) :]
+    fig_str = fig_str[: fig_str.index("}    ") + 1]
+    data, layout, config = json.loads(f"[{fig_str}]", parse_float=clean_float)
     fig_dict = dict(data=data, layout=layout, config=config)
     return json.dumps(fig_dict, indent=2).splitlines(keepends=True)
+
 
 for filename in os.listdir("pandas2"):
     with open(filename, encoding="utf-8") as f1:
@@ -22,5 +25,5 @@ for filename in os.listdir("pandas2"):
             fig1 = get_fig(f1.read())
             fig2 = get_fig(f2.read())
             if any(l1 != l2 for l1, l2 in zip(fig1, fig2)):
-                print(''.join(difflib.unified_diff(fig1, fig2)))
+                print("".join(difflib.unified_diff(fig1, fig2)))
                 raise ValueError(f"Pandas 1/2 difference in {filename}")

--- a/test/percy/compare-pandas.py
+++ b/test/percy/compare-pandas.py
@@ -1,0 +1,8 @@
+import os
+
+os.chdir(os.path.dirname(__file__))
+
+for filename in os.listdir("pandas2"):
+    with open(filename, encoding="utf-8") as f:
+        with open(os.path.join("pandas2", filename)) as f2:
+            assert f.read() == f2.read(), f"Pandas 1/2 difference in {filename}"

--- a/test/percy/compare-pandas.py
+++ b/test/percy/compare-pandas.py
@@ -1,8 +1,26 @@
+import difflib
+import json
 import os
 
 os.chdir(os.path.dirname(__file__))
 
+def clean_float(numstr):
+    # round numbers to 3 digits, to remove floating-point differences
+    return round(float(numstr), 3)
+
+def get_fig(html):
+    # strip off all the rest of the html and js
+    fig_str = html[html.index('[{', html.rindex('Plotly.newPlot(')):]
+    fig_str = fig_str[:fig_str.index('}    ') + 1]
+    data, layout, config = json.loads(f'[{fig_str}]', parse_float=clean_float)
+    fig_dict = dict(data=data, layout=layout, config=config)
+    return json.dumps(fig_dict, indent=2).splitlines(keepends=True)
+
 for filename in os.listdir("pandas2"):
-    with open(filename, encoding="utf-8") as f:
+    with open(filename, encoding="utf-8") as f1:
         with open(os.path.join("pandas2", filename)) as f2:
-            assert f.read() == f2.read(), f"Pandas 1/2 difference in {filename}"
+            fig1 = get_fig(f1.read())
+            fig2 = get_fig(f2.read())
+            if any(l1 != l2 for l1, l2 in zip(fig1, fig2)):
+                print(''.join(difflib.unified_diff(fig1, fig2)))
+                raise ValueError(f"Pandas 1/2 difference in {filename}")


### PR DESCRIPTION
Fixes #4179 
Fixes #4065 

Pandas v2.0 removed `df.append`, need to change to `pd.concat`. Note that `pd.concat` has been available since at least [v0.13](https://pandas.pydata.org/pandas-docs/version/0.13/generated/pandas.concat.html) so there should be no issue with older versions _requiring_ that we use `df.append`.

Tested by having the `px` Percy tests generate the same HTML files with both `pandas==1.1.5` (the oldest version with a Py3.9 wheel) and `pandas==2.0.1` (latest) and check that the HTML is identical before shipping it off to Percy.

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [x] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
