### PR TITLE
Add classes to docs sections

### DIFF
--- a/doc/nb.tpl
+++ b/doc/nb.tpl
@@ -18,7 +18,6 @@
 {% endblock input_group %}
 
 {% block markdowncell %}
-{{ cell.id }}
 {%- if 'What About Dash?' in cell.source or
     'Sign up for Dash Club' in cell.source or
     'best way to build analytical apps in Python using Plotly figures' in cell.source -%}

--- a/doc/nb.tpl
+++ b/doc/nb.tpl
@@ -17,6 +17,19 @@
     {%- endif -%}
 {% endblock input_group %}
 
+{% block markdowncell %}
+{{ cell.id }}
+{%- if 'What About Dash?' in cell.source or
+    'Sign up for Dash Club' in cell.source or
+    'best way to build analytical apps in Python using Plotly figures' in cell.source -%}
+    <div class="chatbot-exclude">
+    {{ super() }}
+    </div>
+{% else %}
+    {{ super() }}
+{%- endif -%}
+{% endblock markdowncell %}
+
 {%- block footer %}
 {{ super() }}
 {{ '{% endraw %}' }}

--- a/doc/nb.tpl
+++ b/doc/nb.tpl
@@ -20,7 +20,8 @@
 {% block markdowncell %}
 {%- if 'What About Dash?' in cell.source or
     'Sign up for Dash Club' in cell.source or
-    'best way to build analytical apps in Python using Plotly figures' in cell.source -%}
+    'best way to build analytical apps in Python using Plotly figures' in cell.source or
+    '### Reference' in cell.source -%}
     <div class="chatbot-exclude">
     {{ super() }}
     </div>

--- a/doc/what_about_dash.md
+++ b/doc/what_about_dash.md
@@ -2,6 +2,7 @@
 
 <!-- #region -->
 ### What About Dash?
+<div class="what-about-dash">
 
 [Dash](https://dash.plot.ly/) is an open-source framework for building analytical applications, with no Javascript required, and it is tightly integrated with the Plotly graphing library.
 
@@ -24,4 +25,5 @@ app.layout = html.Div([
 
 app.run_server(debug=True, use_reloader=False)  # Turn off reloader if inside Jupyter
 ```
+</div>
 <!-- #endregion -->

--- a/doc/what_about_dash.md
+++ b/doc/what_about_dash.md
@@ -1,8 +1,7 @@
 
 
-<!-- #region -->
+<!-- #region class="what-about-dash" -->
 ### What About Dash?
-<div class="what-about-dash">
 
 [Dash](https://dash.plot.ly/) is an open-source framework for building analytical applications, with no Javascript required, and it is tightly integrated with the Plotly graphing library.
 
@@ -25,5 +24,4 @@ app.layout = html.Div([
 
 app.run_server(debug=True, use_reloader=False)  # Turn off reloader if inside Jupyter
 ```
-</div>
 <!-- #endregion -->

--- a/doc/what_about_dash.md
+++ b/doc/what_about_dash.md
@@ -1,6 +1,6 @@
 
 
-<!-- #region class="what-about-dash" -->
+<!-- #region -->
 ### What About Dash?
 
 [Dash](https://dash.plot.ly/) is an open-source framework for building analytical applications, with no Javascript required, and it is tightly integrated with the Plotly graphing library.


### PR DESCRIPTION
Add classes to three docs sections that are on multiple pages
- The What About Dash section
- The Dash Club section
- The Dash app example

To exclude them from the content used in the chatbot

