### PR TITLE
Fix KeyError when using column of pd.Categorical dtype with unobserved categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Ensure scatter `mode` is deterministic from `px` [[#4429](https://github.com/plotly/plotly.py/pull/4429)]
 - Fix issue with creating dendrogram in subplots [[#4411](https://github.com/plotly/plotly.py/pull/4411)],
 - Fix issue with px.line not accepting "spline" line shape [[#2812](https://github.com/plotly/plotly.py/issues/2812)]
+- Fix KeyError when using column of `pd.Categorical` dtype with unobserved categories [[#4437](https://github.com/plotly/plotly.py/pull/4437)]
 
 ## [5.18.0] - 2023-10-25
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2042,7 +2042,9 @@ def get_groups_and_orders(args, grouper):
         groups = {tuple(single_group_name): df}
     else:
         required_grouper = [g for g in grouper if g != one_group]
-        grouped = df.groupby(required_grouper, sort=False)  # skip one_group groupers
+        grouped = df.groupby(
+            required_grouper, sort=False, observed=True
+        )  # skip one_group groupers
         group_indices = grouped.indices
         sorted_group_names = [
             g if len(required_grouper) != 1 else (g,) for g in group_indices

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_colors.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_colors.py
@@ -53,3 +53,11 @@ def test_r_colorscales():
                 assert scale.replace("_r", "") in scale_names
             else:
                 assert scale + "_r" in scale_names
+
+
+def test_color_categorical_dtype():
+    df = px.data.tips()
+    df["day"] = df["day"].astype("category")
+    px.scatter(
+        df[df.day != df.day.cat.categories[0]], x="total_bill", y="tip", facet_col="day"
+    )

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_colors.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_colors.py
@@ -59,5 +59,5 @@ def test_color_categorical_dtype():
     df = px.data.tips()
     df["day"] = df["day"].astype("category")
     px.scatter(
-        df[df.day != df.day.cat.categories[0]], x="total_bill", y="tip", facet_col="day"
+        df[df.day != df.day.cat.categories[0]], x="total_bill", y="tip", color="day"
     )


### PR DESCRIPTION
This PR passes `observed=True` to omit categorical values with no observations in the dataset. Fixes #4274 and #4433.

Also silences the FutureWarning from pandas-dev/pandas#43999 since pandas 2.1 that the default of `observed=False` will be changed to `True` in a future version.

Following code raises `KeyError: 'Fri'` before this fix:

```python
import plotly.express as px
df = px.data.tips()
df["day"] = df["day"].astype("category")
px.scatter(
    df[df.day != "Fri"],
    x="total_bill",
    y="tip",
    facet_col="day",
)
```