### PR TITLE
Remove deprecated append_trace

### DIFF
--- a/doc/python/3d-axes.md
+++ b/doc/python/3d-axes.md
@@ -6,7 +6,7 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.15.1
+      jupytext_version: 1.16.4
   kernelspec:
     display_name: Python 3 (ipykernel)
     language: python
@@ -114,7 +114,7 @@ fig = make_subplots(rows=2, cols=2,
                     print_grid=False)
 for i in [1,2]:
     for j in [1,2]:
-        fig.append_trace(
+        fig.add_trace(
             go.Mesh3d(
                 x=(60*np.random.randn(N)),
                 y=(25*np.random.randn(N)),

--- a/doc/python/histograms.md
+++ b/doc/python/histograms.md
@@ -6,9 +6,9 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.14.1
+      jupytext_version: 1.16.4
   kernelspec:
-    display_name: Python 3
+    display_name: Python 3 (ipykernel)
     language: python
     name: python3
   language_info:
@@ -20,7 +20,7 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.8.8
+    version: 3.11.10
   plotly:
     description: How to make Histograms in Python with Plotly.
     display_as: statistical
@@ -438,12 +438,12 @@ trace5 = go.Histogram(x=x,
                       autobinx = False
                       )
 
-fig.append_trace(trace0, 1, 1)
-fig.append_trace(trace1, 1, 2)
-fig.append_trace(trace2, 2, 1)
-fig.append_trace(trace3, 2, 2)
-fig.append_trace(trace4, 3, 1)
-fig.append_trace(trace5, 3, 2)
+fig.add_trace(trace0, 1, 1)
+fig.add_trace(trace1, 1, 2)
+fig.add_trace(trace2, 2, 1)
+fig.add_trace(trace3, 2, 2)
+fig.add_trace(trace4, 3, 1)
+fig.add_trace(trace5, 3, 2)
 
 fig.show()
 ```

--- a/doc/python/horizontal-bar-charts.md
+++ b/doc/python/horizontal-bar-charts.md
@@ -5,10 +5,10 @@ jupyter:
     text_representation:
       extension: .md
       format_name: markdown
-      format_version: '1.1'
-      jupytext_version: 1.1.1
+      format_version: '1.3'
+      jupytext_version: 1.16.4
   kernelspec:
-    display_name: Python 3
+    display_name: Python 3 (ipykernel)
     language: python
     name: python3
   language_info:
@@ -20,7 +20,7 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.6.7
+    version: 3.11.10
   plotly:
     description: How to make horizontal bar charts in Python with Plotly.
     display_as: basic
@@ -239,7 +239,7 @@ x = ['Japan', 'United Kingdom', 'Canada', 'Netherlands',
 fig = make_subplots(rows=1, cols=2, specs=[[{}, {}]], shared_xaxes=True,
                     shared_yaxes=False, vertical_spacing=0.001)
 
-fig.append_trace(go.Bar(
+fig.add_trace(go.Bar(
     x=y_saving,
     y=x,
     marker=dict(
@@ -252,7 +252,7 @@ fig.append_trace(go.Bar(
     orientation='h',
 ), 1, 1)
 
-fig.append_trace(go.Scatter(
+fig.add_trace(go.Scatter(
     x=y_net_worth, y=x,
     mode='lines+markers',
     line_color='rgb(128, 0, 128)',

--- a/doc/python/subplots.md
+++ b/doc/python/subplots.md
@@ -6,9 +6,9 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.14.1
+      jupytext_version: 1.16.4
   kernelspec:
-    display_name: Python 3
+    display_name: Python 3 (ipykernel)
     language: python
     name: python3
   language_info:
@@ -20,7 +20,7 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.8.8
+    version: 3.11.10
   plotly:
     description: How to make subplots in with Plotly's Python graphing library. Examples
       of stacked, custom-sized, gridded, and annotated subplots.
@@ -80,17 +80,17 @@ import plotly.graph_objects as go
 
 fig = make_subplots(rows=3, cols=1)
 
-fig.append_trace(go.Scatter(
+fig.add_trace(go.Scatter(
     x=[3, 4, 5],
     y=[1000, 1100, 1200],
 ), row=1, col=1)
 
-fig.append_trace(go.Scatter(
+fig.add_trace(go.Scatter(
     x=[2, 3, 4],
     y=[100, 110, 120],
 ), row=2, col=1)
 
-fig.append_trace(go.Scatter(
+fig.add_trace(go.Scatter(
     x=[0, 1, 2],
     y=[10, 11, 12]
 ), row=3, col=1)


### PR DESCRIPTION
This was deprecated a while ago https://github.com/plotly/plotly.py/blob/main/MIGRATION_GUIDE.md#new-add-trace-methods-that-handle-subplots
