### PR TITLE
Handle `extras` option in `IntegerValidator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Updated
 - Specify Python version 3.8-3.11 for development virtual environments and pin `pytest` at version 8.1.1 to match.
+- Update `IntegerValidator` to handle `extras` option to allow supporting additional keyword values. For example, 'bold' and 'normal' as well as integers as used in font weights [#4612].
 
 ## [5.22.0] - 2024-05-01
 


### PR DESCRIPTION
`extras` are added to plotly.js integer validator in https://github.com/plotly/plotly.js/pull/6990/commits/37dee4852e335067508add73de7ee7a59e8db045
i.e. to handle cases like *bold* and *normal* in `font.weight` which could also be a number between 1-1000.

This commit would be required in updating to upcoming plotly.js v2.33.0.

@LiamConnors 
cc: @emilykl @gvwilson  