### PR TITLE
Pin sphinx dependencies

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -21,6 +21,12 @@ squarify
 scikit-image==0.18.1
 scikit-learn
 sphinx==3.5.4
+sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-jsmath==1.0.1
 sphinx_bootstrap_theme
 recommonmark
 pathlib

--- a/release.md
+++ b/release.md
@@ -270,4 +270,3 @@ From `packages/python/plotly-geo`, build the conda package
 ```
 
 Then upload to the plotly anaconda channel as described above.
-


### PR DESCRIPTION
We are encountering this https://github.com/sphinx-doc/sphinx/issues/11890

```
Running Sphinx v3.5.4

Sphinx version error:
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
make: *** [Makefile:34: html] Error 2
```

when trying to generate some of the reference docs. 
Setting these to the last versions that worked successfully for the docs build