### PR TITLE
Add support for local `plotly.js/` builds to `setup.py`

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -224,7 +224,30 @@ the `plotly/plotly.js` GitHub repository (and place them in
 `plotly/package_data`). It will then regenerate all of the `graph_objs`
 classes based on the new schema.
 
-For dev branches, it is also possible to use `updateplotlyjsdev --devrepo reponame --devbranch branchname` to update to development versions of `plotly.js`. This will fetch the `plotly.js` in the CircleCI artifact of the branch `branchname` of the repo `reponame`. If `--devrepo` or `--devbranch` are omitted, `updateplotlyjsdev` defaults using `plotly/plotly.js` and `master` respectively.
+For dev branches, it is also possible to use `updateplotlyjsdev` in two configurations:
+
+### CircleCI Release
+
+If your devbranch is part of the official plotly.js repository, you can use 
+```bash
+python setup.py updateplotlyjsdev --devrepo reponame --devbranch branchname
+``` 
+to update to development versions of `plotly.js`. This will fetch the `plotly.js` in the CircleCI artifact of the branch `branchname` of the repo `reponame`. If `--devrepo` or `--devbranch` are omitted, `updateplotlyjsdev` defaults using `plotly/plotly.js` and `master` respectively.
+
+### Local Repository
+
+If you have a local repository of `plotly.js` you'd like to try, you can run:
+
+```bash
+# In your plotly.js/ directory, prepare the package:
+
+$ npm run build
+$ npm pack
+$ mv plotly.js-*.tgz plotly.js.tgz
+
+# In your plotly.py/packages/python/plotly/ directory:
+$ python setup.py updateplotlyjsdev --local /path/to/your/plotly.js/
+```
 
 ## Testing
 

--- a/packages/python/plotly/setup.py
+++ b/packages/python/plotly/setup.py
@@ -1,7 +1,9 @@
 import os
 import sys
+import time
 import platform
 import json
+import shutil
 
 from setuptools import setup, Command
 from setuptools.command.egg_info import egg_info
@@ -137,10 +139,10 @@ class NPM(Command):
     ]
 
     def initialize_options(self):
-        pass
+        self.local = None
 
     def finalize_options(self):
-        pass
+        self.set_undefined_options("updateplotlyjsdev", ("local", "local"))
 
     def get_npm_name(self):
         npmName = "npm"
@@ -187,6 +189,14 @@ class NPM(Command):
                 stdout=sys.stdout,
                 stderr=sys.stderr,
             )
