### PR TITLE
doc: add append_trace and orthographic projection examples

### DIFF
--- a/doc/python/3d-camera-controls.md
+++ b/doc/python/3d-camera-controls.md
@@ -287,6 +287,29 @@ fig.update_layout(scene_camera=camera, title=name)
 fig.show()
 ```
 
+### Orthographic Projection
+
+By default, 3D plots use perspective projection where objects farther from the camera appear smaller. You can switch to orthographic projection, where objects maintain their size regardless of distance. This is useful for technical and engineering visualizations where preserving relative dimensions is important.
+
+```python
+import plotly.graph_objects as go
+import pandas as pd
+
+z_data = pd.read_csv('https://raw.githubusercontent.com/plotly/datasets/master/api_docs/mt_bruno_elevation.csv')
+
+fig = go.Figure(data=go.Surface(z=z_data, showscale=False))
+fig.update_layout(
+    scene_camera=dict(
+        projection=dict(type="orthographic"),
+        eye=dict(x=1.25, y=1.25, z=1.25)
+    ),
+    title=dict(text="Mt Bruno Elevation (Orthographic Projection)"),
+    width=500, height=500,
+    margin=dict(t=40, r=0, l=20, b=20)
+)
+fig.show()
+```
+
 #### Reference
 
 

--- a/doc/python/creating-and-updating-figures.md
+++ b/doc/python/creating-and-updating-figures.md
@@ -235,6 +235,21 @@ fig.add_trace(go.Bar(x=[1, 2, 3], y=[1, 3, 2]))
 fig.show()
 ```
 
+The `append_trace()` method can be used to add traces to subplots created with `make_subplots()`. Note that `append_trace()` is deprecated in favor of `add_trace()`, which supports the same `row` and `col` parameters and also returns the figure for method chaining.
+
+```python
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+fig = make_subplots(rows=1, cols=2)
+
+fig.append_trace(go.Scatter(x=[1, 2, 3], y=[4, 2, 3], name="Trace 1"), row=1, col=1)
+fig.append_trace(go.Bar(x=[1, 2, 3], y=[2, 3, 1], name="Trace 2"), row=1, col=2)
+
+fig.update_layout(title_text="Using append_trace() with Subplots")
+fig.show()
+```
+
 You can also add traces to a figure produced by a figure factory or Plotly Express.
 
 ```python


### PR DESCRIPTION
## Summary

Add two documentation examples from the wishlist in #1965:

1. **`append_trace()` example** in `creating-and-updating-figures.md` — demonstrates usage with `make_subplots()` alongside the existing prose mention, and notes the deprecation in favor of `add_trace()`
2. **Orthographic projection example** in `3d-camera-controls.md` — demonstrates `scene_camera.projection.type = 'orthographic'` with an explanation of when orthographic vs perspective projection is useful

Part of #1965.

🤖 Generated with [Claude Code](https://claude.com/claude-code)