### PR TITLE
Update docs to plotly.py 6.3.0

### DIFF
--- a/doc/apidoc/conf.py
+++ b/doc/apidoc/conf.py
@@ -24,7 +24,7 @@ author = "Plotly"
 # The short X.Y version
 version = ""
 # The full version, including alpha/beta/rc tags
-release = "6.2.0"
+release = "6.3.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,4 +1,4 @@
-plotly==6.2.0
+plotly==6.3.0
 anywidget
 cufflinks==0.17.3
 dash-bio


### PR DESCRIPTION
Update docs version in support of plotly.py 6.3.0 release.