### PR TITLE
If IPython is merely installed, don't assume that it's actually used

### DIFF
--- a/plotly/io/_renderers.py
+++ b/plotly/io/_renderers.py
@@ -542,10 +542,11 @@ elif ipython:
             # orca not found
             pass
 
-    # Check if we're running in ipython terminal
+    # Check if we're running in ipython terminal. Or, if we aren't
+    # running ipython at all.
     ipython_info = ipython.get_ipython()
     shell = ipython_info.__class__.__name__
-    if not default_renderer and (shell == "TerminalInteractiveShell"):
+    if not default_renderer and (shell in ("TerminalInteractiveShell", "NoneType")):
         default_renderer = "browser"
 
     # Check if we're running in a Jupyter notebook or JupyterLab


### PR DESCRIPTION
In my virtual environment, there happens to be installed IPython package. It wasn't installed by myself, it's merely a transitive dependency of some another package. It's neither intended to be used, nor is actually used by my project. However, mere presense of the IPython package, due to the over-simplistic decision code in this module (io._renderers) leads to drastic behavior change in Plotly.py: calling Figure._repr_html_() causes lots of JS garbage to be printed on terminal (by common sense, this should be a side-effects free function, only returning a value). On a higher level, this breaks natural Plotly.py integration in frameworks like Shiny.py (because again, instead of HTML representation being returned for a framework to process, parts of that representation are dumped on terminal).

The real underlying issue is that Plotly.py should not force-import any "optional" packages behind users' back. However, this is a deeper issue requiring consideration and will be reported separately. This patch is a quick solution for the problem describe above.

From interactive session:

```
>>> import IPython
>>> IPython.get_ipython().__class__.__name__
'NoneType'
```

----


## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [ ] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [ ] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [ ] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).
