### PR TITLE
build+docs: use Python 3.11 and pin a recent version of pytest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [5.23.0] - TBD
+
+### Updated
+- Specify Python version 3.8-3.11 for development virtual environments and pin `pytest` at version 8.1.1 to match.
+
 ## [5.22.0] - 2024-05-01
 
 ### Updated

--- a/contributing.md
+++ b/contributing.md
@@ -125,12 +125,15 @@ learn and become confident about git, like http://try.github.io/.
 
 ### Create a virtual environment for plotly development
 
-You can use either [conda][conda-env] or [virtualenv][virtualenv] to create a virtual environment for plotly development, e.g.
+You can use either [conda][conda-env] or [virtualenv][virtualenv] to create a virtual environment for plotly development, e.g.:
 
 ```bash
-conda create -n plotly-dev python
+conda create -n plotly-dev python=3.11
 conda activate plotly-dev
 ```
+
+As of May 2024 our dependencies have been tested against Python versions 3.8 to 3.11.
+We will support Python 3.12 and higher versions soon.
 
 [conda-env]: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-with-commands
 [virtualenv]: http://docs.python-guide.org/en/latest/dev/virtualenvs/

--- a/packages/python/plotly/optional-requirements.txt
+++ b/packages/python/plotly/optional-requirements.txt
@@ -14,7 +14,7 @@ numpy
 ## testing dependencies ##
 coverage==4.3.1
 mock==2.0.0
-pytest==3.5.1
+pytest==8.1.1
 backports.tempfile==1.0
 xarray
 pytz


### PR DESCRIPTION
-   `conda create -n plotly-dev python` currently gives Python 3.12.3.
-   `pytest -v packages/python/plotly/plotly/tests/` then fails with `ModuleNotFoundError: No module named 'imp'`.
    -   `pip install imp` fails: the `imp` module was deprecated in Python 3.11 and has been removed in Python 3.12.
-   So update `contributing.md` to specify `conda create -n plotly-dev python=3.11`
-   But now `pytest` fails
    -   `File "<frozen importlib._bootstrap>", line 1072, in _find_spec`
    -   `AttributeError: 'AssertionRewritingHook' object has no attribute 'find_spec'`
-   Problem was `pytest==3.5.1` in `packages/python/plotly/optional-requirements.txt`
-   Update to `pytest==8.1.1` and `pytest` runs
    -   Some tests are failing (orca problems, `statsmodels` not installed, etc.)
    -   Will fix these in separate PRs
-   Note: updating `pytest` also solves the problem with the `imp` module not being available in Python 3.12.

## Code PR

- [X] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [X] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [X] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.

closes #4591 
