### PR TITLE
Visualization of the plotly.py project's codebase

### DIFF
--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,167 @@
+```mermaid
+
+graph LR
+
+    plotly_graph_objects["plotly.graph_objects"]
+
+    plotly_basedatatypes["plotly.basedatatypes"]
+
+    plotly_validators["plotly.validators"]
+
+    plotly_io["plotly.io"]
+
+    plotly_express["plotly.express"]
+
+    plotly_graph_objects -- "Uses" --> plotly_basedatatypes
+
+    plotly_graph_objects -- "Interacts with" --> plotly_validators
+
+    plotly_basedatatypes -- "Provides base for" --> plotly_graph_objects
+
+    plotly_basedatatypes -- "Invokes" --> plotly_validators
+
+    plotly_validators -- "Validates properties for" --> plotly_basedatatypes
+
+    plotly_io -- "Renders" --> plotly_graph_objects
+
+    plotly_express -- "Generates" --> plotly_graph_objects
+
+    click plotly_graph_objects href "https://github.com/plotly/plotly.py/blob/main/.codeboarding//plotly_graph_objects.md" "Details"
+
+    click plotly_io href "https://github.com/plotly/plotly.py/blob/main/.codeboarding//plotly_io.md" "Details"
+
+    click plotly_express href "https://github.com/plotly/plotly.py/blob/main/.codeboarding//plotly_express.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+These five components represent the core functionality of `plotly.py` and are essential for its operation:
+
+*   `plotly.graph_objects`: This is the *definition* of a Plotly figure. Without it, there would be no structured way to represent plots, traces, or layouts. It's the language Plotly uses to describe visualizations.
+
+*   `plotly.basedatatypes`: This module provides the *foundation* and *enforcement* for `graph_objects`. It ensures that all Plotly objects behave consistently and that their properties are managed correctly. It's the underlying engine that makes `graph_objects` work.
+
+*   `plotly.validators`: Data integrity is paramount in plotting. This component *validates* all inputs, preventing errors and ensuring that the figures generated are consistent with the Plotly.js schema. It's the quality control mechanism.
+
+*   `plotly.io`: A plotting library is only useful if you can *see* and *share* the plots. This module handles all rendering and export functionalities, making the visualizations accessible in various environments and formats. It's the output mechanism.
+
+*   `plotly.express`: While `graph_objects` provides fine-grained control, `plotly.express` offers *ease of use* and *rapid prototyping*. It significantly lowers the barrier to entry for common plotting tasks, making Plotly more accessible to a wider audience, especially data scientists. It's the user-friendly interface.
+
+
+
+### plotly.graph_objects
+
+This is the central component for defining the structure of Plotly figures. It contains all the classes representing various plot types (traces like `Scatter`, `Bar`, `Heatmap`), layout properties (`Layout`, `XAxis`, `YAxis`), and animation frames. Users directly interact with `Figure` objects from this module to construct their visualizations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/graph_objects/__init__.py#L1-L1" target="_blank" rel="noopener noreferrer">`plotly.graph_objects.__init__` (1:1)</a>
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/commands.py#L1-L1" target="_blank" rel="noopener noreferrer">`plotly.graph_objs` (1:1)</a>
+
+
+
+
+
+### plotly.basedatatypes
+
+This module provides the foundational abstract classes (`BasePlotlyType`, `BaseFigure`) that serve as the base for all objects within `plotly.graph_objects`. It implements the core mechanisms for property management, attribute validation, and fundamental figure operations (e.g., `update`, `add_trace`). It ensures consistency and proper behavior across all Plotly objects.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/basedatatypes.py#L1-L1" target="_blank" rel="noopener noreferrer">`plotly.basedatatypes` (1:1)</a>
+
+
+
+
+
+### plotly.validators
+
+This component is crucial for data integrity. It comprises a collection of validator classes that ensure all properties assigned to Plotly objects conform to the expected data types, ranges, and formats defined by the Plotly.js schema. It prevents invalid data from being used and provides informative error messages.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/_plotly_utils/basevalidators.py#L1-L1" target="_blank" rel="noopener noreferrer">`_plotly_utils.basevalidators` (1:1)</a>
+
+
+
+
+
+### plotly.io
+
+This module handles all input/output operations for Plotly figures. It is responsible for rendering figures to various formats (e.g., HTML, JSON, static images) and managing figure templates. It acts as the primary interface for saving, displaying, and exporting visualizations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/io/__init__.py#L1-L1" target="_blank" rel="noopener noreferrer">`plotly.io.__init__` (1:1)</a>
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/io/_html.py#L1-L1" target="_blank" rel="noopener noreferrer">`plotly.io._html` (1:1)</a>
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/io/_json.py#L1-L1" target="_blank" rel="noopener noreferrer">`plotly.io._json` (1:1)</a>
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/io/_kaleido.py#L1-L1" target="_blank" rel="noopener noreferrer">`plotly.io._kaleido` (1:1)</a>
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/io/_orca.py#L1-L1" target="_blank" rel="noopener noreferrer">`plotly.io._orca` (1:1)</a>
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/io/_renderers.py#L1-L1" target="_blank" rel="noopener noreferrer">`plotly.io._renderers` (1:1)</a>
+
+
+
+
+
+### plotly.express
+
+This module provides a simplified, high-level API for quickly creating common statistical charts. It abstracts away the complexities of direct `plotly.graph_objects` construction, allowing users to generate plots with minimal code, often directly from data structures like pandas DataFrames.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/express/__init__.py#L1-L1" target="_blank" rel="noopener noreferrer">`plotly.express.__init__` (1:1)</a>
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/express/_core.py#L1-L1" target="_blank" rel="noopener noreferrer">`plotly.express._core` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/plotly_express.md
+++ b/.codeboarding/plotly_express.md
@@ -1,0 +1,181 @@
+```mermaid
+
+graph LR
+
+    Core_Charting_Engine["Core Charting Engine"]
+
+    Chart_Type_Definitions["Chart Type Definitions"]
+
+    Data_Preprocessing_and_Input_Handling["Data Preprocessing and Input Handling"]
+
+    Color_and_Styling_Management["Color and Styling Management"]
+
+    Image_Display_Utilities["Image Display Utilities"]
+
+    Trendline_Calculation["Trendline Calculation"]
+
+    Sample_Data_Provider["Sample Data Provider"]
+
+    Chart_Type_Definitions -- "Calls, Configures" --> Core_Charting_Engine
+
+    Data_Preprocessing_and_Input_Handling -- "Prepares Data, Provides Special Inputs" --> Core_Charting_Engine
+
+    Color_and_Styling_Management -- "Provides Styling Options, Influences Defaults" --> Core_Charting_Engine
+
+    Image_Display_Utilities -- "Provides Image Traces, Handles Image Data" --> Core_Charting_Engine
+
+    Trendline_Calculation -- "Calculates Trendlines, Integrates Trendlines" --> Core_Charting_Engine
+
+    Sample_Data_Provider -- "Provides Sample Data" --> Chart_Type_Definitions
+
+    Core_Charting_Engine -- "Requests Calculations" --> Trendline_Calculation
+
+    Core_Charting_Engine -- "Applies Styles" --> Color_and_Styling_Management
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+`plotly.express` is a high-level, simplified API built on top of `plotly.graph_objects` designed for quickly creating common statistical charts. It abstracts away the complexities of direct `plotly.graph_objects` construction, allowing users to generate plots with minimal code, often directly from data structures like pandas DataFrames.
+
+
+
+### Core Charting Engine
+
+This is the central orchestrator of `plotly.express`. It takes user data and arguments, processes them, and constructs `plotly.graph_objects` figures. It integrates functionalities from other modules like data handling, styling, and trendline calculations to generate a complete plot. It also manages default settings for plots.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/express/_core.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.express._core` (0:0)</a>
+
+
+
+
+
+### Chart Type Definitions
+
+This component exposes the high-level API functions (e.g., `px.scatter`, `px.bar`) that users directly invoke to create specific chart types. It acts as a user-friendly facade, simplifying the complex underlying charting logic.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/express/_chart_types.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.express._chart_types` (0:0)</a>
+
+
+
+
+
+### Data Preprocessing and Input Handling
+
+Manages the preparation, validation, and transformation of various input data formats and special arguments (like `IdentityMap`, `Constant`, `Range`) into a standardized structure suitable for the Core Charting Engine.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/express/_special_inputs.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.express._special_inputs` (0:0)</a>
+
+
+
+
+
+### Color and Styling Management
+
+Provides a comprehensive set of predefined color palettes (discrete and sequential) and utilities for applying and managing color scales, symbols, line dashes, and pattern shapes. It enables extensive customization of chart aesthetics.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/commands.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.express.colors` (0:0)</a>
+
+
+
+
+
+### Image Display Utilities
+
+Specializes in handling and rendering image-based visualizations, such as heatmaps and direct image displays. It provides the specific logic required for processing and presenting image data within the Plotly framework.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/express/_imshow.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.express._imshow` (0:0)</a>
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/express/imshow_utils.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.express.imshow_utils` (0:0)</a>
+
+
+
+
+
+### Trendline Calculation
+
+Contains the implementations for various statistical trendline calculations (e.g., Ordinary Least Squares, LOWESS). It provides the analytical backbone for adding regression and smoothing lines to charts.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/commands.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.express.trendline_functions` (0:0)</a>
+
+
+
+
+
+### Sample Data Provider
+
+Offers a collection of readily available sample datasets. These datasets are primarily used for demonstration, testing, and quick prototyping, allowing users to explore `plotly.express` functionalities without external data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/commands.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.express.data` (0:0)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/plotly_graph_objects.md
+++ b/.codeboarding/plotly_graph_objects.md
@@ -1,0 +1,255 @@
+```mermaid
+
+graph LR
+
+    plotly_graph_objects["plotly.graph_objects"]
+
+    plotly_graph_objs__figure_Figure["plotly.graph_objs._figure.Figure"]
+
+    plotly_graph_objs__layout_Layout["plotly.graph_objs._layout.Layout"]
+
+    plotly_graph_objs__frame_Frame["plotly.graph_objs._frame.Frame"]
+
+    plotly_graph_objs__scatter_Scatter["plotly.graph_objs._scatter.Scatter"]
+
+    plotly_graph_objs__bar_Bar["plotly.graph_objs._bar.Bar"]
+
+    plotly_basedatatypes_BasePlotlyType["plotly.basedatatypes.BasePlotlyType"]
+
+    plotly_basedatatypes_BaseFigure["plotly.basedatatypes.BaseFigure"]
+
+    plotly_io["plotly.io"]
+
+    plotly_utils["plotly.utils"]
+
+    plotly_graph_objects -- "exposes" --> plotly_graph_objs__figure_Figure
+
+    plotly_graph_objects -- "exposes" --> plotly_graph_objs__layout_Layout
+
+    plotly_graph_objects -- "exposes" --> plotly_graph_objs__scatter_Scatter
+
+    plotly_graph_objects -- "exposes" --> plotly_graph_objs__bar_Bar
+
+    plotly_graph_objs__figure_Figure -- "contains" --> plotly_graph_objs__layout_Layout
+
+    plotly_graph_objs__figure_Figure -- "contains" --> plotly_graph_objs__scatter_Scatter
+
+    plotly_graph_objs__figure_Figure -- "contains" --> plotly_graph_objs__frame_Frame
+
+    plotly_graph_objs__figure_Figure -- "inherits from" --> plotly_basedatatypes_BaseFigure
+
+    plotly_graph_objs__layout_Layout -- "inherits from" --> plotly_basedatatypes_BasePlotlyType
+
+    plotly_graph_objs__scatter_Scatter -- "inherits from" --> plotly_basedatatypes_BasePlotlyType
+
+    plotly_basedatatypes_BaseFigure -- "inherits from" --> plotly_basedatatypes_BasePlotlyType
+
+    plotly_basedatatypes_BasePlotlyType -- "uses" --> plotly_utils
+
+    plotly_graph_objs__figure_Figure -- "uses" --> plotly_io
+
+    plotly_basedatatypes_BaseFigure -- "uses" --> plotly_io
+
+    click plotly_graph_objects href "https://github.com/plotly/plotly.py/blob/main/.codeboarding//plotly_graph_objects.md" "Details"
+
+    click plotly_io href "https://github.com/plotly/plotly.py/blob/main/.codeboarding//plotly_io.md" "Details"
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+This subsystem is the cornerstone of Plotly's Python API for creating interactive visualizations. It provides a rich, object-oriented model for defining every aspect of a plot, from data traces to layout properties and animation frames.
+
+
+
+### plotly.graph_objects
+
+This module acts as the primary public interface and aggregation point for all Plotly graph objects. Users import directly from here to access classes like `Figure`, `Scatter`, `Bar`, `Layout`, etc., simplifying the API for figure construction. It essentially re-exports classes defined in `plotly.graph_objs`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/commands.py#L1-L1" target="_blank" rel="noopener noreferrer">`plotly.graph_objects` (1:1)</a>
+
+
+
+
+
+### plotly.graph_objs._figure.Figure
+
+Represents a complete Plotly figure. This is the central object users instantiate and manipulate to build their plots. It serves as a top-level container for `data` (traces), `layout` properties, and `frames`. It provides methods for adding, removing, and updating these elements, and interacts with `plotly.io` for rendering.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/graph_objs/_figure.py#L6-L24433" target="_blank" rel="noopener noreferrer">`plotly.graph_objs._figure.Figure` (6:24433)</a>
+
+
+
+
+
+### plotly.graph_objs._layout.Layout
+
+Defines the overall visual properties and arrangement of a Plotly figure. This includes attributes such as titles, axes configurations, annotations, shapes, and general plot dimensions. It is crucial for customizing the aesthetic and structural presentation of a visualization. It is a child object of `Figure`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/graph_objs/_layout.py#L7-L3509" target="_blank" rel="noopener noreferrer">`plotly.graph_objs._layout.Layout` (7:3509)</a>
+
+
+
+
+
+### plotly.graph_objs._frame.Frame
+
+Represents a single frame within an animated Plotly figure. Each `Frame` object holds specific data and layout modifications that are applied when that frame is active, enabling the creation of dynamic and interactive visualizations. These are contained within a `Figure` object.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/graph_objs/_frame.py#L7-L222" target="_blank" rel="noopener noreferrer">`plotly.graph_objs._frame.Frame` (7:222)</a>
+
+
+
+
+
+### plotly.graph_objs._scatter.Scatter
+
+A concrete trace type specifically designed for creating scatter plots. It defines properties related to x/y coordinates, marker styles, line properties, and hover information, allowing for detailed customization of scatter visualizations. This serves as a representative example of the numerous trace types available (e.g., `Bar`, `Heatmap`, etc.).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/graph_objs/_scatter.py#L7-L2752" target="_blank" rel="noopener noreferrer">`plotly.graph_objs._scatter.Scatter` (7:2752)</a>
+
+
+
+
+
+### plotly.graph_objs._bar.Bar
+
+A concrete trace type for generating bar charts. It provides properties for defining bar values, colors, and text labels, enabling the creation of various bar chart representations. This is another key example of a commonly used trace type, demonstrating the pattern for other trace implementations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/graph_objs/_bar.py#L7-L2600" target="_blank" rel="noopener noreferrer">`plotly.graph_objs._bar.Bar` (7:2600)</a>
+
+
+
+
+
+### plotly.basedatatypes.BasePlotlyType
+
+This is the foundational abstract base class from which almost all Plotly objects (figures, traces, layouts, and their nested properties) inherit. It establishes the core infrastructure for defining, validating, and accessing properties, ensuring a consistent and robust object model across the entire Plotly library. It manages property storage, validation, and parent-child relationships.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/basedatatypes.py#L4337-L5763" target="_blank" rel="noopener noreferrer">`plotly.basedatatypes.BasePlotlyType` (4337:5763)</a>
+
+
+
+
+
+### plotly.basedatatypes.BaseFigure
+
+A specialized base class for `Figure` objects, extending `BasePlotlyType`. It provides the fundamental methods and properties for managing collections of traces and the overall layout, and handles interactions with the Plotly rendering backend. It forms the common interface for all figure-like objects, including `Figure` and `FigureWidget`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/basedatatypes.py#L400-L4334" target="_blank" rel="noopener noreferrer">`plotly.basedatatypes.BaseFigure` (400:4334)</a>
+
+
+
+
+
+### plotly.io
+
+This module is dedicated to input/output operations for Plotly figures. It facilitates the rendering of figures to various formats (e.g., HTML, JSON, static images) and their display in different environments (e.g., Jupyter notebooks). It acts as the crucial bridge between the in-memory figure representation and its external visualization or persistence.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/commands.py#L1-L1" target="_blank" rel="noopener noreferrer">`plotly.io` (1:1)</a>
+
+
+
+
+
+### plotly.utils
+
+This module contains a collection of general-purpose utility functions that are utilized throughout the Plotly library. In the context of `graph_objects` and `basedatatypes`, it provides essential helpers for tasks such as string manipulation, type checking, and generating informative error messages, contributing to the overall robustness and correctness of the object model.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`plotly.utils` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/plotly_io.md
+++ b/.codeboarding/plotly_io.md
@@ -1,0 +1,285 @@
+```mermaid
+
+graph LR
+
+    Core_IO_Interface["Core IO Interface"]
+
+    HTML_Export_Component["HTML Export Component"]
+
+    JSON_Serialization_Component["JSON Serialization Component"]
+
+    Kaleido_Image_Export_Component["Kaleido Image Export Component"]
+
+    Orca_Image_Export_Component["Orca Image Export Component"]
+
+    Renderer_Management_Component["Renderer Management Component"]
+
+    Base_Renderers_Component["Base Renderers Component"]
+
+    Template_Management_Component["Template Management Component"]
+
+    IO_Utilities_Component["IO Utilities Component"]
+
+    Defaults_and_Configuration_Component["Defaults and Configuration Component"]
+
+    Core_IO_Interface -- "Exposes Functions From" --> HTML_Export_Component
+
+    Core_IO_Interface -- "Exposes Functions From" --> JSON_Serialization_Component
+
+    Core_IO_Interface -- "Exposes Functions From" --> Kaleido_Image_Export_Component
+
+    Core_IO_Interface -- "Exposes Functions From" --> Orca_Image_Export_Component
+
+    Core_IO_Interface -- "Exposes Functions From" --> Renderer_Management_Component
+
+    Core_IO_Interface -- "Exposes Functions From" --> Template_Management_Component
+
+    Core_IO_Interface -- "Exposes Functions From" --> Defaults_and_Configuration_Component
+
+    HTML_Export_Component -- "Calls" --> JSON_Serialization_Component
+
+    HTML_Export_Component -- "Uses" --> IO_Utilities_Component
+
+    JSON_Serialization_Component -- "Uses" --> IO_Utilities_Component
+
+    Kaleido_Image_Export_Component -- "Calls" --> JSON_Serialization_Component
+
+    Kaleido_Image_Export_Component -- "Uses" --> IO_Utilities_Component
+
+    Kaleido_Image_Export_Component -- "Configured By" --> Defaults_and_Configuration_Component
+
+    Orca_Image_Export_Component -- "Calls" --> JSON_Serialization_Component
+
+    Orca_Image_Export_Component -- "Uses" --> IO_Utilities_Component
+
+    Renderer_Management_Component -- "Uses" --> Base_Renderers_Component
+
+    Renderer_Management_Component -- "Uses" --> IO_Utilities_Component
+
+    Renderer_Management_Component -- "Configured By" --> Defaults_and_Configuration_Component
+
+    Base_Renderers_Component -- "Calls" --> JSON_Serialization_Component
+
+    Base_Renderers_Component -- "Calls" --> Kaleido_Image_Export_Component
+
+    Base_Renderers_Component -- "Calls" --> Orca_Image_Export_Component
+
+    Base_Renderers_Component -- "Uses" --> IO_Utilities_Component
+
+    Template_Management_Component -- "Interacts With" --> JSON_Serialization_Component
+
+    IO_Utilities_Component -- "Supports" --> HTML_Export_Component
+
+    IO_Utilities_Component -- "Supports" --> JSON_Serialization_Component
+
+    IO_Utilities_Component -- "Supports" --> Kaleido_Image_Export_Component
+
+    IO_Utilities_Component -- "Supports" --> Orca_Image_Export_Component
+
+    IO_Utilities_Component -- "Supports" --> Renderer_Management_Component
+
+    IO_Utilities_Component -- "Supports" --> Base_Renderers_Component
+
+    Defaults_and_Configuration_Component -- "Configures" --> Kaleido_Image_Export_Component
+
+    Defaults_and_Configuration_Component -- "Configures" --> Renderer_Management_Component
+
+```
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Component Details
+
+
+
+Component Overview for `plotly.io`
+
+
+
+### Core IO Interface
+
+This component serves as the public API for the `plotly.io` module. It orchestrates and exposes functions from various sub-modules, allowing users to perform operations like converting figures to HTML, JSON, or images, and managing templates and renderers. It acts as the central hub for all input/output functionalities.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/commands.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.io` (0:0)</a>
+
+
+
+
+
+### HTML Export Component
+
+Responsible for converting Plotly figures into HTML strings or standalone HTML files. It handles embedding Plotly.js, figure data, and configuration options to create interactive web visualizations, supporting various inclusion methods for the Plotly.js library (e.g., CDN, local).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/io/_html.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.io._html` (0:0)</a>
+
+
+
+
+
+### JSON Serialization Component
+
+Manages the serialization and deserialization of Plotly figures and related objects to and from JSON format. It provides functions for converting Python objects to JSON strings, handling Plotly-specific encoding rules, and supports different JSON encoding engines (e.g., built-in `json`, `orjson`).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/io/_json.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.io._json` (0:0)</a>
+
+
+
+
+
+### Kaleido Image Export Component
+
+Facilitates the export of Plotly figures to static image formats (PNG, JPEG, SVG, PDF) using the Kaleido engine. It manages the interaction with the Kaleido executable, including its availability checks, version handling, and configuration through global defaults.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/io/_kaleido.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.io._kaleido` (0:0)</a>
+
+
+
+
+
+### Orca Image Export Component
+
+Provides a legacy mechanism for exporting Plotly figures to static images, leveraging the deprecated Orca server. It handles the Orca server lifecycle (startup, shutdown), port management, and image generation, serving as an alternative to Kaleido for older setups.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/io/_orca.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.io._orca` (0:0)</a>
+
+
+
+
+
+### Renderer Management Component
+
+Manages the registration, selection, and activation of different rendering environments for displaying Plotly figures. It allows users to set default renderers for various contexts (e.g., Jupyter notebooks, VS Code) and controls automatic figure display behavior.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/io/_renderers.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.io._renderers` (0:0)</a>
+
+
+
+
+
+### Base Renderers Component
+
+Defines the abstract and concrete base classes for various Plotly figure rendering strategies. It provides the common interface (`to_mimebundle`) for different output formats (JSON, Plotly mimetype, static images) and handles the underlying calls to image and JSON export functions.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/io/_base_renderers.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.io._base_renderers` (0:0)</a>
+
+
+
+
+
+### Template Management Component
+
+Manages the creation, registration, loading, and application of Plotly figure templates. It provides functionalities to define, register, and use consistent styling, layout, and data transformations across multiple figures, including loading built-in templates from package data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/io/_templates.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.io._templates` (0:0)</a>
+
+
+
+
+
+### IO Utilities Component
+
+A collection of common utility functions that support various input/output operations across the `plotly.io` module. This includes validating and coercing figure objects, handling output types, broadcasting arguments, and generating Plotly CDN URLs.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/io/_utils.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.io._utils` (0:0)</a>
+
+
+
+
+
+### Defaults and Configuration Component
+
+Manages global default settings and configurations for various `plotly.io` operations, such as image export parameters (e.g., Kaleido/Orca settings) and renderer behavior. It provides a centralized place to store and retrieve module-wide preferences.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/plotly/plotly.py/blob/master/plotly/io/_defaults.py#L0-L0" target="_blank" rel="noopener noreferrer">`plotly.io._defaults` (0:0)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
Hey I am leaving the documentation PR list, even though it is not exactly fitting there.
I usually create a discussion before such PR, but as you don't have the discussions enabled I decided to open a PR (feel free to close it).

