### PR TITLE
docs: fix typos (seperate -> separate)

### DIFF
--- a/plotly/figure_factory/_facet_grid.py
+++ b/plotly/figure_factory/_facet_grid.py
@@ -819,7 +819,7 @@ def create_facet_grid(
     else:
         SUBPLOT_SPACING = 0.015
 
-    # seperate kwargs for marker and else
+    # separate kwargs for marker and else
     if "marker" in kwargs:
         kwargs_marker = kwargs["marker"]
     else:

--- a/plotly/figure_factory/utils.py
+++ b/plotly/figure_factory/utils.py
@@ -236,7 +236,7 @@ def annotation_dict_for_label(
 
 def list_of_options(iterable, conj="and", period=True):
     """
-    Returns an English listing of objects seperated by commas ','
+    Returns an English listing of objects separated by commas ','
 
     For example, ['foo', 'bar', 'baz'] becomes 'foo, bar and baz'
     if the conjunction 'and' is selected.


### PR DESCRIPTION
This PR fixes two spelling errors in the figure_factory module:

- Fix 'seperated' -> 'separated' in utils.py docstring
- Fix 'seperate' -> 'separate' in _facet_grid.py comment

These are minor documentation/comment fixes with no functional changes.