### PR TITLE
adding a jinja2 example to the interactive HTML export

### DIFF
--- a/doc/python/interactive-html-export.md
+++ b/doc/python/interactive-html-export.md
@@ -57,7 +57,20 @@ By default, the resulting HTML file is a fully self-contained HTML file which ca
 
 ### Inserting Plotly Output into HTML using a Jinja2 Template
 
-You can insert Plotly output and text related to your data into HTML templates using Jinja2.   First create an HTML template file containing a variable like `{{ fig }}`.  Then use the following Python to replace `{{ fig }}` in the template with HTML that will display the Plotly figure "fig":
+You can insert Plotly output and text related to your data into HTML templates using Jinja2.   Use `.to_html` to send the HTML to a Python string variable rather using write_html to send the HTML to  a disk file.  Use the `full_html=False` option to output just the code necessary to add a figure to a template that will provide e.g. the `<HTML>` tag rather than asking Plotly to ouput a complete webpage.  First create an HTML template file containing a Jinja `{{ variable }}`.  In this example, we customize the HTML in the template file by replacing the Jinja variable `{{ fig }}` with our graphic `fig`. 
+
+```
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Here's a Plotly graph!</h1>
+{{ fig }}
+<p>And here's some text after the graph.</p>
+</body>
+</html>
+```
+
+Then use the following Python to replace `{{ fig }}` in the template with HTML that will display the Plotly figure "fig":
 
 ```
 import plotly.express as px

--- a/doc/python/interactive-html-export.md
+++ b/doc/python/interactive-html-export.md
@@ -57,7 +57,7 @@ By default, the resulting HTML file is a fully self-contained HTML file which ca
 
 ### Inserting Plotly Output into HTML using a Jinja2 Template
 
-You can insert Plotly output and text related to your data into HTML templates using Jinja2.   Use `.to_html` to send the HTML to a Python string variable rather using write_html to send the HTML to  a disk file.  Use the `full_html=False` option to output just the code necessary to add a figure to a template that will provide e.g. the `<HTML>` tag rather than asking Plotly to ouput a complete webpage.  First create an HTML template file containing a Jinja `{{ variable }}`.  In this example, we customize the HTML in the template file by replacing the Jinja variable `{{ fig }}` with our graphic `fig`. 
+You can insert Plotly output and text related to your data into HTML templates using Jinja2. Use `.to_html` to send the HTML to a Python string variable rather than using `write_html` to send the HTML to a disk file.  Use the `full_html=False` option to output just the code necessary to add a figure to a template. We don't want to output a full HTML page, as the template will define the rest of the page's structure — for example, the page's `HTML` and `BODY` tags.  First create an HTML template file containing a Jinja `{{ variable }}`.  In this example, we customize the HTML in the template file by replacing the Jinja variable `{{ fig }}` with our graphic `fig`. 
 
 ```
 <!DOCTYPE html>

--- a/doc/python/interactive-html-export.md
+++ b/doc/python/interactive-html-export.md
@@ -55,6 +55,29 @@ fig.write_html("path/to/file.html")
 
 By default, the resulting HTML file is a fully self-contained HTML file which can be uploaded to a web server or shared via email or other file-sharing mechanisms. The downside to this approach is that the file is very large (5Mb+) because it contains an inlined copy of the Plotly.js library required to make the figure interactive. This can be controlled via the `include_plotlyjs` argument (see below).
 
+### Inserting Plotly Output into HTML using a Jinja2 Template
+
+You can insert Plotly output and text related to your data into HTML templates using Jinja2.   First create an HTML template file containing a variable like `{{ fig }}`.  Then use the following Python to replace `{{ fig }}` in the template with HTML that will display the Plotly figure "fig":
+
+```
+import plotly.express as px
+from jinja2 import Template
+
+data_canada = px.data.gapminder().query("country == 'Canada'")
+fig = px.bar(data_canada, x='year', y='pop')
+
+output_html_path=r"/path/to/output.html"
+input_template_path = r"/path/to/template.html"
+
+plotly_jinja_data = {"fig":fig.to_html(full_html=False)}
+#consider also defining the include_plotlyjs parameter to point to an external Plotly.js as described above
+
+with open(output_html_path, "w", encoding="utf-8") as output_file:
+    with open(input_template_path) as template_file:
+        j2_template = Template(template_file.read())
+        output_file.write(j2_template.render(plotly_jinja_data))
+```
+
 
 ### HTML export in Dash
 


### PR DESCRIPTION
I often need to write one program that inserts Plotly graphics and customized text into an HTML file.  Jinja2 is an obvious way to do so.  Here I add an example to the documentation.


If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [X] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [X] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [X] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [X] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [X] Every new/modified example is independently runnable
- [X] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [X] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [Not applicable] The random seed is set if using randomly-generated data in new/modified examples


- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets

I welcome a conversation about how to deal with disk files.  It's hard to create a realistic example without a read/write file system -- so I left place holders for paths.

- [X] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [X] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [Not applicable] Data frames are always called `df`
- [X] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ Not applicable] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ Not applicable ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example

- [ ] `fig.show()` is at the end of each new/modified example

I did not see value to doing so.  If this is relevant, please add it.

- [X] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [X] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

-->
