### PR TITLE
preload _plotly_utils to display full reference content for plotly.colors

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,8 @@ plugins:
       handlers:
         python:
           options:
+            preload_modules:
+              - _plotly_utils
             docstring_style: google
             show_source: false
             show_root_heading: true


### PR DESCRIPTION
We need to preload `_plotly_utils`, a separate package in the repo, to display the full reference content for `plotly.colors`