### PR TITLE
Suppress `DeprecationWarning` when updating `template.data`

### DIFF
--- a/plotly/graph_objs/layout/_template.py
+++ b/plotly/graph_objs/layout/_template.py
@@ -1,6 +1,7 @@
-from plotly.basedatatypes import BaseLayoutHierarchyType as _BaseLayoutHierarchyType
 import copy as _copy
+import warnings
 
+from plotly.basedatatypes import BaseLayoutHierarchyType as _BaseLayoutHierarchyType
 
 class Template(_BaseLayoutHierarchyType):
 
@@ -324,7 +325,12 @@ an instance of :class:`plotly.graph_objs.layout.Template`"""
         _v = arg.pop("data", None)
         _v = data if data is not None else _v
         if _v is not None:
-            self["data"] = _v
+            # Template.data contains key for deprecated scattermapbox trace
+            # In order to prevent false deprecation warnings from surfacing,
+            # we suppress deprecation warnings for this line only
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=DeprecationWarning)
+                self["data"] = _v
         _v = arg.pop("layout", None)
         _v = layout if layout is not None else _v
         if _v is not None:

--- a/plotly/graph_objs/layout/_template.py
+++ b/plotly/graph_objs/layout/_template.py
@@ -3,8 +3,8 @@ import warnings
 
 from plotly.basedatatypes import BaseLayoutHierarchyType as _BaseLayoutHierarchyType
 
-class Template(_BaseLayoutHierarchyType):
 
+class Template(_BaseLayoutHierarchyType):
     # class properties
     # --------------------
     _parent_path_str = "layout"

--- a/plotly/graph_objs/layout/_template.py
+++ b/plotly/graph_objs/layout/_template.py
@@ -325,9 +325,10 @@ an instance of :class:`plotly.graph_objs.layout.Template`"""
         _v = arg.pop("data", None)
         _v = data if data is not None else _v
         if _v is not None:
-            # Template.data contains key for deprecated scattermapbox trace
+            # Template.data contains a 'scattermapbox' key, which causes a
+            # go.Scattermapbox trace object to be created during validation.
             # In order to prevent false deprecation warnings from surfacing,
-            # we suppress deprecation warnings for this line only
+            # we suppress deprecation warnings for this line only.
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=DeprecationWarning)
                 self["data"] = _v

--- a/tests/test_core/test_graph_objs/test_graph_objs.py
+++ b/tests/test_core/test_graph_objs/test_graph_objs.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
+import warnings
 
+import pytest
 import plotly.graph_objs as go
 
 
@@ -154,3 +156,28 @@ class TestPop(TestCase):
 
     def test_pop_invalid_prop_with_default(self):
         self.assertEqual(self.layout.pop("bogus", 42), 42)
+
+class TestDeprecationWarnings(TestCase):
+    def test_warn_on_deprecated_mapbox_traces(self):
+        # This test will fail if any of the following traces
+        # fails to emit a DeprecationWarning
+        for trace_constructor in [
+            go.Scattermapbox,
+            go.Densitymapbox,
+            go.Choroplethmapbox,
+        ]:
+            with pytest.warns(DeprecationWarning):
+                _ = go.Figure([trace_constructor()])
+
+    def test_no_warn_on_non_deprecated_traces(self):
+        # This test will fail if any of the following traces emits a DeprecationWarning
+        for trace_constructor in [
+            go.Scatter,
+            go.Bar,
+            go.Scattermap,
+            go.Densitymap,
+            go.Choroplethmap,
+        ]:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                _ = go.Figure([trace_constructor()])

