### PR TITLE
docs: fix typos in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,12 @@ then explains the technical aspects of preparing your contribution.
 
 ## Code of Conduct
 
-Please note that all contributos are required to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+Please note that all contributors are required to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Different Ways to Contribute
 
 There are many ways to contribute to plotly.py.
-To do any effectively,
+To do so effectively,
 it is important to understand the structure of the code and the repository.
 
 -   The [`plotly.graph_objects`](https://plotly.com/python/graph-objects/) module (usually imported as `go`)


### PR DESCRIPTION

**Repo:** plotly/plotly.py (⭐ 16000)
**Type:** docs
**Files changed:** 1
**Lines:** +2/-2

## What
Fixes two small typos in `CONTRIBUTING.md`: "contributos" → "contributors", and "To do any effectively" → "To do so effectively".

## Why
The contributing guide is the first document a prospective contributor reads. Small typos undermine polish and the second one ("To do any effectively") is grammatically broken, making the sentence unclear. Trivial, low-risk improvement to the onboarding doc.

## Testing
Documentation-only change. Verified via `git diff` that only the intended lines are modified. No code paths affected, no tests need to run.

## Risk
Low — markdown text only, no code or build configuration touched.
