### PR TITLE
Update python 3.12 test requirements to speed up CI

### DIFF
--- a/packages/python/plotly/test_requirements/requirements_312_no_numpy_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_312_no_numpy_optional.txt
@@ -18,3 +18,4 @@ scikit-image==0.22.0
 psutil==5.9.7
 kaleido
 orjson==3.9.10
+jupyter-console==6.4.4

--- a/packages/python/plotly/test_requirements/requirements_312_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_312_optional.txt
@@ -19,3 +19,4 @@ scikit-image==0.22.0
 psutil==5.9.7
 kaleido
 orjson==3.9.10
+jupyter-console==6.4.4


### PR DESCRIPTION
The python 3.12 tests are stuck in a dependency resolution loop for ~8 minutes as opposed to around a minute for other versions of python. This brings the dependency installation time down to around the same as the other versions of python. 