### PR TITLE
Remove references to plotly.js CDN and requirejs

### DIFF
--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -3528,12 +3528,6 @@ Invalid property path '{key_path_str}' for layout
             plotly.min.js bundle that is assumed to reside in the same
             directory as the HTML file.
 
-            If 'require', Plotly.js is loaded using require.js.  This option
-            assumes that require.js is globally available and that it has been
-            globally configured to know how to find Plotly.js as 'plotly'.
-            This option is not advised when full_html=True as it will result
-            in a non-functional html file.
-
             If a string that ends in '.js', a script tag is included that
             references the specified path. This approach can be used to point
             the resulting HTML file to an alternative CDN or local bundle.
@@ -3618,12 +3612,6 @@ Invalid property path '{key_path_str}' for layout
             is included in the output.  HTML files generated with this option are
             fully self-contained and can be used offline.
 
-            If 'cdn', a script tag that references the plotly.js CDN is included
-            in the output. HTML files generated with this option are about 3MB
-            smaller than those generated with include_plotlyjs=True, but they
-            require an active internet connection in order to load the plotly.js
-            library.
-
             If 'directory', a script tag is included that references an external
             plotly.min.js bundle that is assumed to reside in the same
             directory as the HTML file. If `file` is a string to a local file
@@ -3636,12 +3624,6 @@ Invalid property path '{key_path_str}' for layout
             useful when many figures will be saved as HTML files in the same
             directory because the plotly.js source code will be included only
             once per output directory, rather than once per output file.
-
-            If 'require', Plotly.js is loaded using require.js.  This option
-            assumes that require.js is globally available and that it has been
-            globally configured to know how to find Plotly.js as 'plotly'.
-            This option is not advised when full_html=True as it will result
-            in a non-functional html file.
 
             If a string that ends in '.js', a script tag is included that
             references the specified path. This approach can be used to point

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -3524,12 +3524,6 @@ Invalid property path '{key_path_str}' for layout
             is included in the output.  HTML files generated with this option are
             fully self-contained and can be used offline.
 
-            If 'cdn', a script tag that references the plotly.js CDN is included
-            in the output. HTML files generated with this option are about 3MB
-            smaller than those generated with include_plotlyjs=True, but they
-            require an active internet connection in order to load the plotly.js
-            library.
-
             If 'directory', a script tag is included that references an external
             plotly.min.js bundle that is assumed to reside in the same
             directory as the HTML file.

--- a/packages/python/plotly/plotly/io/_base_renderers.py
+++ b/packages/python/plotly/plotly/io/_base_renderers.py
@@ -8,7 +8,6 @@ from os.path import isdir
 from plotly import utils, optional_imports
 from plotly.io import to_json, to_image, write_image, write_html
 from plotly.io._orca import ensure_server
-from plotly.io._utils import plotly_cdn_url
 from plotly.offline.offline import _get_jconfig, get_plotlyjs
 from plotly.tools import return_figure_from_figure_or_data
 
