### PR TITLE
Add webp support to `px.imshow`

### DIFF
--- a/doc/python/imshow.md
+++ b/doc/python/imshow.md
@@ -74,6 +74,19 @@ fig = px.imshow(img, binary_format="jpeg", binary_compression_level=0)
 fig.show()
 ```
 
+```python
+import plotly.express as px
+from skimage import data
+img = data.astronaut()
+fig = px.imshow(
+  img,
+  # Pillow backend parameters are documented here: https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#webp
+  # Available parameters depend on the `binary_format`
+  binary_backend_kwargs={"lossless": False}
+)
+fig.show()
+```
+
 ### Display single-channel 2D data as a heatmap
 
 For a 2D image, `px.imshow` uses a colorscale to map scalar data to colors. The default colorscale is the one of the active template (see [the tutorial on templates](/python/templates/)).

--- a/doc/python/imshow.md
+++ b/doc/python/imshow.md
@@ -74,6 +74,9 @@ fig = px.imshow(img, binary_format="jpeg", binary_compression_level=0)
 fig.show()
 ```
 
+Image data is encoded as a lossless base64-encoded WebP string by default.
+The example below uses a lossy WebP instead by passing a setting to the underlying image library backend.
+
 ```python
 import plotly.express as px
 from skimage import data

--- a/packages/python/plotly/_plotly_utils/data_utils.py
+++ b/packages/python/plotly/_plotly_utils/data_utils.py
@@ -10,7 +10,9 @@ except ImportError:
     pil_imported = False
 
 
-def image_array_to_data_uri(img, backend="pil", compression=4, ext="png"):
+def image_array_to_data_uri(
+    img, backend="pil", compression=4, ext="webp", backend_kwargs=None
+):
     """Converts a numpy array of uint8 into a base64 png or jpg string.
 
     Parameters
@@ -22,8 +24,10 @@ def image_array_to_data_uri(img, backend="pil", compression=4, ext="png"):
         otherwise pypng.
     compression: int, between 0 and 9
         compression level to be passed to the backend
-    ext: str, 'png' or 'jpg'
+    ext: str, 'webp', 'png', or 'jpg'
         compression format used to generate b64 string
+    backend_kwargs : dict or None
+        keyword arguments to be passed to the backend
     """
     # PIL and pypng error messages are quite obscure so we catch invalid compression values
     if compression < 0 or compression > 9:
@@ -41,7 +45,12 @@ def image_array_to_data_uri(img, backend="pil", compression=4, ext="png"):
     if backend == "auto":
         backend = "pil" if pil_imported else "pypng"
     if ext != "png" and backend != "pil":
-        raise ValueError("jpg binary strings are only available with PIL backend")
+        raise ValueError(
+            "webp and jpg binary strings are only available with PIL backend"
+        )
+
+    if backend_kwargs is None:
+        backend_kwargs = {}
 
     if backend == "pypng":
         ndim = img.ndim
@@ -49,7 +58,12 @@ def image_array_to_data_uri(img, backend="pil", compression=4, ext="png"):
         if ndim == 3:
             img = img.reshape((sh[0], sh[1] * sh[2]))
         w = Writer(
-            sh[1], sh[0], greyscale=(ndim == 2), alpha=alpha, compression=compression
+            sh[1],
+            sh[0],
+            greyscale=(ndim == 2),
+            alpha=alpha,
+            compression=compression,
+            **backend_kwargs
         )
         img_png = from_array(img, mode=mode)
         prefix = "data:image/png;base64,"
@@ -63,13 +77,22 @@ def image_array_to_data_uri(img, backend="pil", compression=4, ext="png"):
                 "install pillow or use `backend='pypng'."
             )
         pil_img = Image.fromarray(img)
-        if ext == "jpg" or ext == "jpeg":
+        if ext == "webp":
+            prefix = "data:image/webp;base64,"
+            ext = "webp"
+        elif ext == "jpg" or ext == "jpeg":
             prefix = "data:image/jpeg;base64,"
             ext = "jpeg"
         else:
             prefix = "data:image/png;base64,"
             ext = "png"
         with BytesIO() as stream:
-            pil_img.save(stream, format=ext, compress_level=compression)
+            pil_img.save(
+                stream,
+                format=ext,
+                compress_level=compression,
+                lossless=True,
+                **backend_kwargs
+            )
             base64_string = prefix + base64.b64encode(stream.getvalue()).decode("utf-8")
     return base64_string

