### PR TITLE
ci: Exempt plotly.py from exclude-newer rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ dev_pandas3 = [
 
 [tool.uv]
 exclude-newer = "72 hours"
+exclude-newer-package = { plotly = false }
 conflicts = [
     [{ extra = "dev_pandas1" }, { extra = "dev_pandas2" }],
     [{ extra = "dev_pandas1" }, { extra = "dev_pandas3" }],

--- a/uv.lock
+++ b/uv.lock
@@ -66,6 +66,9 @@ conflicts = [[
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "PT72H"
 
+[options.exclude-newer-package]
+plotly = false
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"


### PR DESCRIPTION
### Link to issue

Closes #5611

### Description of change

Exempt plotly.py from exclude-newer rule

### Testing strategy

Check CI after this PR is created.

### Additional information (optional)

- The issue this fixes only occurs within 72 hours of a new plotly.py release

### Guidelines

- [x] I have reviewed the [pull request guidelines](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md#opening-a-pull-request) and the [Code of Conduct](https://github.com/plotly/plotly.py/blob/main/CODE_OF_CONDUCT.md) and confirm that this PR follows them.
- [x] I have added an entry to the [changelog](https://github.com/plotly/plotly.py/blob/main/CHANGELOG.md) if needed (not required for documentation PRs).
