### PR TITLE
Fix broken links

### DIFF
--- a/doc/apidoc/Makefile
+++ b/doc/apidoc/Makefile
@@ -36,7 +36,7 @@ help:
 	# Remove files which were added only for docstring generation
 	rm ../../packages/python/plotly/plotly/colors/diverging.py ../../packages/python/plotly/plotly/colors/sequential.py ../../packages/python/plotly/plotly/colors/qualitative.py ../../packages/python/plotly/plotly/colors/cyclical.py ../../packages/python/plotly/plotly/colors/colorbrewer.py ../../packages/python/plotly/plotly/colors/carto.py ../../packages/python/plotly/plotly/colors/cmocean.py
 	rm ../../packages/python/plotly/plotly/express/colors/diverging.py ../../packages/python/plotly/plotly/express/colors/sequential.py ../../packages/python/plotly/plotly/express/colors/qualitative.py ../../packages/python/plotly/plotly/express/colors/cyclical.py ../../packages/python/plotly/plotly/express/colors/colorbrewer.py ../../packages/python/plotly/plotly/express/colors/carto.py ../../packages/python/plotly/plotly/express/colors/cmocean.py
-	rename 's/graph_objs/graph_objects/' _build/html/*.html _build/html/generated/*.html
+	rename 's/graph_objs/graph_objects/' _build/html/*.html _build/html/generated/*.html _build/html/generated/generated/*.html
 	mv _build/html/generated/plotly.graph_objs.html _build/html/generated/plotly.graph_objects.html
 	sed -i 's/graph_objs/graph_objects/g' _build/html/*.html
 	sed -i 's/graph_objs/graph_objects/g' _build/html/*.inv


### PR DESCRIPTION
We have these links on the reference docs

<img width="1043" alt="image" src="https://github.com/plotly/plotly.py/assets/12749831/5d8b5f71-5ee0-4f5e-b727-93c0aa38ec0b">

That go here: https://plotly.com/python-api-reference/generated/generated/plotly.graph_objects.Figure.html

But the names in the built api docs are different.

<img width="468" alt="image" src="https://github.com/plotly/plotly.py/assets/12749831/7488daff-58d3-4343-97a6-b734a180bc22">

https://github.com/plotly/plotly.py-docs/tree/gh-pages/generated/generated

We are renaming everything else to `graph_objects` except these. 

This PR should fix the links, but I need to investigate more why these are in a different directory and if they should be included.