### PR TITLE
Fix accidental creation of `js/` directory under `site-packages/` when installing Plotly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,10 @@ include = [
     "js/install.json",  # used by Jupyter extension
 ]
 
+[tool.hatch.build.targets.wheel]
+# Prevent js/ directory from being installed as top-level package
+exclude = ["js"]
+
 [tool.hatch.build.targets.wheel.shared-data]
 # Specify files from this package which will be copied to the user's system on install
 # This is how the jupyterlab extension gets installed


### PR DESCRIPTION
### Link to issue

Closes #5584 

### Description of change
Fixes issue since Plotly 6.7.0, introduced by #5540, where `pip install plotly` would unintentionally create a `js/` directory under `site-packages/`, interfering with any other package which might use the `js/` name.

### Demo

N/A

### Testing strategy

**To reproduce the issue:**
1. Create a fresh Python virtual environment
2. Run `pip install plotly==6.7.0` (or `uv pip install ...`)
3. Notice that the following directory exists: `$VENV_ROOT/lib/pythonX.Y/site-packages/js`

**To verify that this PR fixes the issue:**
1. Check out this branch
2. Run `python -m build` from the root folder, and make sure it runs without error
  - Verify that new `dist/plotly-6.7.0.tar.gz` and `dist/plotly-6.7.0-py3-none-any.whl` files are created
4. Create a fresh Python virtual environment
5. Run `pip install dist/plotly-6.7.0-py3-none-any.whl`
6. Verify that `$VENV_ROOT/lib/pythonX.Y/site-packages/js` DOES NOT exist
7. Verify that `$VENV_ROOT/share/jupyter/labextensions/jupyterlab-plotly/install.json` DOES exist
8. To test installing the tar file, repeat steps 4-7 replacing the `.whl` file path with the `.tar.gz` file path

### Guidelines

- [x] I have reviewed the [pull request guidelines](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md#opening-a-pull-request) and the [Code of Conduct](https://github.com/plotly/plotly.py/blob/main/CODE_OF_CONDUCT.md) and confirm that this PR follows them.
- [x] I have added an entry to the [changelog](https://github.com/plotly/plotly.py/blob/main/CHANGELOG.md) if needed (not required for documentation PRs).
