### PR TITLE
Fix bug in IntegerValidator when an array contains both strings and integers, and add tests for IntegerValidator extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## UNRELEASED
+
+### Updated
+- Fixed a bug in integer validation of arrays that threw an error when an array contained a mix of strings and integers.
+
 ## [5.23.0] - 2024-07-23
 
 ### Updated

--- a/packages/python/plotly/_plotly_utils/basevalidators.py
+++ b/packages/python/plotly/_plotly_utils/basevalidators.py
@@ -950,7 +950,8 @@ class IntegerValidator(BaseValidator):
                 invalid_els = [
                     e
                     for e in v
-                    if not (isinstance(e, int) and self.min_val <= e <= self.max_val) and e not in self.extras
+                    if not (isinstance(e, int) and self.min_val <= e <= self.max_val)
+                    and e not in self.extras
                 ]
 
                 if invalid_els:

--- a/packages/python/plotly/_plotly_utils/basevalidators.py
+++ b/packages/python/plotly/_plotly_utils/basevalidators.py
@@ -950,7 +950,7 @@ class IntegerValidator(BaseValidator):
                 invalid_els = [
                     e
                     for e in v
-                    if not (self.min_val <= e <= self.max_val) and e not in self.extras
+                    if not (isinstance(e, int) and self.min_val <= e <= self.max_val) and e not in self.extras
                 ]
 
                 if invalid_els:

--- a/packages/python/plotly/_plotly_utils/tests/validators/test_integer_validator.py
+++ b/packages/python/plotly/_plotly_utils/tests/validators/test_integer_validator.py
@@ -38,7 +38,7 @@ def validator_extras():
 
 @pytest.fixture
 def validator_extras_aok():
-    return IntegerValidator("prop", "parent", min=-2, max=10, array_ok=True, extras=[['normal', 'bold'], ['italics']])
+    return IntegerValidator("prop", "parent", min=-2, max=10, array_ok=True, extras=['normal', 'bold', 'italics'])
 
 # ### Acceptance ###
 @pytest.mark.parametrize("val", [1, -19, 0, -1234])
@@ -69,7 +69,7 @@ def test_acceptance_extras(val, validator_extras):
     assert validator_extras.validate_coerce(val) == val
 
 # Test extras for array_ok
-@pytest.mark.parametrize("val", [['normal', 'bold'], ['italics']])
+@pytest.mark.parametrize("val", [[10, 'normal', 'bold'], ['italics'], [10, -2], [5]])
 def test_acceptance_extras_array(val, validator_extras_aok):
     assert validator_extras_aok.validate_coerce(val) == val
 

--- a/packages/python/plotly/_plotly_utils/tests/validators/test_integer_validator.py
+++ b/packages/python/plotly/_plotly_utils/tests/validators/test_integer_validator.py
@@ -32,6 +32,9 @@ def validator_max():
 def validator_aok(request):
     return IntegerValidator("prop", "parent", min=-2, max=10, array_ok=True)
 
+@pytest.fixture
+def validator_extras():
+    return IntegerValidator("prop", "parent", extras=['normal', 'bold'])
 
 # ### Acceptance ###
 @pytest.mark.parametrize("val", [1, -19, 0, -1234])
@@ -56,6 +59,18 @@ def test_rejection_by_value(val, validator):
 def test_acceptance_min_max(val, validator_min_max):
     assert validator_min_max.validate_coerce(val) == approx(val)
 
