### PR TITLE
Convert base64 in BaseFigure.to_dict instead of validate_coerce

### DIFF
--- a/packages/python/plotly/_plotly_utils/basevalidators.py
+++ b/packages/python/plotly/_plotly_utils/basevalidators.py
@@ -503,7 +503,7 @@ class DataArrayValidator(BaseValidator):
         elif has_skipped_key(self.parent_name):
             v = to_scalar_or_list(v)
         elif is_homogeneous_array(v):
-            v = to_typed_array_spec(v)
+            v = copy_to_readonly_numpy_array(v)
         elif is_simple_array(v):
             v = to_scalar_or_list(v)
         else:

--- a/packages/python/plotly/_plotly_utils/basevalidators.py
+++ b/packages/python/plotly/_plotly_utils/basevalidators.py
@@ -51,83 +51,6 @@ def to_scalar_or_list(v):
         return v
 
 
-plotlyjsShortTypes = {
-    "int8": "i1",
-    "uint8": "u1",
-    "int16": "i2",
-    "uint16": "u2",
-    "int32": "i4",
-    "uint32": "u4",
-    "float32": "f4",
-    "float64": "f8",
-}
-
-int8min = -128
-int8max = 127
-int16min = -32768
-int16max = 32767
-int32min = -2147483648
-int32max = 2147483647
-
-uint8max = 255
-uint16max = 65535
-uint32max = 4294967295
-
-
-def to_typed_array_spec(v):
-    """
-    Convert numpy array to plotly.js typed array spec
-    If not possible return the original value
-    """
-    v = copy_to_readonly_numpy_array(v)
-
-    np = get_module("numpy", should_load=False)
-    if not isinstance(v, np.ndarray):
-        return v
-
-    dtype = str(v.dtype)
-
-    # convert default Big Ints until we could support them in plotly.js
-    if dtype == "int64":
-        max = v.max()
-        min = v.min()
-        if max <= int8max and min >= int8min:
-            v = v.astype("int8")
-        elif max <= int16max and min >= int16min:
-            v = v.astype("int16")
-        elif max <= int32max and min >= int32min:
-            v = v.astype("int32")
-        else:
-            return v
-
-    elif dtype == "uint64":
-        max = v.max()
-        min = v.min()
-        if max <= uint8max and min >= 0:
-            v = v.astype("uint8")
-        elif max <= uint16max and min >= 0:
-            v = v.astype("uint16")
-        elif max <= uint32max and min >= 0:
-            v = v.astype("uint32")
-        else:
-            return v
-
-    dtype = str(v.dtype)
-
-    if dtype in plotlyjsShortTypes:
-        arrObj = {
-            "dtype": plotlyjsShortTypes[dtype],
-            "bdata": base64.b64encode(v).decode("ascii"),
-        }
-
-        if v.ndim > 1:
-            arrObj["shape"] = str(v.shape)[1:-1]
-
-        return arrObj
-
-    return v
-
-
 def copy_to_readonly_numpy_array(v, kind=None, force_numeric=False):
     """
     Convert an array-like value into a read-only numpy array
@@ -290,15 +213,6 @@ def is_typed_array_spec(v):
     Return whether a value is considered to be a typed array spec for plotly.js
     """
     return isinstance(v, dict) and "bdata" in v and "dtype" in v
-
-
-def has_skipped_key(all_parent_keys):
-    """
-    Return whether any keys in the parent hierarchy are in the list of keys that
-    are skipped for conversion to the typed array spec
-    """
-    skipped_keys = ["geojson", "layer", "range"]
-    return any(skipped_key in all_parent_keys for skipped_key in skipped_keys)
 
 
 def is_none_or_typed_array_spec(v):
@@ -500,8 +414,6 @@ class DataArrayValidator(BaseValidator):
     def validate_coerce(self, v):
         if is_none_or_typed_array_spec(v):
             pass
-        elif has_skipped_key(self.parent_name):
-            v = to_scalar_or_list(v)
         elif is_homogeneous_array(v):
             v = copy_to_readonly_numpy_array(v)
         elif is_simple_array(v):

--- a/packages/python/plotly/_plotly_utils/utils.py
+++ b/packages/python/plotly/_plotly_utils/utils.py
@@ -1,3 +1,4 @@
+import base64
 import decimal
 import json as _json
 import sys
