### PR TITLE
 pin `pydantic` version in requirements_39_pandas_2_optional.txt

### DIFF
--- a/packages/python/plotly/test_requirements/requirements_39_pandas_2_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_39_pandas_2_optional.txt
@@ -20,4 +20,5 @@ scikit-image==0.18.1
 psutil==5.7.0
 kaleido
 vaex
+pydantic<=1.10.11 # for vaex, see https://github.com/vaexio/vaex/issues/2384
 polars


### PR DESCRIPTION
Fix test failing with:
```
 pydantic.errors.PydanticImportError: `BaseSettings` has been moved to the `pydantic-settings` package
```

by pinning `pydantic` version. Used by `vaex`

See https://github.com/vaexio/vaex/issues/2384

----
## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

-->
