### PR TITLE
ci: Pin python-frontmatter to keep Python 3.9 compatibility

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -27,7 +27,7 @@ pooch
 psutil
 pyarrow
 pyshp==2.1.2
-python-frontmatter
+python-frontmatter==1.1.0
 recommonmark
 requests
 scikit-image==0.20.0


### PR DESCRIPTION
### Description of change

Pin the version of python-frontmatter used in building the docs in CI.

### Testing strategy

Check the CI run.

### Additional information (optional)

- v1.2.0 of python-frontmatter started using typing utilities that aren't compatible with Python 3.9 and set a minimum Python version of 3.10
- This pins python-frontmatter to the last version before that change

### Guidelines

- [x] I have reviewed the [pull request guidelines](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md#opening-a-pull-request) and the [Code of Conduct](https://github.com/plotly/plotly.py/blob/main/CODE_OF_CONDUCT.md) and confirm that this PR follows them.
- [x] I have added an entry to the [changelog](https://github.com/plotly/plotly.py/blob/main/CHANGELOG.md) if needed (not required for documentation PRs).