@@ -286,11 +285,6 @@ class HtmlRenderer(MimetypeRenderer):
         {mathjax_config}
         if (typeof require !== 'undefined') {{
         require.undef("plotly");
-        requirejs.config({{
-            paths: {{
-                'plotly': ['{plotly_cdn}']
-            }}
-        }});
         require(['plotly'], function(Plotly) {{
             window._Plotly = Plotly;
         }});
@@ -299,7 +293,6 @@ class HtmlRenderer(MimetypeRenderer):
         """.format(
                     win_config=_window_plotly_config,
                     mathjax_config=_mathjax_config,
-                    plotly_cdn=plotly_cdn_url().rstrip(".js"),
                 )
 
             else:

--- a/packages/python/plotly/plotly/io/_base_renderers.py
+++ b/packages/python/plotly/plotly/io/_base_renderers.py
@@ -327,9 +327,6 @@ class HtmlRenderer(MimetypeRenderer):
         if self.requirejs:
             include_plotlyjs = "require"
             include_mathjax = False
-        elif self.connected:
-            include_plotlyjs = "cdn"
-            include_mathjax = "cdn"
         else:
             include_plotlyjs = True
             include_mathjax = "cdn"
@@ -760,7 +757,7 @@ class DatabricksRenderer(ExternalRenderer):
         auto_play=False,
         post_script=None,
         animation_opts=None,
-        include_plotlyjs="cdn",
+        include_plotlyjs=True,
     ):
 
         self.config = config
@@ -840,9 +837,6 @@ class SphinxGalleryHtmlRenderer(HtmlRenderer):
         if self.requirejs:
             include_plotlyjs = "require"
             include_mathjax = False
-        elif self.connected:
-            include_plotlyjs = "cdn"
-            include_mathjax = "cdn"
         else:
             include_plotlyjs = True
             include_mathjax = "cdn"
@@ -875,7 +869,7 @@ class SphinxGalleryOrcaRenderer(ExternalRenderer):
         filename_html = filename_root + ".html"
         filename_png = filename_root + ".png"
         figure = return_figure_from_figure_or_data(fig_dict, True)
-        _ = write_html(fig_dict, file=filename_html, include_plotlyjs="cdn")
+        _ = write_html(fig_dict, file=filename_html, include_plotlyjs=True)
         try:
             write_image(figure, filename_png)
         except (ValueError, ImportError):

--- a/packages/python/plotly/plotly/io/_base_renderers.py
+++ b/packages/python/plotly/plotly/io/_base_renderers.py
@@ -248,7 +248,6 @@ class HtmlRenderer(MimetypeRenderer):
         self,
         connected=False,
         full_html=False,
-        requirejs=True,
         global_init=False,
         config=None,
         auto_play=False,
@@ -260,7 +259,6 @@ class HtmlRenderer(MimetypeRenderer):
         self.auto_play = auto_play
         self.connected = connected
         self.global_init = global_init
-        self.requirejs = requirejs
         self.full_html = full_html
         self.animation_opts = animation_opts
         self.post_script = post_script
@@ -274,27 +272,6 @@ class HtmlRenderer(MimetypeRenderer):
                     )
                 )
 
-            if not self.requirejs:
-                raise ValueError("global_init is only supported with requirejs=True")
-
-            if self.connected:
-                # Connected so we configure requirejs with the plotly CDN
-                script = """\
-        <script type="text/javascript">
-        {win_config}
-        {mathjax_config}
-        if (typeof require !== 'undefined') {{
-        require.undef("plotly");
-        require(['plotly'], function(Plotly) {{
-            window._Plotly = Plotly;
-        }});
-        }}
-        </script>
-        """.format(
-                    win_config=_window_plotly_config,
-                    mathjax_config=_mathjax_config,
-                )
-
             else:
                 # If not connected then we embed a copy of the plotly.js
                 # library in the notebook
@@ -302,15 +279,7 @@ class HtmlRenderer(MimetypeRenderer):
         <script type="text/javascript">
         {win_config}
         {mathjax_config}
-        if (typeof require !== 'undefined') {{
-        require.undef("plotly");
-        define('plotly', function(require, exports, module) {{
-            {script}
-        }});
-        require(['plotly'], function(Plotly) {{
-            window._Plotly = Plotly;
-        }});
-        }}
+        {script}
         </script>
         """.format(
                     script=get_plotlyjs(),
@@ -324,12 +293,8 @@ class HtmlRenderer(MimetypeRenderer):
 
         from plotly.io import to_html
 
-        if self.requirejs:
-            include_plotlyjs = "require"
-            include_mathjax = False
-        else:
-            include_plotlyjs = True
-            include_mathjax = "cdn"
+        include_plotlyjs = True
+        include_mathjax = "cdn"
 
         # build post script
         post_script = [
@@ -406,7 +371,6 @@ class NotebookRenderer(HtmlRenderer):
         super(NotebookRenderer, self).__init__(
             connected=connected,
             full_html=False,
-            requirejs=True,
             global_init=True,
             config=config,
             auto_play=auto_play,
@@ -434,7 +398,6 @@ class KaggleRenderer(HtmlRenderer):
         super(KaggleRenderer, self).__init__(
             connected=True,
             full_html=False,
-            requirejs=True,
             global_init=True,
             config=config,
             auto_play=auto_play,
@@ -462,7 +425,6 @@ class AzureRenderer(HtmlRenderer):
         super(AzureRenderer, self).__init__(
             connected=True,
             full_html=False,
-            requirejs=True,
             global_init=True,
             config=config,
             auto_play=auto_play,
@@ -487,7 +449,6 @@ class ColabRenderer(HtmlRenderer):
         super(ColabRenderer, self).__init__(
             connected=True,
             full_html=True,
-            requirejs=False,
             global_init=False,
             config=config,
             auto_play=auto_play,
@@ -822,7 +783,6 @@ class SphinxGalleryHtmlRenderer(HtmlRenderer):
         super(SphinxGalleryHtmlRenderer, self).__init__(
             connected=connected,
             full_html=False,
-            requirejs=False,
             global_init=False,
             config=config,
             auto_play=auto_play,
@@ -834,12 +794,8 @@ class SphinxGalleryHtmlRenderer(HtmlRenderer):
 
         from plotly.io import to_html
 
-        if self.requirejs:
-            include_plotlyjs = "require"
-            include_mathjax = False
-        else:
-            include_plotlyjs = True
-            include_mathjax = "cdn"
+        include_plotlyjs = True
+        include_mathjax = "cdn"
 
         html = to_html(
             fig_dict,

--- a/packages/python/plotly/plotly/io/_html.py
+++ b/packages/python/plotly/plotly/io/_html.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import webbrowser
 
 from _plotly_utils.optional_imports import get_module
-from plotly.io._utils import validate_coerce_fig_to_dict, plotly_cdn_url
+from plotly.io._utils import validate_coerce_fig_to_dict
 from plotly.offline.offline import _get_jconfig, get_plotlyjs
 
 _json = get_module("json")
@@ -270,9 +270,8 @@ def to_html(
     elif include_plotlyjs == "cdn":
         load_plotlyjs = """\
         {win_config}
-        <script charset="utf-8" src="{cdn_url}"></script>\
     """.format(
-            win_config=_window_plotly_config, cdn_url=plotly_cdn_url()
+            win_config=_window_plotly_config
         )
 
     elif include_plotlyjs == "directory":

--- a/packages/python/plotly/plotly/io/_html.py
+++ b/packages/python/plotly/plotly/io/_html.py
@@ -254,27 +254,10 @@ def to_html(
     if isinstance(include_plotlyjs, str):
         include_plotlyjs = include_plotlyjs.lower()
 
-    # Start/end of requirejs block (if any)
-    require_start = ""
-    require_end = ""
-
     # Init and load
     load_plotlyjs = ""
 
-    # Init plotlyjs. This block needs to run before plotly.js is loaded in
-    # order for MathJax configuration to work properly
-    if include_plotlyjs == "require":
-        require_start = 'require(["plotly"], function(Plotly) {'
-        require_end = "});"
-
-    elif include_plotlyjs == "cdn":
-        load_plotlyjs = """\
-        {win_config}
-    """.format(
-            win_config=_window_plotly_config
-        )
-
-    elif include_plotlyjs == "directory":
+    if include_plotlyjs == "directory":
         load_plotlyjs = """\
         {win_config}
         <script charset="utf-8" src="plotly.min.js"></script>\
@@ -342,10 +325,8 @@ include_mathjax may be specified as False, 'cdn', or a string ending with '.js'
             <div id="{id}" class="plotly-graph-div" \
 style="height:{height}; width:{width};"></div>\
             <script type="text/javascript">\
-                {require_start}\
-                    window.PLOTLYENV=window.PLOTLYENV || {{}};{base_url_line}\
-                    {script};\
-                {require_end}\
+                window.PLOTLYENV=window.PLOTLYENV || {{}};{base_url_line}\
+                {script};\
             </script>\
         </div>""".format(
         mathjax_script=mathjax_script,
@@ -354,9 +335,7 @@ style="height:{height}; width:{width};"></div>\
         width=div_width,
         height=div_height,
         base_url_line=base_url_line,
-        require_start=require_start,
         script=script,
-        require_end=require_end,
     ).strip()
 
     if full_html:

--- a/packages/python/plotly/plotly/io/_html.py
+++ b/packages/python/plotly/plotly/io/_html.py
@@ -57,21 +57,9 @@ def to_html(
         is included in the output.  HTML files generated with this option are
         fully self-contained and can be used offline.
 
-        If 'cdn', a script tag that references the plotly.js CDN is included
-        in the output. The url used is versioned to match the bundled plotly.js.
-        HTML files generated with this option are about 3MB smaller than those
-        generated with include_plotlyjs=True, but they require an active
-        internet connection in order to load the plotly.js library.
-
         If 'directory', a script tag is included that references an external
         plotly.min.js bundle that is assumed to reside in the same
         directory as the HTML file.
-
-        If 'require', Plotly.js is loaded using require.js.  This option
-        assumes that require.js is globally available and that it has been
-        globally configured to know how to find Plotly.js as 'plotly'.
-        This option is not advised when full_html=True as it will result
-        in a non-functional html file.
 
         If a string that ends in '.js', a script tag is included that
         references the specified path. This approach can be used to point
@@ -392,12 +380,6 @@ def write_html(
         is included in the output.  HTML files generated with this option are
         fully self-contained and can be used offline.
 
-        If 'cdn', a script tag that references the plotly.js CDN is included
-        in the output. The url used is versioned to match the bundled plotly.js.
-        HTML files generated with this option are about 3MB smaller than those
-        generated with include_plotlyjs=True, but they require an active
-        internet connection in order to load the plotly.js library.
-
         If 'directory', a script tag is included that references an external
         plotly.min.js bundle that is assumed to reside in the same
         directory as the HTML file.  If `file` is a string to a local file
@@ -410,12 +392,6 @@ def write_html(
         useful when many figures will be saved as HTML files in the same
         directory because the plotly.js source code will be included only
         once per output directory, rather than once per output file.
-
-        If 'require', Plotly.js is loaded using require.js.  This option
-        assumes that require.js is globally available and that it has been
-        globally configured to know how to find Plotly.js as 'plotly'.
-        This option is not advised when full_html=True as it will result
-        in a non-functional html file.
 
         If a string that ends in '.js', a script tag is included that
         references the specified path. This approach can be used to point

--- a/packages/python/plotly/plotly/io/_utils.py
+++ b/packages/python/plotly/plotly/io/_utils.py
@@ -41,10 +41,3 @@ Invalid output type: {output_type}
     Must be one of: 'Figure', 'FigureWidget'"""
         )
     return cls
-
-
-def plotly_cdn_url(cdn_ver=get_plotlyjs_version()):
-    """Return a valid plotly CDN url."""
-    return "https://cdn.plot.ly/plotly-{cdn_ver}.min.js".format(
-        cdn_ver=cdn_ver,
-    )

--- a/packages/python/plotly/plotly/tests/test_core/test_offline/test_offline.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_offline/test_offline.py
@@ -9,7 +9,6 @@ import pytest
 
 import plotly
 import plotly.io as pio
-from plotly.io._utils import plotly_cdn_url
 
 packages_root = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.realpath(plotly.__file__))))
@@ -36,9 +35,6 @@ plotly_config_script = """\
 <script type="text/javascript">\
 window.PlotlyConfig = {MathJaxConfig: 'local'};</script>"""
 
-cdn_script = '<script charset="utf-8" src="{cdn_url}"></script>'.format(
-    cdn_url=plotly_cdn_url()
-)
 
 directory_script = '<script charset="utf-8" src="plotly.min.js"></script>'
 
@@ -124,7 +120,6 @@ class PlotlyOfflineTestCase(PlotlyOfflineBaseTestCase):
 
             self.assertIn(plotly_config_script, html)
             self.assertIn(PLOTLYJS, html)
-            self.assertNotIn(cdn_script, html)
             self.assertNotIn(directory_script, html)
 
     def test_including_plotlyjs_truthy_div(self):
@@ -137,7 +132,6 @@ class PlotlyOfflineTestCase(PlotlyOfflineBaseTestCase):
 
             self.assertIn(plotly_config_script, html)
             self.assertIn(PLOTLYJS, html)
-            self.assertNotIn(cdn_script, html)
             self.assertNotIn(directory_script, html)
 
     def test_including_plotlyjs_false_html(self):
@@ -156,7 +150,6 @@ class PlotlyOfflineTestCase(PlotlyOfflineBaseTestCase):
 
             self.assertNotIn(plotly_config_script, html)
             self.assertNotIn(PLOTLYJS, html)
-            self.assertNotIn(cdn_script, html)
             self.assertNotIn(directory_script, html)
 
     def test_including_plotlyjs_false_div(self):
@@ -166,7 +159,6 @@ class PlotlyOfflineTestCase(PlotlyOfflineBaseTestCase):
             )
             self.assertNotIn(plotly_config_script, html)
             self.assertNotIn(PLOTLYJS, html)
-            self.assertNotIn(cdn_script, html)
             self.assertNotIn(directory_script, html)
 
     def test_including_plotlyjs_cdn_html(self):
@@ -182,7 +174,6 @@ class PlotlyOfflineTestCase(PlotlyOfflineBaseTestCase):
             )
             self.assertIn(plotly_config_script, html)
             self.assertNotIn(PLOTLYJS, html)
-            self.assertIn(cdn_script, html)
             self.assertNotIn(directory_script, html)
 
     def test_including_plotlyjs_cdn_div(self):
@@ -192,7 +183,6 @@ class PlotlyOfflineTestCase(PlotlyOfflineBaseTestCase):
             )
             self.assertIn(plotly_config_script, html)
             self.assertNotIn(PLOTLYJS, html)
-            self.assertIn(cdn_script, html)
             self.assertNotIn(directory_script, html)
 
     def test_including_plotlyjs_directory_html(self):
@@ -209,7 +199,6 @@ class PlotlyOfflineTestCase(PlotlyOfflineBaseTestCase):
             )
             self.assertIn(plotly_config_script, html)
             self.assertNotIn(PLOTLYJS, html)
-            self.assertNotIn(cdn_script, html)
             self.assertIn(directory_script, html)
 
         # plot creates plotly.min.js in the output directory
@@ -230,7 +219,6 @@ class PlotlyOfflineTestCase(PlotlyOfflineBaseTestCase):
 
             self.assertIn(plotly_config_script, html)
             self.assertNotIn(PLOTLYJS, html)
-            self.assertNotIn(cdn_script, html)
             self.assertIn(directory_script, html)
 
         # plot does NOT create a plotly.min.js file in the output directory
@@ -257,7 +245,6 @@ class PlotlyOfflineTestCase(PlotlyOfflineBaseTestCase):
                 )
             )
             self.assertNotIn(PLOTLYJS, html)
-            self.assertNotIn(cdn_script, html)
             self.assertNotIn(directory_script, html)
             self.assertIn(include_plotlyjs, html)
 
@@ -275,7 +262,6 @@ class PlotlyOfflineTestCase(PlotlyOfflineBaseTestCase):
                 fig, include_plotlyjs=include_plotlyjs, output_type="div"
             )
             self.assertNotIn(PLOTLYJS, html)
-            self.assertNotIn(cdn_script, html)
             self.assertNotIn(directory_script, html)
             self.assertIn(include_plotlyjs, html)
 

--- a/packages/python/plotly/plotly/tests/test_core/test_offline/test_offline.py
+++ b/packages/python/plotly/plotly/tests/test_core/test_offline/test_offline.py
@@ -161,30 +161,6 @@ class PlotlyOfflineTestCase(PlotlyOfflineBaseTestCase):
             self.assertNotIn(PLOTLYJS, html)
             self.assertNotIn(directory_script, html)
 
-    def test_including_plotlyjs_cdn_html(self):
-        for include_plotlyjs in ["cdn", "CDN", "Cdn"]:
-            html = self._read_html(
-                plotly.offline.plot(
-                    fig,
-                    include_plotlyjs=include_plotlyjs,
-                    output_type="file",
-                    filename=html_filename,
-                    auto_open=False,
-                )
-            )
-            self.assertIn(plotly_config_script, html)
-            self.assertNotIn(PLOTLYJS, html)
-            self.assertNotIn(directory_script, html)
-
-    def test_including_plotlyjs_cdn_div(self):
-        for include_plotlyjs in ["cdn", "CDN", "Cdn"]:
-            html = plotly.offline.plot(
-                fig, include_plotlyjs=include_plotlyjs, output_type="div"
-            )
-            self.assertIn(plotly_config_script, html)
-            self.assertNotIn(PLOTLYJS, html)
-            self.assertNotIn(directory_script, html)
-
     def test_including_plotlyjs_directory_html(self):
         self.assertFalse(os.path.exists(os.path.join(here, "plotly.min.js")))
 

--- a/packages/python/plotly/plotly/tests/test_io/test_html.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_html.py
@@ -6,7 +6,6 @@ import numpy as np
 
 import plotly.graph_objs as go
 import plotly.io as pio
-from plotly.io._utils import plotly_cdn_url
 
 
 if sys.version_info >= (3, 3):
@@ -34,10 +33,6 @@ def fig1(request):
 
 # HTML
 # ----
-
-
-def test_versioned_cdn_included(fig1):
-    assert plotly_cdn_url() in pio.to_html(fig1, include_plotlyjs="cdn")
 
 
 def test_html_deterministic(fig1):

--- a/packages/python/plotly/plotly/tests/test_io/test_renderers.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_renderers.py
@@ -140,14 +140,6 @@ def assert_offline(html):
     assert get_plotlyjs() in html
 
 
-def assert_requirejs(html):
-    assert 'require(["plotly"]' in html
-
-
-def assert_not_requirejs(html):
-    assert 'require(["plotly"]' not in html
-
-
 def test_colab_renderer_show(fig1):
     pio.renderers.default = "colab"
 
@@ -165,7 +157,6 @@ def test_colab_renderer_show(fig1):
     html = mock_arg1["text/html"]
     assert_full_html(html)
     assert_html_renderer_connected(html)
-    assert_not_requirejs(html)
 
     # check kwargs
     mock_kwargs = mock_call_args[1]
@@ -208,7 +199,6 @@ def test_notebook_connected_show(fig1, name, connected):
     # Check html display contents
     bundle_html = mock_arg1["text/html"]
     assert_not_full_html(bundle_html)
-    assert_requirejs(bundle_html)
 
     # check kwargs
     mock_kwargs = mock_call_args[1]
@@ -270,7 +260,6 @@ def test_browser_renderer_show(fig1, renderer):
     html = response.content.decode("utf8")
     assert_full_html(html)
     assert_offline(html)
-    assert_not_requirejs(html)
 
 
 # Validation

--- a/packages/python/plotly/plotly/tests/test_io/test_renderers.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_renderers.py
@@ -12,7 +12,6 @@ import webbrowser
 import plotly.graph_objs as go
 import plotly.io as pio
 from plotly.offline import get_plotlyjs
-from plotly.io._utils import plotly_cdn_url
 
 if sys.version_info >= (3, 3):
     import unittest.mock as mock
@@ -135,10 +134,6 @@ def assert_full_html(html):
 
 def assert_not_full_html(html):
     assert not html.startswith("<html")
-
-
-def assert_html_renderer_connected(html):
-    assert plotly_cdn_url().rstrip(".js") in html
 
 
 def assert_offline(html):
@@ -312,9 +307,7 @@ def test_repr_html(renderer):
     template = (
         '<div>                        <script type="text/javascript">'
         "window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n        "
-        '<script charset="utf-8" src="'
-        + plotly_cdn_url()
-        + '"></script>                '
+        '<script charset="utf-8" src="' + '"></script>                '
         '<div id="cd462b94-79ce-42a2-887f-2650a761a144" class="plotly-graph-div" '
         'style="height:100%; width:100%;"></div>            <script type="text/javascript">'
         "                                    window.PLOTLYENV=window.PLOTLYENV || {};"

--- a/packages/python/plotly/plotly/tests/test_io/test_renderers.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_renderers.py
@@ -156,7 +156,6 @@ def test_colab_renderer_show(fig1):
     # Check html contents
     html = mock_arg1["text/html"]
     assert_full_html(html)
-    assert_html_renderer_connected(html)
 
     # check kwargs
     mock_kwargs = mock_call_args[1]
@@ -183,10 +182,7 @@ def test_notebook_connected_show(fig1, name, connected):
 
     # Check init display contents
     bundle_display_html = mock_arg1_html
-    if connected:
-        assert_html_renderer_connected(bundle_display_html)
-    else:
-        assert_offline(bundle_display_html)
+    assert_offline(bundle_display_html)
 
     # ### Check display call ###
     # Get display call arguments


### PR DESCRIPTION
This removes references in the base renderers to the CDN and requirejs. 
* Latest plotly.js used to be on a CDN, but it isn't anymore (we decided it was too much maintenance years ago)
* Requirejs is essentially unmaintained and newer versions of jupyter lab and jupyter notebook don't support it anymore, so this fixes some of the notebook 7 and lab 4 issues we've been seeing. 
* Removes setting `window._Plotly` because that appears to be unused

This should fix #4336. 