### PR TITLE
fix: Skip base64 conversion for empty arrays (fixes #4919)

### DIFF
--- a/packages/python/plotly/_plotly_utils/utils.py
+++ b/packages/python/plotly/_plotly_utils/utils.py
@@ -51,8 +51,8 @@ def to_typed_array_spec(v):
 
     # convert default Big Ints until we could support them in plotly.js
     if dtype == "int64":
-        max = v.max() if v else 0
-        min = v.min() if v else 0
+        max = v.max() if v.size > 0 else 0
+        min = v.min() if v.size > 0 else 0
         if max <= int8max and min >= int8min:
             v = v.astype("int8")
         elif max <= int16max and min >= int16min:
@@ -63,8 +63,8 @@ def to_typed_array_spec(v):
             return v
 
     elif dtype == "uint64":
-        max = v.max() if v else 0
-        min = v.min() if v else 0
+        max = v.max() if v.size > 0 else 0
+        min = v.min() if v.size > 0 else 0
         if max <= uint8max and min >= 0:
             v = v.astype("uint8")
         elif max <= uint16max and min >= 0:

--- a/packages/python/plotly/_plotly_utils/utils.py
+++ b/packages/python/plotly/_plotly_utils/utils.py
@@ -43,16 +43,18 @@ def to_typed_array_spec(v):
     """
     v = copy_to_readonly_numpy_array(v)
 
+    # Skip b64 encoding if numpy is not installed,
+    # or if v is not a numpy array, or if v is empty
     np = get_module("numpy", should_load=False)
-    if not np or not isinstance(v, np.ndarray):
+    if not np or not isinstance(v, np.ndarray) or v.size == 0:
         return v
 
     dtype = str(v.dtype)
 
     # convert default Big Ints until we could support them in plotly.js
     if dtype == "int64":
-        max = v.max() if v.size > 0 else 0
-        min = v.min() if v.size > 0 else 0
+        max = v.max()
+        min = v.min()
         if max <= int8max and min >= int8min:
             v = v.astype("int8")
         elif max <= int16max and min >= int16min:
@@ -63,8 +65,8 @@ def to_typed_array_spec(v):
             return v
 
     elif dtype == "uint64":
-        max = v.max() if v.size > 0 else 0
-        min = v.min() if v.size > 0 else 0
+        max = v.max()
+        min = v.min()
         if max <= uint8max and min >= 0:
             v = v.astype("uint8")
         elif max <= uint16max and min >= 0:

--- a/packages/python/plotly/_plotly_utils/utils.py
+++ b/packages/python/plotly/_plotly_utils/utils.py
@@ -51,8 +51,8 @@ def to_typed_array_spec(v):
 
     # convert default Big Ints until we could support them in plotly.js
     if dtype == "int64":
-        max = v.max()
-        min = v.min()
+        max = v.max() if v else 0
+        min = v.min() if v else 0
         if max <= int8max and min >= int8min:
             v = v.astype("int8")
         elif max <= int16max and min >= int16min:
@@ -63,8 +63,8 @@ def to_typed_array_spec(v):
             return v
 
     elif dtype == "uint64":
-        max = v.max()
-        min = v.min()
+        max = v.max() if v else 0
+        min = v.min() if v else 0
         if max <= uint8max and min >= 0:
             v = v.astype("uint8")
         elif max <= uint16max and min >= 0:

--- a/packages/python/plotly/plotly/tests/test_io/test_to_from_json.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_to_from_json.py
@@ -2,6 +2,7 @@ import plotly.graph_objs as go
 import plotly.io as pio
 import pytest
 import plotly
+import numpy as np
 import json
 import os
 import tempfile
@@ -259,3 +260,16 @@ def test_write_json_from_file_string(fig1, pretty, remove_uids):
         # Check contents that were written
         expected = pio.to_json(fig1, pretty=pretty, remove_uids=remove_uids)
         assert result == expected
+
+
+def test_to_dict_empty_np_array_int64():
+    fig = go.Figure(
+        [
+            go.Bar(
+                x=np.array([], dtype="str"),
+                y=np.array([], dtype="int64"),
+            )
+        ]
+    )
+    # to_dict() should not raise an exception
+    fig.to_dict()

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_px.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_px.py
@@ -360,3 +360,18 @@ def test_render_mode(backend):
     )
     assert fig.data[0].type == "histogram2dcontour"
     assert fig.data[1].type == "scatter"
+
+
+def test_empty_df_int64(backend):
+    # Load px data, then filter it such that the dataframe is empty
+    df = px.data.tips(return_type=backend)
+    df = nw.from_native(px.data.tips(return_type=backend))
+    df_empty = df.filter(nw.col("day") == "banana").to_native()
+
+    fig = px.scatter(
+        df_empty,
+        x="total_bill",
+        y="size",  # size is an int64 column
+    )
+    # to_dict() should not raise an exception
+    fig.to_dict()


### PR DESCRIPTION
Closes #4919 

The error was caused by trying to take the min/max of an empty array. 

The error only shows up when the empty array is typed, and is specifically a 'big int' type (`int64` or `uint64`), because the min/max call only happens in those cases.

This PR:
- Modifies `to_typed_array_spec()` function to just skip b64 encoding entirely in the case of an empty array
- Adds tests for the scenario where an empty array of type `int64` is passed into a figure (`go` and `px`). These tests fail on `master` but pass on this branch.