### PR TITLE
Add support for dataframes that have `toPandas` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Updated
 - Updated Plotly.js from version 2.24.1 to version 2.24.2. See the [plotly.js CHANGELOG](https://github.com/plotly/plotly.js/blob/master/CHANGELOG.md#2242----2023-06-09) for more information. These changes are reflected in the auto-generated `plotly.graph_objects` module.
 - `px` methods now accept data-frame-like objects that support a [dataframe interchange protocol](https://data-apis.org/dataframe-protocol/latest/index.html), such as polars, vaex, modin etc. This protocol has priority on `to_pandas` call, but will only be used if pandas>=2.0.2 is installed in the environment.
+- `px` methods now accept data-frame-like objects that support a `toPandas()` method.
 
 ## [5.15.0] - 2023-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Updated
 - Updated Plotly.js from version 2.24.1 to version 2.24.2. See the [plotly.js CHANGELOG](https://github.com/plotly/plotly.js/blob/master/CHANGELOG.md#2242----2023-06-09) for more information. These changes are reflected in the auto-generated `plotly.graph_objects` module.
 - `px` methods now accept data-frame-like objects that support a [dataframe interchange protocol](https://data-apis.org/dataframe-protocol/latest/index.html), such as polars, vaex, modin etc. This protocol has priority on `to_pandas` call, but will only be used if pandas>=2.0.2 is installed in the environment.
-- `px` methods now accept data-frame-like objects that support a `toPandas()` method, such as Spark DataFrames.
+- `px` methods now accept data-frame-like objects that support a `toPandas()` method, such as Spark DataFrames, or a `to_pandas_df()` method, such as Vaex DataFrames.
 
 ## [5.15.0] - 2023-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Updated
 - Updated Plotly.js from version 2.24.1 to version 2.24.2. See the [plotly.js CHANGELOG](https://github.com/plotly/plotly.js/blob/master/CHANGELOG.md#2242----2023-06-09) for more information. These changes are reflected in the auto-generated `plotly.graph_objects` module.
 - `px` methods now accept data-frame-like objects that support a [dataframe interchange protocol](https://data-apis.org/dataframe-protocol/latest/index.html), such as polars, vaex, modin etc. This protocol has priority on `to_pandas` call, but will only be used if pandas>=2.0.2 is installed in the environment.
-- `px` methods now accept data-frame-like objects that support a `toPandas()` method.
+- `px` methods now accept data-frame-like objects that support a `toPandas()` method, such as Spark DataFrames.
 
 ## [5.15.0] - 2023-06-08
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1428,8 +1428,9 @@ def build_dataframe(args, constructor):
             # def __dataframe__(self, ...):
             #   if not some_condition:
             #     self.to_pandas(...)
-            if not hasattr(df_not_pandas, "to_pandas") or hasattr(
-                df_not_pandas, "toPandas"
+            if not (
+                hasattr(df_not_pandas, "to_pandas")
+                or hasattr(df_not_pandas, "toPandas")
             ):
                 raise exc
             if hasattr(df_not_pandas, "toPandas"):

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1334,6 +1334,9 @@ def build_dataframe(args, constructor):
         elif hasattr(args["data_frame"], "toPandas"):
             args["data_frame"] = args["data_frame"].toPandas()
             columns = args["data_frame"].columns
+        elif hasattr(args["data_frame"], "to_pandas_df"):
+            args["data_frame"] = args["data_frame"].to_pandas_df()
+            columns = args["data_frame"].columns
         else:
             args["data_frame"] = pd.DataFrame(args["data_frame"])
             columns = args["data_frame"].columns
@@ -1431,10 +1434,13 @@ def build_dataframe(args, constructor):
             if not (
                 hasattr(df_not_pandas, "to_pandas")
                 or hasattr(df_not_pandas, "toPandas")
+                or hasattr(df_not_pandas, "to_pandas_df")
             ):
                 raise exc
             if hasattr(df_not_pandas, "toPandas"):
                 args["data_frame"] = df_not_pandas.toPandas()
+            elif hasattr(df_not_pandas, "to_pandas_df"):
+                args["data_frame"] = df_not_pandas.to_pandas_df()
             else:
                 args["data_frame"] = df_not_pandas.to_pandas()
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1331,6 +1331,9 @@ def build_dataframe(args, constructor):
         elif hasattr(args["data_frame"], "to_pandas"):
             args["data_frame"] = args["data_frame"].to_pandas()
             columns = args["data_frame"].columns
+        elif hasattr(args["data_frame"], "toPandas"):
+            args["data_frame"] = args["data_frame"].toPandas()
+            columns = args["data_frame"].columns
         else:
             args["data_frame"] = pd.DataFrame(args["data_frame"])
             columns = args["data_frame"].columns
@@ -1425,9 +1428,14 @@ def build_dataframe(args, constructor):
             # def __dataframe__(self, ...):
             #   if not some_condition:
             #     self.to_pandas(...)
-            if not hasattr(df_not_pandas, "to_pandas"):
+            if not hasattr(df_not_pandas, "to_pandas") or hasattr(
+                df_not_pandas, "toPandas"
+            ):
                 raise exc
-            args["data_frame"] = df_not_pandas.to_pandas()
+            if hasattr(df_not_pandas, "toPandas"):
+                args["data_frame"] = df_not_pandas.toPandas()
+            else:
+                args["data_frame"] = df_not_pandas.to_pandas()
 
     df_input = args["data_frame"]
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1431,18 +1431,14 @@ def build_dataframe(args, constructor):
             # def __dataframe__(self, ...):
             #   if not some_condition:
             #     self.to_pandas(...)
-            if not (
-                hasattr(df_not_pandas, "to_pandas")
-                or hasattr(df_not_pandas, "toPandas")
-                or hasattr(df_not_pandas, "to_pandas_df")
-            ):
-                raise exc
             if hasattr(df_not_pandas, "toPandas"):
                 args["data_frame"] = df_not_pandas.toPandas()
             elif hasattr(df_not_pandas, "to_pandas_df"):
                 args["data_frame"] = df_not_pandas.to_pandas_df()
-            else:
+            elif hasattr(df_not_pandas, "to_pandas"):
                 args["data_frame"] = df_not_pandas.to_pandas()
+            else:
+                raise exc
 
     df_input = args["data_frame"]
 


### PR DESCRIPTION
Add support for dataframes that have `toPandas` method



## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [x] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

