### PR TITLE
Update map tiles in docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.5
+  browser-tools: circleci/browser-tools@1.4.6
 
 commands:
   test_core:

--- a/doc/python/filled-area-on-mapbox.md
+++ b/doc/python/filled-area-on-mapbox.md
@@ -60,7 +60,7 @@ fig = go.Figure(go.Scattermapbox(
 
 fig.update_layout(
     mapbox = {
-        'style': "stamen-terrain",
+        'style': "open-street-map",
         'center': {'lon': -73, 'lat': 46 },
         'zoom': 5},
     showlegend = False)
@@ -81,7 +81,7 @@ fig = go.Figure(go.Scattermapbox(
     lat = [30, 6, 6, 30, 30,    None, 20, 30, 30, 20, 20, None, 40, 50, 50, 40, 40]))
 
 fig.update_layout(
-    mapbox = {'style': "stamen-terrain", 'center': {'lon': 30, 'lat': 30}, 'zoom': 2},
+    mapbox = {'style': "open-street-map", 'center': {'lon': 30, 'lat': 30}, 'zoom': 2},
     showlegend = False,
     margin = {'l':0, 'r':0, 'b':0, 't':0})
 
@@ -102,7 +102,7 @@ fig = go.Figure(go.Scattermapbox(
 
 fig.update_layout(
     mapbox = {
-        'style': "stamen-terrain",
+        'style': "open-street-map",
         'center': { 'lon': -73.6, 'lat': 45.5},
         'zoom': 12, 'layers': [{
             'source': {

--- a/doc/python/lines-on-mapbox.md
+++ b/doc/python/lines-on-mapbox.md
@@ -51,7 +51,7 @@ import plotly.express as px
 
 fig = px.line_mapbox(us_cities, lat="lat", lon="lon", color="State", zoom=3, height=300)
 
-fig.update_layout(mapbox_style="stamen-terrain", mapbox_zoom=4, mapbox_center_lat = 41,
+fig.update_layout(mapbox_style="open-street-map", mapbox_zoom=4, mapbox_center_lat = 41,
     margin={"r":0,"t":0,"l":0,"b":0})
 
 fig.show()
@@ -95,7 +95,7 @@ for feature, name in zip(geo_df.geometry, geo_df.name):
         names = np.append(names, None)
 
 fig = px.line_mapbox(lat=lats, lon=lons, hover_name=names,
-                     mapbox_style="stamen-terrain", zoom=1)
+                     mapbox_style="open-street-map", zoom=1)
 fig.show()
 ```
 
@@ -123,7 +123,7 @@ fig.update_layout(
     margin ={'l':0,'t':0,'b':0,'r':0},
     mapbox = {
         'center': {'lon': 10, 'lat': 10},
-        'style': "stamen-terrain",
+        'style': "open-street-map",
         'center': {'lon': -20, 'lat': -20},
         'zoom': 1})
 

--- a/doc/python/mapbox-density-heatmaps.md
+++ b/doc/python/mapbox-density-heatmaps.md
@@ -37,7 +37,7 @@ jupyter:
 
 To plot on Mapbox maps with Plotly you _may_ need a Mapbox account and a public [Mapbox Access Token](https://www.mapbox.com/studio). See our [Mapbox Map Layers](/python/mapbox-layers/) documentation for more information.
 
-### Stamen Terrain base map (no token needed): density mapbox with `plotly.express`
+### OpenStreetMap base map (no token needed): density mapbox with `plotly.express`
 
 [Plotly Express](/python/plotly-express/) is the easy-to-use, high-level interface to Plotly, which [operates on a variety of types of data](/python/px-arguments/) and produces [easy-to-style figures](/python/styling-plotly-express/).
 
@@ -50,11 +50,11 @@ df = pd.read_csv('https://raw.githubusercontent.com/plotly/datasets/master/earth
 import plotly.express as px
 fig = px.density_mapbox(df, lat='Latitude', lon='Longitude', z='Magnitude', radius=10,
                         center=dict(lat=0, lon=180), zoom=0,
-                        mapbox_style="stamen-terrain")
+                        mapbox_style="open-street-map")
 fig.show()
 ```
 
-### Stamen Terrain base map (no token needed): density mapbox with `plotly.graph_objects`
+### OpenStreetMap base map (no token needed): density mapbox with `plotly.graph_objects`
 
 If Plotly Express does not provide a good starting point, it is also possible to use [the more generic `go.Densitymapbox` class from `plotly.graph_objects`](/python/graph-objects/).
 
@@ -65,7 +65,7 @@ quakes = pd.read_csv('https://raw.githubusercontent.com/plotly/datasets/master/e
 import plotly.graph_objects as go
 fig = go.Figure(go.Densitymapbox(lat=quakes.Latitude, lon=quakes.Longitude, z=quakes.Magnitude,
                                  radius=10))
-fig.update_layout(mapbox_style="stamen-terrain", mapbox_center_lon=180)
+fig.update_layout(mapbox_style="open-street-map", mapbox_center_lon=180)
 fig.update_layout(margin={"r":0,"t":0,"l":0,"b":0})
 fig.show()
 ```

--- a/doc/python/mapbox-layers.md
+++ b/doc/python/mapbox-layers.md
@@ -64,7 +64,7 @@ The word "mapbox" in the trace names and `layout.mapbox` refers to the Mapbox GL
 The accepted values for `layout.mapbox.style` are one of:
 
 - `"white-bg"` yields an empty white canvas which results in no external HTTP requests
-- `"open-street-map"`, `"carto-positron"`, `"carto-darkmatter"`, `"stamen-terrain"`, `"stamen-toner"` or `"stamen-watercolor"` yield maps composed of _raster_ tiles from various public tile servers which do not require signups or access tokens
+- `"open-street-map"`, `"carto-positron"`, and `"carto-darkmatter"` yield maps composed of _raster_ tiles from various public tile servers which do not require signups or access tokens. There is currently a known issue with `"stamen-terrain"`, `"stamen-toner"` and `"stamen-watercolor"` tiles, which will be fixed in a future Plotly.py release.
 - `"basic"`, `"streets"`, `"outdoors"`, `"light"`, `"dark"`, `"satellite"`, or `"satellite-streets"` yield maps composed of _vector_ tiles from the Mapbox service, and _do_ require a Mapbox Access Token or an on-premise Mapbox installation.
 - A Mapbox service style URL, which requires a Mapbox Access Token or an on-premise Mapbox installation.
 - A Mapbox Style object as defined at https://docs.mapbox.com/mapbox-gl-js/style-spec/


### PR DESCRIPTION
Update tiles in docs, until we do the next release which allows using stamen tiles again.

<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

-->
