### PR TITLE
Stacked grouped bar chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
 
+### Added
+- New grouped_stacked_bar chart in figure_factory
+
 ### Fixed
 - Ensure scatter `mode` is deterministic from `px` [[#4429](https://github.com/plotly/plotly.py/pull/4429)]
 - Fix issue with creating dendrogram in subplots [[#4411](https://github.com/plotly/plotly.py/pull/4411)],

--- a/doc/python/figure-factories.md
+++ b/doc/python/figure-factories.md
@@ -46,7 +46,7 @@ The following types of plots are still difficult to create with Graph Objects or
   * [Tables](/python/figure-factory-table/)
   * [Ternary Contour Plots](/python/ternary-contour/)
   * [Triangulated Surface Plots](/python/trisurf/)
-  * [Groupes Stacked Bar Plots](/python/grouped-stacked-bar)
+  * [Grouped Stacked Bar Plots](/python/grouped-stacked-bar)
 
 Deprecated "legacy" Figure Factories include:
 

--- a/doc/python/figure-factories.md
+++ b/doc/python/figure-factories.md
@@ -46,6 +46,7 @@ The following types of plots are still difficult to create with Graph Objects or
   * [Tables](/python/figure-factory-table/)
   * [Ternary Contour Plots](/python/ternary-contour/)
   * [Triangulated Surface Plots](/python/trisurf/)
+  * [Groupes Stacked Bar Plots](/python/grouped-stacked-bar)
 
 Deprecated "legacy" Figure Factories include:
 

--- a/doc/python/grouped-stacked-bar.md
+++ b/doc/python/grouped-stacked-bar.md
@@ -23,11 +23,11 @@ jupyter:
     version: 3.7.7
   plotly:
     description: How to make a grouped and stacked bar chart in Python with Plotly.
-    display_as: scientific
+    display_as: statistical
     language: python
     layout: base
     name: Grouped Stacked Bar Charts
-    order: 27
+    order: 17
     page_type: u-guide
     permalink: python/grouped-stacked-bar/
     thumbnail: thumbnail/grouped-stacked-bar.jpg

--- a/doc/python/grouped-stacked-bar.md
+++ b/doc/python/grouped-stacked-bar.md
@@ -41,12 +41,7 @@ This page details the use of a [figure factory](/python/figure-factories/). For 
 import plotly.figure_factory as ff
 import plotly.express as px
 
-df = (
-    px.data.tips()
-    .groupby(["day", "sex", "smoker"])
-    [["total_bill", "tip"]].sum()
-    .reset_index()
-)
+df = px.data.tips().groupby(["day", "sex", "smoker"])[["total_bill", "tip"]].sum().reset_index()
 
 fig = ff.create_grouped_stacked_bar(
     df,
@@ -65,12 +60,7 @@ fig.show()
 import plotly.figure_factory as ff
 import plotly.express as px
 
-df = (
-    px.data.tips()
-    .groupby(["day", "sex", "smoker"])
-    [["total_bill", "tip"]].sum()
-    .reset_index()
-)
+df = px.data.tips().groupby(["day", "sex", "smoker"])[["total_bill", "tip"]].sum().reset_index()
 
 fig = ff.create_grouped_stacked_bar(
     df,

--- a/doc/python/grouped-stacked-bar.md
+++ b/doc/python/grouped-stacked-bar.md
@@ -1,0 +1,98 @@
+---
+jupyter:
+  jupytext:
+    notebook_metadata_filter: all
+    text_representation:
+      extension: .md
+      format_name: markdown
+      format_version: '1.3'
+      jupytext_version: 1.14.7
+  kernelspec:
+    display_name: Python 3
+    language: python
+    name: python3
+  language_info:
+    codemirror_mode:
+      name: ipython
+      version: 3
+    file_extension: .py
+    mimetype: text/x-python
+    name: python
+    nbconvert_exporter: python
+    pygments_lexer: ipython3
+    version: 3.7.7
+  plotly:
+    description: How to make a grouped and stacked bar chart in Python with Plotly.
+    display_as: basic
+    language: python
+    layout: base
+    name: Grouped Stacked Bar Charts
+    order: 13
+    page_type: u-guide
+    permalink: python/grouped-stacked-bar/
+    thumbnail: thumbnail/grouped-stacked-bar.jpg
+---
+
+This page details the use of a [figure factory](/python/figure-factories/). For more examples with bar charts, see [this page](/python/bar-charts/).
+
+#### Simple Grouped Stacked Bar Chart
+
+```python
+import plotly.figure_factory as ff
+import plotly.express as px
+
+df = (
+    px.data.tips()
+    .groupby(["day", "sex", "smoker"])
+    [["total_bill", "tip"]].sum()
+    .reset_index()
+)
+
+fig = ff.create_grouped_stacked_bar(
+    df,
+    x="smoker",
+    stack_group="day",
+    color="sex",
+    y="tip",
+)
+fig.update_layout(legend_title=None)
+fig.show()
+```
+
+#### Advanced Grouped Stacked Bar Chart
+
+```python
+import plotly.figure_factory as ff
+import plotly.express as px
+
+df = (
+    px.data.tips()
+    .groupby(["day", "sex", "smoker"])
+    [["total_bill", "tip"]].sum()
+    .reset_index()
+)
+
+fig = ff.create_grouped_stacked_bar(
+    df,
+    x="smoker",
+    stack_group="day",
+    color="sex",
+    y="tip",
+    # Manage the gap between groups
+    stack_group_gap=0.2,
+    # Manage the gap between bars within groups
+    bar_gap=0.05,
+    # Manage the category orders
+    category_orders={
+      "day": ["Thur", "Fri", "Sat", "Sun"],
+    },
+    # The grouped stacked bar chart respects the template colors
+    # Each group will be displayed with nuances of the colorway
+    # You can also specify the list of colors with `color_discrete_sequence`
+    template="ggplot2",
+    # Unified hover label
+    hover_unified=True,
+)
+fig.update_layout(legend_title=None)
+fig.show()
+```

--- a/doc/python/grouped-stacked-bar.md
+++ b/doc/python/grouped-stacked-bar.md
@@ -23,11 +23,11 @@ jupyter:
     version: 3.7.7
   plotly:
     description: How to make a grouped and stacked bar chart in Python with Plotly.
-    display_as: basic
+    display_as: scientific
     language: python
     layout: base
     name: Grouped Stacked Bar Charts
-    order: 13
+    order: 27
     page_type: u-guide
     permalink: python/grouped-stacked-bar/
     thumbnail: thumbnail/grouped-stacked-bar.jpg

--- a/packages/python/plotly/plotly/figure_factory/__init__.py
+++ b/packages/python/plotly/plotly/figure_factory/__init__.py
@@ -28,6 +28,7 @@ from plotly.figure_factory._violin import create_violin
 if optional_imports.get_module("pandas") is not None:
     from plotly.figure_factory._county_choropleth import create_choropleth
     from plotly.figure_factory._hexbin_mapbox import create_hexbin_mapbox
+    from plotly.figure_factory._grouped_stacked_bar import create_grouped_stacked_bar
 else:
 
     def create_choropleth(*args, **kwargs):
@@ -35,6 +36,9 @@ else:
 
     def create_hexbin_mapbox(*args, **kwargs):
         raise ImportError("Please install pandas to use `create_hexbin_mapbox`")
+
+    def create_grouped_stacked_bar(*args, **kwargs):
+        raise ImportError("Please install pandas to use `create_grouped_stacked_bar`")
 
 
 if optional_imports.get_module("skimage") is not None:
@@ -55,6 +59,7 @@ __all__ = [
     "create_distplot",
     "create_facet_grid",
     "create_gantt",
+    "create_grouped_stacked_bar",
     "create_hexbin_mapbox",
     "create_ohlc",
     "create_quiver",

--- a/packages/python/plotly/plotly/figure_factory/_grouped_stacked_bar.py
+++ b/packages/python/plotly/plotly/figure_factory/_grouped_stacked_bar.py
@@ -1,0 +1,175 @@
+from copy import deepcopy
+import colorsys
+from plotly.graph_objects import Bar
+from plotly.express._core import build_dataframe
+from plotly.express._doc import make_docstring
+from plotly.express._chart_types import bar
+import plotly.colors as pyc
+import plotly.io as pio
+import plotly.graph_objects as go
+
+
+def create_grouped_stacked_bar(
+    data_frame=None,
+    x=None,
+    y=None,
+    color=None,
+    stack_group=None,
+    stack_group_gap=None,
+    bar_gap=None,
+    color_discrete_sequence=None,
+    labels=None,
+    category_orders=None,
+    hover_name=None,
+    hover_data=None,
+    hover_unified=False,
+    custom_data=None,
+    text=None,
+    error_x=None,
+    error_x_minus=None,
+    error_y=None,
+    error_y_minus=None,
+    orientation=None,
+    opacity=None,
+    range_x=None,
+    range_y=None,
+    title=None,
+    template=None,
+    width=None,
+    height=None,
+):
+    """
+    Returns a bar chart with grouped and stacked bars.
+    """
+    args = deepcopy(locals())
+    if data_frame is not None:
+        df_copy = deepcopy(data_frame)
+    if color is not None:
+        color_copy = deepcopy(color)
+    args = build_dataframe(args=args, constructor=Bar)
+    df_color = args["data_frame"].copy()
+    args["color"] = stack_group
+    args["data_frame"] = df_copy
+    args = build_dataframe(args=args, constructor=Bar)
+
+    color_col = color if isinstance(color, str) else "color"
+    group_col = stack_group if isinstance(stack_group, str) else "stack_group"
+    x_col = x if isinstance(x, str) else "x"
+    if not isinstance(stack_group, str):
+        args["data_frame"] = args["data_frame"].rename(columns={"color": "stack_group"})
+    args["data_frame"] = args["data_frame"].join(df_color[[color_col]])
+    args["color"] = color_copy
+
+    data_frame = args.pop("data_frame").sort_values([color_col, group_col, x_col])
+    hover_data = args.pop("hover_data") or [group_col]
+    args.pop("stack_group")
+    args.pop("hover_unified")
+    groups = list(data_frame[group_col].unique())
+    if category_orders is not None and group_col in category_orders:
+        groups = [g for g in category_orders[group_col] if g in groups] + [
+            g for g in groups if g not in category_orders[group_col]
+        ]
+    n_groups = len(groups)
+    stack_group_gap = args.pop("stack_group_gap") or 1 / n_groups
+    bar_gap = args.pop("bar_gap") or 0
+    group_width = (1 - stack_group_gap - (n_groups - 1) * bar_gap) / n_groups
+    n_colors = data_frame[color_col].nunique()
+
+    def get_colors(base_color, n_colors):
+        hls_tuple = colorsys.rgb_to_hls(
+            *pyc.convert_colors_to_same_type(base_color, "tuple")[0][0]
+        )
+        if n_colors == 1:
+            return [base_color]
+
+        if n_colors == 2:
+            light = colorsys.hls_to_rgb(hls_tuple[0], min(1, max(0.75, hls_tuple[1] + 0.2)), hls_tuple[2])
+            return pyc.sample_colorscale([light, base_color], n_colors)
+
+        light = colorsys.hls_to_rgb(hls_tuple[0], min(1, max(0.8, hls_tuple[1] + 0.2)), hls_tuple[2])
+        dark = colorsys.hls_to_rgb(hls_tuple[0], max(0, min(0.3, hls_tuple[1] - 0.2)), hls_tuple[2])
+        return pyc.sample_colorscale([light, base_color, dark], n_colors)
+
+    if template is None:
+        if pio.templates.default is not None:
+            template = pio.templates.default
+        else:
+            template = "plotly"
+
+    try:
+        # retrieve the actual template if we were given a name
+        template = pio.templates[template]
+    except Exception:
+        # otherwise try to build a real template
+        template = go.layout.Template(template)
+
+    color_discrete_sequence = args.pop("color_discrete_sequence")
+    if color_discrete_sequence is None:
+        color_discrete_sequence = template.layout.colorway
+    elif isinstance(color_discrete_sequence, str):
+        color_discrete_sequence = pyc.colorscale_to_colors(
+            pyc.get_colorscale(color_discrete_sequence)
+        )
+
+    value_axis = "y"
+    base_axis = "x"
+    if orientation == "h":
+        value_axis = "x"
+        base_axis = "y"
+
+    fig = None
+    for i, group in enumerate(groups):
+        group_df = data_frame.query(f"{group_col} == @group")
+        n_colors = group_df[color_col].nunique()
+        colors = get_colors(
+            color_discrete_sequence[i % len(color_discrete_sequence)],
+            n_colors,
+        )
+        group_fig = (
+            bar(
+                group_df,
+                color_discrete_sequence=colors,
+                hover_data=hover_data,
+                **args,
+            )
+            .update_traces(
+                offsetgroup=str(i),
+                offset=(i - n_groups / 2) * (group_width + bar_gap) + 1 / 2 * bar_gap,
+                width=group_width,
+                legendgroup=group,
+                legendgrouptitle_text=group,
+                **{f"{value_axis}axis": f"{value_axis}{i + 1}"},
+            )
+        )
+        if fig is None:
+            fig = group_fig
+        else:
+            fig.add_traces(group_fig.data)
+            fig.update_layout(
+                **{
+                    f"{value_axis}axis{i + 1}": {
+                        "visible": False,
+                        "matches": value_axis,
+                        "overlaying": value_axis,
+                        "anchor": base_axis,
+                    }
+                }
+            )
+    fig.update_layout(
+        **{f"{base_axis}axis_type": "category"}
+    )
+    if hover_unified:
+        fig.update_layout(hovermode="x unified").update_traces(hovertemplate="%{y}")
+
+    return fig
+
+
+create_grouped_stacked_bar.__doc__ = make_docstring(
+    create_grouped_stacked_bar,
+    override_dict={
+        "stack_group": "Values from this column or array_like are used to group the bar stacks.",
+        "stack_group_gap": "Value between 0 and 1. Sets the gap between the stack groups.",
+        "bar_gap": "Value between 0 and 1. Sets the gap between the bars within each group.",
+        "hover_unified": "Whether to show the hover in a unified format.",
+    }
+)

--- a/packages/python/plotly/plotly/figure_factory/_grouped_stacked_bar.py
+++ b/packages/python/plotly/plotly/figure_factory/_grouped_stacked_bar.py
@@ -83,11 +83,17 @@ def create_grouped_stacked_bar(
             return [base_color]
 
         if n_colors == 2:
-            light = colorsys.hls_to_rgb(hls_tuple[0], min(1, max(0.75, hls_tuple[1] + 0.2)), hls_tuple[2])
+            light = colorsys.hls_to_rgb(
+                hls_tuple[0], min(1, max(0.75, hls_tuple[1] + 0.2)), hls_tuple[2]
+            )
             return pyc.sample_colorscale([light, base_color], n_colors)
 
-        light = colorsys.hls_to_rgb(hls_tuple[0], min(1, max(0.8, hls_tuple[1] + 0.2)), hls_tuple[2])
-        dark = colorsys.hls_to_rgb(hls_tuple[0], max(0, min(0.3, hls_tuple[1] - 0.2)), hls_tuple[2])
+        light = colorsys.hls_to_rgb(
+            hls_tuple[0], min(1, max(0.8, hls_tuple[1] + 0.2)), hls_tuple[2]
+        )
+        dark = colorsys.hls_to_rgb(
+            hls_tuple[0], max(0, min(0.3, hls_tuple[1] - 0.2)), hls_tuple[2]
+        )
         return pyc.sample_colorscale([light, base_color, dark], n_colors)
 
     if template is None:
@@ -125,21 +131,18 @@ def create_grouped_stacked_bar(
             color_discrete_sequence[i % len(color_discrete_sequence)],
             n_colors,
         )
-        group_fig = (
-            bar(
-                group_df,
-                color_discrete_sequence=colors,
-                hover_data=hover_data,
-                **args,
-            )
-            .update_traces(
-                offsetgroup=str(i),
-                offset=(i - n_groups / 2) * (group_width + bar_gap) + 1 / 2 * bar_gap,
-                width=group_width,
-                legendgroup=group,
-                legendgrouptitle_text=group,
-                **{f"{value_axis}axis": f"{value_axis}{i + 1}"},
-            )
+        group_fig = bar(
+            group_df,
+            color_discrete_sequence=colors,
+            hover_data=hover_data,
+            **args,
+        ).update_traces(
+            offsetgroup=str(i),
+            offset=(i - n_groups / 2) * (group_width + bar_gap) + 1 / 2 * bar_gap,
+            width=group_width,
+            legendgroup=group,
+            legendgrouptitle_text=group,
+            **{f"{value_axis}axis": f"{value_axis}{i + 1}"},
         )
         if fig is None:
             fig = group_fig
@@ -155,9 +158,7 @@ def create_grouped_stacked_bar(
                     }
                 }
             )
-    fig.update_layout(
-        **{f"{base_axis}axis_type": "category"}
-    )
+    fig.update_layout(**{f"{base_axis}axis_type": "category"})
     if hover_unified:
         fig.update_layout(hovermode="x unified").update_traces(hovertemplate="%{y}")
 
@@ -171,5 +172,5 @@ create_grouped_stacked_bar.__doc__ = make_docstring(
         "stack_group_gap": "Value between 0 and 1. Sets the gap between the stack groups.",
         "bar_gap": "Value between 0 and 1. Sets the gap between the bars within each group.",
         "hover_unified": "Whether to show the hover in a unified format.",
-    }
+    },
 )

--- a/packages/python/plotly/plotly/figure_factory/_grouped_stacked_bar.py
+++ b/packages/python/plotly/plotly/figure_factory/_grouped_stacked_bar.py
@@ -1,12 +1,39 @@
-from copy import deepcopy
 import colorsys
-from plotly.graph_objects import Bar
-from plotly.express._core import build_dataframe
-from plotly.express._doc import make_docstring
-from plotly.express._chart_types import bar
+from copy import deepcopy
+from typing import Union
+
 import plotly.colors as pyc
 import plotly.io as pio
 import plotly.graph_objects as go
+from plotly.express._core import build_dataframe
+from plotly.express._doc import make_docstring
+from plotly.express._chart_types import bar
+
+
+def get_colors(base_color: Union[str, tuple], n_colors: int):
+    """Get a palette of colors derived from base color.
+
+    This function leverages the HLS color space.
+    """
+    hls_tuple = colorsys.rgb_to_hls(
+        *pyc.convert_colors_to_same_type(base_color, "tuple")[0][0]
+    )
+    if n_colors == 1:
+        return [base_color]
+
+    if n_colors == 2:
+        light = colorsys.hls_to_rgb(
+            hls_tuple[0], min(1, max(0.75, hls_tuple[1] + 0.2)), hls_tuple[2]
+        )
+        return pyc.sample_colorscale([light, base_color], n_colors)
+
+    light = colorsys.hls_to_rgb(
+        hls_tuple[0], min(1, max(0.8, hls_tuple[1] + 0.2)), hls_tuple[2]
+    )
+    dark = colorsys.hls_to_rgb(
+        hls_tuple[0], max(0, min(0.3, hls_tuple[1] - 0.2)), hls_tuple[2]
+    )
+    return pyc.sample_colorscale([light, base_color, dark], n_colors)
 
 
 def create_grouped_stacked_bar(
@@ -41,17 +68,19 @@ def create_grouped_stacked_bar(
     """
     Returns a bar chart with grouped and stacked bars.
     """
+
+    # Leverage the `build_dataframe` function twice to create the dataframe
+    # with color and stack_group columns
     args = deepcopy(locals())
     if data_frame is not None:
         df_copy = deepcopy(data_frame)
     if color is not None:
         color_copy = deepcopy(color)
-    args = build_dataframe(args=args, constructor=Bar)
+    args = build_dataframe(args=args, constructor=go.Bar)
     df_color = args["data_frame"].copy()
     args["color"] = stack_group
     args["data_frame"] = df_copy
-    args = build_dataframe(args=args, constructor=Bar)
-
+    args = build_dataframe(args=args, constructor=go.Bar)
     color_col = color if isinstance(color, str) else "color"
     group_col = stack_group if isinstance(stack_group, str) else "stack_group"
     x_col = x if isinstance(x, str) else "x"
@@ -62,8 +91,12 @@ def create_grouped_stacked_bar(
 
     data_frame = args.pop("data_frame").sort_values([color_col, group_col, x_col])
     hover_data = args.pop("hover_data") or [group_col]
+
+    # Remove arguments that can't be passed to px.bar, they are used separately
     args.pop("stack_group")
     args.pop("hover_unified")
+
+    # Create the groups metadata, including their order and bar width
     groups = list(data_frame[group_col].unique())
     if category_orders is not None and group_col in category_orders:
         groups = [g for g in category_orders[group_col] if g in groups] + [
@@ -75,33 +108,12 @@ def create_grouped_stacked_bar(
     group_width = (1 - stack_group_gap - (n_groups - 1) * bar_gap) / n_groups
     n_colors = data_frame[color_col].nunique()
 
-    def get_colors(base_color, n_colors):
-        hls_tuple = colorsys.rgb_to_hls(
-            *pyc.convert_colors_to_same_type(base_color, "tuple")[0][0]
-        )
-        if n_colors == 1:
-            return [base_color]
-
-        if n_colors == 2:
-            light = colorsys.hls_to_rgb(
-                hls_tuple[0], min(1, max(0.75, hls_tuple[1] + 0.2)), hls_tuple[2]
-            )
-            return pyc.sample_colorscale([light, base_color], n_colors)
-
-        light = colorsys.hls_to_rgb(
-            hls_tuple[0], min(1, max(0.8, hls_tuple[1] + 0.2)), hls_tuple[2]
-        )
-        dark = colorsys.hls_to_rgb(
-            hls_tuple[0], max(0, min(0.3, hls_tuple[1] - 0.2)), hls_tuple[2]
-        )
-        return pyc.sample_colorscale([light, base_color, dark], n_colors)
-
+    # Retrieve the template information to create groups with the right colors
     if template is None:
         if pio.templates.default is not None:
             template = pio.templates.default
         else:
             template = "plotly"
-
     try:
         # retrieve the actual template if we were given a name
         template = pio.templates[template]
@@ -109,6 +121,7 @@ def create_grouped_stacked_bar(
         # otherwise try to build a real template
         template = go.layout.Template(template)
 
+    # `color_discrete_sequence` can be used to override the template colors
     color_discrete_sequence = args.pop("color_discrete_sequence")
     if color_discrete_sequence is None:
         color_discrete_sequence = template.layout.colorway
@@ -117,6 +130,7 @@ def create_grouped_stacked_bar(
             pyc.get_colorscale(color_discrete_sequence)
         )
 
+    # Manage the orientation
     value_axis = "y"
     base_axis = "x"
     if orientation == "h":
@@ -124,6 +138,8 @@ def create_grouped_stacked_bar(
         base_axis = "y"
 
     fig = None
+    # Create the figures for each group then combine into one,
+    # with overlapping y-axis (or x-axis if horizontal)
     for i, group in enumerate(groups):
         group_df = data_frame.query(f"{group_col} == @group")
         n_colors = group_df[color_col].nunique()
@@ -148,6 +164,7 @@ def create_grouped_stacked_bar(
             fig = group_fig
         else:
             fig.add_traces(group_fig.data)
+            # Ensure the y-axes (or x-axes) overlap and match
             fig.update_layout(
                 **{
                     f"{value_axis}axis{i + 1}": {
@@ -158,7 +175,12 @@ def create_grouped_stacked_bar(
                     }
                 }
             )
+
+    # Set the base axis type to category to work well with groups
     fig.update_layout(**{f"{base_axis}axis_type": "category"})
+
+    # Optionally unify the hover, with a modification of the hovertemplate
+    # to have a nice display
     if hover_unified:
         fig.update_layout(hovermode="x unified").update_traces(hovertemplate="%{y}")
 

--- a/packages/python/plotly/plotly/tests/test_optional/test_figure_factory/test_figure_factory.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_figure_factory/test_figure_factory.py
@@ -4518,28 +4518,31 @@ class TestHexbinMapbox(NumpyTestUtilsMixin, TestCaseNoTemplate):
         assert len(fig7.frames) == n_frames
         assert fig6.data[0].geojson == fig1.data[0].geojson
 
+
 class TestBarStackGroup(NumpyTestUtilsMixin, TestCaseNoTemplate):
-    data = pd.read_csv(StringIO(
-        "loc,prod,type,value,err\n"
-        "L1,P1,R1,4,0.2\n"
-        "L1,P1,R2,4.5,0.2\n"
-        "L1,P1,R3,4.5,0.2\n"
-        "L1,P2,R1,5.6,0.2\n"
-        "L1,P2,R2,5,0.2\n"
-        "L1,P3,R1,3.5,0.2\n"
-        "L1,P3,R2,3.5,0.2\n"
-        "L1,P3,R3,3.5,0.2\n"
-        "L2,P1,R1,2,0.2\n"
-        "L2,P1,R2,2,0.2\n"
-        "L2,P2,R1,2.5,0.2\n"
-        "L2,P2,R2,3,0.2\n"
-        "L2,P3,R2,3.5,0.2\n"
-        "L3,P1,R1,2,0.2\n"
-        "L3,P1,R2,2,0.2\n"
-        "L3,P2,R1,2.5,0.2\n"
-        "L3,P2,R2,3,0.2\n"
-        "L3,P3,R2,3.5,0.2\n"
-    ))
+    data = pd.read_csv(
+        StringIO(
+            "loc,prod,type,value,err\n"
+            "L1,P1,R1,4,0.2\n"
+            "L1,P1,R2,4.5,0.2\n"
+            "L1,P1,R3,4.5,0.2\n"
+            "L1,P2,R1,5.6,0.2\n"
+            "L1,P2,R2,5,0.2\n"
+            "L1,P3,R1,3.5,0.2\n"
+            "L1,P3,R2,3.5,0.2\n"
+            "L1,P3,R3,3.5,0.2\n"
+            "L2,P1,R1,2,0.2\n"
+            "L2,P1,R2,2,0.2\n"
+            "L2,P2,R1,2.5,0.2\n"
+            "L2,P2,R2,3,0.2\n"
+            "L2,P3,R2,3.5,0.2\n"
+            "L3,P1,R1,2,0.2\n"
+            "L3,P1,R2,2,0.2\n"
+            "L3,P2,R1,2.5,0.2\n"
+            "L3,P2,R2,3,0.2\n"
+            "L3,P3,R2,3.5,0.2\n"
+        )
+    )
 
     def test_simple_stack_group(self):
         fig = ff.create_grouped_stacked_bar(
@@ -4579,7 +4582,12 @@ class TestBarStackGroup(NumpyTestUtilsMixin, TestCaseNoTemplate):
             stackgroup="prod",
             stackgroupgap=0.33,
             error_y="err",
-            labels={"loc": "Location", "value": "Revenue", "type": "Type", "prod": "Product"},
+            labels={
+                "loc": "Location",
+                "value": "Revenue",
+                "type": "Type",
+                "prod": "Product",
+            },
             hover_name="prod",
             category_orders={
                 "loc": ["L3", "L2", "L1"],

--- a/packages/python/plotly/plotly/tests/test_optional/test_figure_factory/test_figure_factory.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_figure_factory/test_figure_factory.py
@@ -4550,7 +4550,7 @@ class TestBarStackGroup(NumpyTestUtilsMixin, TestCaseNoTemplate):
             x="loc",
             y="value",
             color="type",
-            stackgroup="prod",
+            stack_group="prod",
         )
 
         assert len(fig.data) == len(self.data.drop_duplicates(["prod", "type"]))
@@ -4564,7 +4564,7 @@ class TestBarStackGroup(NumpyTestUtilsMixin, TestCaseNoTemplate):
             x="value",
             y="x",
             color="type",
-            stackgroup="prod",
+            stack_group="prod",
             orientation="h",
         )
 
@@ -4579,8 +4579,9 @@ class TestBarStackGroup(NumpyTestUtilsMixin, TestCaseNoTemplate):
             x="loc",
             y="value",
             color="type",
-            stackgroup="prod",
-            stackgroupgap=0.33,
+            stack_group="prod",
+            stack_group_gap=0.33,
+            bar_gap=0.033,
             error_y="err",
             labels={
                 "loc": "Location",
@@ -4595,6 +4596,7 @@ class TestBarStackGroup(NumpyTestUtilsMixin, TestCaseNoTemplate):
                 "prod": ["P3"],
             },
             template="ggplot2",
+            hover_unified=True,
         )
 
         assert fig.layout.xaxis.categoryarray == ["L3", "L2", "L1"]

--- a/packages/python/plotly/plotly/tests/test_optional/test_figure_factory/test_figure_factory.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_figure_factory/test_figure_factory.py
@@ -4562,7 +4562,7 @@ class TestBarStackGroup(NumpyTestUtilsMixin, TestCaseNoTemplate):
         fig = ff.create_grouped_stacked_bar(
             self.data,
             x="value",
-            y="x",
+            y="loc",
             color="type",
             stack_group="prod",
             orientation="h",
@@ -4599,7 +4599,7 @@ class TestBarStackGroup(NumpyTestUtilsMixin, TestCaseNoTemplate):
             hover_unified=True,
         )
 
-        assert fig.layout.xaxis.categoryarray == ["L3", "L2", "L1"]
+        assert fig.layout.xaxis.categoryarray == ("L3", "L2", "L1")
         type_order = []
         prod_order = []
         for t in fig.data:


### PR DESCRIPTION
### What's new

Adds a new figure factory for grouped stacked bar charts

```python
import plotly.express as px
import plotly.figure_factory as ff

df = px.data.tips().groupby(["day", "sex", "smoker"])[["total_bill", "tip"]].sum().reset_index()

fig = ff.create_grouped_stacked_bar(
    df,
    x="smoker",
    stack_group="sex",
    color="day",
    y="tip",
    category_orders={"day": ["Thur", "Fri", "Sat", "Sun"]},
)
fig.show()
```

![image](https://github.com/plotly/plotly.py/assets/20662281/c9d2c1d0-c6b5-4e30-a829-bdc34e767568)


```python
import plotly.express as px
import plotly.figure_factory as ff

df = px.data.tips().groupby(["day", "sex", "smoker"])[["total_bill", "tip"]].sum().reset_index()

fig = ff.create_grouped_stacked_bar(
    df,
    x="sex",
    stack_group="day",
    color="smoker",
    y="tip",
    category_orders={"day": ["Thur", "Fri", "Sat", "Sun"]},
    template="seaborn",
    stack_group_gap=0.33,
    bar_gap=0.02,
)
fig.show()
```

![image](https://github.com/plotly/plotly.py/assets/20662281/bfa739c6-2cc2-4246-b506-29c1059e4f06)

Issues: #2976 #3251 

### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [x] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [x] Every new/modified example is independently runnable
- [x] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [x] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [x] The random seed is set if using randomly-generated data in new/modified examples
- [x] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [x] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [x] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [x] Data frames are always called `df`
- [x] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [x] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [x] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [x] `fig.show()` is at the end of each new/modified example
- [x] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [x] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [x] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [x] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [x] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).
