### PR TITLE
_bullet has an issue building measure and range bars if the data set …

### DIFF
--- a/packages/python/plotly/plotly/figure_factory/_bullet.py
+++ b/packages/python/plotly/plotly/figure_factory/_bullet.py
@@ -88,19 +88,19 @@ def _bullet(
                 range_colors[0], range_colors[1], len(df.iloc[row]["ranges"]), "rgb"
             )
             x = (
-                [sorted(df.iloc[row]["ranges"])[-1 - idx]]
+                [sorted(df.iloc[row]["ranges"], key=abs, reverse=True)[idx]]
                 if orientation == "h"
                 else [0]
             )
             y = (
                 [0]
                 if orientation == "h"
-                else [sorted(df.iloc[row]["ranges"])[-1 - idx]]
+                else [sorted(df.iloc[row]["ranges"], key=abs, reverse=True)[idx]]
             )
             bar = go.Bar(
                 x=x,
                 y=y,
-                marker=dict(color=inter_colors[-1 - idx]),
+                marker=dict(color=inter_colors[sorted(df.iloc[row]["ranges"]).index(sorted(df.iloc[row]["ranges"], key=abs, reverse=True)[idx])]),
                 name="ranges",
                 hoverinfo="x" if orientation == "h" else "y",
                 orientation=orientation,
@@ -120,19 +120,19 @@ def _bullet(
                 "rgb",
             )
             x = (
-                [sorted(df.iloc[row]["measures"])[-1 - idx]]
+                [sorted(df.iloc[row]["measures"], key=abs, reverse=True)[idx]]
                 if orientation == "h"
                 else [0.5]
             )
             y = (
                 [0.5]
                 if orientation == "h"
-                else [sorted(df.iloc[row]["measures"])[-1 - idx]]
+                else [sorted(df.iloc[row]["measures"], key=abs, reverse=True)[idx]]
             )
             bar = go.Bar(
                 x=x,
                 y=y,
-                marker=dict(color=inter_colors[-1 - idx]),
+                marker=dict(color=inter_colors[sorted(df.iloc[row]["measures"]).index(sorted(df.iloc[row]["measures"], key=abs, reverse=True)[idx])]),
                 name="measures",
                 hoverinfo="x" if orientation == "h" else "y",
                 orientation=orientation,


### PR DESCRIPTION
…has negative values. The issue is with the method of sorting the data from highest to lowest. The data needs to be sorted so both, the largest positive and negative values are plotted first.

Here is the current implementation - you can see since the sort function puts the -5000 tick mark last and the bar on top of all less negative values.
![Screenshot 2024-01-26 130212](https://github.com/plotly/plotly.py/assets/7718524/8b10fd08-c254-453c-b28a-af953dbd4462)

Here is a fix.
![Screenshot 2024-01-26 130307](https://github.com/plotly/plotly.py/assets/7718524/2fafea51-bc2a-443d-91bd-a4d34cc0587f)

I did a little search on this function and it looks like it is being depreciated. I appologize if I have butchered the PR process.


<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

-->