--- a/tests/test_core/test_graph_objs/test_graph_objs.py
+++ b/tests/test_core/test_graph_objs/test_graph_objs.py
@@ -48,7 +48,6 @@ OLD_CLASS_NAMES = [
 
 class TestBackwardsCompat(TestCase):
     def test_old_class_names(self):
-
         # these were all defined at one point, we want to maintain backwards
         # compat, so we basically just create a checkpoint with this test.
 
@@ -156,6 +155,7 @@ class TestPop(TestCase):
 
     def test_pop_invalid_prop_with_default(self):
         self.assertEqual(self.layout.pop("bogus", 42), 42)
+
 
 class TestDeprecationWarnings(TestCase):
     def test_warn_on_deprecated_mapbox_traces(self):

--- a/tests/test_optional/test_px/test_px.py
+++ b/tests/test_optional/test_px/test_px.py
@@ -415,6 +415,7 @@ def test_warn_on_deprecated_mapbox_px_constructors():
             else:
                 fig_constructor(lat=[10, 20, 30], lon=[10, 20, 30])
 
+
 def test_no_warn_on_non_deprecated_px_constructors():
     # This test will fail if any of the following px constructors
     # emits a DeprecationWarning
@@ -433,6 +434,7 @@ def test_no_warn_on_non_deprecated_px_constructors():
                 fig_constructor(lat=[10, 20, 30], lon=[10, 20, 30])
             else:
                 fig_constructor(x=[1, 2, 3], y=[1, 2, 3])
+
 
 def test_no_warn_on_update_template():
     # This test will fail if update_layout(template=...) emits a DeprecationWarning

--- a/tests/test_optional/test_px/test_px.py
+++ b/tests/test_optional/test_px/test_px.py
@@ -1,9 +1,11 @@
+from itertools import permutations
+import warnings
+
 import plotly.express as px
 import plotly.io as pio
 import narwhals.stable.v1 as nw
 import numpy as np
 import pytest
-from itertools import permutations
 
 
 def test_scatter(backend):
@@ -394,3 +396,47 @@ def test_load_px_data(return_type):
         else:
             df = getattr(px.data, fname)(return_type=return_type)
         assert len(df) > 0
+
+
+def test_warn_on_deprecated_mapbox_px_constructors():
+    # This test will fail if any of the following px constructors
+    # fails to emit a DeprecationWarning
+    for fig_constructor in [
+        px.line_mapbox,
+        px.scatter_mapbox,
+        px.density_mapbox,
+        px.choropleth_mapbox,
+    ]:
+        # Look for warnings with the string "_mapbox" in them
+        # to make sure the warning is coming from px rather than go
+        with pytest.warns(DeprecationWarning, match="_mapbox"):
+            if fig_constructor == px.choropleth_mapbox:
+                fig_constructor(locations=["CA", "TX", "NY"])
+            else:
+                fig_constructor(lat=[10, 20, 30], lon=[10, 20, 30])
+
+def test_no_warn_on_non_deprecated_px_constructors():
+    # This test will fail if any of the following px constructors
+    # emits a DeprecationWarning
+    for fig_constructor in [
+        px.scatter,
+        px.line,
+        px.scatter_map,
+        px.density_map,
+        px.choropleth_map,
+    ]:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            if fig_constructor == px.choropleth_map:
+                fig_constructor(locations=["CA", "TX", "NY"])
+            elif fig_constructor in {px.scatter_map, px.density_map}:
+                fig_constructor(lat=[10, 20, 30], lon=[10, 20, 30])
+            else:
+                fig_constructor(x=[1, 2, 3], y=[1, 2, 3])
+
+def test_no_warn_on_update_template():
+    # This test will fail if update_layout(template=...) emits a DeprecationWarning
+    fig = px.line(x=[1, 2, 3], y=[1, 2, 3])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        fig.update_layout(template="plotly_white")


### PR DESCRIPTION
Closes #4997 

The Mapbox deprecation warning added to `go.Scattermapbox` in #4900 is falsely triggered whenever a `px` figure is created, because the default template contains a `'scattermapbox'` key in `template.data`, which causes a `go.Scattermapbox` trace object to be created during validation.

The Python warning filters [suppress these warnings by default ](https://docs.python.org/3.13/library/exceptions.html#DeprecationWarning) since they are not emitted at the top level, but they may surface in Pytest (which enables all warnings) or for anyone using custom warnings settings.

This PR edits the `Template` constructor to ignore `DeprecationWarning`s emitted while setting `template.data`. It also adds tests to verify that deprecation warnings are correctly emitted.

Note: I've also opened #5081 to track work for removing `mapbox` and made a note to remove `'scattermapbox'` from templates as part of that work.

---

This reduces the warning noise in our own unit tests as well.

`test_optional` on `main`:
![Screen Shot 2025-03-12 at 4 40 08 PM](https://github.com/user-attachments/assets/0f670db1-e7b2-4952-8f7c-824f03d4e6ea)

`test_optional` on this branch:
![Screen Shot 2025-03-12 at 4 40 44 PM](https://github.com/user-attachments/assets/7c635243-a71a-4c21-a728-b7a4f89181b9)