+# With extras
+@pytest.mark.parametrize("val", ['normal', 'bold'])
+def test_acceptance_extras(val, validator_extras):
+    assert validator_extras.validate_coerce(val) == val
+
+# Test rejection by extras
+@pytest.mark.parametrize("val", ['italic', 'bolditalic'])
+def test_rejection_extras(val, validator_extras):
+    with pytest.raises(ValueError) as validation_failure:
+        validator_extras.validate_coerce(val)
+
+    assert "Invalid value" in str(validation_failure.value)
 
 @pytest.mark.parametrize(
     "val", [-1.01, -10, 2.1, 3, np.iinfo(int).max, np.iinfo(int).min]

--- a/packages/python/plotly/_plotly_utils/tests/validators/test_integer_validator.py
+++ b/packages/python/plotly/_plotly_utils/tests/validators/test_integer_validator.py
@@ -32,13 +32,18 @@ def validator_max():
 def validator_aok(request):
     return IntegerValidator("prop", "parent", min=-2, max=10, array_ok=True)
 
+
 @pytest.fixture
 def validator_extras():
-    return IntegerValidator("prop", "parent", min=-2, max=10, extras=['normal', 'bold'])
+    return IntegerValidator("prop", "parent", min=-2, max=10, extras=["normal", "bold"])
+
 
 @pytest.fixture
 def validator_extras_aok():
-    return IntegerValidator("prop", "parent", min=-2, max=10, array_ok=True, extras=['normal', 'bold'])
+    return IntegerValidator(
+        "prop", "parent", min=-2, max=10, array_ok=True, extras=["normal", "bold"]
+    )
+
 
 # ### Acceptance ###
 @pytest.mark.parametrize("val", [1, -19, 0, -1234])
@@ -63,23 +68,27 @@ def test_rejection_by_value(val, validator):
 def test_acceptance_min_max(val, validator_min_max):
     assert validator_min_max.validate_coerce(val) == approx(val)
 
+
 # With extras
-@pytest.mark.parametrize("val", ['normal', 'bold', 10, -2])
+@pytest.mark.parametrize("val", ["normal", "bold", 10, -2])
 def test_acceptance_extras(val, validator_extras):
     assert validator_extras.validate_coerce(val) == val
 
+
 # Test extras for array_ok
-@pytest.mark.parametrize("val", [[10, 'normal', 'bold'], ['normal'], [10, -2], [5]])
+@pytest.mark.parametrize("val", [[10, "normal", "bold"], ["normal"], [10, -2], [5]])
 def test_acceptance_extras_array(val, validator_extras_aok):
     assert validator_extras_aok.validate_coerce(val) == val
 
+
 # Test rejection by extras
-@pytest.mark.parametrize("val", ['invalid value', 'different invalid value', -3, 11])
+@pytest.mark.parametrize("val", ["invalid value", "different invalid value", -3, 11])
 def test_rejection_extras(val, validator_extras):
     with pytest.raises(ValueError) as validation_failure:
         validator_extras.validate_coerce(val)
 
     assert "Invalid value" in str(validation_failure.value)
+
 
 @pytest.mark.parametrize(
     "val", [-1.01, -10, 2.1, 3, np.iinfo(int).max, np.iinfo(int).min]

--- a/packages/python/plotly/_plotly_utils/tests/validators/test_integer_validator.py
+++ b/packages/python/plotly/_plotly_utils/tests/validators/test_integer_validator.py
@@ -34,7 +34,11 @@ def validator_aok(request):
 
 @pytest.fixture
 def validator_extras():
-    return IntegerValidator("prop", "parent", extras=['normal', 'bold'])
+    return IntegerValidator("prop", "parent", min=-2, max=10, extras=['normal', 'bold'])
+
+@pytest.fixture
+def validator_extras_aok():
+    return IntegerValidator("prop", "parent", min=-2, max=10, array_ok=True, extras=[['normal', 'bold'], ['italics']])
 
 # ### Acceptance ###
 @pytest.mark.parametrize("val", [1, -19, 0, -1234])
@@ -60,12 +64,17 @@ def test_acceptance_min_max(val, validator_min_max):
     assert validator_min_max.validate_coerce(val) == approx(val)
 
 # With extras
-@pytest.mark.parametrize("val", ['normal', 'bold'])
+@pytest.mark.parametrize("val", ['normal', 'bold', 10, -2])
 def test_acceptance_extras(val, validator_extras):
     assert validator_extras.validate_coerce(val) == val
 
+# Test extras for array_ok
+@pytest.mark.parametrize("val", [['normal', 'bold'], ['italics']])
+def test_acceptance_extras_array(val, validator_extras_aok):
+    assert validator_extras_aok.validate_coerce(val) == val
+
 # Test rejection by extras
-@pytest.mark.parametrize("val", ['italic', 'bolditalic'])
+@pytest.mark.parametrize("val", ['italic', 'bolditalic', -3, 11])
 def test_rejection_extras(val, validator_extras):
     with pytest.raises(ValueError) as validation_failure:
         validator_extras.validate_coerce(val)

--- a/packages/python/plotly/_plotly_utils/tests/validators/test_integer_validator.py
+++ b/packages/python/plotly/_plotly_utils/tests/validators/test_integer_validator.py
@@ -38,7 +38,7 @@ def validator_extras():
 
 @pytest.fixture
 def validator_extras_aok():
-    return IntegerValidator("prop", "parent", min=-2, max=10, array_ok=True, extras=['normal', 'bold', 'italics'])
+    return IntegerValidator("prop", "parent", min=-2, max=10, array_ok=True, extras=['normal', 'bold'])
 
 # ### Acceptance ###
 @pytest.mark.parametrize("val", [1, -19, 0, -1234])
@@ -69,12 +69,12 @@ def test_acceptance_extras(val, validator_extras):
     assert validator_extras.validate_coerce(val) == val
 
 # Test extras for array_ok
-@pytest.mark.parametrize("val", [[10, 'normal', 'bold'], ['italics'], [10, -2], [5]])
+@pytest.mark.parametrize("val", [[10, 'normal', 'bold'], ['normal'], [10, -2], [5]])
 def test_acceptance_extras_array(val, validator_extras_aok):
     assert validator_extras_aok.validate_coerce(val) == val
 
 # Test rejection by extras
-@pytest.mark.parametrize("val", ['italic', 'bolditalic', -3, 11])
+@pytest.mark.parametrize("val", ['invalid value', 'different invalid value', -3, 11])
 def test_rejection_extras(val, validator_extras):
     with pytest.raises(ValueError) as validation_failure:
         validator_extras.validate_coerce(val)


### PR DESCRIPTION
Follow-up PR to #4612. Adds basic tests for passing and rejecting - also fixes a bug found while testing where the integer validator threw an error when arrays contained both strings and integers. 

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [x] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
~~- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).~~
- [x] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
~~- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).~~