### PR TITLE
Use matplotlib background colors when converting from matplotlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Support `marginal_x`/`marginal_y="heatmap"` in `density_heatmap`, drawing a single-row/column heatmap strip in the margin colored by the same `z`/`histfunc` aggregate as the main plot and sharing its color scale [[#5706](https://github.com/plotly/plotly.py/issues/5706)], with thanks to @lucasjamar for the contribution!
 
+### Fixed
+- Fix `mpl_to_plotly` not setting `paper_bgcolor` and `plot_bgcolor` from the matplotlib figure and axes backgrounds, so converted figures match the source figure's background colors [[#5285](https://github.com/plotly/plotly.py/pull/5285)], with thanks to @robertoffmoura for the contribution!
+
 ## [7.0.0] - 2026-08-25
 
 ### Fixed

--- a/plotly/matplotlylib/mplexporter/utils.py
+++ b/plotly/matplotlylib/mplexporter/utils.py
@@ -271,6 +271,7 @@ def get_figure_properties(fig):
         "figwidth": fig.get_figwidth(),
         "figheight": fig.get_figheight(),
         "dpi": fig.dpi,
+        "figbg": export_color(fig.patch.get_facecolor()),
     }
 
 

--- a/plotly/matplotlylib/renderer.py
+++ b/plotly/matplotlylib/renderer.py
@@ -87,6 +87,7 @@ class PlotlyRenderer(Renderer):
             autosize=False,
             hovermode="closest",
         )
+        self.plotly_fig["layout"].template.layout.plot_bgcolor = "white"
         self.mpl_x_bounds, self.mpl_y_bounds = mpltools.get_axes_bounds(fig)
         margin = go.layout.Margin(
             l=int(self.mpl_x_bounds[0] * self.plotly_fig["layout"]["width"]),

--- a/plotly/matplotlylib/renderer.py
+++ b/plotly/matplotlylib/renderer.py
@@ -11,7 +11,6 @@ import warnings
 
 import plotly.graph_objs as go
 from plotly.matplotlylib.mplexporter import Renderer
-from plotly.matplotlylib.mplexporter.utils import export_color
 from plotly.matplotlylib import mpltools
 
 
@@ -21,15 +20,11 @@ def _export_color(color):
     matplotlib uses "none" for fully transparent colors, which plotly does not
     accept, so transparent colors are exported as transparent black.
     Colors already exported by the mplexporter (hex or rgba strings) are
-    passed through unchanged; raw matplotlib colors are converted with the
-    mplexporter's export_color.
+    passed through unchanged.
     """
     if isinstance(color, str):
         return "rgba(0,0,0,0)" if color == "none" else color
-    if isinstance(color, (list, tuple)) and all(isinstance(c, str) for c in color):
-        return [_export_color(c) for c in color]
-    bgcolor = export_color(color)
-    return "rgba(0,0,0,0)" if bgcolor == "none" else bgcolor
+    return [_export_color(c) for c in color]
 
 
 class PlotlyRenderer(Renderer):
@@ -106,9 +101,7 @@ class PlotlyRenderer(Renderer):
             autosize=False,
             hovermode="closest",
         )
-        self.plotly_fig["layout"].paper_bgcolor = _export_color(
-            fig.patch.get_facecolor()
-        )
+        self.plotly_fig["layout"].paper_bgcolor = _export_color(props["figbg"])
         self.mpl_x_bounds, self.mpl_y_bounds = mpltools.get_axes_bounds(fig)
         margin = go.layout.Margin(
             l=int(self.mpl_x_bounds[0] * self.plotly_fig["layout"]["width"]),

--- a/plotly/matplotlylib/renderer.py
+++ b/plotly/matplotlylib/renderer.py
@@ -11,6 +11,7 @@ import warnings
 
 import plotly.graph_objs as go
 from plotly.matplotlylib.mplexporter import Renderer
+from plotly.matplotlylib.mplexporter.utils import export_color
 from plotly.matplotlylib import mpltools
 
 
@@ -20,11 +21,15 @@ def _export_color(color):
     matplotlib uses "none" for fully transparent colors, which plotly does not
     accept, so transparent colors are exported as transparent black.
     Colors already exported by the mplexporter (hex or rgba strings) are
-    passed through unchanged.
+    passed through unchanged; raw matplotlib colors are converted with the
+    mplexporter's export_color.
     """
     if isinstance(color, str):
         return "rgba(0,0,0,0)" if color == "none" else color
-    return [_export_color(c) for c in color]
+    if isinstance(color, (list, tuple)) and all(isinstance(c, str) for c in color):
+        return [_export_color(c) for c in color]
+    bgcolor = export_color(color)
+    return "rgba(0,0,0,0)" if bgcolor == "none" else bgcolor
 
 
 class PlotlyRenderer(Renderer):
@@ -101,6 +106,9 @@ class PlotlyRenderer(Renderer):
             autosize=False,
             hovermode="closest",
         )
