### PR TITLE
Add dependabot config for updating uv.lock

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 3  # Should match tool.uv.exclude-newer option in pyproject.toml

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -4,6 +4,6 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
     cooldown:
       default-days: 3  # Should match tool.uv.exclude-newer option in pyproject.toml


### PR DESCRIPTION
Closes #5557

Configure dependabot to update `uv.lock` following documentation here:

https://docs.astral.sh/uv/guides/integration/dependabot/