### PR TITLE
Update Plotly.py version for docs

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,5 +1,5 @@
 jupytext
-plotly==5.21.0
+plotly==5.22.0
 jupyter
 notebook
 pandas==1.2.0

--- a/doc/apidoc/conf.py
+++ b/doc/apidoc/conf.py
@@ -26,7 +26,7 @@ author = "Plotly"
 # The short X.Y version
 version = ""
 # The full version, including alpha/beta/rc tags
-release = "5.21.0"
+release = "5.22.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/python/getting-started.md
+++ b/doc/python/getting-started.md
@@ -58,13 +58,13 @@ We also encourage you to join the [Plotly Community Forum](http://community.plot
 `plotly` may be installed using `pip`:
 
 ```
-$ pip install plotly==5.21.0
+$ pip install plotly==5.22.0
 ```
 
 or `conda`:
 
 ```
-$ conda install -c plotly plotly=5.21.0
+$ conda install -c plotly plotly=5.22.0
 ```
 This package contains everything you need to write figures to standalone HTML files.
 
@@ -152,7 +152,7 @@ The instructions above apply to JupyterLab 3.x. **For JupyterLab 2 or earlier**,
 
 ```
 # JupyterLab 2.x renderer support
-jupyter labextension install jupyterlab-plotly@5.21.0 @jupyter-widgets/jupyterlab-manager
+jupyter labextension install jupyterlab-plotly@5.22.0 @jupyter-widgets/jupyterlab-manager
 ```
 
 Please check out our [Troubleshooting guide](/python/troubleshooting/) if you run into any problems with JupyterLab, particularly if you are using multiple python environments inside Jupyter.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-plotly==5.21.0
+plotly==5.22.0
 jupytext==1.1.1
 ipywidgets==7.7.2
 jupyter-client<7

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -45,3 +45,4 @@ jinja2<3.1
 parmed<=3.4.4; python_version<"3.8"
 dask==2022.2.0
 polars
+geoparse<=2.0.3


### PR DESCRIPTION
This PR updates the docs to use the latest, just released, plotly.py - 5.22
Release step here: https://github.com/plotly/plotly.py/blob/master/release.md#update-documentation-site

Note: Docs build failed for three pages because of an incompatibility between the latest version of geoparse and the library versions we are using in examples.
Pinning it here to the previous version to get the docs for the released merged, and then I can look at updating the requirements for the docs to later versions.