@@ -5,7 +6,111 @@ import re
 from functools import reduce
 
 from _plotly_utils.optional_imports import get_module
-from _plotly_utils.basevalidators import ImageUriValidator
+from _plotly_utils.basevalidators import (
+    ImageUriValidator,
+    copy_to_readonly_numpy_array,
+    is_homogeneous_array,
+)
+
+
+int8min = -128
+int8max = 127
+int16min = -32768
+int16max = 32767
+int32min = -2147483648
+int32max = 2147483647
+
+uint8max = 255
+uint16max = 65535
+uint32max = 4294967295
+
+plotlyjsShortTypes = {
+    "int8": "i1",
+    "uint8": "u1",
+    "int16": "i2",
+    "uint16": "u2",
+    "int32": "i4",
+    "uint32": "u4",
+    "float32": "f4",
+    "float64": "f8",
+}
+
+
+def to_typed_array_spec(v):
+    """
+    Convert numpy array to plotly.js typed array spec
+    If not possible return the original value
+    """
+    v = copy_to_readonly_numpy_array(v)
+
+    np = get_module("numpy", should_load=False)
+    if not isinstance(v, np.ndarray):
+        return v
+
+    dtype = str(v.dtype)
+
+    # convert default Big Ints until we could support them in plotly.js
+    if dtype == "int64":
+        max = v.max()
+        min = v.min()
+        if max <= int8max and min >= int8min:
+            v = v.astype("int8")
+        elif max <= int16max and min >= int16min:
+            v = v.astype("int16")
+        elif max <= int32max and min >= int32min:
+            v = v.astype("int32")
+        else:
+            return v
+
+    elif dtype == "uint64":
+        max = v.max()
+        min = v.min()
+        if max <= uint8max and min >= 0:
+            v = v.astype("uint8")
+        elif max <= uint16max and min >= 0:
+            v = v.astype("uint16")
+        elif max <= uint32max and min >= 0:
+            v = v.astype("uint32")
+        else:
+            return v
+
+    dtype = str(v.dtype)
+
+    if dtype in plotlyjsShortTypes:
+        arrObj = {
+            "dtype": plotlyjsShortTypes[dtype],
+            "bdata": base64.b64encode(v).decode("ascii"),
+        }
+
+        if v.ndim > 1:
+            arrObj["shape"] = str(v.shape)[1:-1]
+
+        return arrObj
+
+    return v
+
+
+def is_skipped_key(key):
+    """
+    Return whether any keys in the parent hierarchy are in the list of keys that
+    are skipped for conversion to the typed array spec
+    """
+    skipped_keys = ["geojson", "layer", "range"]
+    return any(skipped_key in key for skipped_key in skipped_keys)
+
+
+def convert_to_base64(obj):
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if is_skipped_key(key):
+                continue
+            elif is_homogeneous_array(value):
+                obj[key] = to_typed_array_spec(value)
+            else:
+                convert_to_base64(value)
+    elif isinstance(obj, list) or isinstance(obj, tuple):
+        for i, value in enumerate(obj):
+            convert_to_base64(value)
 
 
 def cumsum(x):

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -15,9 +15,9 @@ from _plotly_utils.utils import (
     display_string_positions,
     chomp_empty_strings,
     find_closest_string,
+    convert_to_base64,
 )
 from _plotly_utils.exceptions import PlotlyKeyError
-from _plotly_utils.utils import convert_to_base64
 from .optional_imports import get_module
 
 from . import shapeannotation

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -17,7 +17,7 @@ from _plotly_utils.utils import (
     find_closest_string,
 )
 from _plotly_utils.exceptions import PlotlyKeyError
-from packages.python.plotly.plotly.io._utils import convert_to_base64
+from _plotly_utils.utils import convert_to_base64
 from .optional_imports import get_module
 
 from . import shapeannotation

--- a/packages/python/plotly/plotly/basedatatypes.py
+++ b/packages/python/plotly/plotly/basedatatypes.py
@@ -17,6 +17,7 @@ from _plotly_utils.utils import (
     find_closest_string,
 )
 from _plotly_utils.exceptions import PlotlyKeyError
+from packages.python.plotly.plotly.io._utils import convert_to_base64
 from .optional_imports import get_module
 
 from . import shapeannotation
