### PR TITLE
Fix tick marker mirroring (matplotlib conversion)

### DIFF
--- a/plotly/matplotlylib/mpltools.py
+++ b/plotly/matplotlylib/mpltools.py
@@ -265,15 +265,12 @@ def get_axes_bounds(fig):
     return (x_min, x_max), (y_min, y_max)
 
 
-def get_axis_mirror(main_spine, mirror_spine):
-    if main_spine and mirror_spine:
+def get_axis_mirror(main_spine, mirror_spine, main_tick_markers, mirror_tick_markers):
+    if main_spine and mirror_spine and main_tick_markers and mirror_tick_markers:
         return "ticks"
-    elif main_spine and not mirror_spine:
-        return False
-    elif not main_spine and mirror_spine:
-        return False  # can't handle this case yet!
-    else:
-        return False  # nuttin'!
+    if main_spine and mirror_spine:
+        return True
+    return False
 
 
 def get_bar_gap(bar_starts, bar_ends, tol=1e-10):

--- a/plotly/matplotlylib/mpltools.py
+++ b/plotly/matplotlylib/mpltools.py
@@ -250,15 +250,12 @@ def get_axes_bounds(fig):
     return (x_min, x_max), (y_min, y_max)
 
 
-def get_axis_mirror(main_spine, mirror_spine):
-    if main_spine and mirror_spine:
+def get_axis_mirror(main_spine, mirror_spine, main_tick_markers, mirror_tick_markers):
+    if main_spine and mirror_spine and main_tick_markers and mirror_tick_markers:
         return "ticks"
-    elif main_spine and not mirror_spine:
-        return False
-    elif not main_spine and mirror_spine:
-        return False  # can't handle this case yet!
-    else:
-        return False  # nuttin'!
+    if main_spine and mirror_spine:
+        return True
+    return False
 
 
 def get_bar_gap(bar_starts, bar_ends, tol=1e-10):

--- a/plotly/matplotlylib/renderer.py
+++ b/plotly/matplotlylib/renderer.py
@@ -169,8 +169,16 @@ class PlotlyRenderer(Renderer):
         top_spine = mpltools.get_spine_visible(ax, "top")
         left_spine = mpltools.get_spine_visible(ax, "left")
         right_spine = mpltools.get_spine_visible(ax, "right")
-        xaxis["mirror"] = mpltools.get_axis_mirror(bottom_spine, top_spine)
-        yaxis["mirror"] = mpltools.get_axis_mirror(left_spine, right_spine)
+        bottom_tick_markers = ax.xaxis.get_tick_params()["bottom"]
+        top_tick_markers = ax.xaxis.get_tick_params()["top"]
+        left_tick_markers = ax.yaxis.get_tick_params()["left"]
+        right_tick_markers = ax.yaxis.get_tick_params()["right"]
+        xaxis["mirror"] = mpltools.get_axis_mirror(
+            bottom_spine, top_spine, bottom_tick_markers, top_tick_markers
+        )
+        yaxis["mirror"] = mpltools.get_axis_mirror(
+            left_spine, right_spine, left_tick_markers, right_tick_markers
+        )
         xaxis["showline"] = bottom_spine
         yaxis["showline"] = top_spine
 

--- a/plotly/matplotlylib/renderer.py
+++ b/plotly/matplotlylib/renderer.py
@@ -197,7 +197,12 @@ class PlotlyRenderer(Renderer):
             left_spine, right_spine, left_tick_markers, right_tick_markers
         )
         xaxis["showline"] = bottom_spine
-        yaxis["showline"] = top_spine
+        yaxis["showline"] = left_spine
+        # hide tick markers when the mpl main-side tick markers are hidden
+        if not bottom_tick_markers:
+            xaxis["ticks"] = ""
+        if not left_tick_markers:
+            yaxis["ticks"] = ""
 
         # put axes in our figure
         self.plotly_fig["layout"]["xaxis{0}".format(self.axis_ct)] = xaxis

--- a/plotly/matplotlylib/renderer.py
+++ b/plotly/matplotlylib/renderer.py
@@ -186,8 +186,16 @@ class PlotlyRenderer(Renderer):
         top_spine = mpltools.get_spine_visible(ax, "top")
         left_spine = mpltools.get_spine_visible(ax, "left")
         right_spine = mpltools.get_spine_visible(ax, "right")
-        xaxis["mirror"] = mpltools.get_axis_mirror(bottom_spine, top_spine)
-        yaxis["mirror"] = mpltools.get_axis_mirror(left_spine, right_spine)
+        bottom_tick_markers = ax.xaxis.get_tick_params()["bottom"]
+        top_tick_markers = ax.xaxis.get_tick_params()["top"]
+        left_tick_markers = ax.yaxis.get_tick_params()["left"]
+        right_tick_markers = ax.yaxis.get_tick_params()["right"]
+        xaxis["mirror"] = mpltools.get_axis_mirror(
+            bottom_spine, top_spine, bottom_tick_markers, top_tick_markers
+        )
+        yaxis["mirror"] = mpltools.get_axis_mirror(
+            left_spine, right_spine, left_tick_markers, right_tick_markers
+        )
         xaxis["showline"] = bottom_spine
         yaxis["showline"] = top_spine
 

