### PR TITLE
 Add example of Annotations with Log Axes

### DIFF
--- a/doc/python/text-and-annotations.md
+++ b/doc/python/text-and-annotations.md
@@ -6,9 +6,9 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.14.1
+      jupytext_version: 1.16.1
   kernelspec:
-    display_name: Python 3
+    display_name: Python 3 (ipykernel)
     language: python
     name: python3
   language_info:
@@ -20,7 +20,7 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.8.8
+    version: 3.10.11
   plotly:
     description: How to add text labels and annotations to plots in python.
     display_as: file_settings
@@ -205,6 +205,45 @@ fig.add_annotation(x=4, y=4,
 fig.update_layout(showlegend=False)
 
 fig.show()
+```
+
+#### Text Annotations with Log Axis Type
+
+If the `x` or `y` positions of an annotation reference a log axis, you need to provide that position as a `log10` value when adding the annotation. In this example, the yaxis is a log axis so we pass the `log10` value of `1000` to the annotation's `y` position.
+
+```python
+import plotly.graph_objects as go
+import math
+
+dates = [
+    "2024-01-01",
+    "2024-01-02",
+    "2024-01-03",
+    "2024-01-04",
+    "2024-01-05",
+    "2024-01-06",
+]
+y_values = [1, 30, 70, 100, 1000, 10000000]
+
+fig = go.Figure(
+    data=[go.Scatter(x=dates, y=y_values, mode="lines+markers")],
+    layout=go.Layout(
+        yaxis=dict(
+            type="log",
+        )
+    ),
+)
+
+fig.add_annotation(
+    x="2024-01-05",
+    y=math.log10(1000),
+    text="Log axis annotation",
+    showarrow=True,
+    xanchor="right",
+)
+
+fig.show()
+
 ```
 
 ### 3D Annotations

--- a/doc/python/text-and-annotations.md
+++ b/doc/python/text-and-annotations.md
@@ -207,9 +207,9 @@ fig.update_layout(showlegend=False)
 fig.show()
 ```
 
-#### Text Annotations with Log Axis Type
+#### Text Annotations with Log Axes
 
-If the `x` or `y` positions of an annotation reference a log axis, you need to provide that position as a `log10` value when adding the annotation. In this example, the yaxis is a log axis so we pass the `log10` value of `1000` to the annotation's `y` position.
+If the `x` or `y` positions of an annotation reference a log axis, you need to provide that position as a `log10` value when adding the annotation. In this example, the `yaxis` is a log axis so we pass the `log10` value of `1000` to the annotation's `y` position.
 
 ```python
 import plotly.graph_objects as go
@@ -243,7 +243,6 @@ fig.add_annotation(
 )
 
 fig.show()
-
 ```
 
 ### 3D Annotations


### PR DESCRIPTION
Add example of Annotations with Log Axes

https://github.com/plotly/plotly.js/issues/6880


### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [x] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [x] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [x] Every new/modified example is independently runnable
- [x] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [x] The random seed is set if using randomly-generated data in new/modified examples
- [x] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [x] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [x] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [x] Data frames are always called `df`
- [x] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [x] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [x] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [x] `fig.show()` is at the end of each new/modified example
- [x] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [x] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

