### PR TITLE
corrected a label from Canada to Oceania

### DIFF
--- a/doc/python/bar-charts.md
+++ b/doc/python/bar-charts.md
@@ -124,7 +124,7 @@ import plotly.express as px
 df = px.data.gapminder().query("continent == 'Oceania'")
 fig = px.bar(df, x='year', y='pop',
              hover_data=['lifeExp', 'gdpPercap'], color='country',
-             labels={'pop':'population of Canada'}, height=400)
+             labels={'pop':'population of Oceania'}, height=400)
 fig.show()
 ```
 


### PR DESCRIPTION
This addresses issue #5129, which flagged a typo in the documentation.