### PR TITLE
Fix failing docs build by updating call to `color_discrete_sequence`  with new call signature

### DIFF
--- a/_plotly_utils/colors/_swatches.py
+++ b/_plotly_utils/colors/_swatches.py
@@ -15,7 +15,7 @@ def _swatches(module_names, module_contents, template=None):
     from plotly.express._core import apply_default_cascade
 
     args = dict(template=template)
-    apply_default_cascade(args)
+    apply_default_cascade(args, constructor=None)
 
     sequences = [
         (k, v)
@@ -66,7 +66,7 @@ def _swatches_continuous(module_names, module_contents, template=None):
     from plotly.express._core import apply_default_cascade
 
     args = dict(template=template)
-    apply_default_cascade(args)
+    apply_default_cascade(args, constructor=None)
 
     sequences = [
         (k, v)
@@ -122,7 +122,7 @@ def _swatches_cyclical(module_names, module_contents, template=None):
     from plotly.express._core import apply_default_cascade
 
     args = dict(template=template)
-    apply_default_cascade(args)
+    apply_default_cascade(args, constructor=None)
 
     rows = 2
     cols = 4


### PR DESCRIPTION
I merged #5437 too hastily and introduced a bug that surfaced in the docs build.

Updates call to `color_discrete_sequence`  with new call signature in `_plotly_utils/`, so that `px.colors.qualitative.swatches()` runs without error.

On `main`, `px.colors.qualitative.swatches()` returns an error, which causes the `build-docs` job to fail.

On this branch, `px.colors.qualitative.swatches()` runs as expected.