### PR TITLE
Fix x and y axis naming in dendrogram trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [UNRELEASED]
+
+### Fixed
+- Fix issue with creating dendrogram in subplots [[#4411](https://github.com/plotly/plotly.py/pull/4411)],
+
 ## [5.18.0] - 2023-10-25
 
 ### Updated

--- a/packages/python/plotly/plotly/figure_factory/_dendrogram.py
+++ b/packages/python/plotly/plotly/figure_factory/_dendrogram.py
@@ -387,8 +387,8 @@ class _Dendrogram(object):
             except ValueError:
                 y_index = ""
 
-            trace["xaxis"] = "x" + x_index
-            trace["yaxis"] = "y" + y_index
+            trace["xaxis"] = f"x{x_index}"
+            trace["yaxis"] = f"y{y_index}"
 
             trace_list.append(trace)
 


### PR DESCRIPTION
It's a very simple bug, so I don't think it needs any additional tests or even deserves a changelog entry :cry:

https://github.com/plotly/plotly.py/blob/69c20f7b9c711124061b3321c730ccb0866ba2dc/packages/python/plotly/plotly/figure_factory/_dendrogram.py#L380-L391

If `x_index` is int from line 381, line 390 will cause `TypeError: can only concatenate str (not "int") to str` from concatenating str(`"x"`) and int(`3`).
The error could accur when someone tries to create a dendrogram plot in a subplot in which the `xaxis`'s name is not `xaxis` but `xaxis3`.

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

