### PR TITLE
Fix rendering in documentation of histogram histfunc

### DIFF
--- a/packages/python/plotly/plotly/express/_chart_types.py
+++ b/packages/python/plotly/plotly/express/_chart_types.py
@@ -497,7 +497,7 @@ histogram.__doc__ = make_docstring(
         y=["If `orientation` is `'v'`, these values are used as inputs to `histfunc`."]
         + _wide_mode_xy_append,
         histfunc=[
-            "The arguments to this function are the values of `y`(`x`) if `orientation` is `'v'`(`'h'`).",
+            "The arguments to this function are the values of `y` (`x`) if `orientation` is `'v'` (`'h'`).",
         ],
     ),
 )

--- a/packages/python/plotly/plotly/express/_doc.py
+++ b/packages/python/plotly/plotly/express/_doc.py
@@ -448,7 +448,7 @@ docs = dict(
     ],
     histfunc=[
         "str (default `'count'` if no arguments are provided, else `'sum'`)",
-        "One of `'count'`, `'sum'`, `'avg'`, `'min'`, or `'max'`."
+        "One of `'count'`, `'sum'`, `'avg'`, `'min'`, or `'max'`.",
         "Function used to aggregate values for summarization (note: can be normalized with `histnorm`).",
     ],
     histnorm=[


### PR DESCRIPTION
Previously it rendered as
![image](https://github.com/plotly/plotly.py/assets/396076/32008c0b-c8c2-4152-b1c6-d390c5652f7a)
Now there should be a space after the period in "`'max'`.Function used to aggregate should render as" and the final sentence should render as
> The arguments to this function are the values of `y` (`x`) if `orientation` is `'v'` (`'h'`).

### Documentation PR

- [x] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [x] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- <strike>[] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible</strike>
- <strike>[] Every new/modified example has a descriptive title and motivating sentence or paragraph</strike>
- <strike>[] Every new/modified example is independently runnable</strike>
- <strike>[] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized</strike>
- <strike>[] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible</strike>
- <strike>[] The random seed is set if using randomly-generated data in new/modified examples</strike>
- <strike>[] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets</strike>
- <strike>[] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations</strike>
- <strike>[] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`</strike>
- <strike>[] Data frames are always called `df`</strike>
- <strike>[] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)</strike>
- <strike>[] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example</strike>
- <strike>[] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example</strike>
- <strike>[] `fig.show()` is at the end of each new/modified example</strike>
- <strike>[] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example</strike>
- <strike>[] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)</strike>

