### PR TITLE
fix a typo in `_ternary_contour.py`

### DIFF
--- a/plotly/figure_factory/_ternary_contour.py
+++ b/plotly/figure_factory/_ternary_contour.py
@@ -382,7 +382,7 @@ def _contour_trace(
     ncontours=None,
     colorscale="Electric",
     linecolor="rgb(150,150,150)",
-    interp_mode="llr",
+    interp_mode="ilr",
     coloring=None,
     v_min=0,
     v_max=1,


### PR DESCRIPTION
It should be `ilr` instead of `llr`.