### PR TITLE
Bump kaleido version to rc13 in pyproject.toml and CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
 
 [project.optional-dependencies]
 express = ["numpy"]
-kaleido = ["kaleido==1.0.0rc11"]
+kaleido = ["kaleido==1.0.0rc13"]
 dev = ["black==25.1.0"]
 
 [project.scripts]

--- a/test_requirements/requirements_optional.txt
+++ b/test_requirements/requirements_optional.txt
@@ -18,7 +18,7 @@ matplotlib
 scikit-image
 psutil
 # kaleido>=1.0.0  # Uncomment and delete line below once Kaleido v1 is released
-git+https://github.com/plotly/Kaleido.git@v1.0.0rc12#subdirectory=src/py
+kaleido==1.0.0rc13
 orjson
 polars[timezone]
 pyarrow


### PR DESCRIPTION
Now that `kaleido==1.0.0rc13` is [released on PyPI](https://pypi.org/project/kaleido/1.0.0rc13/)