### PR TITLE
Add more ways to make charts

### DIFF
--- a/doc/python/renderers.md
+++ b/doc/python/renderers.md
@@ -188,7 +188,7 @@ This renderer displays figures as static PDF files. This is especially useful fo
 In editors that support it (JupyterLab, nteract, and the Visual Studio Code notebook interface), this renderer displays the JSON representation of a figure in a collapsible interactive tree structure.  This can be very useful for examining the structure of complex figures.
 
 ##### Multiple Renderers
-You can specify that multiple renderers should be used by joining their names on `"+"` characters.  This is useful when writing code that needs to support multiple contexts.  For example, if a notebook specifies a default renderer string of  `"notebook+plotly_mimetype+pdf"` then this notebook would be able to run in the classic Jupyter Notebook, in JupyterLab, and it would support being exported to PDF using `nbconvert`.
+You can specify that multiple renderers should be used by joining their names on `"+"` characters. This is useful when writing code that needs to support multiple contexts. For example, if a notebook specifies a default renderer string of  `"notebook+plotly_mimetype+pdf"`, then this notebook would be able to run in the classic Jupyter Notebook as well as in JupyterLab, and it would support being exported to PDF using `nbconvert`.
 
 #### Customizing Built-In Renderers
 Most built-in renderers have configuration options to customize their behavior.  To view a description of a renderer, including its configuration options, access the renderer object using dictionary-style key lookup on the `plotly.io.renderers` configuration object and then display it.  Here is an example of accessing and displaying the `png` renderer.


### PR DESCRIPTION

<img width="989" height="482" alt="image" src="https://github.com/user-attachments/assets/deaf2c32-c215-4782-8cb1-d4aa50fe0b27" />

....

<img width="1014" height="752" alt="image" src="https://github.com/user-attachments/assets/7bbc655b-aafa-4a21-a330-b25ca6afa58c" />


<!--
Please uncomment this block and fill in this checklist if your PR makes substantial changes to documentation in the `doc` directory.
Not all boxes must be checked for every PR:
check those that apply to your PR and leave the rest unchecked to discuss with your reviewer.

If your PR modifies code of the `plotly` package, we have a different checklist below.

## Documentation PR

- [ ] I have seen the [`doc/README.md`](https://github.com/plotly/plotly.py/blob/main/doc/README.md) file.
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `main` branch.
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible.
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph.
- [ ] Every new/modified example is independently runnable.
- [ ] Every new/modified example is optimized for short line count and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized.
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible.
- [ ] The random seed is set if using randomly-generated data.
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets.
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations.
- [ ] Imports are `plotly.graph_objects as go`, `plotly.express as px`, and/or `plotly.io as pio`.
- [ ] Data frames are always called `df`.
- [ ] `fig = <something>` is called high up in each new/modified example (either `px.<something>` or `make_subplots` or `go.Figure`).
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)`.
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls.
- [ ] `fig.show()` is at the end of each example.
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any example.
- [ ] Named colors are used instead of hex codes wherever possible.
- [ ] Code blocks are marked with `&#96;&#96;&#96;python`.

## Code PR

- [ ] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the code generator and *not* the generated files.
- [ ] I have added tests or modified existing tests.
- [ ] For a new feature, I have added documentation examples (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if changing anything substantial.
- [ ] For a new feature or a change in behavior, I have updated the relevant docstrings in the code.

-->