--- a/plotly/matplotlylib/tests/test_renderer.py
+++ b/plotly/matplotlylib/tests/test_renderer.py
@@ -84,3 +84,77 @@ def test_multiple_traces_native_legend():
     assert plotly_fig.data[0].mode == "lines"
     assert plotly_fig.data[1].mode == "markers"
     assert plotly_fig.data[2].mode == "lines+markers"
+
+
+def test_axis_mirror_with_spines_and_ticks():
+    """Test that mirror=True when both spines and ticks are visible on both sides."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+
+    # Show all spines
+    ax.spines['top'].set_visible(True)
+    ax.spines['bottom'].set_visible(True)
+    ax.spines['left'].set_visible(True)
+    ax.spines['right'].set_visible(True)
+
+    # Show ticks on all sides
+    ax.tick_params(top=True, bottom=True, left=True, right=True)
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.layout.xaxis.mirror == "ticks"
+    assert plotly_fig.layout.yaxis.mirror == "ticks"
+
+
+def test_axis_mirror_with_ticks_only():
+    """Test that mirror=False when spines are not visible on both sides."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+
+    # Hide opposite spines
+    ax.spines['top'].set_visible(False)
+    ax.spines['right'].set_visible(False)
+
+    # Show ticks on all sides
+    ax.tick_params(top=True, bottom=True, left=True, right=True)
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.layout.xaxis.mirror == False
+    assert plotly_fig.layout.yaxis.mirror == False
+
+
+def test_axis_mirror_false_with_one_sided_ticks():
+    """Test that mirror=True when ticks are only on one side but spines are
+    visible on both sides."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+
+    # Default matplotlib behavior - ticks only on bottom and left
+    ax.tick_params(top=False, bottom=True, left=True, right=False)
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.layout.xaxis.mirror == True
+    assert plotly_fig.layout.yaxis.mirror == True
+
+
+def test_axis_mirror_mixed_configurations():
+    """Test different configurations for x and y axes."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+
+    # X-axis: spines and ticks on both sides (mirror="ticks")
+    ax.spines['top'].set_visible(True)
+    ax.spines['bottom'].set_visible(True)
+    ax.tick_params(top=True, bottom=True)
+
+    # Y-axis: spine only on one side (mirror=False)
+    ax.spines['right'].set_visible(False)
+    ax.spines['left'].set_visible(True)
+    ax.tick_params(left=True, right=True)
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.layout.xaxis.mirror == "ticks"
+    assert plotly_fig.layout.yaxis.mirror == False

--- a/plotly/matplotlylib/tests/test_renderer.py
+++ b/plotly/matplotlylib/tests/test_renderer.py
@@ -86,16 +86,17 @@ def test_multiple_traces_native_legend():
     assert plotly_fig.data[2].mode == "lines+markers"
 
 
+
 def test_axis_mirror_with_spines_and_ticks():
     """Test that mirror=True when both spines and ticks are visible on both sides."""
     fig, ax = plt.subplots()
     ax.plot([0, 1], [0, 1])
 
     # Show all spines
-    ax.spines['top'].set_visible(True)
-    ax.spines['bottom'].set_visible(True)
-    ax.spines['left'].set_visible(True)
-    ax.spines['right'].set_visible(True)
+    ax.spines["top"].set_visible(True)
+    ax.spines["bottom"].set_visible(True)
+    ax.spines["left"].set_visible(True)
+    ax.spines["right"].set_visible(True)
 
     # Show ticks on all sides
     ax.tick_params(top=True, bottom=True, left=True, right=True)
@@ -112,8 +113,8 @@ def test_axis_mirror_with_ticks_only():
     ax.plot([0, 1], [0, 1])
 
     # Hide opposite spines
-    ax.spines['top'].set_visible(False)
-    ax.spines['right'].set_visible(False)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
 
     # Show ticks on all sides
     ax.tick_params(top=True, bottom=True, left=True, right=True)
@@ -145,13 +146,13 @@ def test_axis_mirror_mixed_configurations():
     ax.plot([0, 1], [0, 1])
 
     # X-axis: spines and ticks on both sides (mirror="ticks")
-    ax.spines['top'].set_visible(True)
-    ax.spines['bottom'].set_visible(True)
+    ax.spines["top"].set_visible(True)
+    ax.spines["bottom"].set_visible(True)
     ax.tick_params(top=True, bottom=True)
 
     # Y-axis: spine only on one side (mirror=False)
