### PR TITLE
added a cross reference to creating a custom color scale in graph objects

### DIFF
--- a/doc/python/colorscales.md
+++ b/doc/python/colorscales.md
@@ -157,7 +157,7 @@ fig.show()
 
 ### Explicitly Constructing a Color scale
 
-The Plotly Express `color_continuous_scale` argument accepts explicitly-constructed color scales as well:
+The Plotly Express `color_continuous_scale` argument accepts explicitly-constructed color scales as well.  There is an equivalent graph objects example using its [colorscale parameter below.](#custom-heatmap-color-scale-with-graph-objects)
 
 ```python
 import plotly.express as px

--- a/doc/python/colorscales.md
+++ b/doc/python/colorscales.md
@@ -157,7 +157,7 @@ fig.show()
 
 ### Explicitly Constructing a Color scale
 
-The Plotly Express `color_continuous_scale` argument accepts explicitly-constructed color scales as well.  There is an equivalent graph objects example using its [colorscale parameter below.](#custom-heatmap-color-scale-with-graph-objects)
+The Plotly Express `color_continuous_scale` argument accepts explicitly-constructed color scales as well.  There is an equivalent graph objects example using the `colorscale` parameter [below](#custom-heatmap-color-scale-with-graph-objects).
 
 ```python
 import plotly.express as px


### PR DESCRIPTION
There are px examples that do not work in GO.  This link clarifies where to find the equivalent GO example. 