Hi! This PR adds high-level diagrams of the plotly.py codebase to help new contributors quickly get oriented:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/plotly.py/on_boarding.md

The idea is to make onboarding easier—especially for open-source contributors who typically want to work on a specific module. Visualizing the codebase helps people understand how things fit together without needing to read everything up front.

We’ve also released a free GitHub Action that keeps the diagrams automatically updated as the code changes, so there's no ongoing maintenance burden.

I’d love to hear how you currently onboard new contributors—do you think something like this could help?
Feedback is very welcome.

Full transparency: we’re exploring this idea as a potential startup, but we’re still early and figuring out what’s actually useful to developers.

### Documentation PR

- [ ] I've [seen the `doc/README.md` file](https://github.com/plotly/plotly.py/blob/main/doc/README.md)
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `main` branch
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph
- [ ] Every new/modified example is independently runnable
- [ ] Every new/modified example is optimized for short line count	and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible
- [ ] The random seed is set if using randomly-generated data in new/modified examples
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations
- [ ] Imports are `plotly.graph_objects as go` / `plotly.express as px` / `plotly.io as pio`
- [ ] Data frames are always called `df`
- [ ] `fig = <something>` call is high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`)
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)` in every new/modified example
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls in every new/modified example
- [ ] `fig.show()` is at the end of each new/modified example
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any new/modified example
- [ ] Hex codes for colors are not used in any new/modified example in favour of [these nice ones](https://github.com/plotly/plotly.py/issues/2192)