### PR TITLE
fix: remove global warnings.formatwarning assignment

### DIFF
--- a/plotly/matplotlylib/renderer.py
+++ b/plotly/matplotlylib/renderer.py
@@ -14,14 +14,6 @@ from plotly.matplotlylib.mplexporter import Renderer
 from plotly.matplotlylib import mpltools
 
 
-# Warning format
-def warning_on_one_line(msg, category, filename, lineno, file=None, line=None):
-    return "%s:%s: %s:\n\n%s\n\n" % (filename, lineno, category.__name__, msg)
-
-
-warnings.formatwarning = warning_on_one_line
-
-
 class PlotlyRenderer(Renderer):
     """A renderer class inheriting from base for rendering mpl plots in plotly.
 

--- a/plotly/tools.py
+++ b/plotly/tools.py
@@ -55,14 +55,6 @@ DEFAULT_HISTNORM = "probability density"
 ALTERNATIVE_HISTNORM = "probability"
 
 
-# Warning format
-def warning_on_one_line(message, category, filename, lineno, file=None, line=None):
-    return "%s:%s: %s:\n\n%s\n\n" % (filename, lineno, category.__name__, message)
-
-
-warnings.formatwarning = warning_on_one_line
-
-
 ### mpl-related tools ###
 def mpl_to_plotly(fig, resize=False, strip_style=False, verbose=False):
     """Convert a matplotlib figure to plotly dictionary and send.


### PR DESCRIPTION
## Summary

Fixes #5472

This PR removes the global modification of `warnings.formatwarning` that was happening at module import time in two files:
- `plotly/tools.py`
- `plotly/matplotlylib/renderer.py`

## Problem

The previous code was setting a custom `warnings.formatwarning` function at module import time:

```python
warnings.formatwarning = warning_on_one_line
```

This changed the warning format globally for the entire Python process, not just for plotly's warnings. This caused issues for users who expected standard Python warning formatting.

### Before (without this fix)
```python
import warnings
warnings.warn("test warning", UserWarning)
# Output: main.py:2: UserWarning:
#
# test warning
#
```

### After (with this fix)
```python
import warnings
warnings.warn("test warning", UserWarning)
# Output: main.py:2: UserWarning: test warning
#   warnings.warn("test warning", UserWarning)
```

## Solution

Removed the global `warnings.formatwarning` assignment. The custom `warning_on_one_line` function was not being used anywhere else in the codebase, so removing it has no functional impact on plotly itself.

## Changes

- Removed `warning_on_one_line` function and `warnings.formatwarning` assignment from `plotly/tools.py`
- Removed `warning_on_one_line` function and `warnings.formatwarning` assignment from `plotly/matplotlylib/renderer.py`

## Testing

- Verified that warnings now use the standard Python format
- Confirmed no other code depends on the custom warning format
