### PR TITLE
Fix `black` `exclude` parameter in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,7 @@ line-length = 88
 target_version = ['py38', 'py39', 'py310', 'py311', 'py312']
 include = '\.pyi?$'
 exclude = '''
-
-(
+/(
       \.eggs         # exclude a few common directories in the
     | \.git          # root of the project
     | \.hg
@@ -85,7 +84,7 @@ exclude = '''
     | js
     | submodules
     | plotly/matplotlylib/mplexporter
-)
+)/
 '''
 
 [tool.jupyter-packaging.builder]


### PR DESCRIPTION
@gvwilson observed an issue where running `python commands.py codegen` on a fresh pull from `main` shows a LARGE number of changed files via `git status`. Furthermore the new files seem to not have `black` formatting applied (they are full of single-quoted strings, etc.).

This issue turns out to be caused by the `[tool.black]` `exclude` parameter in `pyproject.toml`. The regular expression was missing a leading and trailing `/` character, which caused it to match _every_ file path containing one of the listed strings, rather than just including directories with those names.

Since the directory `graph_objs` contains the string `js`, this caused a significant number of files to be excluded from `black` formatting. Some files were also excluded because their path contained `dist`.

This PR adds leading and trailing `/` characters to the regex so that only directories of those names are excluded. (yes, not Windows-friendly but there are already `/'s in the exclude).

Ultimately we need to clean all of this up and switch to `ruff` but this is a simple fix in the meantime.

## How to test

1. Pull this branch
2. Run `python commands.py codegen`
3. Run `git status`. You should see zero unstaged changes.

You can also run these steps on `main` to compare; running `python commands.py codegen` on `main` results in a large number of unstaged changes.