### PR TITLE
switched from hex codes to CSS colors

### DIFF
--- a/doc/python/dropdowns.md
+++ b/doc/python/dropdowns.md
@@ -365,27 +365,27 @@ fig.add_trace(
     go.Scatter(x=list(df.Date),
                y=list(df.High),
                name="High",
-               line=dict(color="#33CFA5")))
+               line=dict(color="DarkBlue")))
 
 fig.add_trace(
     go.Scatter(x=list(df.Date),
                y=[df.High.mean()] * len(df.index),
                name="High Average",
                visible=False,
-               line=dict(color="#33CFA5", dash="dash")))
+               line=dict(color="DarkBlue", dash="dash")))
 
 fig.add_trace(
     go.Scatter(x=list(df.Date),
                y=list(df.Low),
                name="Low",
-               line=dict(color="#F06A6A")))
+               line=dict(color="Crimson")))
 
 fig.add_trace(
     go.Scatter(x=list(df.Date),
                y=[df.Low.mean()] * len(df.index),
                name="Low Average",
                visible=False,
-               line=dict(color="#F06A6A", dash="dash")))
+               line=dict(color="Crimson", dash="dash")))
 
 # Add Annotations and Buttons
 high_annotations = [dict(x="2016-03-01",


### PR DESCRIPTION
this PR is entirely trying to apply the following expectation. the Crimson is very close to the original; the DarkBlue is on plotly's list and contrasts well with the background and the Crimson and works for people who are red/green color blind.
....

 Hex codes for colors are not used in any new/modified example in favour of these nices ones: 
 https://github.com/plotly/plotly.py/issues/2192
...