### PR TITLE
mpl_to_plotly: map enumerated tick labels to Plotly tickvals/ticktext

### DIFF
--- a/plotly/matplotlylib/mpltools.py
+++ b/plotly/matplotlylib/mpltools.py
@@ -511,6 +511,13 @@ def prep_ticks(ax, index, ax_type, props):
 
     if formatter == "LogFormatterMathtext":
         axis_dict["exponentformat"] = "e"
+
+    ticktext = [tick.label1.get_text() for tick in axis.majorTicks]
+    if ticktext and "DateFormatter" not in formatter:
+        axis_dict["tickmode"] = "array"
+        axis_dict["tickvals"] = [tick.get_loc() for tick in axis.majorTicks]
+        axis_dict["ticktext"] = ticktext
+
     return axis_dict
 
 


### PR DESCRIPTION
Hi,
This fixes https://github.com/plotly/plotly.py/issues/5059 preserving axis labels while converting matplotlib plots.

Code PR

- [x]  I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md) and understand the structure of the package. In particular, if my PR modifies code of plotly.graph_objects, my modifications concern the code generator and not the generated files.
- [ ]  I have added tests or modified existing tests.
- [ ]  For a new feature, I have added documentation examples (please see the doc checklist as well).
- [ ]  I have added a CHANGELOG entry if changing anything substantial.
- [ ]  For a new feature or a change in behavior, I have updated the relevant docstrings in the code

.