### PR TITLE
fix: use "==" with literal to remove warning during "python setup.py updateplotlyjs"

### DIFF
--- a/packages/python/chart-studio/chart_studio/tools.py
+++ b/packages/python/chart-studio/chart_studio/tools.py
@@ -287,7 +287,7 @@ def _get_embed_url(file_owner_or_url, file_id=None):
             "The 'file_id' argument must be a non-negative number."
         )
 
-    if share_key is "":
+    if share_key == "":
         return "{plotly_rest_url}/~{file_owner}/{file_id}.embed".format(
             plotly_rest_url=plotly_rest_url, file_owner=file_owner, file_id=file_id
         )


### PR DESCRIPTION
-   Existing code produces this warning during `python setup.py updateplotlyjs` step from `contributing.md`:

```
/Users/gvwilson/plotly.py/packages/python/chart-studio/chart_studio/tools.py:290: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if share_key is "":
```

-   Revised code uses `==` instead of `is`
    -   Warning goes away
    -   No change in test status

- [X] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
