### PR TITLE
Fix return type

### DIFF
--- a/plotly/io/_html.py
+++ b/plotly/io/_html.py
@@ -471,8 +471,7 @@ def write_html(
 
     Returns
     -------
-    str
-        Representation of figure as an HTML div string
+    None
     """
 
     # Build HTML string


### PR DESCRIPTION
The `write_html` function writes to file and doesn't return a string representation of the figure