### PR TITLE
Remove redundant type="text/javascript" from script tags

### DIFF
--- a/plotly/io/_base_renderers.py
+++ b/plotly/io/_base_renderers.py
@@ -273,7 +273,7 @@ class HtmlRenderer(MimetypeRenderer):
 
             if self.connected:
                 script = """\
-        <script type="text/javascript">
+        <script>
         {win_config}
         {mathjax_config}
         </script>
@@ -288,7 +288,7 @@ class HtmlRenderer(MimetypeRenderer):
                 # If not connected then we embed a copy of the plotly.js
                 # library in the notebook
                 script = """\
-        <script type="text/javascript">
+        <script>
         {win_config}
         {mathjax_config}
         </script>

--- a/plotly/io/_html.py
+++ b/plotly/io/_html.py
@@ -22,12 +22,12 @@ def _generate_sri_hash(content):
 # Build script to set global PlotlyConfig object. This must execute before
 # plotly.js is loaded.
 _window_plotly_config = """\
-<script type="text/javascript">\
+<script>\
 window.PlotlyConfig = {MathJaxConfig: 'local'};\
 </script>"""
 
 _mathjax_config = """\
-<script type="text/javascript">\
+<script>\
 if (window.MathJax && window.MathJax.Hub && window.MathJax.Hub.Config) {window.MathJax.Hub.Config({SVG: {font: "STIX-Web"}});}\
 </script>"""
 
@@ -282,7 +282,7 @@ def to_html(
     elif include_plotlyjs:
         load_plotlyjs = """\
         {win_config}
-        <script type="text/javascript">{plotlyjs}</script>\
+        <script>{plotlyjs}</script>\
     """.format(win_config=_window_plotly_config, plotlyjs=get_plotlyjs())
 
     # ## Handle loading/initializing MathJax ##
@@ -323,7 +323,7 @@ include_mathjax may be specified as False, 'cdn', or a string ending with '.js'
         {load_plotlyjs}\
             <div id="{id}" class="plotly-graph-div" \
 style="height:{height}; width:{width};"></div>\
-            <script type="text/javascript">\
+            <script>\
                 window.PLOTLYENV=window.PLOTLYENV || {{}};{base_url_line}\
                 {script};\
             </script>\

--- a/plotly/offline/offline.py
+++ b/plotly/offline/offline.py
@@ -70,7 +70,7 @@ def get_plotlyjs():
     >>> html = '''
     ... <html>
     ...     <head>
-    ...         <script type="text/javascript">{plotlyjs}</script>
+    ...         <script>{plotlyjs}</script>
     ...     </head>
     ...     <body>
     ...        {div1}
@@ -89,7 +89,7 @@ def get_plotlyjs():
 
 def _build_resize_script(plotdivid, plotly_root="Plotly"):
     resize_script = (
-        '<script type="text/javascript">'
+        '<script>'
         'window.addEventListener("resize", function(){{'
         'if (document.getElementById("{id}")) {{'
         '{plotly_root}.Plots.resize(document.getElementById("{id}"));'
@@ -177,12 +177,12 @@ Unrecognized config options supplied: {bad_config}""".format(bad_config=bad_conf
 # Build script to set global PlotlyConfig object. This must execute before
 # plotly.js is loaded.
 _window_plotly_config = """\
-<script type="text/javascript">\
+<script>\
 window.PlotlyConfig = {MathJaxConfig: 'local'};\
 </script>"""
 
 _mathjax_config = """\
-<script type="text/javascript">\
+<script>\
 if (window.MathJax && window.MathJax.Hub && window.MathJax.Hub.Config) {window.MathJax.Hub.Config({SVG: {font: "STIX-Web"}});}\
 </script>"""
 

--- a/tests/test_core/test_offline/test_offline.py
+++ b/tests/test_core/test_offline/test_offline.py
@@ -35,7 +35,7 @@ fig_frames = {
 PLOTLYJS = plotly.offline.get_plotlyjs()
 
 plotly_config_script = """\
-<script type="text/javascript">\
+<script>\
 window.PlotlyConfig = {MathJaxConfig: 'local'};</script>"""
 
 cdn_script = '<script charset="utf-8" src="{cdn_url}" integrity="{js_hash}" crossorigin="anonymous"></script>'.format(

--- a/tests/test_io/test_renderers.py
+++ b/tests/test_io/test_renderers.py
@@ -306,7 +306,7 @@ def test_repr_html(renderer):
     sri_hash = _generate_sri_hash(plotlyjs_content)
 
     template = (
-        '<div>                        <script type="text/javascript">'
+        '<div>                        <script>'
         "window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n        "
         '<script charset="utf-8" src="'
         + plotly_cdn_url()
@@ -314,7 +314,7 @@ def test_repr_html(renderer):
         + sri_hash
         + '" crossorigin="anonymous"></script>                '
         '<div id="cd462b94-79ce-42a2-887f-2650a761a144" class="plotly-graph-div" '
-        'style="height:100%; width:100%;"></div>            <script type="text/javascript">'
+        'style="height:100%; width:100%;"></div>            <script>'
         "                window.PLOTLYENV=window.PLOTLYENV || {};"
         '                                if (document.getElementById("cd462b94-79ce-42a2-887f-2650a761a144"))'
         ' {                    Plotly.newPlot(                        "cd462b94-79ce-42a2-887f-2650a761a144",'


### PR DESCRIPTION
This PR removes the redundant "type=text/javascript" attribute from script tags in HTML output, as it is unnecessary in HTML5 and causes validator warnings.

Changes:
- Updated plotly/io/_html.py
- Updated plotly/offline/offline.py  
- Updated plotly/io/_base_renderers.py
- Updated corresponding tests

Fixes #5449