### PR TITLE
fix typo in error message formatting in process_args_into_dataframe

### DIFF
--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1215,7 +1215,7 @@ def process_args_into_dataframe(args, wide_mode, var_name, value_name):
                     raise ValueError(
                         "All arguments should have the same length. "
                         "The length of column argument `df[%s]` is %d, whereas the "
-                        "length of  previously-processed arguments %s is %d"
+                        "length of previously-processed arguments %s is %d"
                         % (
                             field,
                             len(df_input[argument]),
@@ -1253,7 +1253,7 @@ def process_args_into_dataframe(args, wide_mode, var_name, value_name):
                     raise ValueError(
                         "All arguments should have the same length. "
                         "The length of argument `%s` is %d, whereas the "
-                        "length of  previously-processed arguments %s is %d"
+                        "length of previously-processed arguments %s is %d"
                         % (field, len(argument), str(list(df_output.keys())), length)
                     )
                 df_output[str(col_name)] = to_unindexed_series(argument, str(col_name))


### PR DESCRIPTION
## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (**if submitting a new feature or correcting a bug**) or
  modified existing tests.
- [ ] **For a new feature**, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry **if fixing/changing/adding anything substantial**.
- [x] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).



A couple issues when following `contributing.md`:
1. the python packages appear to be floating and installed `numpy `at >=2, which did not work; the tests failed with deprecation of `np.NaN`.  I'd submit a change but worry about how much backwards compatibility with `numpy` that might break so instead I forced my numpy down to <2.
2. There were also some dependencies for tests which were not included in `optional_requirements.txt`: these included at least scikit-image statsmodels polars orca -- I resorted to testing just `packages/python/plotly/plotly/tests/test_core` to work around this.
3. Finally, one tests wrote out the file `packages/python/plotly/plotly/tests/test_orca/test_sg_scraper.html` which was not git ignored -- though as a new contributor, I'm not sure if I missed something, the file isn't meant to be ignored, or if it's alright to add an ignore for it.