### PR TITLE
Remove `[all]` extra from `ipython` to prevent old versions of dependencies from being installed

### DIFF
--- a/test_requirements/requirements_optional.txt
+++ b/test_requirements/requirements_optional.txt
@@ -1,18 +1,18 @@
 requests
 pandas
 numpy
-fiona<=1.9.6;python_version<="3.8"
 xarray
 statsmodels
 Pillow
 pytest
 pytz
-ipython[all]
+ipython
 ipykernel
 jupyter
 scipy
 Shapely
 geopandas
+fiona<=1.9.6;python_version<="3.8"  # fiona>1.9.6 is not compatible with geopandas<1; geopandas>=1 is not compatible with python 3.8
 pyshp
 matplotlib
 scikit-image

--- a/test_requirements/requirements_optional.txt
+++ b/test_requirements/requirements_optional.txt
@@ -7,8 +7,8 @@ Pillow
 pytest
 pytz
 ipython
-ipykernel
 jupyter
+anywidget
 scipy
 Shapely
 geopandas
@@ -21,6 +21,5 @@ kaleido
 orjson
 polars[timezone]
 pyarrow
-anywidget
 plotly-geo
 vaex;python_version<="3.9"


### PR DESCRIPTION
Closes #5071 

Some of the extras installed by `ipython[all]` seem to have been causing the resolver to install old dependency versions in the CI.

After removing `[all]` from `ipython`, the tests still pass and `pytest==8.3.5` (the latest) is installed in all CI jobs.