### PR TITLE
Remove 6.0.1 from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [6.0.1] - 2025-02-16
+## Unreleased
 
 ### Fixed
 - Fix `TypeError` when using `orjson` to serialize `pandas.NA`.


### PR DESCRIPTION
There wasn't a version released on this date