### PR TITLE
Add get-chrome function to doc

### DIFF
--- a/doc/python/static-image-export.md
+++ b/doc/python/static-image-export.md
@@ -64,6 +64,13 @@ Plotly also provides a CLI for installing Chrome from the command line.
 
 Run `plotly_get_chrome` to install Chrome.
 
+You can also install Chrome from Python using `plotly.io.get_chrome()`
+
+```python
+import plotly.io as pio
+
+pio.get_chrome()
+```
 
 See the **Additional Information on Browsers with Kaleido** section below for more details on browser compatibility for Kaleido.
 


### PR DESCRIPTION
Add back content on installing chrome from Python, as it will be in the next release