### PR TITLE
Fix script tag for notebook renderers

### DIFF
--- a/plotly/io/_base_renderers.py
+++ b/plotly/io/_base_renderers.py
@@ -295,7 +295,7 @@ class HtmlRenderer(MimetypeRenderer):
         {win_config}
         {mathjax_config}
         </script>
-        <script type="module">{script}</script>
+        <script>{script}</script>
         """.format(
                     script=get_plotlyjs(),
                     win_config=_window_plotly_config,


### PR DESCRIPTION
This updates the `notebook` renderer to use a plain script tag when embedding all of plotly.js rather than using `<script type="module">`. This fixes #4953. For more context on JS modules, see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules. 

Some context:
* `<script type="module">` was added in #4763. 
* Before that PR, it was `<script type="text/javascript">`: https://github.com/plotly/plotly.py/blame/26c4443b1a2efc83a5af3efd179c68f5e13cdfad/packages/python/plotly/plotly/io/_base_renderers.py#L292. It seems like using `type="text/javascript"` is no longer necessary since HTML 5: https://stackoverflow.com/questions/25737619/what-is-the-difference-between-script-type-text-javascript-and-script. 