### PR TITLE
fix(io): force UTF-8 for write_json/read_json file I/O

### DIFF
--- a/plotly/io/_json.py
+++ b/plotly/io/_json.py
@@ -295,7 +295,9 @@ The 'file' argument '{file}' is not a string, pathlib.Path object, or file descr
     else:
         # We previously succeeded in interpreting `file` as a pathlib object.
         # Now we can use `write_bytes()`.
-        path.write_text(json_str)
+        # Explicit UTF-8: Windows default encodings (e.g. cp1252) raise
+        # UnicodeEncodeError for non-ASCII figure text (#5665).
+        path.write_text(json_str, encoding="utf-8")
 
 
 def from_json_plotly(value, engine=None):
@@ -464,7 +466,9 @@ def read_json(file, output_type="Figure", skip_invalid=False, engine=None):
     # Read file contents into JSON string
     # -----------------------------------
     if path is not None:
-        json_str = path.read_text()
+        # Explicit UTF-8 so files written by write_json decode correctly on
+        # Windows (default locale encoding is often not UTF-8) (#5665).
+        json_str = path.read_text(encoding="utf-8")
     else:
         json_str = file.read()
 

--- a/tests/test_io/test_to_from_json.py
+++ b/tests/test_io/test_to_from_json.py
@@ -271,3 +271,17 @@ def test_to_dict_empty_np_array_int64():
     )
     # to_dict() should not raise an exception
     fig.to_dict()
+
+
+def test_write_read_json_utf8_non_ascii(tmp_path):
+    """write_json/read_json must use UTF-8 so Windows cp1252 locales work (#5665)."""
+    fig = go.Figure(layout_title_text="μ 中文")
+    path = tmp_path / "fig_utf8.json"
+    pio.write_json(fig, path)
+    # File bytes must be valid UTF-8 containing the title characters
+    raw = path.read_bytes()
+    raw.decode("utf-8")
+    assert "μ".encode("utf-8") in raw or "\\u03bc".encode("ascii") in raw
+    loaded = pio.read_json(path)
+    title = loaded.layout.title.text
+    assert "μ" in title and "中文" in title


### PR DESCRIPTION
## Description

`pio.write_json` / `pio.read_json` use `Path.write_text` / `Path.read_text` without an encoding. On Windows the default is often **cp1252**, so non-ASCII figure text (e.g. `μ 中文`) raises `UnicodeEncodeError` on write or mangles/fails on read. macOS/Linux work only because their default is already UTF-8.

## Fix

Always pass `encoding="utf-8"` for both write and read path I/O.

## Test

```text
pytest tests/test_io/test_to_from_json.py::test_write_read_json_utf8_non_ascii -q
```

## Linked Issue

Closes #5665
