### PR TITLE
np.int is a deprecated copy of the built-in int

### DIFF
--- a/packages/python/plotly/_plotly_utils/tests/validators/test_integer_validator.py
+++ b/packages/python/plotly/_plotly_utils/tests/validators/test_integer_validator.py
@@ -74,7 +74,7 @@ def test_acceptance_min(val, validator_min):
     assert validator_min.validate_coerce(val) == approx(val)
 
 
-@pytest.mark.parametrize("val", [-2, -123, np.iinfo(np.int).min])
+@pytest.mark.parametrize("val", [-2, -123, np.iinfo(int).min])
 def test_rejection_min(val, validator_min):
     with pytest.raises(ValueError) as validation_failure:
         validator_min.validate_coerce(val)


### PR DESCRIPTION
`np.int` [used to be a copy of the built-in `int`, but is removed](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations). A test relied on it, and now it just uses the built-in one.
If preferred, we could also specify to use the 32 bit or 64 bit one.

```
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the pre
cision. If you wish to review your current use, check the release note link for additional information
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [x] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [x] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [x] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

