### PR TITLE
accept 'c' and 's' arguments in pandas plotting backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
 
+### Updated
+- Accept arguments `'c'` and `'s'` when using pandas plotting backend [[#4464]](https://github.com/plotly/plotly.py/pull/4464)
+
 ### Fixed
 - Ensure scatter `mode` is deterministic from `px` [[#4429](https://github.com/plotly/plotly.py/pull/4429)]
 - Fix issue with creating dendrogram in subplots [[#4411](https://github.com/plotly/plotly.py/pull/4411)],

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_pandas_backend.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_pandas_backend.py
@@ -61,6 +61,10 @@ def test_pandas_example():
     assert len(fig.data) == 1
 
 
+@pytest.mark.skipif(
+    not hasattr(pd.options.plotting, "backend"),
+    reason="Currently installed pandas doesn't support plotting backends.",
+)
 def test_pandas_invalid_c_kwarg():
     pd.options.plotting.backend = "plotly"
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9], "d": [1, 1, 2]})

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_pandas_backend.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_pandas_backend.py
@@ -16,6 +16,10 @@ import pytest
             lambda df: df.plot.scatter("A", "B"),
             lambda df: px.scatter(df, "A", "B"),
         ),
+        (
+            lambda df: df.plot.scatter("A", "B", c="C"),
+            lambda df: px.scatter(df, "A", "B", color="C"),
+        ),
         (lambda df: df.plot.line(), px.line),
         (lambda df: df.plot.area(), px.area),
         (lambda df: df.plot.bar(), px.bar),
@@ -55,3 +59,28 @@ def test_pandas_example():
     df = pd.DataFrame(np.random.randn(1000, 4), index=ts.index, columns=list("ABCD"))
     fig = df.iloc[5].plot.bar()
     assert len(fig.data) == 1
+
+
+def test_pandas_invalid_c_kwarg():
+    pd.options.plotting.backend = "plotly"
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9], "d": [1, 1, 2]})
+    with pytest.raises(
+        ValueError,
+        match="plotly.express.scatter does not support both 'color' and 'c' kwargs",
+    ):
+        df.plot.scatter(x="a", y="b", c="c", color="d")
+    with pytest.raises(
+        ValueError,
+        match="plotly.express.scatter only supports the 'c' kwarg as a column name",
+    ):
+        df.plot.scatter(x="a", y="b", c="blue")
+    with pytest.raises(
+        ValueError,
+        match="plotly.express.scatter does not support both 'size' and 's' kwargs",
+    ):
+        df.plot.scatter(x="a", y="b", s="d", size="d")
+    with pytest.raises(
+        ValueError,
+        match="plotly.express.scatter only supports the 's' kwarg as a column name",
+    ):
+        df.plot.scatter(x="a", y="b", s=2)


### PR DESCRIPTION
I'd like to simplify and better document the expectation of the plotting backend

Here's start anyway - as far as I can tell the other backends all allow passing `c=` to colour by a given column

<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

-->


demo:

![image](https://github.com/plotly/plotly.py/assets/33491632/d18a855a-4fb3-4dd5-b377-78f683966969)

![Screenshot 2023-12-17 105105](https://github.com/plotly/plotly.py/assets/33491632/2e1961d1-bbac-49f1-a9fb-523ae41d3d84)

![image](https://github.com/plotly/plotly.py/assets/33491632/49f97dec-dc11-4335-a5a9-13e44b652340)
