### PR TITLE
Do not assign `offsetgroup` to traces in px unless `barmode="group"`

### DIFF
--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2478,7 +2478,7 @@ def make_figure(args, constructor, trace_patch=None, layout_patch=None):
         constructor = go.Bar
         args = process_dataframe_timeline(args)
 
-    # With marginal histogram, if barmode is not set, set to "overlay"
+    # If we have marginal histograms, set barmode to "overlay"
     if "histogram" in [args.get("marginal_x"), args.get("marginal_y")]:
         layout_patch["barmode"] = "overlay"
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2558,7 +2558,7 @@ def make_figure(args, constructor, trace_patch=None, layout_patch=None):
                 )
 
             # Set 'offsetgroup' only in group barmode (or if no barmode is set)
-            barmode = args.get("barmode") or layout_patch.get("barmode")
+            barmode = layout_patch.get("barmode")
             if trace_spec.constructor in [go.Bar, go.Box, go.Violin, go.Histogram] and (
                 barmode == "group" or barmode is None
             ):

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2562,7 +2562,7 @@ def make_figure(args, constructor, trace_patch=None, layout_patch=None):
             barmode = args.get("barmode")
             if (
                 trace_spec.constructor in [go.Bar, go.Box, go.Violin, go.Histogram]
-                and barmode == "group" or barmode is None
+                and (barmode == "group" or barmode is None)
             ):
                 trace.update(alignmentgroup=True, offsetgroup=trace_name)
             trace_names.add(trace_name)

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2194,8 +2194,6 @@ def make_figure(args, constructor, trace_patch=None, layout_patch=None):
                     legendgroup=trace_name,
                     showlegend=(trace_name != "" and trace_name not in trace_names),
                 )