@@ -3309,6 +3310,9 @@ Invalid property path '{key_path_str}' for layout
 
         if frames:
             res["frames"] = frames
+
+        # Add base64 conversion before sending to the front-end
+        convert_to_base64(res)
 
         return res
 

--- a/packages/python/plotly/plotly/io/_utils.py
+++ b/packages/python/plotly/plotly/io/_utils.py
@@ -1,7 +1,112 @@
-from _plotly_utils.basevalidators import is_homogeneous_array, to_typed_array_spec
+import base64
+from _plotly_utils.basevalidators import (
+    copy_to_readonly_numpy_array,
+    is_homogeneous_array,
+    to_typed_array_spec,
+)
+from packages.python.plotly._plotly_utils.optional_imports import get_module
 import plotly
 import plotly.graph_objs as go
 from plotly.offline import get_plotlyjs_version
+
+int8min = -128
+int8max = 127
+int16min = -32768
+int16max = 32767
+int32min = -2147483648
+int32max = 2147483647
+
+uint8max = 255
+uint16max = 65535
+uint32max = 4294967295
+
+plotlyjsShortTypes = {
+    "int8": "i1",
+    "uint8": "u1",
+    "int16": "i2",
+    "uint16": "u2",
+    "int32": "i4",
+    "uint32": "u4",
+    "float32": "f4",
+    "float64": "f8",
+}
+
+
+def to_typed_array_spec(v):
+    """
+    Convert numpy array to plotly.js typed array spec
+    If not possible return the original value
+    """
+    v = copy_to_readonly_numpy_array(v)
+
+    np = get_module("numpy", should_load=False)
+    if not isinstance(v, np.ndarray):
+        return v
+
+    dtype = str(v.dtype)
+
+    # convert default Big Ints until we could support them in plotly.js
+    if dtype == "int64":
+        max = v.max()
+        min = v.min()
+        if max <= int8max and min >= int8min:
+            v = v.astype("int8")
+        elif max <= int16max and min >= int16min:
+            v = v.astype("int16")
+        elif max <= int32max and min >= int32min:
+            v = v.astype("int32")
+        else:
+            return v
+
+    elif dtype == "uint64":
+        max = v.max()
+        min = v.min()
+        if max <= uint8max and min >= 0:
+            v = v.astype("uint8")
+        elif max <= uint16max and min >= 0:
+            v = v.astype("uint16")
+        elif max <= uint32max and min >= 0:
+            v = v.astype("uint32")
+        else:
+            return v
+
+    dtype = str(v.dtype)
+
+    if dtype in plotlyjsShortTypes:
+        arrObj = {
+            "dtype": plotlyjsShortTypes[dtype],
+            "bdata": base64.b64encode(v).decode("ascii"),
+        }
+
+        if v.ndim > 1:
+            arrObj["shape"] = str(v.shape)[1:-1]
+
+        return arrObj
+
+    return v
+
+
+def is_skipped_key(key):
+    """
+    Return whether any keys in the parent hierarchy are in the list of keys that
+    are skipped for conversion to the typed array spec
+    """
+    skipped_keys = ["geojson", "layer", "range"]
+    return any(skipped_key in key for skipped_key in skipped_keys)
+
+
+def convert_to_base64(obj):
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if is_skipped_key(key):
+                continue
+            elif is_homogeneous_array(value):
+                obj[key] = to_typed_array_spec(value)
+            else:
+                convert_to_base64(value)
+    elif isinstance(obj, list) or isinstance(obj, tuple):
+        for i, value in enumerate(obj):
+            convert_to_base64(value)
 
 
 def validate_coerce_fig_to_dict(fig, validate):
@@ -27,11 +132,7 @@ The fig parameter must be a dict or Figure.
         )
 
     # Add base64 conversion before sending to the front-end
-    for trace in fig_dict["data"]:
-        for key, value in trace.items():
-            if is_homogeneous_array(value):
-                print("to typed array: key:", key, "value:", value)
-                trace[key] = to_typed_array_spec(value)
+    convert_to_base64(fig_dict)
 
     return fig_dict
 

--- a/packages/python/plotly/plotly/io/_utils.py
+++ b/packages/python/plotly/plotly/io/_utils.py
@@ -1,3 +1,4 @@
+from _plotly_utils.basevalidators import is_homogeneous_array, to_typed_array_spec
 import plotly
 import plotly.graph_objs as go
 from plotly.offline import get_plotlyjs_version
