### PR TITLE
Fix issue breaking `fig.write_image()`

### DIFF
--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -3908,7 +3908,7 @@ Invalid property path '{key_path_str}' for layout
                 warnings.warn(
                     ENGINE_PARAM_DEPRECATION_MSG, DeprecationWarning, stacklevel=2
                 )
-            return pio.write_image(self, *args, **kwargs)
+        return pio.write_image(self, *args, **kwargs)
 
     # Static helpers
     # --------------


### PR DESCRIPTION
Closes #5187 

Fix incorrect indentation causing `fig.write_image()` to not generate an image.

With thanks to @petrchmelar for identifying the issue.