### PR TITLE
fix: handle 3-digit shorthand hex in hex_to_rgb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+- Fix `hex_to_rgb` parsing of 3-digit shorthand hexadecimal colors such as `#FFF` [[#5662](https://github.com/plotly/plotly.py/pull/5662)], with thanks to @genrichez for the contribution!
+
 
 ## [6.9.0] - 2026-07-09
 

--- a/_plotly_utils/colors/__init__.py
+++ b/_plotly_utils/colors/__init__.py
@@ -752,9 +752,16 @@ def hex_to_rgb(value):
     """
     Calculates rgb values from a hex color code.
 
-    :param (string) value: Hex color string
+    :param (string) value: Hex color string. May be a full 6-character code
+        or a 3-character shorthand code.
 
     :rtype (tuple) (r_value, g_value, b_value): tuple of rgb values
+
+    Example:
+
+        '#FFFFFF' --> (255, 255, 255)
+        '#FFF'    --> (255, 255, 255)
+
     """
     value = value.lstrip("#")
     if len(value) == 3:

--- a/_plotly_utils/colors/__init__.py
+++ b/_plotly_utils/colors/__init__.py
@@ -757,6 +757,8 @@ def hex_to_rgb(value):
     :rtype (tuple) (r_value, g_value, b_value): tuple of rgb values
     """
     value = value.lstrip("#")
+    if len(value) == 3:
+        value = "".join(c * 2 for c in value)
     hex_total_length = len(value)
     rgb_section_length = hex_total_length // 3
     return tuple(

--- a/plotly/matplotlylib/mpltools.py
+++ b/plotly/matplotlylib/mpltools.py
@@ -10,6 +10,8 @@ import math
 import warnings
 import matplotlib.dates
 
+from _plotly_utils.colors import hex_to_rgb
+
 
 def check_bar_match(old_bar, new_bar):
     """Check if two bars belong in the same collection (bar chart).
@@ -102,25 +104,6 @@ def convert_symbol(mpl_symbol):
         return SYMBOL_MAP[mpl_symbol]
     else:
         return "circle"  # default
-
-
-def hex_to_rgb(value):
-    """
-    Change a hex color to an rgb tuple
-
-    :param (str|unicode) value: The hex string we want to convert.
-    :return: (int, int, int) The red, green, blue int-tuple.
-
-    Example:
-
-        '#FFFFFF' --> (255, 255, 255)
-
-    """
-    value = value.lstrip("#")
-    if len(value) == 3:
-        value = "".join(c * 2 for c in value)
-    lv = len(value)
-    return tuple(int(value[i : i + lv // 3], 16) for i in range(0, lv, lv // 3))
 
 
 def merge_color_and_opacity(color, opacity):

--- a/plotly/matplotlylib/mpltools.py
+++ b/plotly/matplotlylib/mpltools.py
@@ -117,6 +117,8 @@ def hex_to_rgb(value):
 
     """
     value = value.lstrip("#")
+    if len(value) == 3:
+        value = "".join(c * 2 for c in value)
     lv = len(value)
     return tuple(int(value[i : i + lv // 3], 16) for i in range(0, lv, lv // 3))
 

--- a/tests/test_plotly_utils/colors/test_color_conversions.py
+++ b/tests/test_plotly_utils/colors/test_color_conversions.py
@@ -12,6 +12,15 @@ def test_hex_to_rgb_basic_values():
     assert hex_to_rgb("#aabbcc") == (170, 187, 204)
 
 
+def test_hex_to_rgb_shorthand_3_digit():
+    assert hex_to_rgb("#fff") == (255, 255, 255)
+    assert hex_to_rgb("#000") == (0, 0, 0)
+    assert hex_to_rgb("#abc") == (170, 187, 204)
+    assert hex_to_rgb("#f00") == (255, 0, 0)
+    assert hex_to_rgb("#0f0") == (0, 255, 0)
+    assert hex_to_rgb("#00f") == (0, 0, 255)
+
+
 def test_label_rgb_formats_tuple():
     assert label_rgb((255, 0, 0)) == "rgb(255, 0, 0)"
     assert label_rgb((1, 2, 3)) == "rgb(1, 2, 3)"


### PR DESCRIPTION
Closes #5661.

`hex_to_rgb` assumed the input was always 6 digits. 3-digit shorthand like `#FFF` was parsed as `(15, 15, 15 )` instead of `(255, 255, 255)`.

Fix: expand 3-char codes to 6-char before slicing (e.g. `F` → `FF`). Applied to both copies in `_plotly_utils/colors` and `plotly/matplotlylib/mpltools`.

Added tests for the shorthand case.
