### PR TITLE
Remove type='text/javascript' from script tags in HTML

### DIFF
--- a/doc/apidoc/_templates/layout.html
+++ b/doc/apidoc/_templates/layout.html
@@ -2,7 +2,7 @@
 {% extends "!layout.html" %}
 
 {%- block footer %}
-    <script type="text/javascript">
+    <script>
 
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-39373211-1']);
@@ -11,7 +11,7 @@
       _gaq.push(['_trackPageview']);
 
       (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+        var ga = document.createElement('script'); ga.async = true;
         ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
         var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
       })();


### PR DESCRIPTION
**Fixes #5449**

## Problem
The HTML5 spec explicitly discourages setting the \`type="text/javascript"\` attribute on script tags because JavaScript is the default. The current documentation template includes this attribute, which causes warnings in HTML validators.

## Solution
Remove the \`type="text/javascript"\` attribute from script tags in \`doc/apidoc/_templates/layout.html\`.

## Changes
- Removed \`type="text/javascript"\` from the inline script tag
- Removed \`ga.type = 'text/javascript'\` from the dynamically created script element

This is a minimal change that aligns with HTML5 best practices and removes validator warnings.