### PR TITLE
Safe JSON

### DIFF
--- a/packages/python/plotly/plotly/io/_json.py
+++ b/packages/python/plotly/plotly/io/_json.py
@@ -57,16 +57,18 @@ def coerce_to_strict(const):
         return const
 
 
-_swap = (
+_swap_json = (
     ("<", "\\u003c"),
     (">", "\\u003e"),
     ("/", "\\u002f"),
+)
+_swap_orjson = _swap_json + (
     ("\u2028", "\\u2028"),
     ("\u2029", "\\u2029"),
 )
 
 
-def _safe(json_str):
+def _safe(json_str, _swap):
     out = json_str
     for unsafe_char, safe_char in _swap:
         if unsafe_char in out:
@@ -137,7 +139,9 @@ def to_json_plotly(plotly_object, pretty=False, engine=None):
 
         from _plotly_utils.utils import PlotlyJSONEncoder
 
-        return _safe(json.dumps(plotly_object, cls=PlotlyJSONEncoder, **opts))
+        return _safe(
+            json.dumps(plotly_object, cls=PlotlyJSONEncoder, **opts), _swap_json
+        )
     elif engine == "orjson":
         JsonConfig.validate_orjson()
         opts = orjson.OPT_NON_STR_KEYS | orjson.OPT_SERIALIZE_NUMPY
@@ -153,7 +157,9 @@ def to_json_plotly(plotly_object, pretty=False, engine=None):
 
         # Try without cleaning
         try:
-            return _safe(orjson.dumps(plotly_object, option=opts).decode("utf8"))
+            return _safe(
+                orjson.dumps(plotly_object, option=opts).decode("utf8"), _swap_orjson
+            )
         except TypeError:
             pass
 
@@ -163,7 +169,7 @@ def to_json_plotly(plotly_object, pretty=False, engine=None):
             datetime_allowed=True,
             modules=modules,
         )
-        return _safe(orjson.dumps(cleaned, option=opts).decode("utf8"))
+        return _safe(orjson.dumps(cleaned, option=opts).decode("utf8"), _swap_orjson)
 
 
 def to_json(fig, validate=True, pretty=False, remove_uids=True, engine=None):

--- a/packages/python/plotly/plotly/tests/test_io/test_to_from_plotly_json.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_to_from_plotly_json.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import json
 import datetime
+import re
 import sys
 from pytz import timezone
 from _plotly_utils.optional_imports import get_module
@@ -201,6 +202,14 @@ def test_datetime_arrays(datetime_array, engine, pretty):
 
     array_str = to_json_test(dt_values)
     expected = build_test_dict_string(array_str)
+    if orjson:
+        # orjson always serializes datetime64 to ns, but json will return either
+        # full seconds or microseconds, if the rest is zeros.
+        # we don't care about any trailing zeros
+        trailing_zeros = re.compile(r'[.]?0+"')
+        result = trailing_zeros.sub('"', result)
+        expected = trailing_zeros.sub('"', expected)
+
     assert result == expected
     check_roundtrip(result, engine=engine, pretty=pretty)
 

--- a/packages/python/plotly/test_requirements/requirements_37_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_37_optional.txt
@@ -19,3 +19,4 @@ matplotlib==2.2.3
 scikit-image==0.14.4
 psutil==5.7.0
 kaleido
+orjson==3.8.12

--- a/packages/python/plotly/test_requirements/requirements_39_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_39_optional.txt
@@ -19,3 +19,4 @@ matplotlib==2.2.3
 scikit-image==0.18.1
 psutil==5.7.0
 kaleido
+orjson==3.8.12


### PR DESCRIPTION
Fixing a possible XSS issue when our JSON is inserted into an HTML string. We could apply this just to `fig.to_html`, but to be even safer I'm applying it to all JSON serialization, in case users use a different mechanism to insert this into HTML.

Performance is a concern here, but in my testing except in really pathological situations these substitutions are a good deal faster than serialization even by `orjson`.

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.