-            if trace_spec.constructor in [go.Bar, go.Violin, go.Box, go.Histogram]:
-                trace.update(alignmentgroup=True, offsetgroup=trace_name)
             trace_names.add(trace_name)
 
             # Init subplot row/col

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2859,7 +2859,9 @@ def init_figure(args, subplot_type, frame_list, nrows, ncols, col_labels, row_la
             e.args = (
                 e.args[0]
                 + """
-Use the {facet_arg} argument to adjust this spacing.""".format(facet_arg=facet_arg),
+Use the {facet_arg} argument to adjust this spacing.""".format(
+                    facet_arg=facet_arg
+                ),
             )
             raise e
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2139,8 +2139,6 @@ def process_dataframe_timeline(args):
     args["base"] = args["x_start"]
     del args["x_start"], args["x_end"]
 
-    args["barmode"] = "relative"
-
     return args
 
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2478,6 +2478,13 @@ def make_figure(args, constructor, trace_patch=None, layout_patch=None):
         constructor = go.Bar
         args = process_dataframe_timeline(args)
 
+    # With marginal histogram, if barmode is not set, set to "overlay"
+    if (
+        "histogram" in [args.get("marginal_x"), args.get("marginal_y")]
+        and "barmode" not in args
+    ):
+        layout_patch["barmode"] = "overlay"
+
     trace_specs, grouped_mappings, sizeref, show_colorbar = infer_config(
         args, constructor, trace_patch, layout_patch
     )
@@ -2549,13 +2556,6 @@ def make_figure(args, constructor, trace_patch=None, layout_patch=None):
                     legendgroup=trace_name,
                     showlegend=(trace_name != "" and trace_name not in trace_names),
                 )
-
-            # With marginal histogram, if barmode is not set, set to "overlay"
-            if (
-                "histogram" in [args.get("marginal_x"), args.get("marginal_y")]
-                and "barmode" not in args
-            ):
-                layout_patch["barmode"] = "overlay"
 
             # Set 'offsetgroup' only in group barmode (or if no barmode is set)
             barmode = args.get("barmode") or layout_patch.get("barmode")

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2479,9 +2479,7 @@ def make_figure(args, constructor, trace_patch=None, layout_patch=None):
         args = process_dataframe_timeline(args)
 
     # With marginal histogram, if barmode is not set, set to "overlay"
-    if (
-        "histogram" in [args.get("marginal_x"), args.get("marginal_y")]
-    ):
+    if "histogram" in [args.get("marginal_x"), args.get("marginal_y")]:
         layout_patch["barmode"] = "overlay"
 
     trace_specs, grouped_mappings, sizeref, show_colorbar = infer_config(

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2196,8 +2196,8 @@ def make_figure(args, constructor, trace_patch=None, layout_patch=None):
                 )
             # Set 'offsetgroup' only in group barmode
             if (
-                trace_spec.constructor in [go.Bar, go.Violin, go.Box, go.Histogram]
-                and args["barmode"] == "group"
+                trace_spec.constructor in [go.Bar, go.Histogram]
+                and args.get("barmode") == "group"
             ):
                 trace.update(alignmentgroup=True, offsetgroup=trace_name)
             trace_names.add(trace_name)

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2558,10 +2558,11 @@ def make_figure(args, constructor, trace_patch=None, layout_patch=None):
                     legendgroup=trace_name,
                     showlegend=(trace_name != "" and trace_name not in trace_names),
                 )
-            # Set 'offsetgroup' only in group barmode
+            # Set 'offsetgroup' only in group barmode (or if no barmode is set)
+            barmode = args.get("barmode")
             if (
-                trace_spec.constructor in [go.Bar, go.Histogram]
-                and args.get("barmode") == "group"
+                trace_spec.constructor in [go.Bar, go.Box, go.Violin, go.Histogram]
+                and barmode == "group" or barmode is None
             ):
                 trace.update(alignmentgroup=True, offsetgroup=trace_name)
             trace_names.add(trace_name)

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2138,7 +2138,6 @@ def process_dataframe_timeline(args):
     args["x"] = args["x_end"]
     args["base"] = args["x_start"]
     del args["x_start"], args["x_end"]
-
     return args
 
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -652,7 +652,6 @@ def set_cartesian_axis_opts(args, axis, letter, orders):
 
 
 def configure_cartesian_marginal_axes(args, fig, orders):
-
     nrows = len(fig._grid_ref)
     ncols = len(fig._grid_ref[0])
 
@@ -1495,17 +1494,14 @@ def build_dataframe(args, constructor):
     # If data_frame is provided, we parse it into a narwhals DataFrame, while accounting
     # for compatibility with pandas specific paths (e.g. Index/MultiIndex case).
     if df_provided:
-
         # data_frame is pandas-like DataFrame (pandas, modin.pandas, cudf)
         if nw.dependencies.is_pandas_like_dataframe(args["data_frame"]):
-
             columns = args["data_frame"].columns  # This can be multi index
             args["data_frame"] = nw.from_native(args["data_frame"], eager_only=True)
             is_pd_like = True
 
         # data_frame is pandas-like Series (pandas, modin.pandas, cudf)
         elif nw.dependencies.is_pandas_like_series(args["data_frame"]):
-
             args["data_frame"] = nw.from_native(
                 args["data_frame"], series_only=True
             ).to_frame()
@@ -1859,7 +1855,6 @@ def _check_dataframe_all_leaves(df: nw.DataFrame) -> None:
     for row_idx, row in zip(
         null_indices_mask, null_mask.filter(null_indices_mask).iter_rows()
     ):
-
         i = row.index(True)
 
         if not all(row[i:]):
@@ -1988,7 +1983,6 @@ def process_dataframe_hierarchy(args):
 
     if args["color"]:
         if discrete_color:
-
             discrete_aggs.append(args["color"])
             agg_f[args["color"]] = nw.col(args["color"]).max()
             agg_f[f'{args["color"]}{n_unique_token}'] = (
@@ -2043,7 +2037,6 @@ def process_dataframe_hierarchy(args):
         ).drop([f"{col}{n_unique_token}" for col in discrete_aggs])
 
     for i, level in enumerate(path):
-
         dfg = (
             df.group_by(path[i:], drop_null_keys=True)
             .agg(**agg_f)
@@ -2561,14 +2554,16 @@ def make_figure(args, constructor, trace_patch=None, layout_patch=None):
                 )
 
             # With marginal histogram, if barmode is not set, set to "overlay"
-            if "histogram" in [args.get("marginal_x"), args.get("marginal_y")] and "barmode" not in args:
+            if (
+                "histogram" in [args.get("marginal_x"), args.get("marginal_y")]
+                and "barmode" not in args
+            ):
                 layout_patch["barmode"] = "overlay"
 
             # Set 'offsetgroup' only in group barmode (or if no barmode is set)
             barmode = args.get("barmode") or layout_patch.get("barmode")
-            if (
-                trace_spec.constructor in [go.Bar, go.Box, go.Violin, go.Histogram]
-                and (barmode == "group" or barmode is None)
+            if trace_spec.constructor in [go.Bar, go.Box, go.Violin, go.Histogram] and (
+                barmode == "group" or barmode is None
             ):
                 trace.update(alignmentgroup=True, offsetgroup=trace_name)
             trace_names.add(trace_name)
@@ -2864,9 +2859,7 @@ def init_figure(args, subplot_type, frame_list, nrows, ncols, col_labels, row_la
             e.args = (
                 e.args[0]
                 + """
-Use the {facet_arg} argument to adjust this spacing.""".format(
-                    facet_arg=facet_arg
-                ),
+Use the {facet_arg} argument to adjust this spacing.""".format(facet_arg=facet_arg),
             )
             raise e
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2481,7 +2481,7 @@ def make_figure(args, constructor, trace_patch=None, layout_patch=None):
     # With marginal histogram, if barmode is not set, set to "overlay"
     if (
         "histogram" in [args.get("marginal_x"), args.get("marginal_y")]
-        and "barmode" not in args
+        and "barmode" not in layout_patch
     ):
         layout_patch["barmode"] = "overlay"
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2481,7 +2481,6 @@ def make_figure(args, constructor, trace_patch=None, layout_patch=None):
     # With marginal histogram, if barmode is not set, set to "overlay"
     if (
         "histogram" in [args.get("marginal_x"), args.get("marginal_y")]
-        and "barmode" not in layout_patch
     ):
         layout_patch["barmode"] = "overlay"
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2194,6 +2194,12 @@ def make_figure(args, constructor, trace_patch=None, layout_patch=None):
                     legendgroup=trace_name,
                     showlegend=(trace_name != "" and trace_name not in trace_names),
                 )
