### PR TITLE
Remove tenacity dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 - Drop deprecated `pointcloud` and `heatmapgl` traces from the API
+- Drop `tenacity` dependency [#4831](https://github.com/plotly/plotly.js/pull/4831)
 
 ### Updated
 

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,6 @@ dependencies:
   - pandas
   - black
   - pytest
-  - tenacity
   - inflect
   - jupyterlab
   - ipywidgets

--- a/packages/python/plotly/plotly/io/_orca.py
+++ b/packages/python/plotly/plotly/io/_orca.py
@@ -124,13 +124,16 @@ def retry(min_wait=5, max_wait=10, max_delay=60000):
                 except Exception as e:
                     elapsed_time = time.time() - start_time
                     if elapsed_time * 1000 >= max_delay:
-                        raise TimeoutError(f"Retry limit of {max_delay} milliseconds reached.") from e
-                    
+                        raise TimeoutError(
+                            f"Retry limit of {max_delay} milliseconds reached."
+                        ) from e
+
                     wait_time = random.uniform(min_wait, max_wait)
                     print(f"Retrying in {wait_time:.2f} seconds due to {e}...")
                     time.sleep(wait_time)
-                    
+
         return wrapper
+
     return decorator
 
 

--- a/packages/python/plotly/plotly/io/_orca.py
+++ b/packages/python/plotly/plotly/io/_orca.py
@@ -1,17 +1,18 @@
 import atexit
+import functools
 import json
 import os
+import random
 import socket
 import subprocess
 import sys
 import threading
+import time
 import warnings
-from copy import copy
 from contextlib import contextmanager
+from copy import copy
 from pathlib import Path
 from shutil import which
-
-import tenacity
 
 import plotly
 from plotly.files import PLOTLY_DIR, ensure_writable_plotly_dir
@@ -109,6 +110,28 @@ def find_open_port():
     s.close()
 
     return port
+
+
+def retry(min_wait=5, max_wait=10, max_delay=60000):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            start_time = time.time()
+
+            while True:
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    elapsed_time = time.time() - start_time
+                    if elapsed_time * 1000 >= max_delay:
+                        raise TimeoutError(f"Retry limit of {max_delay} milliseconds reached.") from e
+                    
+                    wait_time = random.uniform(min_wait, max_wait)
+                    print(f"Retrying in {wait_time:.2f} seconds due to {e}...")
+                    time.sleep(wait_time)
+                    
+        return wrapper
+    return decorator
 
 
 # Orca configuration class
@@ -1357,10 +1380,7 @@ Install using conda:
                 orca_state["shutdown_timer"] = t
 
 
-@tenacity.retry(
-    wait=tenacity.wait_random(min=5, max=10),
-    stop=tenacity.stop_after_delay(60000),
-)
+@retry(min_wait=5, max_wait=10, max_delay=60000)
 def request_image_with_retrying(**kwargs):
     """
     Helper method to perform an image request to a running orca server process

--- a/packages/python/plotly/recipe/meta.yaml
+++ b/packages/python/plotly/recipe/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - setuptools
   run:
     - python
-    - tenacity >=6.2.0
 
 test:
   imports:

--- a/packages/python/plotly/requirements.txt
+++ b/packages/python/plotly/requirements.txt
@@ -4,6 +4,3 @@
 ###      $ pip install -r requirements.txt      ###
 ###                                             ###
 ###################################################
-
-## retrying requests ##
-tenacity>=6.2.0

--- a/packages/python/plotly/setup.py
+++ b/packages/python/plotly/setup.py
@@ -603,7 +603,7 @@ setup(
     data_files=[
         ("etc/jupyter/nbconfig/notebook.d", ["jupyterlab-plotly.json"]),
     ],
-    install_requires=["tenacity>=6.2.0", "packaging"],
+    install_requires=["packaging"],
     zip_safe=False,
     cmdclass=dict(
         build_py=js_prerelease(versioneer_cmds["build_py"]),

--- a/packages/python/plotly/test_requirements/requirements_310_core.txt
+++ b/packages/python/plotly/test_requirements/requirements_310_core.txt
@@ -1,3 +1,2 @@
 requests==2.25.1
-tenacity==6.2.0
 pytest==7.4.4

--- a/packages/python/plotly/test_requirements/requirements_310_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_310_optional.txt
@@ -1,5 +1,4 @@
 requests==2.25.1
-tenacity==6.2.0
 pandas==1.5.3
 numpy==1.23.0
 xarray==0.17.0

--- a/packages/python/plotly/test_requirements/requirements_311_core.txt
+++ b/packages/python/plotly/test_requirements/requirements_311_core.txt
@@ -1,3 +1,2 @@
 requests==2.25.1
-tenacity==6.2.0
 pytest==7.4.4

--- a/packages/python/plotly/test_requirements/requirements_311_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_311_optional.txt
@@ -1,5 +1,4 @@
 requests==2.25.1
-tenacity==6.2.0
 pandas==1.5.3
 numpy==1.23.2
 xarray==0.17.0

--- a/packages/python/plotly/test_requirements/requirements_312_core.txt
+++ b/packages/python/plotly/test_requirements/requirements_312_core.txt
@@ -1,3 +1,2 @@
 requests==2.25.1
-tenacity==6.2.0
 pytest==7.4.4

--- a/packages/python/plotly/test_requirements/requirements_312_no_numpy_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_312_no_numpy_optional.txt
@@ -1,5 +1,4 @@
 requests==2.31.0
-tenacity==8.2.3
 pandas
 xarray==2023.12.0
 statsmodels

--- a/packages/python/plotly/test_requirements/requirements_312_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_312_optional.txt
@@ -1,5 +1,4 @@
 requests==2.31.0
-tenacity==8.2.3
 pandas
 numpy
 xarray==2023.12.0

--- a/packages/python/plotly/test_requirements/requirements_38_core.txt
+++ b/packages/python/plotly/test_requirements/requirements_38_core.txt
@@ -1,3 +1,2 @@
 requests==2.25.1
-tenacity==6.2.0
 pytest==8.1.1

--- a/packages/python/plotly/test_requirements/requirements_38_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_38_optional.txt
@@ -1,5 +1,4 @@
 requests==2.25.1
-tenacity==6.2.0
 pandas==1.2.4
 numpy==1.20.2
 xarray==0.17.0

--- a/packages/python/plotly/test_requirements/requirements_39_core.txt
+++ b/packages/python/plotly/test_requirements/requirements_39_core.txt
@@ -1,3 +1,2 @@
 requests==2.25.1
-tenacity==6.2.0
 pytest==6.2.3

--- a/packages/python/plotly/test_requirements/requirements_39_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_39_optional.txt
@@ -1,5 +1,4 @@
 requests==2.25.1
-tenacity==6.2.0
 pandas==1.2.4
 numpy==1.21.6
 xarray==0.17.0

--- a/packages/python/plotly/test_requirements/requirements_39_pandas_2_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_39_pandas_2_optional.txt
@@ -1,5 +1,4 @@
 requests==2.25.1
-tenacity==6.2.0
 pandas==2.2.0
 numpy==1.22.4
 xarray==0.17.0


### PR DESCRIPTION
The `tenacity` dependency in Plotly.py (added in https://github.com/plotly/plotly.py/pull/2911) is used today in one place for Orca to provide a pretty naive retry decorator. It's easy enough to write our own with identical functionality.

This means it's possible to remove the sole dependency of Plotly.py. Yay!

The meaningful change is in cf4bfd1