### PR TITLE
Support setting plotly.js path for Kaleido v1 image export

### DIFF
--- a/plotly/io/_defaults.py
+++ b/plotly/io/_defaults.py
@@ -13,6 +13,7 @@ class _Defaults(object):
         self.default_scale = 1
         self.mathjax = None
         self.topojson = None
+        self.plotlyjs = None
 
 
 defaults = _Defaults()

--- a/plotly/io/_kaleido.py
+++ b/plotly/io/_kaleido.py
@@ -369,6 +369,12 @@ To downgrade to Kaleido v0, run:
         from kaleido.errors import ChromeNotFoundError
 
         try:
+            kopts = {}
+            if defaults.plotlyjs:
+                kopts["plotlyjs"] = defaults.plotlyjs
+            if defaults.mathjax:
+                kopts["mathjax"] = defaults.mathjax
+
             # TODO: Refactor to make it possible to use a shared Kaleido instance here
             img_bytes = kaleido.calc_fig_sync(
                 fig_dict,
@@ -379,13 +385,7 @@ To downgrade to Kaleido v0, run:
                     scale=scale or defaults.default_scale,
                 ),
                 topojson=defaults.topojson,
-                kopts=(
-                    dict(
-                        mathjax=defaults.mathjax,
-                    )
-                    if defaults.mathjax
-                    else None
-                ),
+                kopts=kopts,
             )
         except ChromeNotFoundError:
             raise RuntimeError(PLOTLY_GET_CHROME_ERROR_MSG)
@@ -692,15 +692,14 @@ which can be installed using pip:
     from kaleido.errors import ChromeNotFoundError
 
     try:
+        kopts = {}
+        if defaults.plotlyjs:
+            kopts["plotlyjs"] = defaults.plotlyjs
+        if defaults.mathjax:
+            kopts["mathjax"] = defaults.mathjax
         kaleido.write_fig_from_object_sync(
             kaleido_specs,
-            kopts=(
-                dict(
-                    mathjax=defaults.mathjax,
-                )
-                if defaults.mathjax
-                else None
-            ),
+            kopts=kopts,
         )
     except ChromeNotFoundError:
         raise RuntimeError(PLOTLY_GET_CHROME_ERROR_MSG)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
 
 [project.optional-dependencies]
 express = ["numpy"]
-kaleido = ["kaleido==1.0.0rc13"]
+kaleido = ["kaleido==1.0.0rc15"]
 dev = ["black==25.1.0"]
 
 [project.scripts]

--- a/test_requirements/requirements_optional.txt
+++ b/test_requirements/requirements_optional.txt
@@ -18,7 +18,7 @@ matplotlib
 scikit-image
 psutil
 # kaleido>=1.0.0  # Uncomment and delete line below once Kaleido v1 is released
-kaleido==1.0.0rc13
+kaleido==1.0.0rc15
 orjson
 polars[timezone]
 pyarrow

--- a/tests/test_optional/test_kaleido/test_kaleido.py
+++ b/tests/test_optional/test_kaleido/test_kaleido.py
@@ -230,6 +230,13 @@ def test_defaults():
             assert pio._kaleido.scope.topojson == "path/to/topojson/files/"
             assert pio._kaleido.scope.plotlyjs == "https://cdn.plot.ly/plotly-3.0.0.js"
 
+        # Set topojson default back to None
+        # (otherwise image generation will fail)
+        pio.defaults.topojson = None
+        # Generate image for real and make sure it's an SVG
+        result = test_fig.to_image(format="svg", validate=False)
+        assert result.startswith(b"<svg")
+
     finally:
         # Reset defaults to original values and check that they are restored
         pio.defaults.default_format = "png"

--- a/tests/test_optional/test_kaleido/test_kaleido.py
+++ b/tests/test_optional/test_kaleido/test_kaleido.py
@@ -214,8 +214,7 @@ def test_defaults():
                     == "https://cdn.jsdelivr.net/npm/mathjax@3.1.2/es5/tex-svg.js"
                 )
                 assert (
-                    kwargs["kopts"]["plotlyjs"]
-                    == "https://cdn.plot.ly/plotly-3.0.0.js"
+                    kwargs["kopts"]["plotlyjs"] == "https://cdn.plot.ly/plotly-3.0.0.js"
                 )
 
         else:


### PR DESCRIPTION
Closes #5206 

- Adds a `pio.defaults.plotlyjs` entry for setting the Plotly.js path
- Makes sure the value of `pio.defaults.plotlyjs` is passed through to Kaleido when using Kaleido v1