### PR TITLE
Remove require.js from doc nb.tpl file

### DIFF
--- a/doc/nb.tpl
+++ b/doc/nb.tpl
@@ -7,7 +7,6 @@
 ---
 {{ super() }}
 {{ '{% raw %}' }}
-<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.2/require.js"></script>
 
 {%- endblock header-%}
 


### PR DESCRIPTION
Following #4763, we can remove require.js from the docs as well. 