### PR TITLE
Specify image version for build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,7 +374,7 @@ jobs:
 
   full_build:
     docker:
-      - image: continuumio/miniconda3
+      - image: continuumio/miniconda3:24.3.0-0
         environment:
           LANG: en_US.UTF-8
     resource_class: large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -599,3 +599,4 @@ workflows:
       - python_38_orca
       - python_39_percy
       - build-doc
+


### PR DESCRIPTION
One of the tests times out when using the `latest` image for `full_build`. This specifies the most recent image that was working. 
