### PR TITLE
fix: Setting category_orders was leading to missing data

### DIFF
--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2443,9 +2443,7 @@ def get_groups_and_orders(args, grouper):
         # we have a single group, so we can skip all group-by operations!
         groups = {tuple(single_group_name): df}
     else:
-        required_grouper = [
-            key for key in orders if key in grouper and key != one_group
-        ]
+        required_grouper = [key for key in orders if key in grouper]
         order_mapping = {key: orders[key] for key in required_grouper}
         grouped = dict(df.group_by(required_grouper, drop_null_keys=True).__iter__())
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2443,7 +2443,7 @@ def get_groups_and_orders(args, grouper):
         # we have a single group, so we can skip all group-by operations!
         groups = {tuple(single_group_name): df}
     else:
-        required_grouper = [key for key in orders if key in grouper]
+        required_grouper = [group for group in orders if group in grouper]
         grouped = dict(df.group_by(required_grouper, drop_null_keys=True).__iter__())
 
         sorted_group_names = sorted(

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2448,9 +2448,9 @@ def get_groups_and_orders(args, grouper):
 
         sorted_group_names = sorted(
             grouped.keys(),
-            key=lambda group: [
-                orders[key].index(value) if value in orders[key] else -1
-                for key, value in zip(required_grouper, group)
+            key=lambda values: [
+                orders[group].index(value) if value in orders[group] else -1
+                for group, value in zip(required_grouper, values)
             ],
         )
 

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2422,7 +2422,6 @@ def get_groups_and_orders(args, grouper):
     # figure out orders and what the single group name would be if there were one
     single_group_name = []
     unique_cache = dict()
-    grp_to_idx = dict()
 
     for i, col in enumerate(grouper):
         if col == one_group:
@@ -2440,27 +2439,31 @@ def get_groups_and_orders(args, grouper):
             else:
                 orders[col] = list(OrderedDict.fromkeys(list(orders[col]) + uniques))
 
-    grp_to_idx = {k: i for i, k in enumerate(orders)}
-
     if len(single_group_name) == len(grouper):
         # we have a single group, so we can skip all group-by operations!
         groups = {tuple(single_group_name): df}
     else:
-        required_grouper = list(orders.keys())
+        required_grouper = [
+            key for key in orders if key in grouper and key != one_group
+        ]
+        order_mapping = {key: orders[key] for key in required_grouper}
         grouped = dict(df.group_by(required_grouper, drop_null_keys=True).__iter__())
-        sorted_group_names = list(grouped.keys())
 
-        for i, col in reversed(list(enumerate(required_grouper))):
-            sorted_group_names = sorted(
-                sorted_group_names,
-                key=lambda g: orders[col].index(g[i]) if g[i] in orders[col] else -1,
-            )
+        sorted_group_names = sorted(
+            grouped.keys(),
+            key=lambda group: [
+                order_mapping[key].index(value) if value in order_mapping[key] else -1
+                for key, value in zip(required_grouper, group)
+            ],
+        )
 
         # calculate the full group_names by inserting "" in the tuple index for one_group groups
         full_sorted_group_names = [
             tuple(
                 [
-                    "" if col == one_group else sub_group_names[grp_to_idx[col]]
+                    ""
+                    if col == one_group
+                    else sub_group_names[required_grouper.index(col)]
                     for col in grouper
                 ]
             )

--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2444,13 +2444,12 @@ def get_groups_and_orders(args, grouper):
         groups = {tuple(single_group_name): df}
     else:
         required_grouper = [key for key in orders if key in grouper]
-        order_mapping = {key: orders[key] for key in required_grouper}
         grouped = dict(df.group_by(required_grouper, drop_null_keys=True).__iter__())
 
         sorted_group_names = sorted(
             grouped.keys(),
             key=lambda group: [
-                order_mapping[key].index(value) if value in order_mapping[key] else -1
+                orders[key].index(value) if value in orders[key] else -1
                 for key, value in zip(required_grouper, group)
             ],
         )

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_px.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_px.py
@@ -289,6 +289,27 @@ def test_orthogonal_orderings(backend, days, times):
     assert_orderings(backend, days, days, times, times)
 
 
+def test_category_order_with_category_as_x(backend):
+    # https://github.com/plotly/plotly.py/issues/4875
+    tips = nw.from_native(px.data.tips(return_type=backend))
+    fig = px.bar(
+        tips,
+        x="day",
+        y="total_bill",
+        color="smoker",
+        barmode="group",
+        facet_col="sex",
+        category_orders={
+            "day": ["Thur", "Fri", "Sat", "Sun"],
+            "smoker": ["Yes", "No"],
+            "sex": ["Male", "Female"],
+        },
+    )
+    assert fig["layout"]["xaxis"]["categoryarray"] == ("Thur", "Fri", "Sat", "Sun")
+    for trace in fig["data"]:
+        assert sorted(set(trace["x"])) == ["Fri", "Sat", "Sun", "Thur"]
+
+
 def test_permissive_defaults():
     msg = "'PxDefaults' object has no attribute 'should_not_work'"
     with pytest.raises(AttributeError, match=msg):

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_px.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_px.py
@@ -307,7 +307,7 @@ def test_category_order_with_category_as_x(backend):
     )
     assert fig["layout"]["xaxis"]["categoryarray"] == ("Thur", "Fri", "Sat", "Sun")
     for trace in fig["data"]:
-        assert sorted(set(trace["x"])) == ["Fri", "Sat", "Sun", "Thur"]
+        assert set(trace["x"]) == {"Thur", "Fri", "Sat", "Sun"}
 
 
 def test_permissive_defaults():


### PR DESCRIPTION
<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).



-->


closes #4875 

The bug in https://github.com/plotly/plotly.py/pull/4790/files was the change
```diff
- required_grouper = [g for g in grouper if g != one_group]
+ required_grouper = list(orders.keys())
```
and in the linked issue #4875, the group `'day'` appears in `orders` but not in `required_grouper`


I've added a test - here's a visual demo too:

![image](https://github.com/user-attachments/assets/8cd567a8-3203-4140-8196-caad3d6b2be8)


Output is also unchanged (compared with the latest PyPI release) when multiple groups point to the same column:

![image](https://github.com/user-attachments/assets/b8b15da5-f0b6-4906-b8b4-8030e5cbea8b)
