### PR TITLE
Add missing space in unsupported-marginal error message

### DIFF
--- a/plotly/express/_core.py
+++ b/plotly/express/_core.py
@@ -973,7 +973,7 @@ def make_trace_spec(args, constructor, attrs, trace_patch):
                 )
             else:
                 raise ValueError(
-                    f"Invalid value '{args['marginal_' + letter]}' for `marginal_{letter}`."
+                    f"Invalid value '{args['marginal_' + letter]}' for `marginal_{letter}`. "
                     "Supported marginal plot types are: 'rug', 'box', 'violin', 'histogram'."
                 )
             if "color" in attrs or "color" not in args:


### PR DESCRIPTION
### Link to issue

Follow-up to #5625 (no separate issue).

### Description of change

The f-string refactor merged in #5625 concatenated two adjacent string literals without a separating space, so the error message rendered as `...for \`marginal_x\`.Supported marginal plot types...`. This adds the missing space after the period.

### Demo

Before:

```
Invalid value 'density' for `marginal_x`.Supported marginal plot types are: 'rug', 'box', 'violin', 'histogram'.
```

After:

```
Invalid value 'density' for `marginal_x`. Supported marginal plot types are: 'rug', 'box', 'violin', 'histogram'.
```

### Testing strategy

Covered by the existing `test_unsupported_marginal_raises_clear_error` in `tests/test_optional/test_px/test_marginals.py`, which still passes. No changelog entry is added because this only polishes the unreleased change from #5625.

### Guidelines

- [x] I have reviewed the [pull request guidelines](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md#opening-a-pull-request) and the [Code of Conduct](https://github.com/plotly/plotly.py/blob/main/CODE_OF_CONDUCT.md) and confirm that this PR follows them.
- [x] I have added an entry to the [changelog](https://github.com/plotly/plotly.py/blob/main/CHANGELOG.md) if needed (not required for documentation PRs).
