### PR TITLE
Expose `plotly.io.get_chrome()`

### DIFF
--- a/plotly/io/__init__.py
+++ b/plotly/io/__init__.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from ._html import to_html, write_html
     from ._renderers import renderers, show
     from . import base_renderers
-    from ._kaleido import defaults
+    from ._kaleido import defaults, get_chrome
 
     __all__ = [
         "to_image",
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
         "base_renderers",
         "full_figure_for_development",
         "defaults",
+        "get_chrome",
     ]
 else:
     __all__, __getattr__, __dir__ = relative_import(
@@ -59,6 +60,7 @@ else:
             "._renderers.renderers",
             "._renderers.show",
             "._kaleido.defaults",
+            "._kaleido.get_chrome",
         ],
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ dev = [
 ]
 
 [project.scripts]
-plotly_get_chrome = "plotly.io._kaleido:get_chrome"
+plotly_get_chrome = "plotly.io._kaleido:plotly_get_chrome"
 
 [tool.pytest.ini_options]
 markers = [

--- a/tests/test_optional/test_kaleido/test_kaleido.py
+++ b/tests/test_optional/test_kaleido/test_kaleido.py
@@ -298,24 +298,19 @@ def test_fig_to_image():
 def test_get_chrome():
     """Test that plotly.io.get_chrome() can be called."""
 
-    with patch(
-        "plotly.io._kaleido.kaleido.get_chrome_sync",
-        return_value="/mock/path/to/chrome",
-    ) as mock_get_chrome:
-        with patch("builtins.input", return_value="y"):  # Mock user confirmation
-            with patch(
-                "sys.argv", ["plotly_get_chrome", "-y"]
-            ):  # Mock CLI args to skip confirmation
-                if not kaleido_available() or kaleido_major() < 1:
-                    # Test that ValueError is raised when Kaleido requirements aren't met
-                    with pytest.raises(
-                        ValueError,
-                        match="This command requires Kaleido v1.0.0 or greater",
-                    ):
-                        pio.get_chrome()
-                else:
-                    # Test normal operation when Kaleido v1+ is available
-                    pio.get_chrome()
+    if not kaleido_available() or kaleido_major() < 1:
+        # Test that ValueError is raised when Kaleido requirements aren't met
+        with pytest.raises(
+            ValueError, match="This command requires Kaleido v1.0.0 or greater"
+        ):
+            pio.get_chrome()
+    else:
+        # Test normal operation when Kaleido v1+ is available
+        with patch(
+            "plotly.io._kaleido.kaleido.get_chrome_sync",
+            return_value="/mock/path/to/chrome",
+        ) as mock_get_chrome:
+            pio.get_chrome()
 
-                    # Verify that kaleido.get_chrome_sync was called
-                    mock_get_chrome.assert_called_once()
+            # Verify that kaleido.get_chrome_sync was called
+            mock_get_chrome.assert_called_once()

--- a/tests/test_optional/test_kaleido/test_kaleido.py
+++ b/tests/test_optional/test_kaleido/test_kaleido.py
@@ -293,3 +293,29 @@ def test_fig_to_image():
         mock_calc_fig.assert_called_once()
         args, _ = mock_calc_fig.call_args
         assert args[0] == test_fig.to_dict()
+
+
+def test_get_chrome():
+    """Test that plotly.io.get_chrome() can be called."""
+
+    with patch(
+        "plotly.io._kaleido.kaleido.get_chrome_sync",
+        return_value="/mock/path/to/chrome",
+    ) as mock_get_chrome:
+        with patch("builtins.input", return_value="y"):  # Mock user confirmation
+            with patch(
+                "sys.argv", ["plotly_get_chrome", "-y"]
+            ):  # Mock CLI args to skip confirmation
+                if not kaleido_available() or kaleido_major() < 1:
+                    # Test that ValueError is raised when Kaleido requirements aren't met
+                    with pytest.raises(
+                        ValueError,
+                        match="This command requires Kaleido v1.0.0 or greater",
+                    ):
+                        pio.get_chrome()
+                else:
+                    # Test normal operation when Kaleido v1+ is available
+                    pio.get_chrome()
+
+                    # Verify that kaleido.get_chrome_sync was called
+                    mock_get_chrome.assert_called_once()


### PR DESCRIPTION
Closes #5272 

Expose `plotly.io.get_chrome()` as a function which can be called from within a Python script.

`get_chrome()` accepts one optional argument, `path`, which is the location to download Chrome to; if not supplied, the default location defined by `choreographer` will be used.

This PR also slightly refactors `get_chrome()` into two functions:
- `get_chrome()`, which is intended to be called directly in code, and
- `plotly_get_chrome()`, which is a CLI wrapper for `get_chrome()` and intended to be called via the `plotly_get_chrome` command from the command line.

On this branch, running the following code should work:

```python
import plotly.io as pio

pio.get_chrome()
```