+            if self.local is not None:
+                plotly_archive = os.path.join(self.local, "plotly.js.tgz")
+                check_call(
+                    [npmName, "install", plotly_archive],
+                    cwd=node_root,
+                    stdout=sys.stdout,
+                    stderr=sys.stderr,
+                )
             check_call(
                 [npmName, "run", "build:prod"],
                 cwd=node_root,
@@ -224,6 +234,9 @@ class CodegenCommand(Command):
 
         perform_codegen()
 
+def overwrite_schema_local(uri):
+    path = os.path.join(here, "codegen", "resources", "plot-schema.json")
+    shutil.copyfile(uri, path)
 
 def overwrite_schema(url):
     import requests
@@ -234,6 +247,9 @@ def overwrite_schema(url):
     with open(path, "wb") as f:
         f.write(req.content)
 
+def overwrite_bundle_local(uri):
+    path = os.path.join(here, "plotly", "package_data", "plotly.min.js")
+    shutil.copyfile(uri, path)
 
 def overwrite_bundle(url):
     import requests
@@ -281,7 +297,6 @@ def request_json(url):
     req = requests.get(url)
     return json.loads(req.content.decode("utf-8"))
 
-
 def get_latest_publish_build_info(repo, branch):
 
     url = (
@@ -303,6 +318,11 @@ def get_latest_publish_build_info(repo, branch):
     # Extract build info
     return {p: build[p] for p in ["vcs_revision", "build_num", "committer_date"]}
 
+def get_bundle_schema_local(local):
+    plotly_archive = os.path.join(local, "plotly.js.tgz")
+    plotly_bundle = os.path.join(local, "dist/plotly.min.js")
+    plotly_schemas = os.path.join(local, "dist/plot-schema.json")
+    return plotly_archive, plotly_bundle, plotly_schemas
 
 def get_bundle_schema_urls(build_num):
     url = (
@@ -390,23 +410,37 @@ class UpdateBundleSchemaDevCommand(Command):
     def initialize_options(self):
         self.devrepo = None
         self.devbranch = None
+        self.local = None
 
     def finalize_options(self):
         self.set_undefined_options("updateplotlyjsdev", ("devrepo", "devrepo"))
         self.set_undefined_options("updateplotlyjsdev", ("devbranch", "devbranch"))
+        self.set_undefined_options("updateplotlyjsdev", ("local", "local"))
 
     def run(self):
-        build_info = get_latest_publish_build_info(self.devrepo, self.devbranch)
+        if self.local is None:
+            build_info = get_latest_publish_build_info(self.devrepo, self.devbranch)
 
-        archive_url, bundle_url, schema_url = get_bundle_schema_urls(
-            build_info["build_num"]
-        )
+            archive_url, bundle_url, schema_url = get_bundle_schema_urls(
+                build_info["build_num"]
+            )
 
-        # Update bundle in package data
-        overwrite_bundle(bundle_url)
+            # Update bundle in package data
+            overwrite_bundle(bundle_url)
 
-        # Update schema in package data
-        overwrite_schema(schema_url)
+            # Update schema in package data
+            overwrite_schema(schema_url)
+        else:
+            # this info could be more informative but
+            # it doesn't seem as useful in a local context
+            # and requires dependencies and programming.
+            build_info = {"vcs_revision": "local", "committer_date": str(time.time())}
+            self.devrepo = self.local
+            self.devbranch = ""
+
+            archive_uri, bundle_uri, schema_uri = get_bundle_schema_local(self.local)
+            overwrite_bundle_local(bundle_uri)
+            overwrite_schema_local(schema_uri)
 
         # Update plotly.js url in package.json
         package_json_path = os.path.join(node_root, "package.json")
@@ -414,7 +448,7 @@ class UpdateBundleSchemaDevCommand(Command):
             package_json = json.load(f)
 
         # Replace version with bundle url
-        package_json["dependencies"]["plotly.js"] = archive_url
+        package_json["dependencies"]["plotly.js"] = archive_url if self.local is None else archive_uri
         with open(package_json_path, "w") as f:
             json.dump(package_json, f, indent=2)
 
@@ -430,11 +464,13 @@ class UpdatePlotlyJsDevCommand(Command):
     user_options = [
         ("devrepo=", None, "Repository name"),
         ("devbranch=", None, "branch or pull/number"),
+        ("local=", None, "local copy of repo, used by itself")
     ]
 
     def initialize_options(self):
         self.devrepo = "plotly/plotly.js"
         self.devbranch = "master"
+        self.local = None
 
     def finalize_options(self):
         pass

--- a/packages/python/plotly/setup.py
+++ b/packages/python/plotly/setup.py
@@ -234,9 +234,11 @@ class CodegenCommand(Command):
 
         perform_codegen()
 
+
 def overwrite_schema_local(uri):
     path = os.path.join(here, "codegen", "resources", "plot-schema.json")
     shutil.copyfile(uri, path)
+
 
 def overwrite_schema(url):
     import requests
@@ -247,9 +249,11 @@ def overwrite_schema(url):
     with open(path, "wb") as f:
         f.write(req.content)
 
+
 def overwrite_bundle_local(uri):
     path = os.path.join(here, "plotly", "package_data", "plotly.min.js")
     shutil.copyfile(uri, path)
+
 
 def overwrite_bundle(url):
     import requests
@@ -297,6 +301,7 @@ def request_json(url):
     req = requests.get(url)
     return json.loads(req.content.decode("utf-8"))
 
+
 def get_latest_publish_build_info(repo, branch):
 
     url = (
@@ -318,11 +323,13 @@ def get_latest_publish_build_info(repo, branch):
     # Extract build info
     return {p: build[p] for p in ["vcs_revision", "build_num", "committer_date"]}
 
+
 def get_bundle_schema_local(local):
     plotly_archive = os.path.join(local, "plotly.js.tgz")
     plotly_bundle = os.path.join(local, "dist/plotly.min.js")
     plotly_schemas = os.path.join(local, "dist/plot-schema.json")
     return plotly_archive, plotly_bundle, plotly_schemas
+
 
 def get_bundle_schema_urls(build_num):
     url = (
@@ -448,7 +455,9 @@ class UpdateBundleSchemaDevCommand(Command):
             package_json = json.load(f)
 
         # Replace version with bundle url
-        package_json["dependencies"]["plotly.js"] = archive_url if self.local is None else archive_uri
+        package_json["dependencies"]["plotly.js"] = (
+            archive_url if self.local is None else archive_uri
+        )
         with open(package_json_path, "w") as f:
             json.dump(package_json, f, indent=2)
 
@@ -464,7 +473,7 @@ class UpdatePlotlyJsDevCommand(Command):
     user_options = [
         ("devrepo=", None, "Repository name"),
         ("devbranch=", None, "branch or pull/number"),
-        ("local=", None, "local copy of repo, used by itself")
+        ("local=", None, "local copy of repo, used by itself"),
     ]
 
     def initialize_options(self):


### PR DESCRIPTION
Hi, this PR adds a `--local=` flag to `setup.py updateplotlyjsdev` so we don't need to use circleci to use our custom plotly.js w/ plotly.py.

This helps a little bit with community dev flow, I think.

Here is the docs:

https://github.com/plotly/plotly.py/blob/a8f5ad531643cc3d6132803c6b1d1a5d2f22e8bc/contributing.md?plain=1#L237-L250

Thanks!

edit: could probably be made to work with github repos too with a little fetch here and there

## Code PR

This is a small addition to the build system, not a change to plotly.py as such

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [x] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [x] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [x] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).
