### PR TITLE
Add Plotly.js docs updates for 6.3

### DIFF
--- a/doc/python/axes.md
+++ b/doc/python/axes.md
@@ -6,7 +6,7 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.16.3
+      jupytext_version: 1.17.2
   kernelspec:
     display_name: Python 3 (ipykernel)
     language: python
@@ -20,7 +20,7 @@ jupyter:
     name: python
     nbconvert_exporter: python
     pygments_lexer: ipython3
-    version: 3.10.14
+    version: 3.9.0
   plotly:
     description: How to adjust axes properties in Python - axes titles, styling and
       coloring axes and grid lines, ticks, tick labels and more.
@@ -615,6 +615,38 @@ fig = px.line(y=[1, 0])
 
 fig.update_xaxes(zeroline=True, zerolinewidth=2, zerolinecolor='LightPink')
 fig.update_yaxes(zeroline=True, zerolinewidth=2, zerolinecolor='LightPink')
+
+fig.show()
+```
+
+##### Controlling zero line layer
+
+*New in 6.3*
+
+By default, zero lines are displayed below traces. Set `zerolinelayer="above traces"` on an axis to display its zero line above traces:
+
+```python
+import plotly.graph_objects as go
+
+x = ['A', 'B', 'C', 'D', 'A']
+y = [2, 0, 4, -3, 2]
+
+fig = go.Figure(
+    data=[
+        go.Scatter(
+            x=x,
+            y=y,
+            fill='toself',
+            mode='none',
+            fillcolor='lightpink'
+        )
+    ],
+    layout=dict(
+        yaxis=dict(
+            zerolinelayer="above traces"  # Change to "below traces" to see the difference
+        ),
+    )
+)
 
 fig.show()
 ```


### PR DESCRIPTION
<!--
Please uncomment this block and fill in this checklist if your PR makes substantial changes to documentation in the `doc` directory.
Not all boxes must be checked for every PR:
check those that apply to your PR and leave the rest unchecked to discuss with your reviewer.

If your PR modifies code of the `plotly` package, we have a different checklist below.

## Documentation PR

- [ ] I have seen the [`doc/README.md`](https://github.com/plotly/plotly.py/blob/main/doc/README.md) file.
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `main` branch.
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible.
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph.
- [ ] Every new/modified example is independently runnable.
- [ ] Every new/modified example is optimized for short line count and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized.
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible.
- [ ] The random seed is set if using randomly-generated data.
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets.
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations.
- [ ] Imports are `plotly.graph_objects as go`, `plotly.express as px`, and/or `plotly.io as pio`.
- [ ] Data frames are always called `df`.
- [ ] `fig = <something>` is called high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`).
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)`.
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls.
- [ ] `fig.show()` is at the end of each example.
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any example.
- [ ] Named colors are used instead of hex codes wherever possible.
- [ ] Code blocks are marked with `&#96;&#96;&#96;python`.

## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the code generator and *not* the generated files.
- [ ] I have added tests or modified existing tests.
- [ ] For a new feature, I have added documentation examples (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if changing anything substantial.
- [ ] For a new feature or a change in behavior, I have updated the relevant docstrings in the code.

-->
