### PR TITLE
Pin `pandas` version for Python 3.9 in optional requirements for tests

### DIFF
--- a/test_requirements/requirements_optional.txt
+++ b/test_requirements/requirements_optional.txt
@@ -1,5 +1,6 @@
 requests
-pandas
+pandas<2.3.0;python_version<="3.9"  # pandas 2.3.0 dropped support for 3.9 but did not update 'requires-python', so we pin manually here
+pandas;python_version>"3.9"
 numpy
 xarray
 statsmodels


### PR DESCRIPTION
For context: https://github.com/pandas-dev/pandas/issues/61563#issuecomment-2945331441

TL;DR Pandas intended to drop support for Python 3.9 in the Pandas 2.3.0 release, and therefore didn’t upload pre-compiled wheels for Python 3.9; however, they forgot to update requires-python in the pyproject.toml, so `uv` still tries to install it and has to compile from scratch since the wheel isn’t available, which fails.

This fixes the failing Python 3.9 CI jobs on `main`.

