### PR TITLE
Don't use matplotlib internal API _major_tick_kw

### DIFF
--- a/plotly/matplotlylib/mplexporter/utils.py
+++ b/plotly/matplotlylib/mplexporter/utils.py
@@ -200,7 +200,7 @@ def get_text_style(text):
 def get_axis_properties(axis):
     """Return the property dictionary for a matplotlib.Axis instance"""
     props = {}
-    label1On = axis._major_tick_kw.get("label1On", True)
+    label1On = axis.get_tick_params().get("label1On", True)
 
     if isinstance(axis, matplotlib.axis.XAxis):
         if label1On:
@@ -257,7 +257,7 @@ def get_axis_properties(axis):
 
 def get_grid_style(axis):
     gridlines = axis.get_gridlines()
-    if axis._major_tick_kw["gridOn"] and len(gridlines) > 0:
+    if axis.get_tick_params()["gridOn"] and len(gridlines) > 0:
         color = export_color(gridlines[0].get_color())
         alpha = gridlines[0].get_alpha()
         dasharray = get_dasharray(gridlines[0])


### PR DESCRIPTION
### Description of change

The public API is available since matplotlib 3.7 https://github.com/matplotlib/matplotlib/pull/23692

### Guidelines

- [x] I have reviewed the [pull request guidelines](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md#opening-a-pull-request) and the [Code of Conduct](https://github.com/plotly/plotly.py/blob/main/CODE_OF_CONDUCT.md) and confirm that this PR follows them.
- [N/A ]I have added an entry to the [changelog](https://github.com/plotly/plotly.py/blob/main/CHANGELOG.md) if needed (not required for documentation PRs). - I consider this an implementation detail not relevant for the changelog.
