### PR TITLE
Consider necessary columns from complex arguments when interchanging dataframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## UNRELEASED
+
+### Fixed
+- Fixed issue with necessary columns from complex arguments dropped when interchanging dataframes [[#4324](https://github.com/plotly/plotly.py/pull/4324)]
 
 ## [5.16.0] - 2023-08-11
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1419,9 +1419,17 @@ def build_dataframe(args, constructor):
             else:
                 # Save precious resources by only interchanging columns that are
                 # actually going to be plotted.
-                columns = [
+                necessary_columns = [
                     i for i in args.values() if isinstance(i, str) and i in columns
                 ]
+                for field in args:
+                    if field in array_attrables and isinstance(
+                        args[field], (list, dict)
+                    ):
+                        necessary_columns.extend(
+                            [i for i in args[field] if i in columns]
+                        )
+                columns = list(dict.fromkeys(necessary_columns))
                 args["data_frame"] = pd.api.interchange.from_dataframe(
                     args["data_frame"].select_columns_by_name(columns)
                 )

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1423,9 +1423,7 @@ def build_dataframe(args, constructor):
                     i for i in args.values() if isinstance(i, str) and i in columns
                 ]
                 for field in args:
-                    if field in array_attrables and isinstance(
-                        args[field], (list, dict)
-                    ):
+                    if args[field] is not None and field in array_attrables:
                         necessary_columns.extend(
                             [i for i in args[field] if i in columns]
                         )

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1419,15 +1419,13 @@ def build_dataframe(args, constructor):
             else:
                 # Save precious resources by only interchanging columns that are
                 # actually going to be plotted.
-                necessary_columns = [
+                necessary_columns = {
                     i for i in args.values() if isinstance(i, str) and i in columns
-                ]
+                }
                 for field in args:
                     if args[field] is not None and field in array_attrables:
-                        necessary_columns.extend(
-                            [i for i in args[field] if i in columns]
-                        )
-                columns = list(dict.fromkeys(necessary_columns))
+                        necessary_columns.update(i for i in args[field] if i in columns)
+                columns = list(necessary_columns)
                 args["data_frame"] = pd.api.interchange.from_dataframe(
                     args["data_frame"].select_columns_by_name(columns)
                 )

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_input.py
@@ -332,7 +332,10 @@ def test_build_df_from_vaex_and_polars(test_lib):
     reason="plotly doesn't use a dataframe interchange protocol for pandas < 2.0.2",
 )
 @pytest.mark.parametrize("test_lib", ["vaex", "polars"])
-def test_build_df_with_hover_data_from_vaex_and_polars(test_lib):
+@pytest.mark.parametrize(
+    "hover_data", [["sepal_width"], {"sepal_length": False, "sepal_width": ":.2f"}]
+)
+def test_build_df_with_hover_data_from_vaex_and_polars(test_lib, hover_data):
     if test_lib == "vaex":
         import vaex as lib
     else:
@@ -345,7 +348,7 @@ def test_build_df_with_hover_data_from_vaex_and_polars(test_lib):
         data_frame=iris_vaex,
         x="petal_width",
         y="sepal_length",
-        hover_data=["sepal_width"],
+        hover_data=hover_data,
     )
     out = build_dataframe(args, go.Scatter)
     assert_frame_equal(

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_input.py
@@ -293,7 +293,7 @@ def test_build_df_using_interchange_protocol_mock(
         ) as mock_from_dataframe:
             build_dataframe(args, go.Scatter)
         mock_from_dataframe.assert_called_once_with(interchange_dataframe_reduced)
-        assert set(interchange_dataframe.select_columns_by_name.call_args.args[0]) == {
+        assert set(interchange_dataframe.select_columns_by_name.call_args[0][0]) == {
             "petal_width",
             "sepal_length",
         }

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_input.py
@@ -8,6 +8,7 @@ import unittest.mock as mock
 from plotly.express._core import build_dataframe
 from pandas.testing import assert_frame_equal
 
+
 # Fixtures
 # --------
 @pytest.fixture
@@ -292,9 +293,10 @@ def test_build_df_using_interchange_protocol_mock(
         ) as mock_from_dataframe:
             build_dataframe(args, go.Scatter)
         mock_from_dataframe.assert_called_once_with(interchange_dataframe_reduced)
-        interchange_dataframe.select_columns_by_name.assert_called_with(
-            ["petal_width", "sepal_length"]
-        )
+        assert set(interchange_dataframe.select_columns_by_name.call_args.args[0]) == {
+            "petal_width",
+            "sepal_length",
+        }
 
         args = dict(data_frame=input_dataframe_reduced, color=None)
         with mock.patch(


### PR DESCRIPTION
This PR fixes a regression from #4286, where only plain string arguments were considered as necessary columns when interchanging dataframes. This PR considers complex arguments as well (such as `hover_data`).

For example, running the code below resulted in `ValueError: Value of 'hover_data_0' is not the name of a column in 'data_frame'. Expected one of ['petal_length', 'sepal_length'] but received: species`

```python
import numpy as np
import plotly.express as px
import polars as pl

df = px.data.iris()
px.scatter(
    pl.from_pandas(df),
    x="petal_length",
    y="sepal_length",
    hover_data=["species"],  # <-- this was unsupported
)
```

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).