### PR TITLE
Update GeoPandas examples to work with geopandas >= 1.0

### DIFF
--- a/doc/python/scatter-plots-on-maps.md
+++ b/doc/python/scatter-plots-on-maps.md
@@ -74,7 +74,13 @@ fig.show()
 import plotly.express as px
 import geopandas as gpd
 
-geo_df = gpd.read_file(gpd.datasets.get_path('naturalearth_cities'))
+# For GeoPandas >= 1.0, use geodatasets package
+# For older versions, use gpd.datasets
+try:
+    import geodatasets
+    geo_df = gpd.read_file(geodatasets.get_path('naturalearth_cities'))
+except (ImportError, AttributeError):
+    geo_df = gpd.read_file(gpd.datasets.get_path('naturalearth_cities'))
 
 px.set_mapbox_access_token(open(".mapbox_token").read())
 fig = px.scatter_geo(geo_df,

--- a/doc/python/tile-scatter-maps.md
+++ b/doc/python/tile-scatter-maps.md
@@ -56,7 +56,13 @@ fig.show()
 import plotly.express as px
 import geopandas as gpd
 
-geo_df = gpd.read_file(gpd.datasets.get_path('naturalearth_cities'))
+# For GeoPandas >= 1.0, use geodatasets package
+# For older versions, use gpd.datasets
+try:
+    import geodatasets
+    geo_df = gpd.read_file(geodatasets.get_path('naturalearth_cities'))
+except (ImportError, AttributeError):
+    geo_df = gpd.read_file(gpd.datasets.get_path('naturalearth_cities'))
 
 fig = px.scatter_map(geo_df,
                         lat=geo_df.geometry.y,


### PR DESCRIPTION
This PR updates the GeoPandas examples in the documentation to work with both older versions of GeoPandas (< 1.0) and newer versions (>= 1.0).

The gpd.datasets module was removed in GeoPandas 1.0 and replaced with the geodatasets package. The examples now try to use geodatasets first, with a fallback to gpd.datasets for backwards compatibility.

Files updated:
- doc/python/scatter-plots-on-maps.md
- doc/python/tile-scatter-maps.md

Fixes #4778