### PR TITLE
handle deprecation of pandas.Series.dt.to_pydatetime() calls and suppress their FutureWarnings 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Repair crash on Matplotlib 3.8 related to get_offset_position [[#4372](https://github.com/plotly/plotly.py/pull/4372)],
+- Handle deprecation of `pandas.Series.dt.to_pydatetime()` calls and suppress the `FutureWarning` they currently emit. [[#4379](https://github.com/plotly/plotly.py/pull/4379)]
 
 ## [5.17.0] - 2023-09-15
 

--- a/packages/python/plotly/_plotly_utils/basevalidators.py
+++ b/packages/python/plotly/_plotly_utils/basevalidators.py
@@ -7,6 +7,7 @@ import copy
 import io
 import re
 import sys
+import warnings
 
 from _plotly_utils.optional_imports import get_module
 
@@ -100,7 +101,11 @@ def copy_to_readonly_numpy_array(v, kind=None, force_numeric=False):
         elif v.dtype.kind == "M":
             # Convert datetime Series/Index to numpy array of datetimes
             if isinstance(v, pd.Series):
-                v = v.dt.to_pydatetime()
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", FutureWarning)
+                    # Series.dt.to_pydatetime will return Index[object]
+                    # https://github.com/pandas-dev/pandas/pull/52459
+                    v = np.array(v.dt.to_pydatetime())
             else:
                 # DatetimeIndex
                 v = v.to_pydatetime()
@@ -109,7 +114,13 @@ def copy_to_readonly_numpy_array(v, kind=None, force_numeric=False):
         if dtype.kind in numeric_kinds:
             v = v.values
         elif dtype.kind == "M":
-            v = [row.dt.to_pydatetime().tolist() for i, row in v.iterrows()]
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", FutureWarning)
+                # Series.dt.to_pydatetime will return Index[object]
+                # https://github.com/pandas-dev/pandas/pull/52459
+                v = [
+                    np.array(row.dt.to_pydatetime()).tolist() for i, row in v.iterrows()
+                ]
 
     if not isinstance(v, np.ndarray):
         # v has its own logic on how to convert itself into a numpy array

--- a/packages/python/plotly/plotly/io/_json.py
+++ b/packages/python/plotly/plotly/io/_json.py
@@ -1,6 +1,7 @@
 import json
 import decimal
 import datetime
+import warnings
 from pathlib import Path
 
 from plotly.io._utils import validate_coerce_fig_to_dict, validate_coerce_output_type
@@ -535,7 +536,11 @@ def clean_to_json_compatible(obj, **kwargs):
                 return np.ascontiguousarray(obj.values)
             elif obj.dtype.kind == "M":
                 if isinstance(obj, pd.Series):
-                    dt_values = obj.dt.to_pydatetime().tolist()
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore", FutureWarning)
+                        # Series.dt.to_pydatetime will return Index[object]
+                        # https://github.com/pandas-dev/pandas/pull/52459
+                        dt_values = np.array(obj.dt.to_pydatetime()).tolist()
                 else:  # DatetimeIndex
                     dt_values = obj.to_pydatetime().tolist()
 

--- a/packages/python/plotly/plotly/tests/test_io/test_to_from_plotly_json.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_to_from_plotly_json.py
@@ -8,6 +8,7 @@ import json
 import datetime
 import re
 import sys
+import warnings
 from pytz import timezone
 from _plotly_utils.optional_imports import get_module
 
@@ -194,7 +195,13 @@ def test_datetime_arrays(datetime_array, engine, pretty):
     if isinstance(datetime_array, list):
         dt_values = [to_str(d) for d in datetime_array]
     elif isinstance(datetime_array, pd.Series):
-        dt_values = [to_str(d) for d in datetime_array.dt.to_pydatetime().tolist()]
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            # Series.dt.to_pydatetime will return Index[object]
+            # https://github.com/pandas-dev/pandas/pull/52459
+            dt_values = [
+                to_str(d) for d in np.array(datetime_array.dt.to_pydatetime()).tolist()
+            ]
     elif isinstance(datetime_array, pd.DatetimeIndex):
         dt_values = [to_str(d) for d in datetime_array.to_pydatetime().tolist()]
     else:  # numpy datetime64 array


### PR DESCRIPTION
As of Pandas 2.1.0, it is deprecating the behaviour of `Series.dt.to_pydatetime()`, which currently returns a `numpy.ndarray`, and changing it to return a `pandas.Series` of Python datetime objects. 

https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.to_pydatetime.html

This PR fixes #4363. The issue is that user's consoles are currently spammed with a `FutureWarning` containing this warning, which they cannot do anything about as the warning is coming inside the Plotly Package. 

The fix is to first wrap the output of `Series.dt.to_pydatetime()` with an `np.array()` call, so that the code will continue to work when the behaviour change drops. Then secondly, each offending call is put inside a `warnings.catch_warnings()` context manager that suppresses the `FutureWarning` only for the contents of the `with` block.

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [x] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).