+        self.plotly_fig["layout"].paper_bgcolor = _export_color(
+            fig.patch.get_facecolor()
+        )
         self.mpl_x_bounds, self.mpl_y_bounds = mpltools.get_axes_bounds(fig)
         margin = go.layout.Margin(
             l=int(self.mpl_x_bounds[0] * self.plotly_fig["layout"]["width"]),
@@ -166,6 +174,8 @@ class PlotlyRenderer(Renderer):
         ]
         self.current_bars = []
         self.axis_ct += 1
+        # update plot background with the axes background from mpl
+        self.plotly_fig["layout"].plot_bgcolor = _export_color(props["axesbg"])
         # set defaults in axes
         xaxis = go.layout.XAxis(
             anchor="y{0}".format(self.axis_ct), zeroline=False, ticks="inside"

--- a/plotly/matplotlylib/tests/test_renderer.py
+++ b/plotly/matplotlylib/tests/test_renderer.py
@@ -84,3 +84,12 @@ def test_multiple_traces_native_legend():
     assert plotly_fig.data[0].mode == "lines"
     assert plotly_fig.data[1].mode == "markers"
     assert plotly_fig.data[2].mode == "lines+markers"
+
+
+def test_plot_bgcolor_defaults_to_white():
+    plt.figure()
+    plt.plot([0, 1], [0, 1])
+
+    plotly_fig = tls.mpl_to_plotly(plt.gcf())
+
+    assert plotly_fig.layout.template.layout.plot_bgcolor == "white"

--- a/plotly/matplotlylib/tests/test_renderer.py
+++ b/plotly/matplotlylib/tests/test_renderer.py
@@ -86,6 +86,7 @@ def test_multiple_traces_native_legend():
     assert plotly_fig.data[2].mode == "lines+markers"
 
 
+
 def test_plot_bgcolor_defaults_to_white():
     plt.figure()
     plt.plot([0, 1], [0, 1])

--- a/plotly/matplotlylib/tests/test_renderer.py
+++ b/plotly/matplotlylib/tests/test_renderer.py
@@ -199,3 +199,37 @@ def test_filled_path_collection_date_xaxis():
     filled = [t for t in plotly_fig.data if t.fill == "toself"]
     assert len(filled) >= 1
     assert all(isinstance(x, str) for x in filled[0].x)
+
+
+def test_background_colors_from_matplotlib_defaults():
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.layout.plot_bgcolor == "#FFFFFF"
+    assert plotly_fig.layout.paper_bgcolor == "#FFFFFF"
+
+
+def test_custom_background_colors_are_preserved():
+    fig, ax = plt.subplots()
+    fig.patch.set_facecolor("lightyellow")
+    ax.set_facecolor("lightgray")
+    ax.plot([0, 1], [0, 1])
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.layout.plot_bgcolor == "#D3D3D3"
+    assert plotly_fig.layout.paper_bgcolor == "#FFFFE0"
+
+
+def test_semitransparent_axes_background_preserved():
+    """Axes backgrounds with alpha export as mpl-style rgba strings, which
+    must be passed through as-is, not re-parsed by export_color."""
+    fig, ax = plt.subplots()
+    ax.set_facecolor((0.1, 0.2, 0.3, 0.4))
+    ax.plot([0, 1], [0, 1])
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.layout.plot_bgcolor == "rgba(26, 51, 76, 0.4)"


### PR DESCRIPTION
## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the code generator and *not* the generated files.
- [x] I have added tests or modified existing tests.
- [x] For a new feature, I have added documentation examples (please see the doc checklist as well).
- [x] I have added a CHANGELOG entry if changing anything substantial.
- [x] For a new feature or a change in behavior, I have updated the relevant docstrings in the code.
