### PR TITLE
Exclude code blocks that aren't run

### DIFF
--- a/bin/check-all-md.py
+++ b/bin/check-all-md.py
@@ -1,16 +1,15 @@
 from pathlib import Path
 import os
-import re
 import sys
+from run_markdown import _parse_md
 
-PAT = re.compile(r"^```python\n(.+?)\n```", re.MULTILINE | re.DOTALL)
 TMP_FILE = "tmp.py"
 
 for filename in sys.argv[1:]:
     content = Path(filename).read_text()
-    blocks = PAT.findall(content)
-    for i, b in enumerate(blocks):
-        Path(TMP_FILE).write_text(b.strip())
+    blocks = _parse_md(content)
+    for i, block in enumerate(blocks):
+        Path(TMP_FILE).write_text(block["code"].strip())
         sys.stdout.write(f"\n{'=' * 40}\n{filename}: {i}\n")
         sys.stdout.flush()
         sys.stdout.write(f"{'-' * 40}\n")

--- a/bin/run_markdown.py
+++ b/bin/run_markdown.py
@@ -162,17 +162,26 @@ def _parse_md(content):
     blocks = []
     current_block = None
     in_code_block = False
+    in_region_block = False
 
     for i, line in enumerate(lines):
+        # Check for region start/end markers
+        if "<!-- #region" in line:
+            in_region_block = True
+        elif "<!-- #endregion" in line:
+            in_region_block = False
+            
         # Start of Python code block
-        if line.strip().startswith("```python"):
-            in_code_block = True
-            current_block = {
-                "start_line": i,
-                "end_line": None,
-                "code": [],
-                "type": "python",
-            }
+        elif line.strip().startswith("```python"):
+            # Only process code blocks that are NOT inside region blocks
+            if not in_region_block:
+                in_code_block = True
+                current_block = {
+                    "start_line": i,
+                    "end_line": None,
+                    "code": [],
+                    "type": "python",
+                }
 
         # End of code block
         elif line.strip() == "```" and in_code_block:


### PR DESCRIPTION
In the docs we have Python code which is formatted as Python code

<img width="1043" height="518" alt="image" src="https://github.com/user-attachments/assets/b1eac504-52ec-4b48-810b-1e0e3f177c0e" />

but not run. In the Markdown it looks like this, it's inside <!-- #region --> blocks:

```
<!-- #region -->
Code that relied on the `add_*` methods to return a reference to the newly created trace will need to be updated to access the trace from the returned figure.  This can be done by appending `.data[-1]` to the add trace expression.

Here is an example of a version 3 code snippet that adds a scatter trace to a figure, assigns the result to a variable named `scatter`, and then modifies the marker size of the scatter trace.

```python
import plotly.graph_objs as go
fig = go.Figure()
scatter = fig.add_trace(go.Scatter(y=[2, 3, 1]))
scatter.marker.size = 20
```
In version 4, this would be replaced with the following:

```python
import plotly.graph_objects as go
fig = go.Figure()
scatter = fig.add_trace(go.Scatter(y=[2, 3, 1])).data[-1]
scatter.marker.size = 20
```
<!-- #endregion -->
```

This PR modifies the `run_markdown.py` script to not run these sections. 
Also updates the test script to use the same function as `run_markdown.py` uses