### PR TITLE
added Python decorator to the markdown

### DIFF
--- a/doc/python/horizontal-bar-charts.md
+++ b/doc/python/horizontal-bar-charts.md
@@ -112,7 +112,7 @@ fig.show()
 ### Small multiple horizontal bar charts show each component's size more clearly than a stacked bar
 
 Bar charts with multiple components pose a fundamental trade off between presenting the total clearly and presenting the component values clearly. This small multiples approach shows the component magnitudes clearly at the cost of slightly obscuring the totals. A stacked bar does the opposite. Small multiple bar charts often work better in a horizontal orientation; and are easy to create with the px.bar orientation and facet_col parameters.
-```
+```python
 import pandas as pd
 import plotly.express as px
 


### PR DESCRIPTION
The graph on this new example is not displaying.  The new code had line numbers when the rest of the examples did not.  I noticed that there was no python keyword/decorator right at the start of the code block, so added it in this PR.  Is that sufficient to  solve the problem?