### PR TITLE
Update editable installs ref in CONTRIBUTING doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ npm run build
 These commands also create an *editable install* of plotly.py
 so that you can test your changes iteratively without having to rebuild the plotly.py package explicitly;
 for more information please see
-[the `pip` documentation on editable installs](https://pip.pypa.io/en/stable/reference/pip_install/#install-editable)
+[the `pip` documentation on editable installs](https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs)
 Please note that the single quotes are needed to escape the `[]` characters.
 
 ### Formatting


### PR DESCRIPTION
Old URL link in contributing guide now redirects to main pip install page. This update links directly to editable installs [section](https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs) as intended by old URL link.
