### PR TITLE
feat: allow to load plotly data with other backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Updated
 
-- Updated plotly.py to use base64 encoding of arrays in plotly JSON to improve performance. 
+- Updated plotly.py to use base64 encoding of arrays in plotly JSON to improve performance.
 - Add `subtitle` attribute to all Plotly Express traces
+- Allow to load plotly data directly via pandas, polars and pyarrow, without depending directly on any [#4843](https://github.com/plotly/plotly.py/pull/4843)
 
 ## [5.24.1] - 2024-09-12
 

--- a/packages/python/plotly/optional-requirements.txt
+++ b/packages/python/plotly/optional-requirements.txt
@@ -39,6 +39,7 @@ ipython
 
 ## pandas deps for some matplotlib functionality ##
 pandas
+narwhals>=1.12.0
 
 ## scipy deps for some FigureFactory functions ##
 scipy

--- a/packages/python/plotly/plotly/data/__init__.py
+++ b/packages/python/plotly/plotly/data/__init__.py
@@ -1,7 +1,12 @@
 """
 Built-in datasets for demonstration, educational and test purposes.
 """
+import os
+from importlib import import_module
+
 import narwhals.stable.v1 as nw
+
+AVAILABLE_BACKENDS = {"pandas", "polars", "pyarrow"}
 
 
 def gapminder(
@@ -372,9 +377,10 @@ def _get_dataset(d, return_type):
     """
     Loads the dataset using the specified backend.
 
-    Notice that the available backends are 'pandas', 'polars', 'pyarrow' and they all
-    have a `read_csv` function. Therefore we can dynamically load the library via
-    `importlib.import_module` and then call `backend.read_csv(filepath)`.
+    Notice that the available backends are 'pandas', 'polars', 'pyarrow' and they all have
+    a `read_csv` function (pyarrow has it via pyarrow.csv). Therefore we can dynamically
+    load the library using `importlib.import_module` and then call
+    `backend.read_csv(filepath)`.
 
     Parameters
     ----------
@@ -388,23 +394,20 @@ def _get_dataset(d, return_type):
     -------
     Dataframe of `return_type` type
     """
-    import os
-    from importlib import import_module
-
-    AVAILABLE_BACKENDS = {"pandas", "polars", "pyarrow"}
-
     filepath = os.path.join(
         os.path.dirname(os.path.dirname(__file__)),
         "package_data",
         "datasets",
         d + ".csv.gz",
     )
+
     if return_type not in AVAILABLE_BACKENDS:
         msg = f"Unsupported return_type. Found {return_type}, expected one of {AVAILABLE_BACKENDS}"
         raise NotImplementedError(msg)
 
     try:
-        backend = import_module(return_type)
+        module_to_load = "pyarrow.csv" if return_type == "pyarrow" else return_type
+        backend = import_module(module_to_load)
     except ModuleNotFoundError:
         msg = f"return_type={return_type}, but {return_type} is not installed"
         raise ModuleNotFoundError(msg)

--- a/packages/python/plotly/plotly/data/__init__.py
+++ b/packages/python/plotly/plotly/data/__init__.py
@@ -3,7 +3,14 @@ Built-in datasets for demonstration, educational and test purposes.
 """
 import narwhals.stable.v1 as nw
 
-def gapminder(datetimes=False, centroids=False, year=None, pretty_names=False, return_type="pandas"):
+
+def gapminder(
+    datetimes=False,
+    centroids=False,
+    year=None,
+    pretty_names=False,
+    return_type="pandas",
+):
     """
     Each row represents a country on a given year.
 
@@ -17,11 +24,17 @@ def gapminder(datetimes=False, centroids=False, year=None, pretty_names=False, r
         If `centroids` is True, two new columns are added: ['centroid_lat', 'centroid_lon']
         If `year` is an integer, the dataset will be filtered for that year
     """
-    df = nw.from_native(_get_dataset("gapminder", return_type=return_type), eager_only=True)
+    df = nw.from_native(
+        _get_dataset("gapminder", return_type=return_type), eager_only=True
+    )
     if year:
         df = df.filter(nw.col("year") == year)
     if datetimes:
-        df = df.with_columns(nw.concat_str([nw.col("year").cast(nw.String()), nw.lit("-01-01")]).cast(nw.Datetime(time_unit="ns")))
+        df = df.with_columns(
+            nw.concat_str([nw.col("year").cast(nw.String()), nw.lit("-01-01")]).cast(
+                nw.Datetime(time_unit="ns")
+            )
+        )
     if not centroids:
         df = df.drop("centroid_lat", "centroid_lon")
     if pretty_names:
@@ -149,10 +162,12 @@ def stocks(indexed=False, datetimes=False, return_type="pandas"):
         msg = "Cannot set index for backend different from pandas"
         raise NotImplementedError(msg)
 
-    df = nw.from_native(_get_dataset("stocks", return_type=return_type), eager_only=True)
+    df = nw.from_native(
+        _get_dataset("stocks", return_type=return_type), eager_only=True
+    )
     if datetimes:
         df = df.with_columns(nw.col("date").cast(nw.Datetime(time_unit="ns")))
-    
+
     if indexed:  # then it must be pandas
         df = df.to_native().set_index("date")
         df.columns.name = "company"
@@ -171,12 +186,14 @@ def experiment(indexed=False, return_type="pandas"):
         A `pandas.DataFrame` with 100 rows and the following columns:
         `['experiment_1', 'experiment_2', 'experiment_3', 'gender', 'group']`.
         If `indexed` is True, the data frame index is named "participant" """
-    
+
     if indexed and return_type != "pandas":
         msg = "Cannot set index for backend different from pandas"
         raise NotImplementedError(msg)
 
-    df = nw.from_native(_get_dataset("experiment", return_type=return_type), eager_only=True)
+    df = nw.from_native(
+        _get_dataset("experiment", return_type=return_type), eager_only=True
+    )
     if indexed:  # then it must be pandas
         df = df.to_native()
         df.index.name = "participant"
@@ -194,12 +211,14 @@ def medals_wide(indexed=False, return_type="pandas"):
         `['nation', 'gold', 'silver', 'bronze']`.
         If `indexed` is True, the 'nation' column is used as the index and the column index
         is named 'medal'"""
-    
+
     if indexed and return_type != "pandas":
         msg = "Cannot set index for backend different from pandas"
         raise NotImplementedError(msg)
 
-    df = nw.from_native(_get_dataset("medals", return_type=return_type), eager_only=True)
+    df = nw.from_native(
+        _get_dataset("medals", return_type=return_type), eager_only=True
+    )
     if indexed:  # then it must be pandas
         df = df.to_native().set_index("nation")
         df.columns.name = "medal"
@@ -216,18 +235,18 @@ def medals_long(indexed=False, return_type="pandas"):
         A `pandas.DataFrame` with 9 rows and the following columns:
         `['nation', 'medal', 'count']`.
         If `indexed` is True, the 'nation' column is used as the index."""
-    
+
     if indexed and return_type != "pandas":
         msg = "Cannot set index for backend different from pandas"
         raise NotImplementedError(msg)
-    
-    df = (
-        nw.from_native(_get_dataset("medals", return_type=return_type), eager_only=True)
-        .unpivot(
-            index=["nation"],
-            value_name="count",
-            variable_name="medal",
-        ))
+
+    df = nw.from_native(
+        _get_dataset("medals", return_type=return_type), eager_only=True
+    ).unpivot(
+        index=["nation"],
+        value_name="count",
+        variable_name="medal",
+    )
     if indexed:
         df = nw.maybe_set_index(df, "nation")
     return df.to_native()

--- a/packages/python/plotly/plotly/data/__init__.py
+++ b/packages/python/plotly/plotly/data/__init__.py
@@ -16,10 +16,30 @@ def gapminder(
 
     https://www.gapminder.org/data/
 
-    Returns:
-        A `pandas.DataFrame` with 1704 rows and the following columns:
+    Parameters
+    ----------
+    datetimes: bool
+        Whether or not 'year' column will converted to datetime type
+
+    centroids: bool
+        If True, ['centroid_lat', 'centroid_lon'] columns are added
+
+    year: int | None
+        If provided, the dataset will be filtered for that year
+
+    pretty_names: bool
+        If True, prettifies the column names
+
+    return_type: {'pandas', 'polars', 'pyarrow'}
+        Type of the resulting dataframe
+
+    Returns
+    -------
+    Dataframe of `return_type` type
+        Dataframe with 1704 rows and the following columns:
         `['country', 'continent', 'year', 'lifeExp', 'pop', 'gdpPercap',
         'iso_alpha', 'iso_num']`.
+
         If `datetimes` is True, the 'year' column will be a datetime column
         If `centroids` is True, two new columns are added: ['centroid_lat', 'centroid_lon']
         If `year` is an integer, the dataset will be filtered for that year
@@ -61,9 +81,20 @@ def tips(pretty_names=False, return_type="pandas"):
 
     https://vincentarelbundock.github.io/Rdatasets/doc/reshape2/tips.html
 
-    Returns:
-        A `pandas.DataFrame` with 244 rows and the following columns:
-        `['total_bill', 'tip', 'sex', 'smoker', 'day', 'time', 'size']`."""
+    Parameters
+    ----------
+    pretty_names: bool
+        If True, prettifies the column names
+
+    return_type: {'pandas', 'polars', 'pyarrow'}
+        Type of the resulting dataframe
+
+    Returns
+    -------
+    Dataframe of `return_type` type
+        Dataframe with 244 rows and the following columns:
+        `['total_bill', 'tip', 'sex', 'smoker', 'day', 'time', 'size']`.
+    """
 
     df = nw.from_native(_get_dataset("tips", return_type=return_type), eager_only=True)
     if pretty_names:
@@ -87,9 +118,17 @@ def iris(return_type="pandas"):
 
     https://en.wikipedia.org/wiki/Iris_flower_data_set
 
-    Returns:
-        A `pandas.DataFrame` with 150 rows and the following columns:
-        `['sepal_length', 'sepal_width', 'petal_length', 'petal_width', 'species', 'species_id']`."""
+    Parameters
+    ----------
+    return_type: {'pandas', 'polars', 'pyarrow'}
+        Type of the resulting dataframe
+
+    Returns
+    -------
+    Dataframe of `return_type` type
+        Dataframe with 150 rows and the following columns:
+        `['sepal_length', 'sepal_width', 'petal_length', 'petal_width', 'species', 'species_id']`.
+    """
     return _get_dataset("iris", return_type=return_type)
 
 
@@ -97,9 +136,17 @@ def wind(return_type="pandas"):
     """
     Each row represents a level of wind intensity in a cardinal direction, and its frequency.
 
-    Returns:
-        A `pandas.DataFrame` with 128 rows and the following columns:
-        `['direction', 'strength', 'frequency']`."""
+    Parameters
+    ----------
+    return_type: {'pandas', 'polars', 'pyarrow'}
+        Type of the resulting dataframe
+
+    Returns
+    -------
+    Dataframe of `return_type` type
+        Dataframe with 128 rows and the following columns:
+        `['direction', 'strength', 'frequency']`.
+    """
     return _get_dataset("wind", return_type=return_type)
 
 
@@ -108,9 +155,17 @@ def election(return_type="pandas"):
     Each row represents voting results for an electoral district in the 2013 Montreal
     mayoral election.
 
-    Returns:
-        A `pandas.DataFrame` with 58 rows and the following columns:
-        `['district', 'Coderre', 'Bergeron', 'Joly', 'total', 'winner', 'result', 'district_id']`."""
+    Parameters
+    ----------
+    return_type: {'pandas', 'polars', 'pyarrow'}
+        Type of the resulting dataframe
+
+    Returns
+    -------
+    Dataframe of `return_type` type
+        Dataframe with 58 rows and the following columns:
+        `['district', 'Coderre', 'Bergeron', 'Joly', 'total', 'winner', 'result', 'district_id']`.
+    """
     return _get_dataset("election", return_type=return_type)
 
 
@@ -118,10 +173,12 @@ def election_geojson():
     """
     Each feature represents an electoral district in the 2013 Montreal mayoral election.
 
-    Returns:
+    Returns
+    -------
         A GeoJSON-formatted `dict` with 58 polygon or multi-polygon features whose `id`
         is an electoral district numerical ID and whose `district` property is the ID and
-        district name."""
+        district name.
+    """
     import gzip
     import json
     import os
@@ -142,9 +199,17 @@ def carshare(return_type="pandas"):
     Each row represents the availability of car-sharing services near the centroid of a zone
     in Montreal over a month-long period.
 
-    Returns:
-        A `pandas.DataFrame` with 249 rows and the following columns:
-        `['centroid_lat', 'centroid_lon', 'car_hours', 'peak_hour']`."""
+    Parameters
+    ----------
+    return_type: {'pandas', 'polars', 'pyarrow'}
+        Type of the resulting dataframe
+
+    Returns
+    -------
+    Dataframe of `return_type` type
+        Dataframe` with 249 rows and the following columns:
+        `['centroid_lat', 'centroid_lon', 'car_hours', 'peak_hour']`.
+    """
     return _get_dataset("carshare", return_type=return_type)
 
 
@@ -152,12 +217,27 @@ def stocks(indexed=False, datetimes=False, return_type="pandas"):
     """
     Each row in this wide dataset represents closing prices from 6 tech stocks in 2018/2019.
 
-    Returns:
-        A `pandas.DataFrame` with 100 rows and the following columns:
+    Parameters
+    ----------
+    indexed: bool
+        Whether or not the 'date' column is used as the index and the column index
+        is named 'company'. Applicable only if `return_type='pandas'`
+
+    datetimes: bool
+        Whether or not the 'date' column will be of datetime type
+
+    return_type: {'pandas', 'polars', 'pyarrow'}
+        Type of the resulting dataframe
+
+    Returns
+    -------
+    Dataframe of `return_type` type
+        Dataframe with 100 rows and the following columns:
         `['date', 'GOOG', 'AAPL', 'AMZN', 'FB', 'NFLX', 'MSFT']`.
         If `indexed` is True, the 'date' column is used as the index and the column index
+        is named 'company'
         If `datetimes` is True, the 'date' column will be a datetime column
-        is named 'company'"""
+    """
     if indexed and return_type != "pandas":
         msg = "Cannot set index for backend different from pandas"
         raise NotImplementedError(msg)
@@ -181,11 +261,22 @@ def experiment(indexed=False, return_type="pandas"):
     Each row in this wide dataset represents the results of 100 simulated participants
     on three hypothetical experiments, along with their gender and control/treatment group.
 
+    Parameters
+    ----------
+    indexed: bool
+        If True, then the index is named "participant".
+        Applicable only if `return_type='pandas'`
 
-    Returns:
-        A `pandas.DataFrame` with 100 rows and the following columns:
+    return_type: {'pandas', 'polars', 'pyarrow'}
+        Type of the resulting dataframe
+
+    Returns
+    -------
+    Dataframe of `return_type` type
+        Dataframe with 100 rows and the following columns:
         `['experiment_1', 'experiment_2', 'experiment_3', 'gender', 'group']`.
-        If `indexed` is True, the data frame index is named "participant" """
+        If `indexed` is True, the data frame index is named "participant"
+    """
 
     if indexed and return_type != "pandas":
         msg = "Cannot set index for backend different from pandas"
@@ -206,11 +297,23 @@ def medals_wide(indexed=False, return_type="pandas"):
     This dataset represents the medal table for Olympic Short Track Speed Skating for the
     top three nations as of 2020.
 
-    Returns:
-        A `pandas.DataFrame` with 3 rows and the following columns:
+    Parameters
+    ----------
+    indexed: bool
+        Whether or not the 'nation' column is used as the index and the column index
+        is named 'medal'. Applicable only if `return_type='pandas'`
+
+    return_type: {'pandas', 'polars', 'pyarrow'}
+        Type of the resulting dataframe
+
+    Returns
+    -------
+    Dataframe of `return_type` type
+        Dataframe with 3 rows and the following columns:
         `['nation', 'gold', 'silver', 'bronze']`.
         If `indexed` is True, the 'nation' column is used as the index and the column index
-        is named 'medal'"""
+        is named 'medal'
+    """
 
     if indexed and return_type != "pandas":
         msg = "Cannot set index for backend different from pandas"
@@ -231,10 +334,21 @@ def medals_long(indexed=False, return_type="pandas"):
     This dataset represents the medal table for Olympic Short Track Speed Skating for the
     top three nations as of 2020.
 
-    Returns:
-        A `pandas.DataFrame` with 9 rows and the following columns:
-        `['nation', 'medal', 'count']`.
-        If `indexed` is True, the 'nation' column is used as the index."""
+    Parameters
+    ----------
+    indexed: bool
+        Whether or not the 'nation' column is used as the index.
+        Applicable only if `return_type='pandas'`
+
+    return_type: {'pandas', 'polars', 'pyarrow'}
+        Type of the resulting dataframe
+
+    Returns
+    -------
+    Dataframe of `return_type` type
+        Dataframe with 9 rows and the following columns: `['nation', 'medal', 'count']`.
+        If `indexed` is True, the 'nation' column is used as the index.
+    """
 
     if indexed and return_type != "pandas":
         msg = "Cannot set index for backend different from pandas"
@@ -253,6 +367,25 @@ def medals_long(indexed=False, return_type="pandas"):
 
 
 def _get_dataset(d, return_type):
+    """
+    Loads the dataset using the specified backend.
+
+    Notice that the available backends are 'pandas', 'polars', 'pyarrow' and they all
+    have a `read_csv` function. Therefore we can dynamically load the library via
+    `importlib.import_module` and then call `backend.read_csv(filepath)`.
+
+    Parameters
+    ----------
+    d: str
+        Name of the dataset to load.
+
+    return_type: {'pandas', 'polars', 'pyarrow'}
+        Type of the resulting dataframe
+
+    Returns
+    -------
+    Dataframe of `return_type` type
+    """
     import os
     from importlib import import_module
 

--- a/packages/python/plotly/requirements.txt
+++ b/packages/python/plotly/requirements.txt
@@ -4,3 +4,6 @@
 ###      $ pip install -r requirements.txt      ###
 ###                                             ###
 ###################################################
+
+## dataframe agnostic layer ##
+narwhals>=1.12.0

--- a/packages/python/plotly/setup.py
+++ b/packages/python/plotly/setup.py
@@ -603,7 +603,7 @@ setup(
     data_files=[
         ("etc/jupyter/nbconfig/notebook.d", ["jupyterlab-plotly.json"]),
     ],
-    install_requires=["packaging"],
+    install_requires=["narwhals>=1.12.0", "packaging"],
     zip_safe=False,
     cmdclass=dict(
         build_py=js_prerelease(versioneer_cmds["build_py"]),

--- a/packages/python/plotly/test_requirements/requirements_310_core.txt
+++ b/packages/python/plotly/test_requirements/requirements_310_core.txt
@@ -1,2 +1,3 @@
 requests==2.25.1
 pytest==7.4.4
+narwhals>=1.12.0

--- a/packages/python/plotly/test_requirements/requirements_310_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_310_optional.txt
@@ -19,3 +19,4 @@ scikit-image==0.22.0
 psutil==5.7.0
 kaleido
 orjson==3.8.12
+narwhals>=1.12.0

--- a/packages/python/plotly/test_requirements/requirements_311_core.txt
+++ b/packages/python/plotly/test_requirements/requirements_311_core.txt
@@ -1,2 +1,3 @@
 requests==2.25.1
 pytest==7.4.4
+narwhals>=1.12.0

--- a/packages/python/plotly/test_requirements/requirements_311_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_311_optional.txt
@@ -19,3 +19,4 @@ scikit-image==0.22.0
 psutil==5.7.0
 kaleido
 orjson==3.8.12
+narwhals>=1.12.0

--- a/packages/python/plotly/test_requirements/requirements_312_core.txt
+++ b/packages/python/plotly/test_requirements/requirements_312_core.txt
@@ -1,2 +1,3 @@
 requests==2.25.1
 pytest==7.4.4
+narwhals>=1.12.0

--- a/packages/python/plotly/test_requirements/requirements_312_no_numpy_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_312_no_numpy_optional.txt
@@ -19,3 +19,4 @@ psutil==5.9.7
 kaleido
 orjson==3.9.10
 jupyter-console==6.4.4
+narwhals>=1.12.0

--- a/packages/python/plotly/test_requirements/requirements_312_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_312_optional.txt
@@ -20,3 +20,4 @@ psutil==5.9.7
 kaleido
 orjson==3.9.10
 jupyter-console==6.4.4
+narwhals>=1.12.0

--- a/packages/python/plotly/test_requirements/requirements_38_core.txt
+++ b/packages/python/plotly/test_requirements/requirements_38_core.txt
@@ -1,2 +1,3 @@
 requests==2.25.1
 pytest==8.1.1
+narwhals>=1.12.0

--- a/packages/python/plotly/test_requirements/requirements_38_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_38_optional.txt
@@ -19,3 +19,4 @@ matplotlib==3.7.3
 scikit-image==0.18.1
 psutil==5.7.0
 kaleido
+narwhals>=1.12.0

--- a/packages/python/plotly/test_requirements/requirements_39_core.txt
+++ b/packages/python/plotly/test_requirements/requirements_39_core.txt
@@ -1,2 +1,3 @@
 requests==2.25.1
 pytest==6.2.3
+narwhals>=1.12.0

--- a/packages/python/plotly/test_requirements/requirements_39_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_39_optional.txt
@@ -20,3 +20,4 @@ scikit-image==0.18.1
 psutil==5.7.0
 kaleido
 orjson==3.8.12
+narwhals>=1.12.0

--- a/packages/python/plotly/test_requirements/requirements_39_pandas_2_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_39_pandas_2_optional.txt
@@ -21,3 +21,4 @@ kaleido
 vaex
 pydantic<=1.10.11 # for vaex, see https://github.com/vaexio/vaex/issues/2384
 polars
+narwhals>=1.12.0


### PR DESCRIPTION
# Description

Allow to load plotly data directly via pandas, polars and pyarrow, without depending directly on any.

It would indirectly address the following [comment](https://github.com/plotly/plotly.py/pull/4790#discussion_r1825172072) in #4790 

## Comments

I found that the docstrings were out of sync with other formats used in the library and the rendering is not what's expected: [plolty.data api reference page](https://plotly.com/python-api-reference/generated/plotly.data.html#module-plotly.data).

I tried to change it to consistently use numpy style.

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

