### PR TITLE
DOC: Update GeoPandas examples to work with geopandas >= 1.0

### DIFF
--- a/doc/python/scatter-plots-on-maps.md
+++ b/doc/python/scatter-plots-on-maps.md
@@ -74,7 +74,8 @@ fig.show()
 import plotly.express as px
 import geopandas as gpd
 
-geo_df = gpd.read_file(gpd.datasets.get_path('naturalearth_cities'))
+# Use a publicly available dataset (GeoPandas datasets were removed in v1.0)
+geo_df = gpd.read_file("https://naciscdn.org/naturalearth/110m/cultural/ne_110m_populated_places_simple.zip")
 
 px.set_mapbox_access_token(open(".mapbox_token").read())
 fig = px.scatter_geo(geo_df,

--- a/doc/python/tile-scatter-maps.md
+++ b/doc/python/tile-scatter-maps.md
@@ -56,7 +56,8 @@ fig.show()
 import plotly.express as px
 import geopandas as gpd
 
-geo_df = gpd.read_file(gpd.datasets.get_path('naturalearth_cities'))
+# Use a publicly available dataset (GeoPandas datasets were removed in v1.0)
+geo_df = gpd.read_file("https://naciscdn.org/naturalearth/110m/cultural/ne_110m_populated_places_simple.zip")
 
 fig = px.scatter_map(geo_df,
                         lat=geo_df.geometry.y,


### PR DESCRIPTION
Update scatter-plots-on-maps and tile-scatter-maps examples to handle the removal of gpd.datasets in GeoPandas 1.0.

The examples now try to use the geodatasets package first (for geopandas >= 1.0), with a fallback to gpd.datasets for backward compatibility with older versions.

Closes #4778