### PR TITLE
Update print_grid default

### DIFF
--- a/plotly/subplots.py
+++ b/plotly/subplots.py
@@ -59,8 +59,8 @@ def make_subplots(
           - 'bottom-left': Subplots are numbererd with (1, 1) in the bottom
                            left corner
 
-    print_grid: boolean (default True):
-        If True, prints a string representation of the plot grid.  Grid may
+    print_grid: boolean (default False):
+        If True, prints a string representation of the plot grid. Grid may
         also be printed using the `Figure.print_grid()` method on the
         resulting figure.
 


### PR DESCRIPTION
The default changed in v4 https://plotly.com/python/v4-migration/#grid-no-longer-printed-by-default

https://github.com/plotly/plotly.py/compare/update-default-print-grid?expand=1#diff-a822cb37cf57c7ee3510557fdf12ab480742cbfbac619750f37acbd223bdb808R12