### PR TITLE
chore: Update bumpversion script to include rebuilding JupyterLab extension

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,6 +30,7 @@ a link to the plotly.js CHANGELOG.
   - `uv.lock`
   - `js/package.json`
   - `js/package-lock.json`
+  - `plotly/labextension/*`
   - `CHANGELOG.md` (Adds a new header for X.Y.Z above the unreleased items)
   - `CITATION.cff`
 
@@ -37,8 +38,9 @@ a link to the plotly.js CHANGELOG.
   - Note: The current date is used as the release date in `CHANGELOG.md` and `CITATION.cff`. If you want to use a different date, edit these files manually afterward.
   - If the bumpversion command failed for any reason, you can update the versions yourself by doing the following:
     - Manually update the version number (and release date, as needed) in `pyproject.toml`, `CHANGELOG.md` and `CITATION.cff`
-    - Run `npm version X.Y.Z` to update `js/package.json` and `js/package-lock.json`
     - Run `uv lock` to update `uv.lock`
+    - From the `js/` dir, run `npm version X.Y.Z` to update `js/package.json` and `js/package-lock.json`
+    - From the `js/` dir, run `npm run build:labextension` to regenerate the files in `plotly/labextension/`
 
 - Commit and push the changed files to the release branch:
     ```sh

--- a/commands.py
+++ b/commands.py
@@ -328,7 +328,7 @@ def bump_version_pyproject_toml(new_version):
     subprocess.run(["uv", "lock"], check=True)
 
     print(
-        f"Updated version in {pyproject_toml_path} to {new_version},",
+        f"SUCCESS: Updated version in {pyproject_toml_path} to {new_version},",
         "and updated uv lockfile",
     )
     return True
@@ -346,8 +346,20 @@ def bump_version_package_json(new_version):
         check=True,
     )
     print(
-        f"Updated version in {js_dir}/package.json and {js_dir}/package-lock.json to {new_version}"
+        f"SUCCESS: Updated version in {js_dir}/package.json and {js_dir}/package-lock.json to {new_version}"
     )
+
+    # After modifying files in js/, we need to rebuild the JupyterLab extension
+    print("Rebuilding JupyterLab extension (this may take a few seconds)...")
+    subprocess.run(
+        ["npm", "run", "build:labextension"],
+        cwd=js_dir,
+        check=True,
+        stdout=subprocess.DEVNULL,  # Suppress stdout and stderr to avoid terminal clutter
+        stderr=subprocess.DEVNULL,
+    )
+    print(f"SUCCESS: Updated JupyterLab extension files in plotly/labextension")
+
     return True
 
 
@@ -392,7 +404,7 @@ def bump_version_citation_cff(new_version, new_date):
     with open(citation_cff_path, "w") as f:
         f.write(new_content)
     print(
-        f"Updated version in {citation_cff_path} to {new_version}",
+        f"SUCCESS: Updated version in {citation_cff_path} to {new_version}",
         f"and date-released to {new_date}",
     )
     return True
@@ -414,7 +426,7 @@ def bump_version_changelog_md(new_version, new_date):
     already_exists_pattern = rf"(^\s*##\s*\[ *{re.escape(new_version)} *\])"
     if re.search(already_exists_pattern, content, flags=re.MULTILINE):
         print(
-            f"Header for version {new_version} already exists ",
+            f"Header for version {new_version} already exists",
             f"in {changelog_md_path}.",
         )
         return True


### PR DESCRIPTION

<!--
Thank you for your contribution to plotly.py!

Please complete each section below.
-->

### Link to issue
<!-- Link to the issue closed by this PR. If the issue doesn't exist yet, create it. -->

Closes #5567 

### Description of change
Updates the `commands.py bumpversion` script to rebuild the JupyterLab extension files located under `plotly/labextension`.

The lab extension needs to be rebuild every time the `package.json` changes.

### Demo
<img width="791" height="211" alt="Screenshot 2026-04-09 at 6 09 34 PM" src="https://github.com/user-attachments/assets/c32018cc-a063-47a3-adb7-38da5b62e7ce" />


### Testing strategy

Pull this branch, then run `python commands.py bumpversion 6.8.0` and ensure that the following files are modified:

- `plotly/labextension/package.json`
- Files inside `plotly/labextension/static`

### Additional information (optional)

N/A

### Guidelines

- [x] I have reviewed the [pull request guidelines](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md#opening-a-pull-request) and the [Code of Conduct](https://github.com/plotly/plotly.py/blob/main/CODE_OF_CONDUCT.md) and confirm that this PR follows them.
- [x] I have added an entry to the [changelog](https://github.com/plotly/plotly.py/blob/main/CHANGELOG.md) if needed (not required for documentation PRs).
