### PR TITLE
Update _core.py to fix y label string literal

### DIFF
--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1412,7 +1412,7 @@ def build_dataframe(args, constructor):
                 wide_cross_name = "__x__" if wide_y else "__y__"
 
     if wide_mode:
-        value_name = _escape_col_name(columns, "value", [])
+        value_name = _escape_col_name(columns, args["labels"]["y"], [])
         var_name = _escape_col_name(columns, var_name, [])
 
     if needs_interchanging:

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1412,11 +1412,8 @@ def build_dataframe(args, constructor):
                 wide_cross_name = "__x__" if wide_y else "__y__"
 
     if wide_mode:
-        if "labels" in args:
-            if "y" in args["labels"]:
-                y_value = args["labels"]["y"]
-            else:
-                y_value = "value"
+        if "labels" in args and "y" in args["labels"]:
+            y_value = args["labels"]["y"]
         else:
             y_value = "value"
         value_name = _escape_col_name(columns, y_value, [])

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1416,9 +1416,9 @@ def build_dataframe(args, constructor):
             if "y" in args["labels"]:
                 y_value = args["labels"]["y"]
             else:
-                y_value = "y"
+                y_value = "value"
         else:
-            y_value = "y"
+            y_value = "value"
         value_name = _escape_col_name(columns, y_value, [])
         var_name = _escape_col_name(columns, var_name, [])
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1412,8 +1412,11 @@ def build_dataframe(args, constructor):
                 wide_cross_name = "__x__" if wide_y else "__y__"
 
     if wide_mode:
-        if "y" in args["labels"]:
-            y_value = args["labels"]["y"]
+        if "labels" in args:
+            if "y" in args["labels"]:
+                y_value = args["labels"]["y"]
+            else:
+                y_value = "y"
         else:
             y_value = "y"
         value_name = _escape_col_name(columns, y_value, [])

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1412,7 +1412,11 @@ def build_dataframe(args, constructor):
                 wide_cross_name = "__x__" if wide_y else "__y__"
 
     if wide_mode:
-        value_name = _escape_col_name(columns, args["labels"]["y"], [])
+        if "y" in args["labels"]:
+            y_value = args["labels"]["y"]
+        else:
+            y_value = "y"
+        value_name = _escape_col_name(columns, y_value, [])
         var_name = _escape_col_name(columns, var_name, [])
 
     if needs_interchanging:


### PR DESCRIPTION
Remove string literal and replace with args y label value. This allowed the y label to be shown when running px.line. Did not feel the need to add a test or documentation but I did run pytest. Related to issue #4455 

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).


