### PR TITLE
Add matplotlib lines+markers plot conversion test

### DIFF
--- a/plotly/matplotlylib/tests/test_renderer.py
+++ b/plotly/matplotlylib/tests/test_renderer.py
@@ -84,3 +84,20 @@ def test_multiple_traces_native_legend():
     assert plotly_fig.data[0].mode == "lines"
     assert plotly_fig.data[1].mode == "markers"
     assert plotly_fig.data[2].mode == "lines+markers"
+
+
+
+def test_lines_markers_legend_plot():
+    x = [0, 1]
+    y = [0, 1]
+    label = "label"
+    plt.figure()
+    plt.plot(x, y, "o-", label=label)
+    plt.legend()
+
+    plotly_fig = tls.mpl_to_plotly(plt.gcf())
+
+    assert plotly_fig.data[0].mode == "lines+markers"
+    assert plotly_fig.data[0].x == tuple(x)
+    assert plotly_fig.data[0].y == tuple(y)
+    assert plotly_fig.data[0].name == "label"

--- a/plotly/matplotlylib/tests/test_renderer.py
+++ b/plotly/matplotlylib/tests/test_renderer.py
@@ -22,6 +22,22 @@ def test_native_legend_enabled_when_matplotlib_legend_present():
     assert plotly_fig.data[1].name == "Line 2"
 
 
+def test_lines_markers_legend_plot():
+    x = [0, 1]
+    y = [0, 1]
+    label = "label"
+    plt.figure()
+    plt.plot(x, y, "o-", label=label)
+    plt.legend()
+
+    plotly_fig = tls.mpl_to_plotly(plt.gcf())
+
+    assert plotly_fig.data[0].mode == "lines+markers"
+    assert plotly_fig.data[0].x == tuple(x)
+    assert plotly_fig.data[0].y == tuple(y)
+    assert plotly_fig.data[0].name == "label"
+
+
 def test_no_fake_legend_shapes_with_native_legend():
     """Test that fake legend shapes are not created when using native legend."""
     fig, ax = plt.subplots()


### PR DESCRIPTION
Hi,
I'm proposing a fix to an edge case where conversion from matplotlib to plotly would break when converting a "lines+markers" plot with a legend. The issue happens because go.layout.Shape is not expecting "symbol" or "size" properties. My proposed fix is to ignore those two properties for "lines" type legend shapes. Please let me know if another fix would be more appropriate.

Thanks

## Code PR

- [X] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the `codegen` files and not generated files.
- [X] I have added tests (if submitting a new feature or correcting a bug) or
  modified existing tests.
- [X] For a new feature, I have added documentation examples in an existing or
  new tutorial notebook (please see the doc checklist as well).
- [X] I have added a CHANGELOG entry if fixing/changing/adding anything substantial.
- [X] For a new feature or a change in behaviour, I have updated the relevant docstrings in the code to describe the feature or behaviour (please see the doc checklist as well).
