### PR TITLE
Change deprecation version

### DIFF
--- a/doc/python/static-image-export.md
+++ b/doc/python/static-image-export.md
@@ -175,7 +175,7 @@ fig2 = go.Figure(
 )
 
 fig3 = px.pie(
-    values=[30, 20, 10, 40], 
+    values=[30, 20, 10, 40],
     names=['A', 'B', 'C', 'D'],
     title='Pie Chart'
 )
@@ -217,7 +217,7 @@ Image(img_bytes)
 
 ## Specify Image Export Engine
 
-> The `engine` parameter, as well as Orca support, is deprecated in Plotly.py 6.1.0 and will be removed after September 2025.
+> The `engine` parameter, as well as Orca support, is deprecated in Plotly.py 6.2.0 and will be removed after September 2025.
 
 If `kaleido` is installed, it will automatically be used to perform image export.  If it is not installed, plotly.py will attempt to use `orca` instead. The `engine` argument to the `to_image` and `write_image` functions can be used to override this default behavior.
 
@@ -295,7 +295,7 @@ import plotly.io as pio
 pio.defaults.default_height
 ~~~
 
-In earlier versions of Plotly.py, these settings are available on `plotly.io.kaleido.scope`. This is deprecated since version 6.1. Use `plotly.io.defaults` instead.
+In earlier versions of Plotly.py, these settings are available on `plotly.io.kaleido.scope`. This is deprecated since version 6.2. Use `plotly.io.defaults` instead.
 
 ~~~python
 import plotly.io as pio

--- a/doc/python/static-image-generation-migration.md
+++ b/doc/python/static-image-generation-migration.md
@@ -46,7 +46,7 @@ To migrate from either Orca or Kaleido v0, first install the latest Kaleido with
 pip install --upgrade kaleido
 ```
 
-## Chrome 
+## Chrome
 
 Kaleido uses Chrome for static image generation. Versions of Kaleido prior to v1 included Chrome as part of the Kaleido package. Kaleido v1 does not include Chrome; instead, it looks for a compatible version of Chrome (or Chromium) already installed on the machine on which it's running.
 
@@ -54,7 +54,7 @@ See the [Chrome section](/python/static-image-export#chrome) on the Static Image
 
 ## Engine Parameter
 
-The `engine` parameter on static image export methods and functions is deprecated in Plotly.py 6.1 and will be removed after September 2025. Once the `engine` parameter is removed, static image generation will use Kaleido v1 if it's installed, or raise an error if it isn't.
+The `engine` parameter on static image export methods and functions is deprecated in Plotly.py 6.2 and will be removed after September 2025. Once the `engine` parameter is removed, static image generation will use Kaleido v1 if it's installed, or raise an error if it isn't.
 
 You'll need to update your code to remove references to `engine`. For example, `fig.to_image(format="png", engine="orca")` or `fig.to_image(format="png", engine="kaleido")` needs to be updated to `fig.to_image(format="png")`. This change applies to: `fig.to_image`, `fig.write_image`, `plotly.io.to_image`, and `plotly.io.write_image`.
 
@@ -69,7 +69,7 @@ Accessing Kaleido defaults and config settings via `plotly.io.kaleido.scope` is 
 ~~~python
 import plotly.io as pio
 pio.defaults.default_format = "jpeg"
-# Instead of: 
+# Instead of:
 # pio.kaleido.scope.default_format = "jpeg"
 ~~~
 


### PR DESCRIPTION
Change doc to reflect when deprecation notices for Kaleido are introduced

<!--
Please uncomment this block and take a look at this checklist if your PR is making substantial changes to **documentation**/impacts files in the `doc` directory. Check all that apply to your PR, and leave the rest unchecked to discuss with your reviewer! Not all boxes must be checked for every PR :)

If your PR modifies code of the `plotly` package, we have a different checklist
below :-).

### Documentation PR

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/main/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `main` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)

## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).

-->
