### PR TITLE
Fix `suplot` typo

### DIFF
--- a/packages/python/plotly/plotly/_subplots.py
+++ b/packages/python/plotly/plotly/_subplots.py
@@ -190,7 +190,7 @@ def make_subplots(
                   in fraction of cell height ('to_end': to cell top edge)
 
     column_widths: list of numbers or None (default None)
-        list of length `cols` of the relative widths of each column of suplots.
+        list of length `cols` of the relative widths of each column of subplots.
         Values are normalized internally and used to distribute overall width
         of the figure (excluding padding) among the columns.
 
@@ -358,7 +358,7 @@ def make_subplots(
     if not isinstance(rows, int) or rows <= 0:
         raise ValueError(
             """
-The 'rows' argument to make_suplots must be an int greater than 0.
+The 'rows' argument to make_subplots must be an int greater than 0.
     Received value of type {typ}: {val}""".format(
                 typ=type(rows), val=repr(rows)
             )
@@ -368,7 +368,7 @@ The 'rows' argument to make_suplots must be an int greater than 0.
     if not isinstance(cols, int) or cols <= 0:
         raise ValueError(
             """
-The 'cols' argument to make_suplots must be an int greater than 0.
+The 'cols' argument to make_subplots must be an int greater than 0.
     Received value of type {typ}: {val}""".format(
                 typ=type(cols), val=repr(cols)
             )
@@ -399,7 +399,7 @@ The 'start_cell` argument to make_subplots must be one of \
             if not isinstance(item, dict):
                 raise ValueError(
                     """
-Elements of the '{name}' argument to make_suplots must be dictionaries \
+Elements of the '{name}' argument to make_subplots must be dictionaries \
 or None.
     Received value of type {typ}: {val}""".format(
                         name=name, typ=type(item), val=repr(item)
@@ -484,7 +484,7 @@ The 'secondary_y' spec property is not supported for subplot of type '{s_typ}'
     ):
         raise ValueError(
             """
-The 'insets' argument to make_suplots must be a list of dictionaries.
+The 'insets' argument to make_subplots must be a list of dictionaries.
     Received value of type {typ}: {val}""".format(
                 typ=type(insets), val=repr(insets)
             )
@@ -587,7 +587,7 @@ The resulting plot would have {dimsize} {dimname} ({dimvarname}={dimsize}).""".f
     else:
         raise ValueError(
             """
-The 'column_widths' argument to make_suplots must be a list of numbers of \
+The 'column_widths' argument to make_subplots must be a list of numbers of \
 length {cols}.
     Received value of type {typ}: {val}""".format(
                 cols=cols, typ=type(column_widths), val=repr(column_widths)
@@ -607,7 +607,7 @@ length {cols}.
     else:
         raise ValueError(
             """
-The 'row_heights' argument to make_suplots must be a list of numbers of \
+The 'row_heights' argument to make_subplots must be a list of numbers of \
 length {rows}.
     Received value of type {typ}: {val}""".format(
                 rows=rows, typ=type(row_heights), val=repr(row_heights)

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -5709,7 +5709,7 @@ class BaseLayoutType(BaseLayoutHierarchyType):
     # These are used when a layout has multiple instances of subplot types
     # (xaxis2, yaxis3, geo4, etc.)
     #
-    # The base version of each suplot type is defined in the schema and code
+    # The base version of each subplot type is defined in the schema and code
     # generated. So the Layout subclass has statically defined properties
     # for xaxis, yaxis, geo, ternary, and scene. But, we need to dynamically
     # generated properties/validators as needed for xaxis2, yaxis3, etc.

--- a/packages/python/plotly/plotly/subplots.py
+++ b/packages/python/plotly/plotly/subplots.py
@@ -154,7 +154,7 @@ def make_subplots(
                   in fraction of cell height ('to_end': to cell top edge)
 
     column_widths: list of numbers or None (default None)
-        list of length `cols` of the relative widths of each column of suplots.
+        list of length `cols` of the relative widths of each column of subplots.
         Values are normalized internally and used to distribute overall width
         of the figure (excluding padding) among the columns.
 


### PR DESCRIPTION
Closes https://github.com/plotly/plotly.py/issues/4445

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).
