### PR TITLE
fix: custom category order was hard-coded

### DIFF
--- a/packages/python/plotly/plotly/express/_core.py
+++ b/packages/python/plotly/plotly/express/_core.py
@@ -2147,6 +2147,8 @@ def process_dataframe_timeline(args):
 
 
 def process_dataframe_pie(args, trace_patch):
+    import numpy as np
+
     names = args.get("names")
     if names is None:
         return args, trace_patch
@@ -2159,12 +2161,12 @@ def process_dataframe_pie(args, trace_patch):
     uniques = df.get_column(names).unique(maintain_order=True).to_list()
     order = [x for x in OrderedDict.fromkeys(list(order_in) + uniques) if x in uniques]
 
-    # Sort args['data_frame'] by column 'b' according to order `order`.
+    # Sort args['data_frame'] by column `names` according to order `order`.
     token = nw.generate_temporary_column_name(8, df.columns)
     args["data_frame"] = (
         df.with_columns(
-            nw.col("b")
-            .replace_strict(order, range(len(order)), return_dtype=nw.UInt32)
+            nw.col(names)
+            .replace_strict(order, np.arange(len(order)), return_dtype=nw.UInt32)
             .alias(token)
         )
         .sort(token)

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_functions.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_functions.py
@@ -58,25 +58,35 @@ def test_pie_like_px():
 
 def test_pie_custom_category_order(constructor):
     # https://github.com/plotly/plotly.py/issues/4999
-    df = constructor(
-        {
-            "status": ["On Route", "Pending", "Waiting Result", "Delivered"],
-            "count": [28, 10, 73, 8],
-        }
-    )
+    data = {
+        "status": ["On Route", "Pending", "Waiting Result", "Delivered"],
+        "count": [28, 10, 73, 8],
+    }
+    df = constructor(data)
     custom_order = ["Pending", "Waiting Result", "On Route", "Delivered"]
     result = px.pie(
         data_frame=df,
         values="count",
         names="status",
         category_orders={"status": custom_order},
-    ).to_dict()
-    assert list(result["data"][0]["labels"]) == [
+    )
+    assert list(result.to_dict()["data"][0]["labels"]) == [
         "Pending",
         "Waiting Result",
         "On Route",
         "Delivered",
     ]
+    values_ = np.array(
+        [
+            x[0]
+            for x in sorted(
+                zip(data["count"], data["status"]),
+                key=lambda t: custom_order.index(t[1]),
+            )
+        ]
+    )
+    trace = go.Pie(values=values_, labels=custom_order)
+    _compare_figures(trace, result)
 
 
 def test_sunburst_treemap_colorscales():

--- a/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_functions.py
+++ b/packages/python/plotly/plotly/tests/test_optional/test_px/test_px_functions.py
@@ -56,6 +56,29 @@ def test_pie_like_px():
     _compare_figures(trace, fig)
 
 
+def test_pie_custom_category_order(constructor):
+    # https://github.com/plotly/plotly.py/issues/4999
+    df = constructor(
+        {
+            "status": ["On Route", "Pending", "Waiting Result", "Delivered"],
+            "count": [28, 10, 73, 8],
+        }
+    )
+    custom_order = ["Pending", "Waiting Result", "On Route", "Delivered"]
+    result = px.pie(
+        data_frame=df,
+        values="count",
+        names="status",
+        category_orders={"status": custom_order},
+    ).to_dict()
+    assert list(result["data"][0]["labels"]) == [
+        "Pending",
+        "Waiting Result",
+        "On Route",
+        "Delivered",
+    ]
+
+
 def test_sunburst_treemap_colorscales():
     labels = ["Eve", "Cain", "Seth", "Enos", "Noam", "Abel", "Awan", "Enoch", "Azura"]
     parents = ["", "Eve", "Eve", "Seth", "Seth", "Eve", "Eve", "Awan", "Eve"]


### PR DESCRIPTION
closes #4999 

<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `master` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

closes #4999

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/contributing.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

-->
