### PR TITLE
Add type stubs for plotly.express

### DIFF
--- a/plotly/express/__init__.pyi
+++ b/plotly/express/__init__.pyi
@@ -2,7 +2,6 @@
 
 from typing import Any, Literal, Sequence, Mapping, Optional, Union
 import pandas as pd
-import numpy as np
 import plotly.graph_objs as go
 
 # Type aliases for common parameter types
@@ -66,7 +65,6 @@ def scatter(
     width: Optional[int] = None,
     height: Optional[int] = None,
 ) -> go.Figure: ...
-
 def line(
     data_frame: DataFrameLike = None,
     x: ColumnRef = None,
@@ -112,7 +110,6 @@ def line(
     width: Optional[int] = None,
     height: Optional[int] = None,
 ) -> go.Figure: ...
-
 def bar(
     data_frame: DataFrameLike = None,
     x: ColumnRef = None,
@@ -158,7 +155,6 @@ def bar(
     width: Optional[int] = None,
     height: Optional[int] = None,
 ) -> go.Figure: ...
-
 def histogram(
     data_frame: DataFrameLike = None,
     x: ColumnRef = None,
@@ -185,7 +181,9 @@ def histogram(
     orientation: Optional[Literal["v", "h"]] = None,
     barmode: Literal["relative", "overlay", "group"] = "relative",
     barnorm: Optional[Literal["", "fraction", "percent"]] = None,
-    histnorm: Optional[Literal["", "percent", "probability", "density", "probability density"]] = None,
+    histnorm: Optional[
+        Literal["", "percent", "probability", "density", "probability density"]
+    ] = None,
     log_x: bool = False,
     log_y: bool = False,
     range_x: RangeLike = None,
@@ -200,7 +198,6 @@ def histogram(
     width: Optional[int] = None,
     height: Optional[int] = None,
 ) -> go.Figure: ...
-
 def box(
     data_frame: DataFrameLike = None,
     x: ColumnRef = None,
@@ -234,7 +231,6 @@ def box(
     width: Optional[int] = None,
     height: Optional[int] = None,
 ) -> go.Figure: ...
-
 def violin(
     data_frame: DataFrameLike = None,
     x: ColumnRef = None,
@@ -268,7 +264,6 @@ def violin(
     width: Optional[int] = None,
     height: Optional[int] = None,
 ) -> go.Figure: ...
-
 def area(
     data_frame: DataFrameLike = None,
     x: ColumnRef = None,
@@ -310,7 +305,6 @@ def area(
     width: Optional[int] = None,
     height: Optional[int] = None,
 ) -> go.Figure: ...
-
 def pie(
     data_frame: DataFrameLike = None,
     names: ColumnRef = None,
@@ -382,7 +376,6 @@ def scatter_3d(
     width: Optional[int] = None,
     height: Optional[int] = None,
 ) -> go.Figure: ...
-
 def line_3d(
     data_frame: DataFrameLike = None,
     x: ColumnRef = None,
@@ -433,7 +426,9 @@ def scatter_geo(
     lat: ColumnRef = None,
     lon: ColumnRef = None,
     locations: ColumnRef = None,
-    locationmode: Optional[Literal["ISO-3", "USA-states", "country names", "geojson-id"]] = None,
+    locationmode: Optional[
+        Literal["ISO-3", "USA-states", "country names", "geojson-id"]
+    ] = None,
     color: ColumnRef = None,
     text: ColumnRef = None,
     facet_row: ColumnRef = None,
@@ -460,7 +455,11 @@ def scatter_geo(
     size_max: Optional[float] = None,
     opacity: Optional[float] = None,
     projection: Optional[str] = None,
-    scope: Optional[Literal["world", "usa", "europe", "asia", "africa", "north america", "south america"]] = None,
+    scope: Optional[
+        Literal[
+            "world", "usa", "europe", "asia", "africa", "north america", "south america"
+        ]
+    ] = None,
     center: MappingLike = None,
     title: Optional[str] = None,
     subtitle: Optional[str] = None,
@@ -468,13 +467,14 @@ def scatter_geo(
     width: Optional[int] = None,
     height: Optional[int] = None,
 ) -> go.Figure: ...
-
 def line_geo(
     data_frame: DataFrameLike = None,
     lat: ColumnRef = None,
     lon: ColumnRef = None,
     locations: ColumnRef = None,
-    locationmode: Optional[Literal["ISO-3", "USA-states", "country names", "geojson-id"]] = None,
+    locationmode: Optional[
+        Literal["ISO-3", "USA-states", "country names", "geojson-id"]
+    ] = None,
     color: ColumnRef = None,
     line_dash: ColumnRef = None,
     text: ColumnRef = None,
@@ -500,7 +500,11 @@ def line_geo(
     symbol_map: MappingLike = None,
     markers: bool = False,
     projection: Optional[str] = None,
-    scope: Optional[Literal["world", "usa", "europe", "asia", "africa", "north america", "south america"]] = None,
+    scope: Optional[
+        Literal[
+            "world", "usa", "europe", "asia", "africa", "north america", "south america"
+        ]
+    ] = None,
     center: MappingLike = None,
     title: Optional[str] = None,
     subtitle: Optional[str] = None,
@@ -512,13 +516,14 @@ def line_geo(
 # Utility functions
 
 def set_mapbox_access_token(token: str) -> None: ...
-
 def get_trendline_results(fig: go.Figure) -> Optional[pd.DataFrame]: ...
 
 # Special input classes
 class IdentityMap: ...
+
 class Constant:
     def __init__(self, value: Any) -> None: ...
+
 class Range:
     def __init__(self, start: float, stop: float, step: float = 1.0) -> None: ...
 

--- a/test_type_stubs.py
+++ b/test_type_stubs.py
@@ -5,27 +5,29 @@ import plotly.graph_objs as go
 import pandas as pd
 
 # Create test data
-df = pd.DataFrame({
-    'x': [1, 2, 3, 4, 5],
-    'y': [2, 4, 3, 5, 6],
-    'color': ['A', 'B', 'A', 'B', 'A'],
-    'size': [10, 20, 15, 25, 30]
-})
+df = pd.DataFrame(
+    {
+        "x": [1, 2, 3, 4, 5],
+        "y": [2, 4, 3, 5, 6],
+        "color": ["A", "B", "A", "B", "A"],
+        "size": [10, 20, 15, 25, 30],
+    }
+)
 
 # Test scatter - should type-check correctly
-fig1: go.Figure = px.scatter(df, x='x', y='y', color='color', size='size')
+fig1: go.Figure = px.scatter(df, x="x", y="y", color="color", size="size")
 
 # Test line
-fig2: go.Figure = px.line(df, x='x', y='y', color='color')
+fig2: go.Figure = px.line(df, x="x", y="y", color="color")
 
 # Test bar
-fig3: go.Figure = px.bar(df, x='color', y='y')
+fig3: go.Figure = px.bar(df, x="color", y="y")
 
 # Test histogram
-fig4: go.Figure = px.histogram(df, x='y')
+fig4: go.Figure = px.histogram(df, x="y")
 
 # Test box
-fig5: go.Figure = px.box(df, x='color', y='y')
+fig5: go.Figure = px.box(df, x="color", y="y")
 
 # Test with wrong types (should fail type check)
 # fig_bad: int = px.scatter(df, x='x', y='y')  # Uncomment to test type error


### PR DESCRIPTION
Created .pyi stub file with type annotations for the most commonly used plotly.express functions. This enables proper IDE autocomplete and static type checking with mypy/pyright.

Covered functions include scatter, line, bar, histogram, box, violin, area, pie, and 3D/geographic variants. All parameters are properly typed with sensible unions and literals for better developer experience.

Addresses #1103

<!--
Please uncomment this block and fill in this checklist if your PR makes substantial changes to documentation in the `doc` directory.
Not all boxes must be checked for every PR:
check those that apply to your PR and leave the rest unchecked to discuss with your reviewer.

If your PR modifies code of the [plotly](cci:1://file:///Volumes/T7/plotly.py/plotly/tools.py:66:0-117:9) package, we have a different checklist below.

## Documentation PR

- [ ] I have seen the [[doc/README.md](cci:7://file:///Volumes/T7/plotly.py/doc/README.md:0:0-0:0)](https://github.com/plotly/plotly.py/blob/main/doc/README.md) file.
- [ ] This change runs in the current version of Plotly on PyPI and targets the `doc-prod` branch OR it targets the `main` branch.
- [ ] If this PR modifies the first example in a page or adds a new one, it is a `px` example if at all possible.
- [ ] Every new/modified example has a descriptive title and motivating sentence or paragraph.
- [ ] Every new/modified example is independently runnable.
- [ ] Every new/modified example is optimized for short line count and focuses on the Plotly/visualization-related aspects of the example rather than the computation required to produce the data being visualized.
- [ ] Meaningful/relatable datasets are used for all new examples instead of randomly-generated data where possible.
- [ ] The random seed is set if using randomly-generated data.
- [ ] New/modified remote datasets are loaded from https://plotly.github.io/datasets and added to https://github.com/plotly/datasets.
- [ ] Large computations are avoided in the new/modified examples in favour of loading remote datasets that represent the output of such computations.
- [ ] Imports are `plotly.graph_objects as go`, `plotly.express as px`, and/or `plotly.io as pio`.
- [ ] Data frames are always called [df](cci:1://file:///Volumes/T7/plotly.py/plotly/express/_chart_types.py:515:0-564:61).
- [ ] `fig = <something>` is called high up in each new/modified example (either `px.<something>` or [make_subplots](cci:1://file:///Volumes/T7/plotly.py/plotly/tools.py:229:0-467:5) or `go.Figure`).
- [ ] Liberal use is made of `fig.add_*` and `fig.update_*` rather than `go.Figure(data=..., layout=...)`.
- [ ] Specific adders and updaters like `fig.add_shape` and `fig.update_xaxes` are used instead of big `fig.update_layout` calls.
- [ ] `fig.show()` is at the end of each example.
- [ ] `plotly.plot()` and `plotly.iplot()` are not used in any example.
- [ ] Named colors are used instead of hex codes wherever possible.
- [ ] Code blocks are marked with `&#96;&#96;&#96;python`.
-->

## Code PR

- [x] I have read through the [contributing notes](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md) and understand the structure of the package. In particular, if my PR modifies code of `plotly.graph_objects`, my modifications concern the code generator and *not* the generated files.
- [ ] I have added tests or modified existing tests.
- [ ] For a new feature, I have added documentation examples (please see the doc checklist as well).
- [ ] I have added a CHANGELOG entry if changing anything substantial.
- [ ] For a new feature or a change in behavior, I have updated the relevant docstrings in the code.