@@ -24,6 +25,14 @@ The fig parameter must be a dict or Figure.
                 typ=type(fig), v=fig
             )
         )
+
+    # Add base64 conversion before sending to the front-end
+    for trace in fig_dict["data"]:
+        for key, value in trace.items():
+            if is_homogeneous_array(value):
+                print("to typed array: key:", key, "value:", value)
+                trace[key] = to_typed_array_spec(value)
+
     return fig_dict
 
 

--- a/packages/python/plotly/plotly/io/_utils.py
+++ b/packages/python/plotly/plotly/io/_utils.py
@@ -1,112 +1,6 @@
-import base64
-from _plotly_utils.basevalidators import (
-    copy_to_readonly_numpy_array,
-    is_homogeneous_array,
-    to_typed_array_spec,
-)
-from packages.python.plotly._plotly_utils.optional_imports import get_module
 import plotly
 import plotly.graph_objs as go
 from plotly.offline import get_plotlyjs_version
-
-int8min = -128
-int8max = 127
-int16min = -32768
-int16max = 32767
-int32min = -2147483648
-int32max = 2147483647
-
-uint8max = 255
-uint16max = 65535
-uint32max = 4294967295
-
-plotlyjsShortTypes = {
-    "int8": "i1",
-    "uint8": "u1",
-    "int16": "i2",
-    "uint16": "u2",
-    "int32": "i4",
-    "uint32": "u4",
-    "float32": "f4",
-    "float64": "f8",
-}
-
-
-def to_typed_array_spec(v):
-    """
-    Convert numpy array to plotly.js typed array spec
-    If not possible return the original value
-    """
-    v = copy_to_readonly_numpy_array(v)
-
-    np = get_module("numpy", should_load=False)
-    if not isinstance(v, np.ndarray):
-        return v
-
-    dtype = str(v.dtype)
-
-    # convert default Big Ints until we could support them in plotly.js
-    if dtype == "int64":
-        max = v.max()
-        min = v.min()
-        if max <= int8max and min >= int8min:
-            v = v.astype("int8")
-        elif max <= int16max and min >= int16min:
-            v = v.astype("int16")
-        elif max <= int32max and min >= int32min:
-            v = v.astype("int32")
-        else:
-            return v
-
-    elif dtype == "uint64":
-        max = v.max()
-        min = v.min()
-        if max <= uint8max and min >= 0:
-            v = v.astype("uint8")
-        elif max <= uint16max and min >= 0:
-            v = v.astype("uint16")
-        elif max <= uint32max and min >= 0:
-            v = v.astype("uint32")
-        else:
-            return v
-
-    dtype = str(v.dtype)
-
-    if dtype in plotlyjsShortTypes:
-        arrObj = {
-            "dtype": plotlyjsShortTypes[dtype],
-            "bdata": base64.b64encode(v).decode("ascii"),
-        }
-
-        if v.ndim > 1:
-            arrObj["shape"] = str(v.shape)[1:-1]
-
-        return arrObj
-
-    return v
-
-
-def is_skipped_key(key):
-    """
-    Return whether any keys in the parent hierarchy are in the list of keys that
-    are skipped for conversion to the typed array spec
-    """
-    skipped_keys = ["geojson", "layer", "range"]
-    return any(skipped_key in key for skipped_key in skipped_keys)
-
-
-def convert_to_base64(obj):
-    if isinstance(obj, dict):
-        for key, value in obj.items():
-            if is_skipped_key(key):
-                continue
-            elif is_homogeneous_array(value):
-                obj[key] = to_typed_array_spec(value)
-            else:
-                convert_to_base64(value)
-    elif isinstance(obj, list) or isinstance(obj, tuple):
-        for i, value in enumerate(obj):
-            convert_to_base64(value)
 
 
 def validate_coerce_fig_to_dict(fig, validate):
@@ -130,9 +24,6 @@ The fig parameter must be a dict or Figure.
                 typ=type(fig), v=fig
             )
         )
-
-    # Add base64 conversion before sending to the front-end
-    convert_to_base64(fig_dict)
 
     return fig_dict
 


### PR DESCRIPTION
Converting to base64 in BaseFigure.to_dict() offers the same performance improvements without changing the output of the data field of the Figure object. This will only be called through `show()` or in dash