### PR TITLE
Unpin jupyterlab version in optional requirements

### DIFF
--- a/packages/python/plotly/optional-requirements.txt
+++ b/packages/python/plotly/optional-requirements.txt
@@ -45,7 +45,7 @@ scipy
 
 ## jupyter ##
 jupyter
-jupyterlab ~=3.0  # To package js extension as federated module
+jupyterlab
 ipykernel
 
 ## deps for _county_choropleth.py figure factory


### PR DESCRIPTION
The JupyterLab version was pinned in the optional requirements because JupyterLab 3 allowed for both npm _and_ python packaged extensions, while JupyterLab 4 dropped support for npm extensions. Now that #4779 is merged, we no longer need to support npm extensions, so we can unpin this dependency. 