### PR TITLE
Specify `conda-build` version in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,7 +385,7 @@ jobs:
       - run:
           name: Create conda environment
           command: |
-            conda create -n env --yes python=3.9 conda-build conda-verify
+            conda create -n env --yes python=3.9 conda-build=3.28.4 conda-verify
             conda install -n env -c conda-forge jupyterlab=3 nodejs=16
             conda init bash
             mkdir output


### PR DESCRIPTION
Pin `conda-build` version to get Conda build running again.

We are running into this: https://github.com/conda/conda-build/issues/5167 with `conda-build` `24.1.0`