+            # Set 'offsetgroup' only in group barmode
+            if (
+                trace_spec.constructor in [go.Bar, go.Violin, go.Box, go.Histogram]
+                and args["barmode"] == "group"
+            ):
+                trace.update(alignmentgroup=True, offsetgroup=trace_name)
             trace_names.add(trace_name)
 
             # Init subplot row/col

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -652,8 +652,6 @@ def set_cartesian_axis_opts(args, axis, letter, orders):
 
 
 def configure_cartesian_marginal_axes(args, fig, orders):
-    if "histogram" in [args["marginal_x"], args["marginal_y"]]:
-        fig.layout["barmode"] = "overlay"
 
     nrows = len(fig._grid_ref)
     ncols = len(fig._grid_ref[0])
@@ -2147,6 +2145,9 @@ def process_dataframe_timeline(args):
     args["x"] = args["x_end"]
     args["base"] = args["x_start"]
     del args["x_start"], args["x_end"]
+
+    args["barmode"] = "relative"
+
     return args
 
 
@@ -2558,8 +2559,13 @@ def make_figure(args, constructor, trace_patch=None, layout_patch=None):
                     legendgroup=trace_name,
                     showlegend=(trace_name != "" and trace_name not in trace_names),
                 )
+
+            # With marginal histogram, if barmode is not set, set to "overlay"
+            if "histogram" in [args.get("marginal_x"), args.get("marginal_y")] and "barmode" not in args:
+                layout_patch["barmode"] = "overlay"
+
             # Set 'offsetgroup' only in group barmode (or if no barmode is set)
-            barmode = args.get("barmode")
+            barmode = args.get("barmode") or layout_patch.get("barmode")
             if (
                 trace_spec.constructor in [go.Bar, go.Box, go.Violin, go.Histogram]
                 and (barmode == "group" or barmode is None)


### PR DESCRIPTION
Closes #4863

This change is required due to the change in behavior for `offsetgroup` introduced in Plotly.js 3.0: https://github.com/plotly/plotly.js/pull/7009

The above change causes bars to appear as a group if `offsetgroup` is set, even if `barmode` is set to `stacked`, which changes the default behavior of histograms and bar charts, as explained in #4863.

This PR fixes the issue by _only_ setting `offsetgroup` if `barmode="group"`. (We also set `offsetgroup` if `barmode` is not set, since `group` is the default barmode in Plotly.js.)

Note that we can't remove setting `offsetgroup` entirely due to the issue described in my comment [here](https://github.com/plotly/plotly.py/pull/4865#issuecomment-2471300310).

The other changes all relate to making sure we know what the figure's `barmode` will be by the time we need to decide whether to set `offsetgroup`.