### PR TITLE
Disable Kaleido deprecation warnings

### DIFF
--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -3794,23 +3794,25 @@ Invalid property path '{key_path_str}' for layout
         from plotly.io.kaleido import (
             kaleido_available,
             kaleido_major,
+            ENABLE_KALEIDO_V0_DEPRECATION_WARNINGS,
             KALEIDO_DEPRECATION_MSG,
             ORCA_DEPRECATION_MSG,
             ENGINE_PARAM_DEPRECATION_MSG,
         )
 
-        if (
-            kwargs.get("engine", None) in {None, "auto", "kaleido"}
-            and kaleido_available()
-            and kaleido_major() < 1
-        ):
-            warnings.warn(KALEIDO_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
-        if kwargs.get("engine", None) == "orca":
-            warnings.warn(ORCA_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
-        if kwargs.get("engine", None):
-            warnings.warn(
-                ENGINE_PARAM_DEPRECATION_MSG, DeprecationWarning, stacklevel=2
-            )
+        if ENABLE_KALEIDO_V0_DEPRECATION_WARNINGS:
+            if (
+                kwargs.get("engine", None) in {None, "auto", "kaleido"}
+                and kaleido_available()
+                and kaleido_major() < 1
+            ):
+                warnings.warn(KALEIDO_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+            if kwargs.get("engine", None) == "orca":
+                warnings.warn(ORCA_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+            if kwargs.get("engine", None):
+                warnings.warn(
+                    ENGINE_PARAM_DEPRECATION_MSG, DeprecationWarning, stacklevel=2
+                )
 
         return pio.to_image(self, *args, **kwargs)
 
@@ -3887,24 +3889,26 @@ Invalid property path '{key_path_str}' for layout
         from plotly.io.kaleido import (
             kaleido_available,
             kaleido_major,
+            ENABLE_KALEIDO_V0_DEPRECATION_WARNINGS,
             KALEIDO_DEPRECATION_MSG,
             ORCA_DEPRECATION_MSG,
             ENGINE_PARAM_DEPRECATION_MSG,
         )
 
-        if (
-            kwargs.get("engine", None) in {None, "auto", "kaleido"}
-            and kaleido_available()
-            and kaleido_major() < 1
-        ):
-            warnings.warn(KALEIDO_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
-        if kwargs.get("engine", None) == "orca":
-            warnings.warn(ORCA_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
-        if kwargs.get("engine", None):
-            warnings.warn(
-                ENGINE_PARAM_DEPRECATION_MSG, DeprecationWarning, stacklevel=2
-            )
-        return pio.write_image(self, *args, **kwargs)
+        if ENABLE_KALEIDO_V0_DEPRECATION_WARNINGS:
+            if (
+                kwargs.get("engine", None) in {None, "auto", "kaleido"}
+                and kaleido_available()
+                and kaleido_major() < 1
+            ):
+                warnings.warn(KALEIDO_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+            if kwargs.get("engine", None) == "orca":
+                warnings.warn(ORCA_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+            if kwargs.get("engine", None):
+                warnings.warn(
+                    ENGINE_PARAM_DEPRECATION_MSG, DeprecationWarning, stacklevel=2
+                )
+            return pio.write_image(self, *args, **kwargs)
 
     # Static helpers
     # --------------

--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -3740,11 +3740,11 @@ Invalid property path '{key_path_str}' for layout
               - 'webp'
               - 'svg'
               - 'pdf'
-              - 'eps' (deprecated) (Requires the poppler library to be installed)
+              - 'eps' (Kaleido v0.* only) (Requires the poppler library to be installed)
 
             If not specified, will default to:
-                - `plotly.io.defaults.default_format` if engine is "kaleido"
-                - `plotly.io.orca.config.default_format` if engine is "orca" (deprecated)
+                - `plotly.io.defaults.default_format` or `plotly.io.kaleido.scope.default_format` if engine is "kaleido"
+                - `plotly.io.orca.config.default_format` if engine is "orca"
 
         width: int or None
             The width of the exported image in layout pixels. If the `scale`
@@ -3752,8 +3752,8 @@ Invalid property path '{key_path_str}' for layout
             in physical pixels.
 
             If not specified, will default to:
-                - `plotly.io.defaults.default_width` if engine is "kaleido"
-                - `plotly.io.orca.config.default_width` if engine is "orca" (deprecated)
+                - `plotly.io.defaults.default_width` or `plotly.io.kaleido.scope.default_width` if engine is "kaleido"
+                - `plotly.io.orca.config.default_width` if engine is "orca"
 
         height: int or None
             The height of the exported image in layout pixels. If the `scale`
@@ -3761,8 +3761,8 @@ Invalid property path '{key_path_str}' for layout
             in physical pixels.
 
             If not specified, will default to:
-                - `plotly.io.defaults.default_height` if engine is "kaleido"
-                - `plotly.io.orca.config.default_height` if engine is "orca" (deprecated)
+                - `plotly.io.defaults.default_height` or `plotly.io.kaleido.scope.default_height` if engine is "kaleido"
+                - `plotly.io.orca.config.default_height` if engine is "orca"
 
         scale: int or float or None
             The scale factor to use when exporting the figure. A scale factor
@@ -3771,14 +3771,14 @@ Invalid property path '{key_path_str}' for layout
             less than 1.0 will decrease the image resolution.
 
             If not specified, will default to:
-                - `plotly.io.defaults.default_scale` if engine is "kaliedo"
-                - `plotly.io.orca.config.default_scale` if engine is "orca" (deprecated)
+                - `plotly.io.defaults.default_scale` or `plotly.io.kaleido.scope.default_scale` if engine is "kaliedo"
+                - `plotly.io.orca.config.default_scale` if engine is "orca"
 
         validate: bool
             True if the figure should be validated before being converted to
             an image, False otherwise.
 
-        engine (deprecated): str
+        engine: str
             Image export engine to use. This parameter is deprecated and Orca engine support will be
             dropped in the next major Plotly version. Until then, the following values are supported:
             - "kaleido": Use Kaleido for image export
@@ -3834,13 +3834,13 @@ Invalid property path '{key_path_str}' for layout
               - 'webp'
               - 'svg'
               - 'pdf'
-              - 'eps' (deprecated) (Requires the poppler library to be installed)
+              - 'eps' (Kaleido v0.* only) (Requires the poppler library to be installed)
 
             If not specified and `file` is a string then this will default to the
             file extension. If not specified and `file` is not a string then this
             will default to:
-                - `plotly.io.defaults.default_format` if engine is "kaleido"
-                - `plotly.io.orca.config.default_format` if engine is "orca" (deprecated)
+                - `plotly.io.defaults.default_format` or `plotly.io.kaleido.scope.default_format` if engine is "kaleido"
+                - `plotly.io.orca.config.default_format` if engine is "orca"
 
         width: int or None
             The width of the exported image in layout pixels. If the `scale`
@@ -3848,8 +3848,8 @@ Invalid property path '{key_path_str}' for layout
             in physical pixels.
 
             If not specified, will default to:
-                - `plotly.io.defaults.default_width` if engine is "kaleido"
-                - `plotly.io.orca.config.default_width` if engine is "orca" (deprecated)
+                - `plotly.io.defaults.default_width` or `plotly.io.kaleido.scope.default_width` if engine is "kaleido"
+                - `plotly.io.orca.config.default_width` if engine is "orca"
 
         height: int or None
             The height of the exported image in layout pixels. If the `scale`
@@ -3857,8 +3857,8 @@ Invalid property path '{key_path_str}' for layout
             in physical pixels.
 
             If not specified, will default to:
-                - `plotly.io.defaults.default_height` if engine is "kaleido"
-                - `plotly.io.orca.config.default_height` if engine is "orca" (deprecated)
+                - `plotly.io.defaults.default_height` or `plotly.io.kaleido.scope.default_height` if engine is "kaleido"
+                - `plotly.io.orca.config.default_height` if engine is "orca"
 
         scale: int or float or None
             The scale factor to use when exporting the figure. A scale factor
@@ -3867,14 +3867,14 @@ Invalid property path '{key_path_str}' for layout
             less than 1.0 will decrease the image resolution.
 
             If not specified, will default to:
-                - `plotly.io.defaults.default_scale` if engine is "kaleido"
-                - `plotly.io.orca.config.default_scale` if engine is "orca" (deprecated)
+                - `plotly.io.defaults.default_scale` or `plotly.io.kaleido.scope.default_scale` if engine is "kaleido"
+                - `plotly.io.orca.config.default_scale` if engine is "orca"
 
         validate: bool
             True if the figure should be validated before being converted to
             an image, False otherwise.
 
-        engine (deprecated): str
+        engine: str
             Image export engine to use. This parameter is deprecated and Orca engine support will be
             dropped in the next major Plotly version. Until then, the following values are supported:
             - "kaleido": Use Kaleido for image export

--- a/plotly/io/_kaleido.py
+++ b/plotly/io/_kaleido.py
@@ -246,11 +246,11 @@ def to_image(
             - 'webp'
             - 'svg'
             - 'pdf'
-            - 'eps' (deprecated) (Requires the poppler library to be installed and on the PATH)
+            - 'eps' (Kaleido v0.* only) (Requires the poppler library to be installed and on the PATH)
 
         If not specified, will default to:
-            - `plotly.io.defaults.default_format` if engine is "kaleido"
-            - `plotly.io.orca.config.default_format` if engine is "orca" (deprecated)
+            - `plotly.io.defaults.default_format` or `plotly.io.kaleido.scope.default_format` if engine is "kaleido"
+            - `plotly.io.orca.config.default_format` if engine is "orca"
 
     width: int or None
         The width of the exported image in layout pixels. If the `scale`
@@ -258,8 +258,8 @@ def to_image(
         in physical pixels.
 
         If not specified, will default to:
-            - `plotly.io.defaults.default_width` if engine is "kaleido"
-            - `plotly.io.orca.config.default_width` if engine is "orca" (deprecated)
+            - `plotly.io.defaults.default_width` or `plotly.io.kaleido.scope.default_width` if engine is "kaleido"
+            - `plotly.io.orca.config.default_width` if engine is "orca"
 
     height: int or None
         The height of the exported image in layout pixels. If the `scale`
@@ -267,8 +267,8 @@ def to_image(
         in physical pixels.
 
         If not specified, will default to:
-            - `plotly.io.defaults.default_height` if engine is "kaleido"
-            - `plotly.io.orca.config.default_height` if engine is "orca" (deprecated)
+            - `plotly.io.defaults.default_height` or `plotly.io.kaleido.scope.default_height` if engine is "kaleido"
+            - `plotly.io.orca.config.default_height` if engine is "orca"
 
     scale: int or float or None
         The scale factor to use when exporting the figure. A scale factor
@@ -277,14 +277,14 @@ def to_image(
         less than 1.0 will decrease the image resolution.
 
         If not specified, will default to:
-            - `plotly.io.defaults.default_scale` if engine is "kaleido"
-            - `plotly.io.orca.config.default_scale` if engine is "orca" (deprecated)
+            - `plotly.io.defaults.default_scale` or `plotly.io.kaleido.scope.default_scale` if engine is "kaleido"
+            - `plotly.io.orca.config.default_scale` if engine is "orca"
 
     validate: bool
         True if the figure should be validated before being converted to
         an image, False otherwise.
 
-    engine (deprecated): str
+    engine: str
         Image export engine to use. This parameter is deprecated and Orca engine support will be
         dropped in the next major Plotly version. Until then, the following values are supported:
           - "kaleido": Use Kaleido for image export
@@ -430,13 +430,13 @@ def write_image(
           - 'webp'
           - 'svg'
           - 'pdf'
-          - 'eps' (deprecated) (Requires the poppler library to be installed and on the PATH)
+          - 'eps'  (Kaleido v0.* only) (Requires the poppler library to be installed and on the PATH)
 
         If not specified and `file` is a string then this will default to the
         file extension. If not specified and `file` is not a string then this
         will default to:
-            - `plotly.io.defaults.default_format` if engine is "kaleido"
-            - `plotly.io.orca.config.default_format` if engine is "orca" (deprecated)
+            - `plotly.io.defaults.default_format` or `plotly.io.kaleido.scope.default_format` if engine is "kaleido"
+            - `plotly.io.orca.config.default_format` if engine is "orca"
 
     width: int or None
         The width of the exported image in layout pixels. If the `scale`
@@ -444,8 +444,8 @@ def write_image(
         in physical pixels.
 
         If not specified, will default to:
-            - `plotly.io.defaults.default_width` if engine is "kaleido"
-            - `plotly.io.orca.config.default_width` if engine is "orca" (deprecated)
+            - `plotly.io.defaults.default_width` or `plotly.io.kaleido.scope.default_width` if engine is "kaleido"
+            - `plotly.io.orca.config.default_width` if engine is "orca"
 
     height: int or None
         The height of the exported image in layout pixels. If the `scale`
@@ -453,8 +453,8 @@ def write_image(
         in physical pixels.
 
         If not specified, will default to:
-            - `plotly.io.defaults.default_height` if engine is "kaleido"
-            - `plotly.io.orca.config.default_height` if engine is "orca" (deprecated)
+            - `plotly.io.defaults.default_height` or `plotly.io.kaleido.scope.default_height` if engine is "kaleido"
+            - `plotly.io.orca.config.default_height` if engine is "orca"
 
     scale: int or float or None
         The scale factor to use when exporting the figure. A scale factor
@@ -463,14 +463,14 @@ def write_image(
         less than 1.0 will decrease the image resolution.
 
         If not specified, will default to:
-            - `plotly.io.defaults.default_scale` if engine is "kaleido"
-            - `plotly.io.orca.config.default_scale` if engine is "orca" (deprecated)
+            - `plotly.io.defaults.default_scale` or `plotly.io.kaleido.scope.default_scale` if engine is "kaleido"
+            - `plotly.io.orca.config.default_scale` if engine is "orca"
 
     validate: bool
         True if the figure should be validated before being converted to
         an image, False otherwise.
 
-    engine (deprecated): str
+    engine: str
         Image export engine to use. This parameter is deprecated and Orca engine support will be
         dropped in the next major Plotly version. Until then, the following values are supported:
           - "kaleido": Use Kaleido for image export
@@ -577,7 +577,8 @@ def write_images(
         provided to the `fig` argument.
         Specify format as a `str` to apply the same format to all exported images.
         If not specified, and the corresponding `file` argument has a file extension, then `format` will default to the
-        file extension. Otherwise, will default to `plotly.io.defaults.default_format`.
+        file extension. Otherwise, will default to `plotly.io.defaults.default_format`
+        or `plotly.io.kaleido.scope.default_format`.
 
     width: int, None, or list of (int or None)
         The width of the exported image in layout pixels. If the `scale`
@@ -587,7 +588,8 @@ def write_images(
         Use a list to specify widths for each figure or dict in the list
         provided to the `fig` argument.
         Specify width as an `int` to apply the same width to all exported images.
-        If not specified, will default to `plotly.io.defaults.default_width`.
+        If not specified, will default to `plotly.io.defaults.default_width`
+        or `plotly.io.kaleido.scope.default_width`.
 
     height: int, None, or list of (int or None)
         The height of the exported image in layout pixels. If the `scale`
@@ -597,7 +599,8 @@ def write_images(
         Use a list to specify heights for each figure or dict in the list
         provided to the `fig` argument.
         Specify height as an `int` to apply the same height to all exported images.
-        If not specified, will default to `plotly.io.defaults.default_height`.
+        If not specified, will default to `plotly.io.defaults.default_height`
+        or `plotly.io.kaleido.scope.default_height`.
 
     scale: int, float, None, or list of (int, float, or None)
         The scale factor to use when exporting the figure. A scale factor
@@ -608,7 +611,8 @@ def write_images(
         Use a list to specify scale for each figure or dict in the list
         provided to the `fig` argument.
         Specify scale as an `int` or `float` to apply the same scale to all exported images.
-        If not specified, will default to `plotly.io.defaults.default_scale`.
+        If not specified, will default to `plotly.io.defaults.default_scale`
+        or `plotly.io.kaleido.scope.default_scale`.
 
     validate: bool or list of bool
         True if the figure should be validated before being converted to

--- a/plotly/io/_kaleido.py
+++ b/plotly/io/_kaleido.py
@@ -300,7 +300,9 @@ def to_image(
     # Handle engine
     if engine is not None:
         if ENABLE_KALEIDO_V0_DEPRECATION_WARNINGS:
-            warnings.warn(ENGINE_PARAM_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+            warnings.warn(
+                ENGINE_PARAM_DEPRECATION_MSG, DeprecationWarning, stacklevel=2
+            )
     else:
         engine = "auto"
 
@@ -492,7 +494,9 @@ def write_image(
         if engine == "orca":
             warnings.warn(ORCA_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
         if engine not in {None, "auto"}:
-            warnings.warn(ENGINE_PARAM_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+            warnings.warn(
+                ENGINE_PARAM_DEPRECATION_MSG, DeprecationWarning, stacklevel=2
+            )
 
     # Try to cast `file` as a pathlib object `path`.
     path = as_path_object(file)

--- a/plotly/io/kaleido.py
+++ b/plotly/io/kaleido.py
@@ -4,6 +4,7 @@ from ._kaleido import (
     scope,
     kaleido_available,
     kaleido_major,
+    ENABLE_KALEIDO_V0_DEPRECATION_WARNINGS,
     KALEIDO_DEPRECATION_MSG,
     ORCA_DEPRECATION_MSG,
     ENGINE_PARAM_DEPRECATION_MSG,


### PR DESCRIPTION
Closes #5174 

- Disable Kaleido and Orca deprecation warnings (will re-enable following the next release)
- Update docstrings to remove deprecation notices

Note this PR still leaves in place the `plotly.io.defaults.*` method of setting defaults. Either `plotly.io.kaleido.scope.* or `plotly.io.defaults.*` may be used; they will be kept in sync.

@LiamConnors It might be nice to update the docs to recommend the usage of `plotly.io.defaults.*`, but also not essential, maybe not worth the trouble if that's the _only_ docs update needed for the 6.1.0 release.