### PR TITLE
Remove type="text/javascript" from script tags in HTML output

### DIFF
--- a/plotly/io/_base_renderers.py
+++ b/plotly/io/_base_renderers.py
@@ -273,7 +273,7 @@ class HtmlRenderer(MimetypeRenderer):
 
             if self.connected:
                 script = """\
-        <script type="text/javascript">
+        <script>
         {win_config}
         {mathjax_config}
         </script>
@@ -288,7 +288,7 @@ class HtmlRenderer(MimetypeRenderer):
                 # If not connected then we embed a copy of the plotly.js
                 # library in the notebook
                 script = """\
-        <script type="text/javascript">
+        <script>
         {win_config}
         {mathjax_config}
         </script>

--- a/plotly/io/_html.py
+++ b/plotly/io/_html.py
@@ -22,12 +22,12 @@ def _generate_sri_hash(content):
 # Build script to set global PlotlyConfig object. This must execute before
 # plotly.js is loaded.
 _window_plotly_config = """\
-<script type="text/javascript">\
+<script>\
 window.PlotlyConfig = {MathJaxConfig: 'local'};\
 </script>"""
 
 _mathjax_config = """\
-<script type="text/javascript">\
+<script>\
 if (window.MathJax && window.MathJax.Hub && window.MathJax.Hub.Config) {window.MathJax.Hub.Config({SVG: {font: "STIX-Web"}});}\
 </script>"""
 
@@ -282,7 +282,7 @@ def to_html(
     elif include_plotlyjs:
         load_plotlyjs = """\
         {win_config}
-        <script type="text/javascript">{plotlyjs}</script>\
+        <script>{plotlyjs}</script>\
     """.format(win_config=_window_plotly_config, plotlyjs=get_plotlyjs())
 
     # ## Handle loading/initializing MathJax ##
@@ -323,7 +323,7 @@ include_mathjax may be specified as False, 'cdn', or a string ending with '.js'
         {load_plotlyjs}\
             <div id="{id}" class="plotly-graph-div" \
 style="height:{height}; width:{width};"></div>\
-            <script type="text/javascript">\
+            <script>\
                 window.PLOTLYENV=window.PLOTLYENV || {{}};{base_url_line}\
                 {script};\
             </script>\

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -89,7 +89,7 @@ def get_plotlyjs():
 
 def _build_resize_script(plotdivid, plotly_root="Plotly"):
     resize_script = (
-        '<script type="text/javascript">'
+        '<script>'
         'window.addEventListener("resize", function(){{'
         'if (document.getElementById("{id}")) {{'
         '{plotly_root}.Plots.resize(document.getElementById("{id}"));'
@@ -177,12 +177,12 @@ Unrecognized config options supplied: {bad_config}""".format(bad_config=bad_conf
 # Build script to set global PlotlyConfig object. This must execute before
 # plotly.js is loaded.
 _window_plotly_config = """\
-<script type="text/javascript">\
+<script>\
 window.PlotlyConfig = {MathJaxConfig: 'local'};\
 </script>"""
 
 _mathjax_config = """\
-<script type="text/javascript">\
+<script>\
 if (window.MathJax && window.MathJax.Hub && window.MathJax.Hub.Config) {window.MathJax.Hub.Config({SVG: {font: "STIX-Web"}});}\
 </script>"""
 


### PR DESCRIPTION
## Summary

Removes the redundant `type="text/javascript"` attribute from `<script>` tags in HTML output.

## Problem

In HTML5, the `type="text/javascript"` attribute is unnecessary since JavaScript is the default scripting language. Including it adds extra bytes to the HTML output without providing any benefit.

## Changes

- `plotly/io/_html.py`: Removed `type="text/javascript"` from 4 script tag templates
- `plotly/offline/offline.py`: Removed `type="text/javascript"` from 3 script tag templates  
- `plotly/io/_base_renderers.py`: Removed `type="text/javascript"` from 2 script tag templates

## Benefits

- Smaller HTML payload size
- Follows modern HTML5 best practices
- Cleaner output

Fixes #5449
