### PR TITLE
docs: update geopandas examples to use direct URL

### DIFF
--- a/doc/python/scatter-plots-on-maps.md
+++ b/doc/python/scatter-plots-on-maps.md
@@ -74,7 +74,8 @@ fig.show()
 import plotly.express as px
 import geopandas as gpd
 
-geo_df = gpd.read_file(gpd.datasets.get_path('naturalearth_cities'))
+# Load cities data from a URL (compatible with GeoPandas >= 1.0)
+geo_df = gpd.read_file("https://naciscdn.org/naturalearth/110m/cultural/ne_110m_populated_places_simple.zip")
 
 px.set_mapbox_access_token(open(".mapbox_token").read())
 fig = px.scatter_geo(geo_df,

--- a/doc/python/tile-scatter-maps.md
+++ b/doc/python/tile-scatter-maps.md
@@ -56,7 +56,8 @@ fig.show()
 import plotly.express as px
 import geopandas as gpd
 
-geo_df = gpd.read_file(gpd.datasets.get_path('naturalearth_cities'))
+# Load cities data from a URL (compatible with GeoPandas >= 1.0)
+geo_df = gpd.read_file("https://naciscdn.org/naturalearth/110m/cultural/ne_110m_populated_places_simple.zip")
 
 fig = px.scatter_map(geo_df,
                         lat=geo_df.geometry.y,


### PR DESCRIPTION
The gpd.datasets.get_path() method was removed in GeoPandas 1.0. This change updates the examples to use a direct URL to download the naturalearth_cities data, making them compatible with both old and new versions of GeoPandas.

Fixes #4778