### PR TITLE
Install rename

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,9 +61,9 @@ commands:
             cd js
             npm ci
             npm run build
-      
+
       - when:
-          condition: 
+          condition:
             not:
               equal:
                 - <<parameters.pandas_version>>
@@ -315,6 +315,8 @@ jobs:
           name: Install dependencies
           command: |
             cd doc
+            sudo apt-get update
+            sudo apt-get install rename
             curl -LsSf https://astral.sh/uv/install.sh | sh
             uv venv
             source .venv/bin/activate


### PR DESCRIPTION
The `Makefile` here for the docs build uses rename https://github.com/plotly/plotly.py/blob/main/doc/apidoc/Makefile#L39
but the most recent time the docs were deployed this failed. 

```
The HTML pages are in _build/html.
git checkout -- ../../plotly/graph_objs
# Remove files which were added only for docstring generation
rm ../../plotly/colors/diverging.py ../../plotly/colors/sequential.py ../../plotly/colors/qualitative.py ../../plotly/colors/cyclical.py ../../plotly/colors/colorbrewer.py ../../plotly/colors/carto.py ../../plotly/colors/cmocean.py
rm ../../plotly/express/colors/diverging.py ../../plotly/express/colors/sequential.py ../../plotly/express/colors/qualitative.py ../../plotly/express/colors/cyclical.py ../../plotly/express/colors/colorbrewer.py ../../plotly/express/colors/carto.py ../../plotly/express/colors/cmocean.py
rename 's/graph_objs/graph_objects/' _build/html/*.html _build/html/generated/*.html _build/html/generated/generated/*.html
/bin/sh: 1: rename: not found
make: *** [Makefile:39: html] Error 127

Exited with code exit status 2
```

@emilykl @marthacryan are you aware of anything that would have changed. I know we did some updates to the `config.yml` file recently. 