### PR TITLE
Raise a clear error for unsupported marginal plot types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Fixed
-- Raise a clear `ValueError` when an unsupported marginal plot type is passed to Plotly Express, instead of failing later with a cryptic `'NoneType' object has no attribute 'constructor'` message [[#4654](https://github.com/plotly/plotly.py/issues/4654)]
+- Raise a clear `ValueError` when an unsupported marginal plot type is passed to Plotly Express, instead of failing later with a cryptic `'NoneType' object has no attribute 'constructor'` message [[#5625](https://github.com/plotly/plotly.py/pull/5625)]
 
 
 ## [6.8.0] - 2026-06-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+- Raise a clear `ValueError` when an unsupported marginal plot type is passed to Plotly Express, instead of failing later with a cryptic `'NoneType' object has no attribute 'constructor'` message [[#4654](https://github.com/plotly/plotly.py/issues/4654)]
+
 
 ## [6.8.0] - 2026-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Fixed
-- Raise a clear `ValueError` when an unsupported marginal plot type is passed to Plotly Express, instead of failing later with a cryptic `'NoneType' object has no attribute 'constructor'` message [[#5625](https://github.com/plotly/plotly.py/pull/5625)]
+- Raise a clear `ValueError` when an unsupported marginal plot type is passed to Plotly Express, instead of failing later with a cryptic `'NoneType' object has no attribute 'constructor'` message [[#5625](https://github.com/plotly/plotly.py/pull/5625)], with thanks to @eugen-goebel for the contribution!
 
 
 ## [6.8.0] - 2026-06-03

--- a/plotly/express/_core.py
+++ b/plotly/express/_core.py
@@ -973,9 +973,8 @@ def make_trace_spec(args, constructor, attrs, trace_patch):
                 )
             else:
                 raise ValueError(
-                    "Invalid value '%s' for `marginal_%s`. Supported marginal "
-                    "plot types are: 'rug', 'box', 'violin', 'histogram'."
-                    % (args["marginal_" + letter], letter)
+                    f"Invalid value '{args['marginal_' + letter]}' for `marginal_{letter}`."
+                    "Supported marginal plot types are: 'rug', 'box', 'violin', 'histogram'."
                 )
             if "color" in attrs or "color" not in args:
                 if "marker" not in trace_spec.trace_patch:

--- a/plotly/express/_core.py
+++ b/plotly/express/_core.py
@@ -971,6 +971,12 @@ def make_trace_spec(args, constructor, attrs, trace_patch):
                     ),
                     marginal=letter,
                 )
+            else:
+                raise ValueError(
+                    "Invalid value '%s' for `marginal_%s`. Supported marginal "
+                    "plot types are: 'rug', 'box', 'violin', 'histogram'."
+                    % (args["marginal_" + letter], letter)
+                )
             if "color" in attrs or "color" not in args:
                 if "marker" not in trace_spec.trace_patch:
                     trace_spec.trace_patch["marker"] = dict()

--- a/tests/test_optional/test_px/test_marginals.py
+++ b/tests/test_optional/test_px/test_marginals.py
@@ -24,3 +24,15 @@ def test_single_marginals(backend, px_fn, marginal, orientation):
         df, x="total_bill", y="total_bill", marginal=marginal, orientation=orientation
     )
     assert len(fig.data) == 1 + (marginal is not None)
+
+
+def test_unsupported_marginal_raises_clear_error():  # issue 4654
+    # An unsupported marginal type used to fail deep inside make_figure with a
+    # cryptic "'NoneType' object has no attribute 'constructor'". It should
+    # instead raise a clear error naming the supported values.
+    with pytest.raises(ValueError, match="Supported marginal plot types"):
+        px.scatter(x=[1, 2, 3], y=[2, 3, 4], marginal_x="density")
+    with pytest.raises(ValueError, match="Supported marginal plot types"):
+        px.scatter(x=[1, 2, 3], y=[2, 3, 4], marginal_y="density")
+    with pytest.raises(ValueError, match="Supported marginal plot types"):
+        px.histogram(x=[1, 2, 3], marginal="density")


### PR DESCRIPTION
### Link to issue

Closes #4654

### Description of change

`make_trace_spec` now raises a clear `ValueError` listing the supported marginal plot types when an unsupported value is passed to `marginal_x`, `marginal_y` or `marginal`, instead of failing later with a cryptic `'NoneType' object has no attribute 'constructor'`.

### Demo

Before:

```python
>>> import plotly.express as px
>>> px.scatter(x=[1, 2, 3], y=[2, 3, 4], marginal_x="density")
AttributeError: 'NoneType' object has no attribute 'constructor'
```

After:

```python
>>> import plotly.express as px
>>> px.scatter(x=[1, 2, 3], y=[2, 3, 4], marginal_x="density")
ValueError: Invalid value 'density' for `marginal_x`. Supported marginal plot types are: 'rug', 'box', 'violin', 'histogram'.
```

### Testing strategy

Adds `test_unsupported_marginal_raises_clear_error` in `tests/test_optional/test_px/test_marginals.py`, which asserts that an unsupported value for `marginal_x`, `marginal_y` and the singular `marginal` argument raises a `ValueError`. The existing marginal tests still pass.

### Additional information (optional)

The singular `marginal` argument is normalised to `marginal_x` / `marginal_y` before `make_trace_spec` runs, so a single check covers all three parameters.

### Guidelines

- [x] I have reviewed the [pull request guidelines](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md#opening-a-pull-request) and the [Code of Conduct](https://github.com/plotly/plotly.py/blob/main/CODE_OF_CONDUCT.md) and confirm that this PR follows them.
- [x] I have added an entry to the [changelog](https://github.com/plotly/plotly.py/blob/main/CHANGELOG.md) if needed (not required for documentation PRs).
