### PR TITLE
Minor edit: remove Python 2 compatibility handling

### DIFF
--- a/packages/python/plotly/plotly/tests/test_io/test_renderers.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_renderers.py
@@ -389,6 +389,7 @@ def test_missing_webbrowser_module(fig1):
     Assert that no errors occur if the webbrowser module is absent
     """
     import builtins
+
     realimport = builtins.__import__
 
     def webbrowser_absent_import(name, globals, locals, fromlist, level):

--- a/packages/python/plotly/plotly/tests/test_io/test_renderers.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_renderers.py
@@ -388,10 +388,7 @@ def test_missing_webbrowser_module(fig1):
     """
     Assert that no errors occur if the webbrowser module is absent
     """
-    try:
-        import builtins
-    except ImportError:
-        import __builtin__ as builtins
+    import builtins
     realimport = builtins.__import__
 
     def webbrowser_absent_import(name, globals, locals, fromlist, level):


### PR DESCRIPTION
Recently I made this pull request: https://github.com/plotly/plotly.py/pull/4161, but I accidentally included some Python 2 compatibility fixes. We most likely will not be needing this, so this removes it again.