### PR TITLE
Pass tuple to `get_group` to fix warning

### DIFF
--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -17,6 +17,8 @@ from plotly._subplots import (
     _subplot_type_for_trace_type,
 )
 
+pandas_2_2_0 = version.parse(pd.__version__) >= version.parse("2.2.0")
+
 NO_COLOR = "px_no_color_constant"
 trendline_functions = dict(
     lowess=lowess, rolling=rolling, ewm=ewm, expanding=expanding, ols=ols
@@ -2068,10 +2070,15 @@ def get_groups_and_orders(args, grouper):
                     g.insert(i, "")
         full_sorted_group_names = [tuple(g) for g in full_sorted_group_names]
 
-        groups = {
-            sf: grouped.get_group(s if len(s) > 1 else s[0])
-            for sf, s in zip(full_sorted_group_names, sorted_group_names)
-        }
+        groups = {}
+        for sf, s in zip(full_sorted_group_names, sorted_group_names):
+            if len(s) > 1:
+                groups[sf] = grouped.get_group(s)
+            else:
+                if pandas_2_2_0:
+                    groups[sf] = grouped.get_group((s[0],))
+                else:
+                    groups[sf] = grouped.get_group(s[0])
     return groups, orders
 
 

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_input.py
@@ -8,6 +8,7 @@ import unittest.mock as mock
 from plotly.express._core import build_dataframe
 from pandas.testing import assert_frame_equal
 import sys
+import warnings
 
 
 # Fixtures
@@ -667,3 +668,16 @@ def test_x_or_y(fn):
         assert list(fig.data[0].x) == constant
         assert list(fig.data[0].y) == categorical
         assert fig.data[0].orientation == "h"
+
+
+def test_no_futurewarning():
+    with warnings.catch_warnings(record=True) as warn_list:
+        _ = px.scatter(
+            x=[15, 20, 29],
+            y=[10, 20, 30],
+            color=["Category 1", "Category 2", "Category 1"],
+        )
+    future_warnings = [
+        warn for warn in warn_list if issubclass(warn.category, FutureWarning)
+    ]
+    assert len(future_warnings) == 0, "FutureWarning(s) raised!"

--- a/packages/python/plotly/test_requirements/requirements_39_pandas_2_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_39_pandas_2_optional.txt
@@ -1,7 +1,7 @@
 requests==2.25.1
 tenacity==6.2.0
-pandas==2.0.2
-numpy==1.21.6
+pandas==2.2.0
+numpy==1.22.4
 xarray==0.17.0
 statsmodels
 Pillow==8.2.0


### PR DESCRIPTION
https://github.com/plotly/plotly.py/issues/4500

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).
