### PR TITLE
doc: typos

### DIFF
--- a/codegen/resources/plot-schema.json
+++ b/codegen/resources/plot-schema.json
@@ -47008,7 +47008,7 @@
      "editType": "calc",
      "role": "object",
      "side": {
-      "description": "Determines on which side of the the treemap the `pathbar` should be presented.",
+      "description": "Determines on which side of the treemap the `pathbar` should be presented.",
       "dflt": "top",
       "editType": "plot",
       "valType": "enumerated",
@@ -64477,7 +64477,7 @@
     },
     "hovertext": {
      "arrayOk": true,
-     "description": "Sets hover text elements associated with each (a,b) point. If a single string, the same string appears over all the data points. If an array of strings, the items are mapped in order to the the data points in (a,b). To be seen, trace `hoverinfo` must contain a *text* flag.",
+     "description": "Sets hover text elements associated with each (a,b) point. If a single string, the same string appears over all the data points. If an array of strings, the items are mapped in order of the data points in (a,b). To be seen, trace `hoverinfo` must contain a *text* flag.",
      "dflt": "",
      "editType": "style",
      "valType": "string"
@@ -66186,7 +66186,7 @@
     },
     "text": {
      "arrayOk": true,
-     "description": "Sets text elements associated with each (a,b) point. If a single string, the same string appears over all the data points. If an array of strings, the items are mapped in order to the the data points in (a,b). If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.",
+     "description": "Sets text elements associated with each (a,b) point. If a single string, the same string appears over all the data points. If an array of strings, the items are mapped in order of the data points in (a,b). If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.",
      "dflt": "",
      "editType": "calc",
      "valType": "string"
@@ -81356,7 +81356,7 @@
     },
     "hovertext": {
      "arrayOk": true,
-     "description": "Sets hover text elements associated with each (a,b,c) point. If a single string, the same string appears over all the data points. If an array of strings, the items are mapped in order to the the data points in (a,b,c). To be seen, trace `hoverinfo` must contain a *text* flag.",
+     "description": "Sets hover text elements associated with each (a,b,c) point. If a single string, the same string appears over all the data points. If an array of strings, the items are mapped in order of the data points in (a,b,c). To be seen, trace `hoverinfo` must contain a *text* flag.",
      "dflt": "",
      "editType": "style",
      "valType": "string"
@@ -83078,7 +83078,7 @@
     },
     "text": {
      "arrayOk": true,
-     "description": "Sets text elements associated with each (a,b,c) point. If a single string, the same string appears over all the data points. If an array of strings, the items are mapped in order to the the data points in (a,b,c). If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.",
+     "description": "Sets text elements associated with each (a,b,c) point. If a single string, the same string appears over all the data points. If an array of strings, the items are mapped in order of the data points in (a,b,c). If trace `hoverinfo` contains a *text* flag and *hovertext* is not set, these elements will be seen in the hover labels.",
      "dflt": "",
      "editType": "calc",
      "valType": "string"
@@ -93092,7 +93092,7 @@
      "editType": "calc",
      "role": "object",
      "side": {
-      "description": "Determines on which side of the the treemap the `pathbar` should be presented.",
+      "description": "Determines on which side of the treemap the `pathbar` should be presented.",
       "dflt": "top",
       "editType": "plot",
       "valType": "enumerated",

--- a/doc/python/carpet-plot.md
+++ b/doc/python/carpet-plot.md
@@ -117,7 +117,7 @@ fig.show()
 ### Cheater plot layout
 
 
-The layout of cheater plots is not unique and depends upon the `cheaterslope` and axis `cheatertype` parameters. If `x` is not specified, each row of the `x` array is constructed based on the the formula `a + cheaterslope * b`, where `a` and `b` are either the value or the integer index of `a` and `b` respectively, depending on the corresponding axis `cheatertype`. Although the layout of the axis below is different than the plots above, it represents the same data as the axes above.
+The layout of cheater plots is not unique and depends upon the `cheaterslope` and axis `cheatertype` parameters. If `x` is not specified, each row of the `x` array is constructed based on the formula `a + cheaterslope * b`, where `a` and `b` are either the value or the integer index of `a` and `b` respectively, depending on the corresponding axis `cheatertype`. Although the layout of the axis below is different than the plots above, it represents the same data as the axes above.
 
 ```python
 import plotly.graph_objects as go

--- a/doc/python/parallel-categories-diagram.md
+++ b/doc/python/parallel-categories-diagram.md
@@ -114,7 +114,7 @@ fig.show()
 
 #### Multi-Color Parallel Categories Diagram
 
-The color of the ribbons can be specified with the `line.color` property. Similar to other trace types, this property may be set to an array of numbers, which are then mapped to colors according to the the colorscale specified in the `line.colorscale` property.
+The color of the ribbons can be specified with the `line.color` property. Similar to other trace types, this property may be set to an array of numbers, which are then mapped to colors according to the colorscale specified in the `line.colorscale` property.
 
 Here is an example of visualizing the survival rate of passengers in the titanic dataset, where the ribbons are colored based on survival outcome.
 

--- a/doc/python/selections.md
+++ b/doc/python/selections.md
@@ -153,7 +153,7 @@ fig.show()
 ## Referencing Selections on Multiple Cartesian Subplots
 
 
-You can add selections to multiple Cartesian subplots by specifying `xref` and/or `yref`. Here, we add one selection on the plot with axis ids `x` and `y2` and two selections to the the plot with axis ids `x` and `y`.
+You can add selections to multiple Cartesian subplots by specifying `xref` and/or `yref`. Here, we add one selection on the plot with axis ids `x` and `y2` and two selections to the plot with axis ids `x` and `y`.
 
 ```python
 import plotly.graph_objects as go

--- a/doc/python/text-and-annotations.md
+++ b/doc/python/text-and-annotations.md
@@ -162,7 +162,7 @@ fig.show()
 
 ### Controlling Maximum Text Size
 
-The `textfont_size` parameter of the the [pie](/python/pie-charts), [bar](/python/bar-charts)-like, [sunburst](/python/sunburst-charts) and [treemap](/python/treemaps) traces can be used to set the **maximum font size** used in the chart. Note that the `textfont` parameter sets the `insidetextfont` and `outsidetextfont` parameter, which can also be set independently.
+The `textfont_size` parameter of the [pie](/python/pie-charts), [bar](/python/bar-charts)-like, [sunburst](/python/sunburst-charts) and [treemap](/python/treemaps) traces can be used to set the **maximum font size** used in the chart. Note that the `textfont` parameter sets the `insidetextfont` and `outsidetextfont` parameter, which can also be set independently.
 
 ```python
 import plotly.express as px

--- a/plotly/graph_objs/_figure.py
+++ b/plotly/graph_objs/_figure.py
@@ -14026,7 +14026,7 @@ class Figure(BaseFigure):
             Sets hover text elements associated with each (a,b)
             point. If a single string, the same string appears over
             all the data points. If an array of strings, the items
-            are mapped in order to the the data points in (a,b). To
+            are mapped in order of the data points in (a,b). To
             be seen, trace `hoverinfo` must contain a "text" flag.
         hovertextsrc
             Sets the source reference on Chart Studio Cloud for
@@ -14119,7 +14119,7 @@ class Figure(BaseFigure):
             Sets text elements associated with each (a,b) point. If
             a single string, the same string appears over all the
             data points. If an array of strings, the items are
-            mapped in order to the the data points in (a,b). If
+            mapped in order of the data points in (a,b). If
             trace `hoverinfo` contains a "text" flag and
             "hovertext" is not set, these elements will be seen in
             the hover labels.
@@ -17391,7 +17391,7 @@ class Figure(BaseFigure):
             Sets hover text elements associated with each (a,b,c)
             point. If a single string, the same string appears over
             all the data points. If an array of strings, the items
-            are mapped in order to the the data points in (a,b,c).
+            are mapped in order of the data points in (a,b,c).
             To be seen, trace `hoverinfo` must contain a "text"
             flag.
         hovertextsrc
@@ -17497,7 +17497,7 @@ class Figure(BaseFigure):
             Sets text elements associated with each (a,b,c) point.
             If a single string, the same string appears over all
             the data points. If an array of strings, the items are
-            mapped in order to the the data points in (a,b,c). If
+            mapped in order of the data points in (a,b,c). If
             trace `hoverinfo` contains a "text" flag and
             "hovertext" is not set, these elements will be seen in
             the hover labels.

--- a/plotly/graph_objs/_figurewidget.py
+++ b/plotly/graph_objs/_figurewidget.py
@@ -14028,7 +14028,7 @@ class FigureWidget(BaseFigureWidget):
             Sets hover text elements associated with each (a,b)
             point. If a single string, the same string appears over
             all the data points. If an array of strings, the items
-            are mapped in order to the the data points in (a,b). To
+            are mapped in order of the data points in (a,b). To
             be seen, trace `hoverinfo` must contain a "text" flag.
         hovertextsrc
             Sets the source reference on Chart Studio Cloud for
@@ -14121,7 +14121,7 @@ class FigureWidget(BaseFigureWidget):
             Sets text elements associated with each (a,b) point. If
             a single string, the same string appears over all the
             data points. If an array of strings, the items are
-            mapped in order to the the data points in (a,b). If
+            mapped in order of the data points data points in (a,b). If
             trace `hoverinfo` contains a "text" flag and
             "hovertext" is not set, these elements will be seen in
             the hover labels.
@@ -17393,7 +17393,7 @@ class FigureWidget(BaseFigureWidget):
             Sets hover text elements associated with each (a,b,c)
             point. If a single string, the same string appears over
             all the data points. If an array of strings, the items
-            are mapped in order to the the data points in (a,b,c).
+            are mapped in order of the data points data points in (a,b,c).
             To be seen, trace `hoverinfo` must contain a "text"
             flag.
         hovertextsrc
@@ -17499,7 +17499,7 @@ class FigureWidget(BaseFigureWidget):
             Sets text elements associated with each (a,b,c) point.
             If a single string, the same string appears over all
             the data points. If an array of strings, the items are
-            mapped in order to the the data points in (a,b,c). If
+            mapped in order of the data points in (a,b,c). If
             trace `hoverinfo` contains a "text" flag and
             "hovertext" is not set, these elements will be seen in
             the hover labels.

--- a/plotly/graph_objs/_scattercarpet.py
+++ b/plotly/graph_objs/_scattercarpet.py
@@ -417,7 +417,7 @@ class Scattercarpet(_BaseTraceType):
         Sets hover text elements associated with each (a,b) point. If a
         single string, the same string appears over all the data
         points. If an array of strings, the items are mapped in order
-        to the the data points in (a,b). To be seen, trace `hoverinfo`
+        of the data points in (a,b). To be seen, trace `hoverinfo`
         must contain a "text" flag.
 
         The 'hovertext' property is a string and must be specified as:
@@ -830,7 +830,7 @@ class Scattercarpet(_BaseTraceType):
         Sets text elements associated with each (a,b) point. If a
         single string, the same string appears over all the data
         points. If an array of strings, the items are mapped in order
-        to the the data points in (a,b). If trace `hoverinfo` contains
+        of the data points in (a,b). If trace `hoverinfo` contains
         a "text" flag and "hovertext" is not set, these elements will
         be seen in the hover labels.
 
@@ -1239,7 +1239,7 @@ class Scattercarpet(_BaseTraceType):
             Sets hover text elements associated with each (a,b)
             point. If a single string, the same string appears over
             all the data points. If an array of strings, the items
-            are mapped in order to the the data points in (a,b). To
+            are mapped in order of the data points in (a,b). To
             be seen, trace `hoverinfo` must contain a "text" flag.
         hovertextsrc
             Sets the source reference on Chart Studio Cloud for
@@ -1332,7 +1332,7 @@ class Scattercarpet(_BaseTraceType):
             Sets text elements associated with each (a,b) point. If
             a single string, the same string appears over all the
             data points. If an array of strings, the items are
-            mapped in order to the the data points in (a,b). If
+            mapped in order of the data points in (a,b). If
             trace `hoverinfo` contains a "text" flag and
             "hovertext" is not set, these elements will be seen in
             the hover labels.
@@ -1573,7 +1573,7 @@ class Scattercarpet(_BaseTraceType):
             Sets hover text elements associated with each (a,b)
             point. If a single string, the same string appears over
             all the data points. If an array of strings, the items
-            are mapped in order to the the data points in (a,b). To
+            are mapped in order of the data points in (a,b). To
             be seen, trace `hoverinfo` must contain a "text" flag.
         hovertextsrc
             Sets the source reference on Chart Studio Cloud for
@@ -1666,7 +1666,7 @@ class Scattercarpet(_BaseTraceType):
             Sets text elements associated with each (a,b) point. If
             a single string, the same string appears over all the
             data points. If an array of strings, the items are
-            mapped in order to the the data points in (a,b). If
+            mapped in order of the data points in (a,b). If
             trace `hoverinfo` contains a "text" flag and
             "hovertext" is not set, these elements will be seen in
             the hover labels.

--- a/plotly/graph_objs/_scatterternary.py
+++ b/plotly/graph_objs/_scatterternary.py
@@ -1743,7 +1743,7 @@ class Scatterternary(_BaseTraceType):
             Sets text elements associated with each (a,b,c) point.
             If a single string, the same string appears over all
             the data points. If an array of strings, the items are
-            mapped in order to the the data points in (a,b,c). If
+            mapped in order of the data points in (a,b,c). If
             trace `hoverinfo` contains a "text" flag and
             "hovertext" is not set, these elements will be seen in
             the hover labels.

--- a/plotly/graph_objs/_scatterternary.py
+++ b/plotly/graph_objs/_scatterternary.py
@@ -463,7 +463,7 @@ class Scatterternary(_BaseTraceType):
         Sets hover text elements associated with each (a,b,c) point. If
         a single string, the same string appears over all the data
         points. If an array of strings, the items are mapped in order
-        to the the data points in (a,b,c). To be seen, trace
+        of the data points in (a,b,c). To be seen, trace
         `hoverinfo` must contain a "text" flag.
 
         The 'hovertext' property is a string and must be specified as:
@@ -921,7 +921,7 @@ class Scatterternary(_BaseTraceType):
         Sets text elements associated with each (a,b,c) point. If a
         single string, the same string appears over all the data
         points. If an array of strings, the items are mapped in order
-        to the the data points in (a,b,c). If trace `hoverinfo`
+        of the data points in (a,b,c). If trace `hoverinfo`
         contains a "text" flag and "hovertext" is not set, these
         elements will be seen in the hover labels.
 
@@ -1283,7 +1283,7 @@ class Scatterternary(_BaseTraceType):
             Sets hover text elements associated with each (a,b,c)
             point. If a single string, the same string appears over
             all the data points. If an array of strings, the items
-            are mapped in order to the the data points in (a,b,c).
+            are mapped in order of the data points in (a,b,c).
             To be seen, trace `hoverinfo` must contain a "text"
             flag.
         hovertextsrc
@@ -1389,7 +1389,7 @@ class Scatterternary(_BaseTraceType):
             Sets text elements associated with each (a,b,c) point.
             If a single string, the same string appears over all
             the data points. If an array of strings, the items are
-            mapped in order to the the data points in (a,b,c). If
+            mapped in order of the data points in (a,b,c). If
             trace `hoverinfo` contains a "text" flag and
             "hovertext" is not set, these elements will be seen in
             the hover labels.
@@ -1637,7 +1637,7 @@ class Scatterternary(_BaseTraceType):
             Sets hover text elements associated with each (a,b,c)
             point. If a single string, the same string appears over
             all the data points. If an array of strings, the items
-            are mapped in order to the the data points in (a,b,c).
+            are mapped in order of the data points in (a,b,c).
             To be seen, trace `hoverinfo` must contain a "text"
             flag.
         hovertextsrc

--- a/plotly/graph_objs/icicle/_pathbar.py
+++ b/plotly/graph_objs/icicle/_pathbar.py
@@ -33,7 +33,7 @@ class Pathbar(_BaseTraceHierarchyType):
     @property
     def side(self):
         """
-        Determines on which side of the the treemap the `pathbar`
+        Determines on which side of the treemap the `pathbar`
         should be presented.
 
         The 'side' property is an enumeration that may be specified as:
@@ -117,7 +117,7 @@ class Pathbar(_BaseTraceHierarchyType):
             Determines which shape is used for edges between
             `barpath` labels.
         side
-            Determines on which side of the the treemap the
+            Determines on which side of the treemap the
             `pathbar` should be presented.
         textfont
             Sets the font used inside `pathbar`.
@@ -153,7 +153,7 @@ class Pathbar(_BaseTraceHierarchyType):
             Determines which shape is used for edges between
             `barpath` labels.
         side
-            Determines on which side of the the treemap the
+            Determines on which side of the treemap the
             `pathbar` should be presented.
         textfont
             Sets the font used inside `pathbar`.

--- a/plotly/graph_objs/treemap/_pathbar.py
+++ b/plotly/graph_objs/treemap/_pathbar.py
@@ -33,7 +33,7 @@ class Pathbar(_BaseTraceHierarchyType):
     @property
     def side(self):
         """
-        Determines on which side of the the treemap the `pathbar`
+        Determines on which side of the treemap the `pathbar`
         should be presented.
 
         The 'side' property is an enumeration that may be specified as:
@@ -117,7 +117,7 @@ class Pathbar(_BaseTraceHierarchyType):
             Determines which shape is used for edges between
             `barpath` labels.
         side
-            Determines on which side of the the treemap the
+            Determines on which side of the treemap the
             `pathbar` should be presented.
         textfont
             Sets the font used inside `pathbar`.
@@ -153,7 +153,7 @@ class Pathbar(_BaseTraceHierarchyType):
             Determines which shape is used for edges between
             `barpath` labels.
         side
-            Determines on which side of the the treemap the
+            Determines on which side of the treemap the
             `pathbar` should be presented.
         textfont
             Sets the font used inside `pathbar`.


### PR DESCRIPTION
<!--
Please uncomment this block and fill in this checklist if your PR makes substantial changes to documentation in the `doc` directory.
Not all boxes must be checked for every PR:
check those that apply to your PR and leave the rest unchecked to discuss with your reviewer.

If your PR modifies code of the `plotly` package, we have a different checklist below.

## Documentation PR

- [ ] I have seen the [`doc/README.md`](https://github.com/plotly/plotly.py/blob/main/doc/README.md) file.
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `main` branch.
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible.
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph.
- [ ] Every new/modified example is independently runnable.
- [ ] Every new/modified example is optimized for short line count and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized.
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible.
- [ ] The random seed is set if using randomly-generated data.
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets.
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations.
- [ ] Imports are `plotly.graph_objects as go`, `plotly.express as px`, and/or `plotly.io as pio`.
- [ ] Data frames are always called `df`.
- [ ] `fig = <something>` is called high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`).
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)`.
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls.
- [ ] `fig.show()` is at the end of each example.
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any example.
- [ ] Named colors are used instead of hex codes wherever possible.
- [ ] Code blocks are marked with `&#96;&#96;&#96;python`.

## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the code generator and *not* the generated files.
- [ ] I have added tests or modified existing tests.
- [ ] For a new feature, I have added documentation examples (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if changing anything substantial.
- [ ] For a new feature or a change in behavior, I have updated the relevant docstrings in the code.

-->