-    ax.spines['right'].set_visible(False)
-    ax.spines['left'].set_visible(True)
+    ax.spines["right"].set_visible(False)
+    ax.spines["left"].set_visible(True)
     ax.tick_params(left=True, right=True)
 
     plotly_fig = tls.mpl_to_plotly(fig)

--- a/plotly/matplotlylib/tests/test_renderer.py
+++ b/plotly/matplotlylib/tests/test_renderer.py
@@ -89,6 +89,81 @@ def test_multiple_traces_native_legend():
     assert plotly_fig.data[2].mode == "lines+markers"
 
 
+
+def test_axis_mirror_with_spines_and_ticks():
+    """Test that mirror=True when both spines and ticks are visible on both sides."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+
+    # Show all spines
+    ax.spines["top"].set_visible(True)
+    ax.spines["bottom"].set_visible(True)
+    ax.spines["left"].set_visible(True)
+    ax.spines["right"].set_visible(True)
+
+    # Show ticks on all sides
+    ax.tick_params(top=True, bottom=True, left=True, right=True)
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.layout.xaxis.mirror == "ticks"
+    assert plotly_fig.layout.yaxis.mirror == "ticks"
+
+
+def test_axis_mirror_with_ticks_only():
+    """Test that mirror=False when spines are not visible on both sides."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+
+    # Hide opposite spines
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+    # Show ticks on all sides
+    ax.tick_params(top=True, bottom=True, left=True, right=True)
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.layout.xaxis.mirror == False
+    assert plotly_fig.layout.yaxis.mirror == False
+
+
+def test_axis_mirror_false_with_one_sided_ticks():
+    """Test that mirror=True when ticks are only on one side but spines are
+    visible on both sides."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+
+    # Default matplotlib behavior - ticks only on bottom and left
+    ax.tick_params(top=False, bottom=True, left=True, right=False)
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.layout.xaxis.mirror == True
+    assert plotly_fig.layout.yaxis.mirror == True
+
+
+def test_axis_mirror_mixed_configurations():
+    """Test different configurations for x and y axes."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+
+    # X-axis: spines and ticks on both sides (mirror="ticks")
+    ax.spines["top"].set_visible(True)
+    ax.spines["bottom"].set_visible(True)
+    ax.tick_params(top=True, bottom=True)
+
+    # Y-axis: spine only on one side (mirror=False)
+    ax.spines["right"].set_visible(False)
+    ax.spines["left"].set_visible(True)
+    ax.tick_params(left=True, right=True)
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.layout.xaxis.mirror == "ticks"
+    assert plotly_fig.layout.yaxis.mirror == False
+
+
 def test_violinplot_bodies_are_filled_polygons():
     fig, ax = plt.subplots()
     ax.violinplot(np.random.randn(100, 3))

--- a/plotly/matplotlylib/tests/test_renderer.py
+++ b/plotly/matplotlylib/tests/test_renderer.py
@@ -89,7 +89,6 @@ def test_multiple_traces_native_legend():
     assert plotly_fig.data[2].mode == "lines+markers"
 
 
-
 def test_axis_mirror_with_spines_and_ticks():
     """Test that mirror=True when both spines and ticks are visible on both sides."""
     fig, ax = plt.subplots()
@@ -162,6 +161,49 @@ def test_axis_mirror_mixed_configurations():
 
     assert plotly_fig.layout.xaxis.mirror == "ticks"
     assert plotly_fig.layout.yaxis.mirror == False
+
+
+def test_axis_showline_tied_to_main_spine():
+    """Test that showline follows the main-side spine (bottom for x, left for y)."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+
+    # Hide the mirror-side spines only
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.layout.xaxis.showline == True
+    assert plotly_fig.layout.yaxis.showline == True
+
+
+def test_axis_showline_hidden_when_main_spine_hidden():
+    """Test that showline is False when the main-side spine is hidden."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+
+    # Hide the main-side spines but keep the mirror-side ones
+    ax.spines["bottom"].set_visible(False)
+    ax.spines["left"].set_visible(False)
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.layout.xaxis.showline == False
+    assert plotly_fig.layout.yaxis.showline == False
+
+
+def test_ticks_hidden_when_mpl_main_ticks_hidden():
+    """Test that tick markers are hidden when the mpl main-side ticks are hidden."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+
+    ax.tick_params(top=False, bottom=False, left=False, right=False)
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.layout.xaxis.ticks == ""
+    assert plotly_fig.layout.yaxis.ticks == ""
 
 
 def test_violinplot_bodies_are_filled_polygons():


### PR DESCRIPTION
Hi,

This fixes the issue where a matplotlib figure with only bottom and left tick markers would be converted to a plotly figure with markers on all sides.

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the code generator and *not* the generated files.
- [x] I have added tests or modified existing tests.
- [x] For a new feature, I have added documentation examples (please see the doc checklist as well).
- [x] I have added a CHANGELOG entry if changing anything substantial.
- [x] For a new feature or a change in behavior, I have updated the relevant docstrings in the code.
