### PR TITLE
Update python-igraph references

### DIFF
--- a/doc/python/tree-plots.md
+++ b/doc/python/tree-plots.md
@@ -35,10 +35,10 @@ jupyter:
 
 #### Set Up Tree with [igraph](http://igraph.org/python/)
 
-Install igraph with `pip install python-igraph`.
+Install igraph with `pip install igraph`.
 
 ```python
-!pip install python-igraph
+!pip install igraph
 ```
 
 ```python

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -10,7 +10,7 @@ scipy==1.3.1
 patsy==0.5.1
 numpy==1.19.5
 plotly-geo
-python-igraph
+igraph
 geopandas==0.8.1
 pyshp==2.1.2
 shapely==1.7.1

--- a/doc/unconverted/python/3d-network-graph.md
+++ b/doc/unconverted/python/3d-network-graph.md
@@ -33,7 +33,7 @@ Plotly's Python library is free and open source! [Get started](https://plot.ly/p
 
 
 We define our graph as an `igraph.Graph` object. [Python `igraph`](http://igraph.org/python/)
-is a library for high-performance graph generation  and analysis. Install the Python library with `sudo pip install python-igraph`.
+is a library for high-performance graph generation  and analysis. Install the Python library with `pip install igraph`.
 
 ```python
 import igraph as ig

--- a/doc/unconverted/python/3d-network-graph.md
+++ b/doc/unconverted/python/3d-network-graph.md
@@ -33,7 +33,7 @@ Plotly's Python library is free and open source! [Get started](https://plot.ly/p
 
 
 We define our graph as an `igraph.Graph` object. [Python `igraph`](http://igraph.org/python/)
-is a library for high-performance graph generation  and analysis. Install the Python library with `pip install igraph`.
+is a library for high-performance graph generation  and analysis. Install the Python library with `sudo pip install igraph`.
 
 ```python
 import igraph as ig

--- a/doc/unconverted/python/chord-diagram.md
+++ b/doc/unconverted/python/chord-diagram.md
@@ -55,7 +55,7 @@ Namely, if the distance(`V[i], V[j]`), belongs to the $K^{th}$ interval associat
 
 We processed data provided by [Eurovision Song Contest](http://www.eurovision.tv/page/history/by-year/contest?event=2083#Scoreboard), and saved  the corresponding graph in a `gml` file. Now we can read the `gml` file and define  an [`igraph.Graph`](http://igraph.org/python/) object.
 
-Install the Python libraries with `sudo pip install python-igraph` and `sudo pip install networkx`.
+Install the Python libraries with `pip install igraph` and `sudo pip install networkx`.
 
 ```python
 import igraph as ig

--- a/doc/unconverted/python/chord-diagram.md
+++ b/doc/unconverted/python/chord-diagram.md
@@ -55,7 +55,7 @@ Namely, if the distance(`V[i], V[j]`), belongs to the $K^{th}$ interval associat
 
 We processed data provided by [Eurovision Song Contest](http://www.eurovision.tv/page/history/by-year/contest?event=2083#Scoreboard), and saved  the corresponding graph in a `gml` file. Now we can read the `gml` file and define  an [`igraph.Graph`](http://igraph.org/python/) object.
 
-Install the Python libraries with `pip install igraph` and `sudo pip install networkx`.
+Install the Python libraries with `sudo pip install igraph` and `sudo pip install networkx`.
 
 ```python
 import igraph as ig

--- a/doc/unconverted/python/igraph-networkx-comparison.md
+++ b/doc/unconverted/python/igraph-networkx-comparison.md
@@ -31,7 +31,7 @@ Plotly's Python library is free and open source! [Get started](https://plot.ly/p
 
 
 #### Comparison
-In this tutorial we plot the same network - the coauthorship network of scientists working on network theory and experiment - first as an `igraph.Graph` object, with the Kamada-Kawai layout, and then as a `networkx.Graph`, with the Fruchterman-Reingold layout. Install the Python libraries with `sudo pip install python-igraph` and `sudo pip install networkx`.
+In this tutorial we plot the same network - the coauthorship network of scientists working on network theory and experiment - first as an `igraph.Graph` object, with the Kamada-Kawai layout, and then as a `networkx.Graph`, with the Fruchterman-Reingold layout. Install the Python libraries with `pip install igraph` and `sudo pip install networkx`.
 
 The graph data are read from a gml file, posted at UC Irvine [Network Data Repository](http://networkdata.ics.uci.edu/data/netscience/netscience.gml):
 

--- a/doc/unconverted/python/igraph-networkx-comparison.md
+++ b/doc/unconverted/python/igraph-networkx-comparison.md
@@ -31,7 +31,7 @@ Plotly's Python library is free and open source! [Get started](https://plot.ly/p
 
 
 #### Comparison
-In this tutorial we plot the same network - the coauthorship network of scientists working on network theory and experiment - first as an `igraph.Graph` object, with the Kamada-Kawai layout, and then as a `networkx.Graph`, with the Fruchterman-Reingold layout. Install the Python libraries with `pip install igraph` and `sudo pip install networkx`.
+In this tutorial we plot the same network - the coauthorship network of scientists working on network theory and experiment - first as an `igraph.Graph` object, with the Kamada-Kawai layout, and then as a `networkx.Graph`, with the Fruchterman-Reingold layout. Install the Python libraries with `sudo pip install igraph` and `sudo pip install networkx`.
 
 The graph data are read from a gml file, posted at UC Irvine [Network Data Repository](http://networkdata.ics.uci.edu/data/netscience/netscience.gml):
 


### PR DESCRIPTION
To close https://github.com/plotly/plotly.py/issues/4285

Couldn't find a reason for the ` sudo pip install` references on the original PR, https://github.com/plotly/plotly.py/pull/4289, and it seems to work fine without 

