### PR TITLE
Fix to_html responsive height by styling outer wrapper div

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Use presence of `COLAB_NOTEBOOK_ID` env var to enable Colab renderer instead of testing import of `google.colab` [[#5473](https://github.com/plotly/plotly.py/pull/5473)], with thanks to @kevineger for the contribution!
 - Update tests to be compatible with numpy 2.4 [[#5522](https://github.com/plotly/plotly.py/pull/5522)], with thanks to @thunze for the contribution!
 - Add default headers to be passed in to Kaleido v1.3.0 to avoid blocked Open Street Map tiles [#5588](https://github.com/plotly/plotly.py/pull/5588)]
+- Propagate the requested `default_height`/`default_width` to the outer wrapper div produced by `to_html` so that responsive (percentage) dimensions inherit from a sized parent container instead of collapsing to the plotly.js 450px fallback [[#5591](https://github.com/plotly/plotly.py/issues/5591)]
 
 ### Updated
 - The `__eq__` method for  `graph_objects` classes now returns `NotImplemented` to give the other operand an opportunity to handle the comparison [[#5547](https://github.com/plotly/plotly.py/pull/5547)], with thanks to @RazerM for the contribution!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Use presence of `COLAB_NOTEBOOK_ID` env var to enable Colab renderer instead of testing import of `google.colab` [[#5473](https://github.com/plotly/plotly.py/pull/5473)], with thanks to @kevineger for the contribution!
 - Update tests to be compatible with numpy 2.4 [[#5522](https://github.com/plotly/plotly.py/pull/5522)], with thanks to @thunze for the contribution!
 - Add default headers to be passed in to Kaleido v1.3.0 to avoid blocked Open Street Map tiles [#5588](https://github.com/plotly/plotly.py/pull/5588)]
-- Propagate the requested `default_height`/`default_width` to the outer wrapper div produced by `to_html` so that responsive (percentage) dimensions inherit from a sized parent container instead of collapsing to the plotly.js 450px fallback [[#5591](https://github.com/plotly/plotly.py/issues/5591)]
+- Propagate the requested `default_height`/`default_width` to the outer wrapper div produced by `to_html` so that responsive (percentage) dimensions inherit from a sized parent container instead of collapsing to the plotly.js 450px fallback [[#5591](https://github.com/plotly/plotly.py/issues/5591)], with thanks to @SharadhNaidu for the contribution!
 
 ### Updated
 - The `__eq__` method for  `graph_objects` classes now returns `NotImplemented` to give the other operand an opportunity to handle the comparison [[#5547](https://github.com/plotly/plotly.py/pull/5547)], with thanks to @RazerM for the contribution!

--- a/plotly/io/_html.py
+++ b/plotly/io/_html.py
@@ -318,11 +318,11 @@ include_mathjax may be specified as False, 'cdn', or a string ending with '.js'
         )
 
     plotly_html_div = """\
-<div>\
+<div style="height:{height}; width:{width};">\
         {mathjax_script}\
         {load_plotlyjs}\
             <div id="{id}" class="plotly-graph-div" \
-style="height:{height}; width:{width};"></div>\
+style="height:100%; width:100%;"></div>\
             <script>\
                 window.PLOTLYENV=window.PLOTLYENV || {{}};{base_url_line}\
                 {script};\

--- a/tests/test_core/test_offline/test_offline.py
+++ b/tests/test_core/test_offline/test_offline.py
@@ -278,7 +278,7 @@ class PlotlyOfflineTestCase(PlotlyOfflineBaseTestCase):
 
         self.assertNotIn("<html>", html)
         self.assertNotIn("</html>", html)
-        self.assertTrue(html.startswith("<div>") and html.endswith("</div>"))
+        self.assertTrue(html.startswith("<div") and html.endswith("</div>"))
 
     def test_config(self):
         config = dict(linkText="Plotly rocks!", showLink=True, editable=True)

--- a/tests/test_io/test_html.py
+++ b/tests/test_io/test_html.py
@@ -53,6 +53,53 @@ def test_cdn_includes_integrity_attribute(fig1):
     assert match is not None, "CDN script tag with integrity attribute not found"
 
 
+def test_outer_wrapper_carries_requested_dimensions(fig1):
+    """
+    Regression test for https://github.com/plotly/plotly.py/issues/5591.
+
+    The outer wrapper div produced by ``to_html`` must carry the requested
+    height/width so that percentage values propagate from a parent container
+    down to the figure element. Without this, a default of ``height='100%'``
+    collapses to zero (because the wrapper has no height) and plotly.js falls
+    back to its hardcoded 450px, breaking any responsive layout.
+    """
+    html = pio.to_html(fig1, include_plotlyjs="cdn", full_html=False)
+
+    wrapper_match = re.match(r'<div style="([^"]+)">', html)
+    assert wrapper_match is not None, (
+        "Outer wrapper div is missing inline style; responsive parents cannot "
+        "propagate dimensions to the figure."
+    )
+    wrapper_style = wrapper_match.group(1)
+    assert "height:100%" in wrapper_style
+    assert "width:100%" in wrapper_style
+
+    inner_match = re.search(
+        r'<div id="[^"]+" class="plotly-graph-div" style="([^"]+)">',
+        html,
+    )
+    assert inner_match is not None
+    assert "height:100%" in inner_match.group(1)
+    assert "width:100%" in inner_match.group(1)
+
+
+def test_outer_wrapper_respects_explicit_pixel_dimensions(fig1):
+    """Explicit pixel dimensions must reach the outer wrapper unchanged."""
+    html = pio.to_html(
+        fig1,
+        include_plotlyjs="cdn",
+        full_html=False,
+        default_width=600,
+        default_height=400,
+    )
+
+    wrapper_match = re.match(r'<div style="([^"]+)">', html)
+    assert wrapper_match is not None
+    wrapper_style = wrapper_match.group(1)
+    assert "height:400px" in wrapper_style
+    assert "width:600px" in wrapper_style
+
+
 def test_cdn_integrity_hash_matches_bundled_content(fig1):
     """Test that the SRI hash in CDN script tag matches the bundled plotly.js content"""
     html_output = pio.to_html(fig1, include_plotlyjs="cdn")

--- a/tests/test_io/test_renderers.py
+++ b/tests/test_io/test_renderers.py
@@ -307,7 +307,7 @@ def test_repr_html(renderer):
     sri_hash = _generate_sri_hash(plotlyjs_content)
 
     template = (
-        "<div>                        <script>"
+        '<div style="height:100%; width:100%;">                        <script>'
         "window.PlotlyConfig = {MathJaxConfig: 'local'};</script>\n        "
         '<script charset="utf-8" src="'
         + plotly_cdn_url()


### PR DESCRIPTION
### Link to issue

Closes #5591

### Description of change

`to_html` wraps the figure inside an outer `<div>` that has no inline style. The inner figure div sets `style="height:100%; width:100%;"`, but because the wrapper has no height, that `100%` resolves to zero, and plotly.js then falls back to its hardcoded 450px default.

The result: the documented default of `default_height='100%'` cannot inherit from a sized parent container. Any figure placed inside a Jinja template, a Dash container with a `vh`/`%` height, or any responsive layout silently renders at 450px instead of filling its parent. This is the underlying cause of #5591 (and the long-standing plotly/plotly.js#5270). PR #5590 documented a regex-based workaround; this PR addresses the root cause.

The fix moves the requested `default_height`/`default_width` onto the outer wrapper, and changes the inner figure div to `height:100%; width:100%;` so it fills the wrapper:

```diff
- <div>
+ <div style="height:{height}; width:{width};">
          {mathjax_script}
          {load_plotlyjs}
              <div id="{id}" class="plotly-graph-div"
- style="height:{height}; width:{width};"></div>
+ style="height:100%; width:100%;"></div>
```

### Behavior matrix

| Caller's intent | Before this PR | After this PR |
| --- | --- | --- |
| Default (`height='100%'`), figure in container with `height:30vh` | Renders at 450px (collapsed wrapper) | Renders at 30vh as expected |
| Explicit pixel (`default_height=400`) | 400px | 400px (unchanged) |
| Default (`height='100%'`), no sized parent | plotly.js 450px fallback | plotly.js 450px fallback (unchanged) |
| `full_html=True` standalone page | Fills viewport | Fills viewport (unchanged) |

Pixel defaults and standalone-document use cases are byte-for-byte equivalent in observable layout. The only behavioral change is that percentage defaults now actually inherit from a sized parent, which matches the docstring.

### Testing strategy

Two regression tests added in `tests/test_io/test_html.py`:

- `test_outer_wrapper_carries_requested_dimensions` asserts the wrapper div has the percentage style and the inner figure div is set to `100%` of it.
- `test_outer_wrapper_respects_explicit_pixel_dimensions` asserts pixel defaults flow through unchanged.

Existing `test_html_deterministic` and the CDN/integrity tests are unaffected because they assert content presence, not the wrapper element.

### Notes for review

- This is a small visible structural change to `to_html` output. If maintainers prefer to gate it behind an opt-in (e.g. `responsive_layout=True`), I am happy to refactor - just let me know.
- I have not been able to reproduce a downstream consumer (Dash, JupyterLab extension, nbconvert) that depends on the wrapper being unstyled. If you know of one, please flag and I will investigate.

### Guidelines

- [x] I have reviewed the [pull request guidelines](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md#opening-a-pull-request) and the [Code of Conduct](https://github.com/plotly/plotly.py/blob/main/CODE_OF_CONDUCT.md) and confirm that this PR follows them.