### PR TITLE
bug fix to annotation example:  restoring an accidently deleted figure creation line

### DIFF
--- a/doc/python/text-and-annotations.md
+++ b/doc/python/text-and-annotations.md
@@ -789,6 +789,11 @@ This example shows how to add a note about the data source or interpretation at 
 ```python
 import plotly.express as px
 df = px.data.iris()
+
+fig = px.scatter(df, x="sepal_width", y="sepal_length", color="species",
+                 size='petal_length', hover_data=['petal_width'])
+
+
 fig.update_layout(
         title=dict(text="Note: this is the Plotly title element.",
                  # keeping this title string short avoids getting the text cut off in small windows


### PR DESCRIPTION
The line that created the figure in #4873 got deleted during the revision process.  Currently, the "Specifying Source Lines or Figure Notes on the Bottom of a Figure" example adds its annotations to the fig from the prior example code block, with unintended results.  This PR adds the intended figure to the example by restoring the missing line.  The inserted line is nearly identical to a line from the first commit to #4873.  