### PR TITLE
fixing a bug that causes the hovertext to show %{text} rather than th…

### DIFF
--- a/doc/python/hover-text-and-formatting.md
+++ b/doc/python/hover-text-and-formatting.md
@@ -401,6 +401,7 @@ for continent_name, df in continent_data.items():
             x=df['gdpPercap'],
             y=df['lifeExp'],
             marker_size=df['size'],
+            text=df['continent'],
             name=continent_name,
 
             # The next three parameters specify the hover text


### PR DESCRIPTION

There is a bug here that causes the hovertext to show one line as %{text} rather than showing the continent name.  I have fixed it the way the comments imply that the example intended.  either we should add a text parameter as I've done here, or the example could remove the %{text} from the hovertext and from the comments.

This is a one line bug fix bringing the example in congruence with its comments, so I'm going to skip the checklist.  Happy to fill it out later if it would be helpful.
