### PR TITLE
chore: update usage of datetime.now

### DIFF
--- a/packages/python/plotly/plotly/tests/test_io/test_to_from_plotly_json.py
+++ b/packages/python/plotly/plotly/tests/test_io/test_to_from_plotly_json.py
@@ -109,7 +109,7 @@ def numpy_unicode_array(request):
     params=[
         datetime.datetime(2003, 7, 12, 8, 34, 22),
         datetime.datetime.now(),
-        np.datetime64(datetime.datetime.utcnow()),
+        np.datetime64(datetime.datetime.now(datetime.timezone.utc)),
         pd.Timestamp(datetime.datetime.now()),
         eastern.localize(datetime.datetime(2003, 7, 12, 8, 34, 22)),
         eastern.localize(datetime.datetime.now()),


### PR DESCRIPTION
datetime.datetime.utcnow() is deprecated, replace with tz aware function

Note this adds a user warning from numpy but this seems preferable
