### PR TITLE
Jupyterlab v4 take2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,7 +371,7 @@ jobs:
           name: Create conda environment
           command: |
             conda create -n env --yes python=3.9 conda-build conda-verify
-            conda install -n env -c conda-forge jupyterlab nodejs=16
+            conda install -n env -c conda-forge jupyterlab=3 nodejs=16
             conda init bash
             mkdir output
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed another compatibility issue with Pandas 2.0, just affecting `px.*(line_close=True)` [[#4190](https://github.com/plotly/plotly.py/pull/4190)]
   - Added some rounding to the `make_subplots` function to handle situations where the user-input specs cause the domain to exceed 1 by small amounts [[#4153](https://github.com/plotly/plotly.py/pull/4153)]
   - Sanitize JSON output to prevent an XSS vector when graphs are inserted directly into HTML [[#4196](https://github.com/plotly/plotly.py/pull/4196)]
+  - Remove `use_2to3` setuptools arg, which is invalid in the latest Python and setuptools versions [[#4206](https://github.com/plotly/plotly.py/pull/4206)]
 
 ## [5.14.1] - 2023-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Added some rounding to the `make_subplots` function to handle situations where the user-input specs cause the domain to exceed 1 by small amounts [[#4153](https://github.com/plotly/plotly.py/pull/4153)]
   - Sanitize JSON output to prevent an XSS vector when graphs are inserted directly into HTML [[#4196](https://github.com/plotly/plotly.py/pull/4196)]
   - Remove `use_2to3` setuptools arg, which is invalid in the latest Python and setuptools versions [[#4206](https://github.com/plotly/plotly.py/pull/4206)]
+  - Fix [#4066](https://github.com/plotly/plotly.py/issues/4066) JupyterLab v4 giving tiny default graph height [[#4227](https://github.com/plotly/plotly.py/pull/4227)]
 
 ## [5.14.1] - 2023-04-05
 

--- a/packages/javascript/jupyterlab-plotly/src/Figure.ts
+++ b/packages/javascript/jupyterlab-plotly/src/Figure.ts
@@ -849,6 +849,9 @@ export class FigureView extends DOMWidgetView {
     // the model is not directly mutated by the Plotly.js library.
     var initialTraces = _.cloneDeep(this.model.get("_data"));
     var initialLayout = _.cloneDeep(this.model.get("_layout"));
+    if (!initialLayout.height) {
+      initialLayout.height = 360;
+    }
     var config = this.model.get("_config");
     config.editSelection = false;
 

--- a/packages/javascript/jupyterlab-plotly/src/plotly-renderer.ts
+++ b/packages/javascript/jupyterlab-plotly/src/plotly-renderer.ts
@@ -126,12 +126,16 @@ export class RenderedPlotly extends Widget implements IRenderMime.IRenderer {
       | any
       | IPlotlySpec;
 
+    if (!layout.height) {
+      layout.height = 360;
+    }
+
     // Load plotly asynchronously
     const loadPlotly = async (): Promise<void> => {
       if (RenderedPlotly.Plotly === null) {
         RenderedPlotly.Plotly = await import("plotly.js/dist/plotly");
         RenderedPlotly._resolveLoadingPlotly();
-      } 
+      }
       return RenderedPlotly.loadingPlotly;
     };
 

--- a/packages/javascript/jupyterlab-plotly/style/index.css
+++ b/packages/javascript/jupyterlab-plotly/style/index.css
@@ -21,11 +21,6 @@
   overflow: hidden;
 }
 
-/* Output styles */
-.jp-OutputArea .jp-RenderedPlotly {
-  min-height: 360px;
-}
-
 /* Document icon */
 .jp-PlotlyIcon {
   background-image: var(--jp-icon-plotly);

--- a/packages/python/plotly/setup.cfg
+++ b/packages/python/plotly/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 description_file = README.md
-license_file = LICENSE.txt
+license_files = LICENSE.txt
 
 [bdist_wheel]
 universal=1


### PR DESCRIPTION
Putting #4217 on hold for now since I still have not managed to update any local env I create to Jupyterlab 4 successfully, let's go a different route: take from #4217 the fix that I _think_ will work for jupyterlab 4 https://github.com/plotly/plotly.py/commit/3b4b324b23f3819f665003c3432ad3c6d7fa9136 and the little setup fix https://github.com/plotly/plotly.py/commit/411d66a259aa2f1ba8b8b73529944b571fab9859, but pin our build process to jupyterlab 3 for now https://github.com/plotly/plotly.py/commit/8df887d6e3ceb338a2a65e3b02336bc4e64171e6. Turns out a full upgrade of the process to jupyterlab 4 entails also upgrading the build pipeline from Python 3.7 to 3.8 or later, so a bigger and riskier project than I want right now, and I can't find good information about whether the upgraded version of the extension will work with older versions of jupyterlab anyway.

Fortunately even for jupyterlab 3 users this change has a benefit: we previously set 360px as the minimum output height, but with this change that's just the default, if you set a smaller height that's what you'll get.

- [x] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
