### PR TITLE
Add `pull_request` `synchronize` trigger so workflows run when new commits are pushed to PR

### DIFF
--- a/.github/workflows/build-doc.yml
+++ b/.github/workflows/build-doc.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - doc-prod
   pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   build-doc:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 jobs:
   plotlyjs-dev-build:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -2,6 +2,8 @@ name: Build
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -2,6 +2,8 @@ name: Check Python code formatting
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -3,7 +3,7 @@ name: Check Python code formatting
 on:
   push:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 jobs:
   check-code-formatting:

--- a/.github/workflows/run-percy.yml
+++ b/.github/workflows/run-percy.yml
@@ -2,6 +2,8 @@ name: Run Percy
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     types: [opened, reopened, synchronize]
   workflow_dispatch:

--- a/.github/workflows/run-percy.yml
+++ b/.github/workflows/run-percy.yml
@@ -3,7 +3,7 @@ name: Run Percy
 on:
   push:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -2,6 +2,8 @@ name: Test
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 jobs:
   test-core:


### PR DESCRIPTION
### Description of change

Add `synchronize` to the list of `pull_request` events which trigger the workflow to run.

Also add the list of `pull_request` triggers in `build-doc.yml` for consistency (this list is the [same as the default](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request) so there's no actual change in behavior).

Also restricts the `push` event to apply _only_ to the `main` branch; otherwise, pushing to a branch in the repo which also has an open PR causes the workflow to run twice.

---

The `synchronize` event occurs when new commits are added to the head branch of a PR.

Without this trigger, the workflows will run when a PR is first opened (or reopened), but will not run again when new commits are pushed.

I had assumed the `push` event would cover this case, but it seems that event only triggers for branches within the repository, not for forks. Thus we need to use `pull_request synchronize`.

N.b. the exact meaning of each event type is very poorly documented, but [this comment](https://github.com/github/docs/issues/2257#issuecomment-3801300961) confirms the meaning of `synchronize`.