### PR TITLE
document that LaTeX does not work with Jupyter Notebook version 7

### DIFF
--- a/doc/python/LaTeX.md
+++ b/doc/python/LaTeX.md
@@ -35,7 +35,7 @@ jupyter:
 
 #### LaTeX Typesetting
 
-Figure titles, axis labels and annotations all accept LaTeX directives for rendering mathematical formulas and notation, when the entire label is surrounded by dollar signs `$...$`. This rendering is handled by the [MathJax library](https://www.mathjax.org/) (version 2.7.5), which must be loaded in the environment where figures are being rendered. MathJax is included by default in Jupyter-like environments, but when embedding Plotly figures in other contexts it may be required to ensure that MathJax is separately loaded, for example via a `<script>` tag pointing to a content-delivery network (CDN).
+Figure titles, axis labels and annotations all accept LaTeX directives for rendering mathematical formulas and notation, when the entire label is surrounded by dollar signs `$...$`. This rendering is handled by the [MathJax library](https://www.mathjax.org/) (version 2.7.5), which must be loaded in the environment where figures are being rendered. MathJax is included by default in Jupyter-like environments, and LateX directives work with Jupyter Notebook version 6.   LaTeX directives do not work with Jupyter Notebook version 7.    When embedding Plotly figures in other contexts it may be required to ensure that MathJax is separately loaded, for example via a `<script>` tag pointing to a content-delivery network (CDN).
 
 ```python
 import plotly.express as px

--- a/doc/python/LaTeX.md
+++ b/doc/python/LaTeX.md
@@ -35,7 +35,7 @@ jupyter:
 
 #### LaTeX Typesetting
 
-Figure titles, axis labels and annotations all accept LaTeX directives for rendering mathematical formulas and notation, when the entire label is surrounded by dollar signs `$...$`. This rendering is handled by the [MathJax library](https://www.mathjax.org/) (version 2.7.5), which must be loaded in the environment where figures are being rendered. MathJax is included by default in Jupyter-like environments, and LateX directives work with Jupyter Notebook version 6.   LaTeX directives do not work with Jupyter Notebook version 7.    When embedding Plotly figures in other contexts it may be required to ensure that MathJax is separately loaded, for example via a `<script>` tag pointing to a content-delivery network (CDN).
+Figure titles, axis labels and annotations all accept LaTeX directives for rendering mathematical formulas and notation, when the entire label is surrounded by dollar signs `$...$`. This rendering is handled by the [MathJax library](https://www.mathjax.org/) (version 2.7.5), which must be loaded in the environment where figures are being rendered. MathJax is included by default in Jupyter-like environments, and LateX directives work with Jupyter Notebook version 6. LaTeX directives do not work with Jupyter Notebook version 7.  When embedding Plotly figures in other contexts it may be required to ensure that MathJax is separately loaded, for example via a `<script>` tag pointing to a content-delivery network (CDN).
 
 ```python
 import plotly.express as px


### PR DESCRIPTION

This updates the LateX documentation to state clearly that LaTeX rendering does not work with Jupyter Notebook 7.  See #4336.

### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)
