### PR TITLE
Fix bogus `DeprecationWarning`s in codegen rather than in autogenerated file

### DIFF
--- a/codegen/datatypes.py
+++ b/codegen/datatypes.py
@@ -102,7 +102,10 @@ def build_datatype_py(node):
     )
     buffer.write(f"import copy as _copy\n")
 
-    if node.name_property in deprecated_mapbox_traces or node.name_property == "template":
+    if (
+        node.name_property in deprecated_mapbox_traces
+        or node.name_property == "template"
+    ):
         buffer.write(f"import warnings\n")
 
     # Write class definition

--- a/plotly/graph_objs/_choroplethmapbox.py
+++ b/plotly/graph_objs/_choroplethmapbox.py
@@ -1,6 +1,6 @@
 from plotly.basedatatypes import BaseTraceType as _BaseTraceType
 import copy as _copy
-from warnings import warn
+import warnings
 
 
 class Choroplethmapbox(_BaseTraceType):
@@ -2380,7 +2380,7 @@ an instance of :class:`plotly.graph_objs.Choroplethmapbox`"""
         # ------------------
         self._skip_invalid = False
 
-        warn(
+        warnings.warn(
             "*choroplethmapbox* is deprecated!"
             + " Use *choroplethmap* instead."
             + " Learn more at: https://plotly.com/python/mapbox-to-maplibre/",

--- a/plotly/graph_objs/_densitymapbox.py
+++ b/plotly/graph_objs/_densitymapbox.py
@@ -1,6 +1,6 @@
 from plotly.basedatatypes import BaseTraceType as _BaseTraceType
 import copy as _copy
-from warnings import warn
+import warnings
 
 
 class Densitymapbox(_BaseTraceType):
@@ -2321,7 +2321,7 @@ an instance of :class:`plotly.graph_objs.Densitymapbox`"""
         # ------------------
         self._skip_invalid = False
 
-        warn(
+        warnings.warn(
             "*densitymapbox* is deprecated!"
             + " Use *densitymap* instead."
             + " Learn more at: https://plotly.com/python/mapbox-to-maplibre/",

--- a/plotly/graph_objs/_scattermapbox.py
+++ b/plotly/graph_objs/_scattermapbox.py
@@ -1,6 +1,6 @@
 from plotly.basedatatypes import BaseTraceType as _BaseTraceType
 import copy as _copy
-from warnings import warn
+import warnings
 
 
 class Scattermapbox(_BaseTraceType):
@@ -2294,7 +2294,7 @@ an instance of :class:`plotly.graph_objs.Scattermapbox`"""
         # ------------------
         self._skip_invalid = False
 
-        warn(
+        warnings.warn(
             "*scattermapbox* is deprecated!"
             + " Use *scattermap* instead."
             + " Learn more at: https://plotly.com/python/mapbox-to-maplibre/",

--- a/plotly/graph_objs/layout/_template.py
+++ b/plotly/graph_objs/layout/_template.py
@@ -1,10 +1,10 @@
+from plotly.basedatatypes import BaseLayoutHierarchyType as _BaseLayoutHierarchyType
 import copy as _copy
 import warnings
 
-from plotly.basedatatypes import BaseLayoutHierarchyType as _BaseLayoutHierarchyType
-
 
 class Template(_BaseLayoutHierarchyType):
+
     # class properties
     # --------------------
     _parent_path_str = "layout"


### PR DESCRIPTION
Closes #4997 (for real this time); follow-up to #5080

Moves the fix added in #5080 to be in the code-generation script rather than in the auto-generated file itself (whoops).