--- a/packages/python/plotly/plotly/express/_imshow.py
+++ b/packages/python/plotly/plotly/express/_imshow.py
@@ -78,7 +78,8 @@ def imshow(
     binary_string=None,
     binary_backend="auto",
     binary_compression_level=4,
-    binary_format="png",
+    binary_format="webp",
+    binary_backend_kwargs=None,
     text_auto=False,
 ) -> go.Figure:
     """
@@ -204,10 +205,15 @@ def imshow(
         test `len(fig.data[0].source)` and to time the execution of `imshow` to
         tune the level of compression. 0 means no compression (not recommended).
 
-    binary_format: str, 'png' (default) or 'jpg'
-        compression format used to generate b64 string. 'png' is recommended
-        since it uses lossless compression, but 'jpg' (lossy) compression can
-        result if smaller binary strings for natural images.
+    binary_format: str, 'webp' (default), 'png', or 'jpg'
+        compression format used to generate b64 string. 'webp' is recommended
+        since it supports both lossless and lossy compression with better quality
+        then 'png' or 'jpg' of similar sizes, but 'jpg' or 'png' can be used for
+        environments that do not support 'webp'.
+
+    binary_backend_kwargs : dict or None
+        keyword arguments for the image backend. For Pillow, these are passed to `Image.save`.
+        For 'pypng', these are passed to `Writer.__init__`
 
     text_auto: bool or str (default `False`)
         If `True` or a string, single-channel `img` values will be displayed as text.
@@ -502,6 +508,7 @@ def imshow(
                     backend=binary_backend,
                     compression=binary_compression_level,
                     ext=binary_format,
+                    binary_backend_kwargs=binary_backend_kwargs,
                 )
                 for index_tup in itertools.product(*iterables)
             ]

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_imshow.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_imshow.py
@@ -16,7 +16,9 @@ def decode_image_string(image_string):
     """
     Converts image string to numpy array.
     """
-    if "png" in image_string[:22]:
+    if "webp" in image_string[:23]:
+        return np.asarray(Image.open(BytesIO(base64.b64decode(image_string[23:]))))
+    elif "png" in image_string[:22]:
         return np.asarray(Image.open(BytesIO(base64.b64decode(image_string[22:]))))
     elif "jpeg" in image_string[:23]:
         return np.asarray(Image.open(BytesIO(base64.b64decode(image_string[23:]))))
@@ -62,7 +64,7 @@ def test_automatic_zmax_from_dtype():
 
 
 @pytest.mark.parametrize("binary_string", [False, True])
-@pytest.mark.parametrize("binary_format", ["png", "jpg"])
+@pytest.mark.parametrize("binary_format", ["webp", "png", "jpg"])
 def test_origin(binary_string, binary_format):
     for i, img in enumerate([img_rgb, img_gray]):
         fig = px.imshow(
@@ -76,7 +78,9 @@ def test_origin(binary_string, binary_format):
             # The equality below does not hold for jpeg compression since it's lossy
             assert np.all(img[::-1] == decode_image_string(fig.data[0].source))
         if binary_string:
-            if binary_format == "jpg":
+            if binary_format == "webp":
+                assert fig.data[0].source[:15] == "data:image/webp"
+            elif binary_format == "jpg":
                 assert fig.data[0].source[:15] == "data:image/jpeg"
             else:
                 assert fig.data[0].source[:14] == "data:image/png"


### PR DESCRIPTION
WebP images are supported by all browsers (considered "Baseline" by MDN, see https://caniuse.com/webp)

They are typically higher quality and smaller than corresponding PNG and JPEG images:
- https://developers.google.com/speed/webp/docs/webp_study
- https://developers.google.com/speed/webp/docs/webp_lossless_alpha_study

This PR adds support for `webp` as a `binary_format` in `imshow` and adds a way to pass parameters to the backend (Pillow) to allow full configuration of the encoder e.g. choosing between lossless and lossy WebPs, adjusting the speed/size tradeoff.

### Documentation PR

- [X] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [X] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [X] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [X] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [X] Every new/modified example is independently runnable
- [X] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [X] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [X] The random seed is set if using randomly-generated data in new/modified examples
- [X] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [X] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [X] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [X] Data frames are always called `df`
- [X] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [X] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [X] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [X] `fig.show()` is at the end of each new/modified example
- [X] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [X] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [X] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [X] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [X] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [X] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).
