### PR TITLE
fix: pandas DataFrame with non-default Index was resulting in scrambled data in scatter_matrix

### DIFF
--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -1168,16 +1168,13 @@ def _escape_col_name(columns, col_name, extra):
     return col_name
 
 
-def to_unindexed_series(x, name=None, native_namespace=None):
-    """Assuming x is list-like or even an existing Series, returns a new Series (with
-    its index reset if pandas-like). Stripping the index from existing pd.Series is
-    required to get things to match up right in the new DataFrame we're building.
-    """
+def to_named_series(x, name=None, native_namespace=None):
+    """Assuming x is list-like or even an existing Series, returns a new Series named `name`."""
     # With `pass_through=True`, the original object will be returned if unable to convert
     # to a Narwhals Series.
     x = nw.from_native(x, series_only=True, pass_through=True)
     if isinstance(x, nw.Series):
-        return nw.maybe_reset_index(x).rename(name)
+        return x.rename(name)
     elif native_namespace is not None:
         return nw.new_series(name=name, values=x, native_namespace=native_namespace)
     else:
@@ -1306,7 +1303,7 @@ def process_args_into_dataframe(
                                 length,
                             )
                         )
-                    df_output[col_name] = to_unindexed_series(
+                    df_output[col_name] = to_named_series(
                         real_argument, col_name, native_namespace
                     )
                 elif not df_provided:
@@ -1343,7 +1340,7 @@ def process_args_into_dataframe(
                     )
                 else:
                     col_name = str(argument)
-                    df_output[col_name] = to_unindexed_series(
+                    df_output[col_name] = to_named_series(
                         df_input.get_column(argument), col_name
                     )
             # ----------------- argument is likely a column / array / list.... -------
@@ -1362,7 +1359,7 @@ def process_args_into_dataframe(
                             argument.name is not None
                             and argument.name in df_input.columns
                             and (
-                                to_unindexed_series(
+                                to_named_series(
                                     argument, argument.name, native_namespace
                                 )
                                 == df_input.get_column(argument.name)
@@ -1380,7 +1377,7 @@ def process_args_into_dataframe(
                         % (field, len_arg, str(list(df_output.keys())), length)
                     )
 
-                df_output[str(col_name)] = to_unindexed_series(
+                df_output[str(col_name)] = to_named_series(
                     x=argument,
                     name=str(col_name),
                     native_namespace=native_namespace,

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_input.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_input.py
@@ -435,6 +435,29 @@ def test_splom_case(backend):
     assert np.all(fig.data[0].dimensions[0].values == ar[:, 0])
 
 
+def test_scatter_matrix_indexed_pandas():
+    # https://github.com/plotly/plotly.py/issues/4917
+    # https://github.com/plotly/plotly.py/issues/4788
+    df = pd.DataFrame(
+        {
+            "x": [1, 2, 3, 4],
+            "y": [10, 20, 10, 20],
+            "z": [-1, -2, -3, -4],
+            "color": [1, 2, 3, 4],
+        }
+    )
+    df.index = pd.DatetimeIndex(
+        [
+            "1/1/2020 10:00:00+00:00",
+            "2/1/2020 11:00:00+00:00",
+            "3/1/2020 10:00:00+00:00",
+            "4/1/2020 11:00:00+00:00",
+        ]
+    )
+    fig = px.scatter_matrix(df, color="color")
+    assert np.all(fig.data[0].marker["color"] == np.array([1, 2, 3, 4]))
+
+
 def test_int_col_names(constructor):
     # DataFrame with int column names
     lengths = constructor({"0": np.random.random(100)})

--- a/packages/python/plotly/requires-install.txt
+++ b/packages/python/plotly/requires-install.txt
@@ -6,5 +6,5 @@
 ###################################################
 
 ## dataframe agnostic layer ##
-narwhals>=1.13.3
+narwhals>=1.15.1
 packaging

--- a/packages/python/plotly/test_requirements/requirements_310_core.txt
+++ b/packages/python/plotly/test_requirements/requirements_310_core.txt
@@ -1,3 +1,3 @@
 requests==2.25.1
 pytest==7.4.4
-narwhals>=1.13.3
+narwhals>=1.15.1

--- a/packages/python/plotly/test_requirements/requirements_310_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_310_optional.txt
@@ -20,5 +20,5 @@ kaleido
 orjson==3.8.12
 polars[timezone]
 pyarrow
-narwhals>=1.13.3
+narwhals>=1.15.1
 anywidget==0.9.13

--- a/packages/python/plotly/test_requirements/requirements_311_core.txt
+++ b/packages/python/plotly/test_requirements/requirements_311_core.txt
@@ -1,3 +1,3 @@
 requests==2.25.1
 pytest==7.4.4
-narwhals>=1.13.3
+narwhals>=1.15.1

--- a/packages/python/plotly/test_requirements/requirements_311_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_311_optional.txt
@@ -20,5 +20,5 @@ kaleido
 orjson==3.8.12
 polars[timezone]
 pyarrow
-narwhals>=1.13.3
+narwhals>=1.15.1
 anywidget==0.9.13

--- a/packages/python/plotly/test_requirements/requirements_312_core.txt
+++ b/packages/python/plotly/test_requirements/requirements_312_core.txt
@@ -1,3 +1,3 @@
 requests==2.25.1
 pytest==7.4.4
-narwhals>=1.13.3
+narwhals>=1.15.1

--- a/packages/python/plotly/test_requirements/requirements_312_no_numpy_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_312_no_numpy_optional.txt
@@ -19,6 +19,6 @@ kaleido
 orjson==3.9.10
 polars[timezone]
 pyarrow
-narwhals>=1.13.3
+narwhals>=1.15.1
 anywidget==0.9.13
 jupyter-console==6.4.4

--- a/packages/python/plotly/test_requirements/requirements_312_np2_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_312_np2_optional.txt
@@ -21,5 +21,5 @@ kaleido
 orjson==3.9.10
 polars[timezone]
 pyarrow
-narwhals>=1.13.3
+narwhals>=1.15.1
 anywidget==0.9.13

--- a/packages/python/plotly/test_requirements/requirements_312_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_312_optional.txt
@@ -20,6 +20,6 @@ kaleido
 orjson==3.9.10
 polars[timezone]
 pyarrow
-narwhals>=1.13.3
+narwhals>=1.15.1
 anywidget==0.9.13
 jupyter-console==6.4.4

--- a/packages/python/plotly/test_requirements/requirements_38_core.txt
+++ b/packages/python/plotly/test_requirements/requirements_38_core.txt
@@ -1,3 +1,3 @@
 requests==2.25.1
 pytest==8.1.1
-narwhals>=1.13.3
+narwhals>=1.15.1

--- a/packages/python/plotly/test_requirements/requirements_38_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_38_optional.txt
@@ -20,5 +20,5 @@ psutil==5.7.0
 kaleido
 polars[timezone]
 pyarrow
-narwhals>=1.13.3
+narwhals>=1.15.1
 anywidget==0.9.13

--- a/packages/python/plotly/test_requirements/requirements_39_core.txt
+++ b/packages/python/plotly/test_requirements/requirements_39_core.txt
@@ -1,3 +1,3 @@
 requests==2.25.1
 pytest==6.2.3
-narwhals>=1.13.3
+narwhals>=1.15.1

--- a/packages/python/plotly/test_requirements/requirements_39_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_39_optional.txt
@@ -21,5 +21,5 @@ kaleido
 orjson==3.8.12
 polars[timezone]
 pyarrow
-narwhals>=1.13.3
+narwhals>=1.15.1
 anywidget==0.9.13

--- a/packages/python/plotly/test_requirements/requirements_39_pandas_2_optional.txt
+++ b/packages/python/plotly/test_requirements/requirements_39_pandas_2_optional.txt
@@ -21,6 +21,6 @@ vaex
 pydantic<=1.10.11 # for vaex, see https://github.com/vaexio/vaex/issues/2384
 polars[timezone]
 pyarrow
-narwhals>=1.13.3
+narwhals>=1.15.1
 polars
 anywidget==0.9.13


### PR DESCRIPTION
These issue get closed "for free" with the latest Narwhals release, as a result of https://github.com/narwhals-dev/narwhals/issues/1474 having been addressed:

- closes #4917
- closes #4788
- closes #3577
- closes #3576

Furthermore, it allows for the Plotly codebase to be simplified a bit, as `maybe_reset_index` isn't necessary any more. So, I've:
- made that simplification
- bumped the minimum Narwhals 
- added a test to check this stays fixed

Demo:

Latest stable plotly release:

![image](https://github.com/user-attachments/assets/d83203e7-4194-475c-a1d3-78a1e0336e2a)


This branch:

![image](https://github.com/user-attachments/assets/2b36744a-a4d4-4aeb-bc7c-7d47157de515)
