### PR TITLE
fix: handle empty px.histogram() by skipping None label in hover template

### DIFF
--- a/plotly/express/_core.py
+++ b/plotly/express/_core.py
@@ -588,7 +588,8 @@ def make_trace_kwargs(args, trace_spec, trace_data, mapping_labels, sizeref):
             and attr_name == "z"
         ):
             # ensure that stuff like "count" gets into the hoverlabel
-            mapping_labels[attr_label] = "%%{%s}" % attr_name
+            if attr_label is not None:
+                mapping_labels[attr_label] = "%%{%s}" % attr_name
     if trace_spec.constructor not in [go.Parcoords, go.Parcats]:
         # Modify mapping_labels according to hover_data keys
         # if hover_data is a dict

--- a/tests/test_optional/test_px/test_px_functions.py
+++ b/tests/test_optional/test_px/test_px_functions.py
@@ -619,3 +619,13 @@ def test_timeline_cols_already_temporal(constructor, datetime_columns):
     assert len(fig.data) == 3
     assert fig.layout.xaxis.type == "date"
     assert fig.layout.xaxis.title.text is None
+
+
+def test_empty_histogram():
+    """Empty px.histogram() should not raise, matching scatter/bar/pie behavior.
+
+    Regression test for https://github.com/plotly/plotly.py/issues/5534
+    """
+    fig = px.histogram()
+    assert len(fig.data) == 1
+    assert fig.data[0].type == "histogram"


### PR DESCRIPTION
## Summary

`px.histogram()` crashes with `TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'` when called with no data arguments, while other chart types like `px.scatter()`, `px.bar()`, and `px.pie()` handle empty invocations correctly.

## Root Cause

The histogram-specific hover label path in `_core.py` unconditionally adds an entry to `mapping_labels` even when no column is specified. When no data is provided, `attr_label` is `None` (from `get_decorated_label(args, None, 'x')`), resulting in a `{None: '%{x}'}` entry. The hover template list comprehension then fails:

```python
hover_lines = [k + "=" + v for k, v in mapping_labels_copy.items()]
#              None + "=" + ...  → TypeError
```

## Fix

Skip adding to `mapping_labels` when `attr_label` is `None`, consistent with how other chart types handle empty invocations (they never reach the mapping_labels code path since their attrs check `attr_value is not None` first).

## Test

Added `test_empty_histogram` to verify `px.histogram()` returns a valid figure without raising.

Fixes #5534