### PR TITLE
Bump python versions in CI and add python 3.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,9 +167,9 @@ jobs:
           numpy_version: <<parameters.numpy_version>>
 
   # Percy
-  python_39_percy:
+  python_312_percy:
     docker:
-      - image: cimg/python:3.9-browsers
+      - image: cimg/python:3.12-browsers
         environment:
           PERCY_ENABLED: True
           PERCY_PROJECT: plotly/plotly.py
@@ -203,7 +203,6 @@ jobs:
             source .venv/bin/activate
             mkdir tests/percy/pandas2
             mv tests/percy/*.html tests/percy/pandas2/
-            # 1.1 is the earliest minor with Py3.9 wheels
             uv pip install pip
             python -m pip install pandas==1.1.5 numpy==1.26.4
             python tests/percy/plotly-express.py
@@ -451,5 +450,5 @@ workflows:
           python_version: "3.9"
           pandas_version: "1.2.4"
           numpy_version: "1.26.4"
-      - python_39_percy
+      - python_312_percy
       - build-doc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,7 +303,7 @@ jobs:
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, for example, `3.12-browsers`
-      - image: cimg/python:3.12-browsers
+      - image: cimg/python:3.11-browsers
 
     steps:
       - add_ssh_keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,9 +167,9 @@ jobs:
           numpy_version: <<parameters.numpy_version>>
 
   # Percy
-  python_312_percy:
+  python_311_percy:
     docker:
-      - image: cimg/python:3.12-browsers
+      - image: cimg/python:3.11-browsers
         environment:
           PERCY_ENABLED: True
           PERCY_PROJECT: plotly/plotly.py
@@ -450,5 +450,5 @@ workflows:
           python_version: "3.9"
           pandas_version: "1.2.4"
           numpy_version: "1.26.4"
-      - python_312_percy
+      - python_311_percy
       - build-doc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,7 @@ jobs:
             mkdir tests/percy/pandas2
             mv tests/percy/*.html tests/percy/pandas2/
             uv pip install pip
-            python -m pip install pandas==1.1.5 numpy==1.26.4
+            python -m pip install pandas==1.5.3 numpy==1.26.4
             python tests/percy/plotly-express.py
             python tests/percy/compare-pandas.py
             rm -rf tests/percy/pandas2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
     parameters:
       python_version:
         description: "python version"
-        default: "3.10"
+        default: "3.12"
         type: string
     docker:
       - image: cimg/python:<<parameters.python_version>>-browsers
@@ -120,7 +120,7 @@ commands:
 jobs:
   check-code-formatting:
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.12
 
     steps:
       - checkout
@@ -139,7 +139,7 @@ jobs:
   test_core_py:
     parameters:
       python_version:
-        default: "3.10"
+        default: "3.12"
         type: string
     executor:
       name: docker-container
@@ -150,7 +150,7 @@ jobs:
   test_optional_py:
     parameters:
       python_version:
-        default: "3.10"
+        default: "3.12"
         type: string
       pandas_version:
         default: ""
@@ -224,7 +224,7 @@ jobs:
 
   plotlyjs_dev_build:
     docker:
-      - image: cimg/python:3.11-node
+      - image: cimg/python:3.12-node
         environment:
           LANG: en_US.UTF-8
     resource_class: large
@@ -263,7 +263,7 @@ jobs:
 
   full_build:
     docker:
-      - image: cimg/python:3.11-node
+      - image: cimg/python:3.12-node
         environment:
           LANG: en_US.UTF-8
     resource_class: large
@@ -302,8 +302,8 @@ jobs:
     resource_class: xlarge
     docker:
       # specify the version you desire here
-      # use `-browsers` prefix for selenium tests, for example, `3.9-browsers`
-      - image: cimg/python:3.9-browsers
+      # use `-browsers` prefix for selenium tests, for example, `3.12-browsers`
+      - image: cimg/python:3.12-browsers
 
     steps:
       - add_ssh_keys:
@@ -435,6 +435,7 @@ workflows:
                 - "3.10"
                 - "3.11"
                 - "3.12"
+                - "3.13"
       - test_optional_py:
           matrix:
             parameters:
@@ -444,6 +445,7 @@ workflows:
                 - "3.10"
                 - "3.11"
                 - "3.12"
+                - "3.13"
       - test_optional_py:
           name: "test_optional_py-3.9_pandas-1.2.4"
           python_version: "3.9"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,9 +300,7 @@ jobs:
   build-doc:
     resource_class: xlarge
     docker:
-      # specify the version you desire here
-      # use `-browsers` prefix for selenium tests, for example, `3.12-browsers`
-      - image: cimg/python:3.11-browsers
+      - image: cimg/python:3.9-browsers
 
     steps:
       - add_ssh_keys:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,7 +5,7 @@ jupyter
 notebook
 pandas==1.4.0
 statsmodels==0.14.2
-scipy
+scipy==1.9.1
 patsy==0.5.6
 numpy==1.22.4
 plotly-geo

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,7 +5,7 @@ jupyter
 notebook
 pandas==1.4.0
 statsmodels==0.14.2
-scipy==1.9.1
+scipy
 patsy==0.5.6
 numpy==1.22.4
 plotly-geo


### PR DESCRIPTION
Closes #4935 

- Add Python 3.13 to testing matrix for `test_core` and `test_optional`
- Bump hard-coded Python versions in other jobs —
  - to 3.11 for Percy tests
  - to 3.12 for `plotlyjs_dev_build` and `full_build`