### PR TITLE
fix: Update GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,0 @@
-Thanks for your interest in Plotly.py.
-Before opening an issue, please:
-
--   Use the [latest version](https://github.com/plotly/plotly.py/blob/main/CHANGELOG.md) of plotly.py in your report unless not applicable.
--   Search for existing and closed issues.
--   Include a minimal reproducible example with bug reports.
-
-Note that GitHub Issues are meant to be used for bug reports and feature requests.
-Questions about usage should be asked on [community.plotly.com](https://community.plotly.com/c/graphing-libraries/python/10).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a bug report for a plotly.py issue
+title: "[BUG]: "
+labels: bug
+
+---
+
+### Instructions (remove this section before submitting report)
+
+Thanks for your interest in plotly.py!
+
+- Before submitting a new bug report, please search for existing and closed issues. If your bug is not addressed yet, fill out the sections below and submit a new issue.
+- Implementation questions ("How do I do ...?") should be asked on our [Community Forum](https://community.plotly.com/c/plotly-python/5) or on [Stack Overflow](https://stackoverflow.com/questions/tagged/plotly) (tagged 'plotly').
+- Comments should add content to the discussions. Approbation comments such as *+1* or *I would like this feature to be implemented as well* will be deleted by the maintainers. Please use [GitHub reactions](https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments) instead.
+
+### Description
+
+_Add a clear description of the issue that you're having._
+
+### Screenshots/Video
+
+_Add screenshots or a video of the issue._
+
+### Steps to reproduce
+
+_Reports **must** include steps to reproduce the issue. Please use the [latest version](https://github.com/plotly/plotly.py/releases) of plotly.py in your report unless not applicable._
+
+- Go to '...'
+- Click on X
+- Note the issue with Y
+
+### Notes
+
+_Add info here that doesn't fit in the other sections._

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Submit a new feature request for plotly.py
+title: "[FEATURE]: "
+labels: feature
+
+---
+
+### Instructions (remove this section before submitting an issue)
+
+Thanks for your interest in plotly.py!
+
+- Before submitting a new feature request, please search for existing and closed requests. If your request is novel, fill out the sections below and submit a new request.
+- Comments should add content to the discussions. Approbation comments such as *+1* or *I would like this feature to be implemented as well* will be deleted by the maintainers. Please use [GitHub reactions](https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments) instead.
+
+### Description
+
+_Add a clear description of the feature that you're requesting._
+
+
+### Why should this feature be added?
+
+_Provide an argument for why this feature should be added. We can't add everything, so this will help us determine what gets worked on. Please also consider creating a PR and adding the feature yourself. Help is always appreciated._
+
+### Mocks/Designs
+
+_Please add any mocks or designs you might have for the feature._
+
+### Notes
+
+_Add info here that doesn't fit in the other sections._


### PR DESCRIPTION
### Description

Update GitHub issue templates to new format documented [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests).

Closes #5440.

### Changes

- Adds new issue templates
- Removes old issue template

### Testing

Open a new issue once this gets merged to the default branch (main).