### PR TITLE
Add clarification on colors with open markers

### DIFF
--- a/doc/python/marker-style.md
+++ b/doc/python/marker-style.md
@@ -380,7 +380,7 @@ fig.show()
 
 #### Open Marker Colors
 
-In the previous example, each marker has two colors, a marker color (set in Plotly Express with `color="species"`)  and a line color (set on the line with `color="DarkSlateGrey"`. When using open markers, like `"diamond-open"` in the following example, the marker always uses only the marker color. Adding a line color won't update the marker. 
+In the previous example, each marker has two colors, a marker color (set in Plotly Express with `color="species"`)  and a line color (set on the line with `color="DarkSlateGrey"`. All open markers, like "diamond-open" in the following example, have a transparent fill, which means you can specify only one color.  Specify this color using the marker color parameter. This controls the outline color and any dot or cross. For open markers, the line color does nothing.
 
 ```python
 import plotly.express as px

--- a/doc/python/marker-style.md
+++ b/doc/python/marker-style.md
@@ -6,7 +6,7 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.14.1
+      jupytext_version: 1.14.6
   kernelspec:
     display_name: Python 3 (ipykernel)
     language: python
@@ -20,7 +20,7 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.8.0
+    version: 3.10.11
   plotly:
     description: How to style markers in Python with Plotly.
     display_as: file_settings
@@ -361,7 +361,7 @@ fig.show()
 
 ### Using a Custom Marker
 
-To use a custom marker, set the `symbol` on the `marker`. Here we set it to `diamond`.
+To use a custom marker, set the `symbol` on the `marker`. Here we set it to `diamond`. 
 
 
 ```python
@@ -376,6 +376,31 @@ fig.update_traces(
 )
 fig.show()
 
+```
+
+#### Open Marker Colors
+
+In the previous example, each marker has two colors, a marker color (set in Plotly Express with `color="species"`)  and a line color (set on the line with `color="DarkSlateGrey"`. When using open markers, like `"diamond-open"` in the following example, the marker always uses only the marker color. Adding a line color won't update the marker. 
+
+```python
+import plotly.express as px
+
+df = px.data.iris()
+fig = px.scatter(df, x="sepal_width", y="sepal_length", color="species")
+
+fig.update_traces(
+    marker=dict(
+        size=8, 
+        symbol="diamond-open", 
+        line=dict(
+            width=2, 
+#             color="DarkSlateGrey" Line colors don't apply to open markers
+        )
+    ),
+    selector=dict(mode="markers"),
+)
+
+fig.show()
 ```
 
 ### Setting Marker Angles


### PR DESCRIPTION
Add clarification on colors with open markers

### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [x] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [x] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [x] Every new/modified example is independently runnable
- [x] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [x] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [x] The random seed is set if using randomly-generated data in new/modified examples
- [x] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [x] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [x] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [x] Data frames are always called `df`
- [x] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [x] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [x] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [x] `fig.show()` is at the end of each new/modified example
- [x] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [x] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)
