### PR TITLE
add swarm plot to the scatter documentation

### DIFF
--- a/doc/python/line-and-scatter.md
+++ b/doc/python/line-and-scatter.md
@@ -284,6 +284,95 @@ fig.update_traces(textposition="bottom right")
 fig.show()
 ```
 
+### Swarm (or Beeswarm) Plots 
+
+Swarm plots show the distribution of values in a column by giving each entry one dot and adjusting the y-value so that dots do not overlap and appear symmetrically around the y=0 line.  They complement histograms, box plots, and violin plots.  This example could be generalized to implement a swarm plot for multiple categories by adjusting the y-coordinate for each category.
+
+```python
+import pandas as pd
+import plotly.express as px
+import collections
+
+
+def swarm(
+    X_series,
+    point_size=16,
+    fig_width = 800,
+    gap_multiplier=1.2,
+):
+    #sorting will align columns in attractive arcs rather than having columns the vary unpredicatbly in the x-dimension
+    X_series=X_series.copy().sort_values()
+
+
+    # we need to reason in terms of the marker size that is measured in px
+    # so we need to think about each x-coordinate as being a fraction of the way from the 
+    # minimum X value to the maximum X value
+    min_x = min(X_series)
+    max_x = max(X_series)
+    
+    list_of_rows = []
+    # we will count the number of points in each "bin" / vertical strip of the graph
+    # to be able to assign a y-coordinate that avoids overlapping
+    bin_counter = collections.Counter()
+
+    for x_val in X_series:
+        # assign this x_value to bin number
+        # each bin is a vertical strip wide enough for one marker
+        bin=(((fig_width*(x_val-min_x))/(max_x-min_x))  // point_size)
+        
+        #update the count of dots in that strip
+        bin_counter.update([bin])
+        
+        # if this is an odd numbered entry in its bin, make its y coordinate negative
+        # the y coordinate of the first entry is 0, so entries 3, 5, and 7 get negative y coordinates
+        if bin_counter[bin]%2 == 1:
+            negative_1_if_count_is_odd = -1
+        else:
+            negative_1_if_count_is_odd = 1
+
+        # the collision free y coordinate gives the items in a vertical bin
+        # coordinates:  0, 1, -1, 2, -2, 3, -3 ... and so on to evenly spread
+        # their locations above and below the y-axis (we'll make a correction below to deal with even numbers of entries)
+        # we then scale this by the point_size*gap_multiplier to get a y coordinate in px
+
+        collision_free_y_coordinate=(bin_counter[bin]//2)*negative_1_if_count_is_odd*point_size*gap_multiplier              
+        list_of_rows.append({"x":x_val,"y":collision_free_y_coordinate,"bin":bin})
+
+    # if the number of points is even, 
+    # move y-coordinates down to put an equal number of entries above and below the axis
+    for row in list_of_rows:
+        if bin_counter[row["bin"]]%2==0:
+            row["y"]-=point_size*gap_multiplier/2
+
+    df = pd.DataFrame(list_of_rows)
+    
+    fig = px.scatter(
+        df,
+        x="x",
+        y="y",
+        hover_data="x",
+    )
+    #we want to suppress the y coordinate in the hover value because the y-coordinate is irrelevant/misleading
+    fig.update_traces(
+        marker_size=point_size,
+        hovertemplate="<b>value</b>: %{x}",
+    )
+    # we have to set the width and height because we aim to avoid icon collisions and we specify the icon size
+    # in the same units as the width and height
+    fig.update_layout(width=fig_width, height=(point_size*max(bin_counter.values())+200))
+    fig.update_yaxes(
+    showticklabels=False,  # Turn off y-axis labels
+    ticks='',               # Remove the ticks
+    title=""
+    )
+    fig.show()
+
+
+
+df_iris = px.data.iris() # iris is a pandas DataFrame
+swarm(df_iris["sepal_length"])
+```
+
 ## Scatter and line plots with go.Scatter
 
 If Plotly Express does not provide a good starting point, it is possible to use [the more generic `go.Scatter` class from `plotly.graph_objects`](/python/graph-objects/). Whereas `plotly.express` has two functions `scatter` and `line`, `go.Scatter` can be used both for plotting points (makers) or lines, depending on the value of `mode`. The different options of `go.Scatter` are documented in its [reference page](https://plotly.com/python/reference/scatter/).


### PR DESCRIPTION
This is inspired by #5087.  Many thanks to @suterberg for inspiring it and getting me started.

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [ Y] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ Y] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `main` branch
- [ N/A] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ Y] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ Y] Every new/modified example is independently runnable
- [ Y] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ Y] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ N/A] The random seed is set if using randomly-generated data in new/modified examples
- [ Y] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ Y] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ Y ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ Y ] Data frames are always called `df`
- [ it's as high as it can logically go ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ Y ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ Y ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ Y ] `fig.show()` is at the end of each new/modified example
- [ Y ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ Y ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/CONTRIBUTING.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

-->
