### PR TITLE
Kaleido doc string updates

### DIFF
--- a/plotly/io/_kaleido.py
+++ b/plotly/io/_kaleido.py
@@ -14,7 +14,7 @@ ENGINE_SUPPORT_TIMELINE = "September 2025"
 
 PLOTLY_GET_CHROME_ERROR_MSG = """
 
-Kaleido requires Google Chrome to be installed. 
+Kaleido requires Google Chrome to be installed.
 
 Either download and install Chrome yourself following Google's instructions for your operating system,
 or install it from your terminal by running:
@@ -549,46 +549,66 @@ def write_images(
     Parameters
     ----------
     fig:
-        Iterable of figure objects or dicts representing a figure
+        List of figure objects or dicts representing a figure.
+        Also accepts a single figure or dict representing a figure.
 
-    file: str or writeable
-        Iterables of strings or pathlib.Path objects representing local file paths to write to.
+    file: str, pathlib.Path, or list of (str or pathlib.Path)
+        List of str or pathlib.Path objects representing local file paths to write to.
+        Can also be a single str or pathlib.Path object if fig argument is
+        a single figure or dict representing a figure.
 
-    format: str or None
-        The desired image format. One of
+    format: str, None, or list of (str or None)
+        The image format to use for exported images.
+        Supported formats are:
           - 'png'
           - 'jpg' or 'jpeg'
           - 'webp'
           - 'svg'
           - 'pdf'
 
-        If not specified, this will default to `plotly.io.defaults.default_format`.
+        Use a list to specify formats for each figure or dict in the list
+        provided to the `fig` argument.
+        Specify format as a `str` to apply the same format to all exported images.
+        If not specified, will default to `plotly.io.defaults.default_format`.
 
-    width: int or None
+    width: int, None, or list of (int or None)
         The width of the exported image in layout pixels. If the `scale`
         property is 1.0, this will also be the width of the exported image
         in physical pixels.
 
+        Use a list to specify widths for each figure or dict in the list
+        provided to the `fig` argument.
+        Specify width as an `int` to apply the same width to all exported images.
         If not specified, will default to `plotly.io.defaults.default_width`.
 
-    height: int or None
+    height: int, None, or list of (int or None)
         The height of the exported image in layout pixels. If the `scale`
         property is 1.0, this will also be the height of the exported image
         in physical pixels.
 
+        Use a list to specify heights for each figure or dict in the list
+        provided to the `fig` argument.
+        Specify height as an `int` to apply the same height to all exported images.
         If not specified, will default to `plotly.io.defaults.default_height`.
 
-    scale: int or float or None
+    scale: int, float, None, or list of (int, float, or None)
         The scale factor to use when exporting the figure. A scale factor
         larger than 1.0 will increase the image resolution with respect
         to the figure's layout pixel dimensions. Whereas as scale factor of
         less than 1.0 will decrease the image resolution.
 
+        Use a list to specify scale for each figure or dict in the list
+        provided to the `fig` argument.
+        Specify scale as an `int` or `float` to apply the same scale to all exported images.
         If not specified, will default to `plotly.io.defaults.default_scale`.
 
-    validate: bool
+    validate: bool or list of bool
         True if the figure should be validated before being converted to
         an image, False otherwise.
+
+        Use a list to specify validation setting for each figure in the list
+        provided to the `fig` argument.
+        Specify validate as a boolean to apply the same validation setting to all figures.
 
     Returns
     -------

--- a/plotly/io/_kaleido.py
+++ b/plotly/io/_kaleido.py
@@ -569,7 +569,8 @@ def write_images(
         Use a list to specify formats for each figure or dict in the list
         provided to the `fig` argument.
         Specify format as a `str` to apply the same format to all exported images.
-        If not specified, will default to `plotly.io.defaults.default_format`.
+        If not specified, and the corresponding `file` argument has a file extension, then `format` will default to the
+        file extension. Otherwise, will default to `plotly.io.defaults.default_format`.
 
     width: int, None, or list of (int or None)
         The width of the exported image in layout pixels. If the `scale`


### PR DESCRIPTION
<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/master/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `main` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/master/CONTRIBUTING.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

-->
