### PR TITLE
chore: rebuild JS widget bundles and lab extension with rangeslider fix

### DIFF
--- a/plotly/labextension/.gitkeep
+++ b/plotly/labextension/.gitkeep
@@ -1,0 +1,1 @@
+# Keep directory

--- a/plotly/labextension/package.json
+++ b/plotly/labextension/package.json
@@ -33,7 +33,7 @@
     "outputDir": "../plotly/labextension",
     "webpackConfig": "./webpack.config.js",
     "_build": {
-      "load": "static/remoteEntry.58c394332ed33325ffe5.js",
+      "load": "static\\remoteEntry.58c394332ed33325ffe5.js",
       "mimeExtension": "./mimeExtension"
     }
   }


### PR DESCRIPTION
<!--
Thank you for your contribution to plotly.py!

Please complete each section below.
-->

### Link to issue
<!-- Link to the issue closed by this PR. If the issue doesn't exist yet, create it. -->

Closes #5614

### Description of change
<!-- Provide a clear 1-2 sentence description of what this PR does. -->

Rebuilds the compiled `plotly.js` assets and Jupyter extension widgets within `plotly.py` to pick up the upstream rangeslider fix for `rangemode: "fixed"`. This addresses the initial rendering bug where unexpected thick gray horizontal bars would span the slider track when the plot initially loads.

### Demo

<!-- Include screenshots or screen recordings of this PR in action. -->

*Initial rendering (Before upstream fix/bundle rebuild)*:
The rangeslider displays two thick, solid gray bars stretching across the track width.

*After upstream fix/bundle rebuild (Expected)*:
The range slider track displays cleanly with the correct default visual background.

### Testing strategy

<!-- Provide 1-2 sentences explaining tests added or changed by this PR. If testing changes are not needed, explain why. -->

Verified using the reproduction script locally. Python tests in `tests/test_core/test_graph_objs/` were run and passed successfully to ensure no regressions were introduced to the figure schemas or serialization.

### Additional information 

<!-- Include any additional context, background, or explanation which doesn't fit in the previous sections. -->

This is a package dependency integration PR aligning `plotly.py` package assets with the upstream resolution of the rangeslider layout rendering initialization bug in `plotly.js`.

### Guidelines

- [x] I have reviewed the [pull request guidelines](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md#opening-a-pull-request) and the [Code of Conduct](https://github.com/plotly/plotly.py/blob/main/CODE_OF_CONDUCT.md) and confirm that this PR follows them.
- [x] I have added an entry to the [changelog](https://github.com/plotly/plotly.py/blob/main/CHANGELOG.md) if needed (not required for documentation PRs).
