### PR TITLE
Remove stale "fig" parameter from full_figure_for_development docstring

### DIFF
--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -3462,9 +3462,6 @@ Invalid property path '{key_path_str}' for layout
 
         Parameters
         ----------
-        fig:
-            Figure object or dict representing a figure
-
         warn: bool
             If False, suppress warnings about not using this in production.
 


### PR DESCRIPTION
The method `BaseFigure.full_figure_for_development(self, warn=True, as_dict=False)` documents a `fig` parameter it doesn't have - the entry was carried over from the module-level `plotly.io.full_figure_for_development(fig, ...)` function, where `fig` is a real parameter (left unchanged).

Doc-only change; no behavior modified.