### PR TITLE
Fix FigureWidget.show to return FigureWidget instead of displaying Figure

### DIFF
--- a/packages/python/plotly/plotly/basewidget.py
+++ b/packages/python/plotly/plotly/basewidget.py
@@ -142,6 +142,9 @@ class BaseFigureWidget(BaseFigure, anywidget.AnyWidget):
         # views of this widget
         self._view_count = 0
 
+    def show(self, *args, **kwargs):
+        return self
+        
     # Python -> JavaScript Messages
     # -----------------------------
     def _send_relayout_msg(self, layout_data, source_view_id=None):


### PR DESCRIPTION
Fixes #4854 by overriding the `BaseFigure` parent class implementation of `show()` that  `FigureWidget` inherits (see issue for more context). This changes the behavior to be the same as between these two cases (assuming `fig = go.FigureWidget()`):
* `fig`
* `fig.show()`