### PR TITLE
Use correct filepath for README.md in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ maintainers = [
     { name="Emily Kellison-Linn", email="emily@plot.ly" }
 ]
 description = "An open-source interactive data visualization library for Python"
-readme = {file = "README.txt", content-type = "text/markdown"}
+readme = {file = "README.md", content-type = "text/markdown"}
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
@LiamConnors noticed this! I think when I was changing over to pyproject.toml I just accidentally used `.txt` instead of `.md` - it would probably show up when we test this in test.pypi.org.
