### PR TITLE
Add codegen check CI job

### DIFF
--- a/.github/workflows/check-codegen.yml
+++ b/.github/workflows/check-codegen.yml
@@ -1,0 +1,45 @@
+name: Check Python codegen
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  check-python-codegen:
+    name: Check Python codegen
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      with:
+        python-version: "3.x"
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+
+    - name: Install dependencies
+      run: |
+        uv venv
+        source .venv/bin/activate
+        uv pip install ".[dev_codegen]"
+    - name: Run codegen
+      run: |
+        source .venv/bin/activate
+        python commands.py codegen
+    - name: Check for changes
+      run: |
+        # Fail if codegen produced any changes to the working directory.
+        # This means the committed generated files are out of date and codegen
+        # needs to be re-run locally and the results committed.
+        if [ -n "$(git status --porcelain)" ]; then
+          echo "::error::Generated files are out of date. Please run 'python commands.py codegen' locally and commit the result."
+          echo "The following files differ after running codegen:"
+          git status --porcelain
+          echo ""
+          exit 1
+        fi
+        echo "Generated files are up to date."

--- a/.github/workflows/check-codegen.yml
+++ b/.github/workflows/check-codegen.yml
@@ -25,7 +25,8 @@ jobs:
       run: |
         uv venv
         source .venv/bin/activate
-        uv pip install ".[dev_codegen]"
+        uv lock --check
+        uv sync --extra dev_codegen
     - name: Run codegen
       run: |
         source .venv/bin/activate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,13 @@ dev_build = [
     "build",
     "jupyterlab"
 ]
+dev_codegen = [             # Dependencies for running Python codegen
+    "plotly[dev_core]",
+    "inflect"
+]
 dev_optional = [
     "plotly[dev_build]",
+    "plotly[dev_codegen]",
     "plotly[express]",
     "plotly[kaleido]",
     "anywidget",
@@ -62,7 +67,6 @@ dev_optional = [
     # fiona>1.9.6 is not compatible with geopandas<1; geopandas>=1 is not compatible with python 3.8
     "fiona<=1.9.6;python_version<='3.8'",
     "geopandas",
-    "inflect",
     "orjson",
     "pandas",
     "pdfrw",

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-07-25T16:47:51.95233Z"
 exclude-newer-span = "PT72H"
 
 [options.exclude-newer-package]
@@ -6724,6 +6724,17 @@ dev-build = [
     { name = "requests", version = "2.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas2') or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas3') or (extra == 'extra-6-plotly-dev-pandas2' and extra == 'extra-6-plotly-dev-pandas3')" },
     { name = "ruff" },
 ]
+dev-codegen = [
+    { name = "inflect", version = "7.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9' or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas2') or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas3') or (extra == 'extra-6-plotly-dev-pandas2' and extra == 'extra-6-plotly-dev-pandas3')" },
+    { name = "inflect", version = "7.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas2') or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas3') or (extra == 'extra-6-plotly-dev-pandas2' and extra == 'extra-6-plotly-dev-pandas3')" },
+    { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9' or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas2') or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas3') or (extra == 'extra-6-plotly-dev-pandas2' and extra == 'extra-6-plotly-dev-pandas3')" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*' or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas2') or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas3') or (extra == 'extra-6-plotly-dev-pandas2' and extra == 'extra-6-plotly-dev-pandas3')" },
+    { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas2') or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas3') or (extra == 'extra-6-plotly-dev-pandas2' and extra == 'extra-6-plotly-dev-pandas3')" },
+    { name = "requests", version = "2.32.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9' or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas2') or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas3') or (extra == 'extra-6-plotly-dev-pandas2' and extra == 'extra-6-plotly-dev-pandas3')" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*' or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas2') or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas3') or (extra == 'extra-6-plotly-dev-pandas2' and extra == 'extra-6-plotly-dev-pandas3')" },
+    { name = "requests", version = "2.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas2') or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas3') or (extra == 'extra-6-plotly-dev-pandas2' and extra == 'extra-6-plotly-dev-pandas3')" },
+    { name = "ruff" },
+]
 dev-core = [
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9' or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas2') or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas3') or (extra == 'extra-6-plotly-dev-pandas2' and extra == 'extra-6-plotly-dev-pandas3')" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*' or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas2') or (extra == 'extra-6-plotly-dev-pandas1' and extra == 'extra-6-plotly-dev-pandas3') or (extra == 'extra-6-plotly-dev-pandas2' and extra == 'extra-6-plotly-dev-pandas3')" },
@@ -6823,7 +6834,7 @@ requires-dist = [
     { name = "colorcet", marker = "extra == 'dev-optional'" },
     { name = "fiona", marker = "python_full_version < '3.9' and extra == 'dev-optional'", specifier = "<=1.9.6" },
     { name = "geopandas", marker = "extra == 'dev-optional'" },
-    { name = "inflect", marker = "extra == 'dev-optional'" },
+    { name = "inflect", marker = "extra == 'dev-codegen'" },
     { name = "jupyterlab", marker = "extra == 'dev-build'" },
     { name = "kaleido", marker = "extra == 'kaleido'", specifier = ">=1.3.0" },
     { name = "narwhals", specifier = ">=1.15.1" },
@@ -6838,7 +6849,9 @@ requires-dist = [
     { name = "pdfrw", marker = "extra == 'dev-optional'" },
     { name = "pillow", marker = "extra == 'dev-optional'" },
     { name = "plotly", extras = ["dev-build"], marker = "extra == 'dev-optional'" },
+    { name = "plotly", extras = ["dev-codegen"], marker = "extra == 'dev-optional'" },
     { name = "plotly", extras = ["dev-core"], marker = "extra == 'dev-build'" },
+    { name = "plotly", extras = ["dev-core"], marker = "extra == 'dev-codegen'" },
     { name = "plotly", extras = ["dev-optional"], marker = "extra == 'dev'" },
     { name = "plotly", extras = ["express"], marker = "extra == 'dev-optional'" },
     { name = "plotly", extras = ["kaleido"], marker = "extra == 'dev-optional'" },
@@ -6855,7 +6868,7 @@ requires-dist = [
     { name = "vaex", marker = "python_full_version < '3.10' and extra == 'dev-optional'" },
     { name = "xarray", marker = "extra == 'dev-optional'" },
 ]
-provides-extras = ["express", "kaleido", "dev-core", "dev-build", "dev-optional", "dev", "dev-pandas1", "dev-pandas2", "dev-pandas3"]
+provides-extras = ["express", "kaleido", "dev-core", "dev-build", "dev-codegen", "dev-optional", "dev", "dev-pandas1", "dev-pandas2", "dev-pandas3"]
 
 [[package]]
 name = "pluggy"


### PR DESCRIPTION
### Link to issue

Closes #5680

### Description of change
Adds a CI job which runs the Python codegen script and fails if the generated files do not match what's committed in the repo.

Also adds a `[dev_codegen]` extra in `pyproject.toml` which installs only the packages needed to run the codegen. This is used in the CI job. `uv.lock` is also updated accordingly.

This will ensure that the generated Python files (`python/graph_objs/`) are always up-to-date.

### Testing

The job fails on this PR because the codgen files are [currently out of date on `v7.0`](https://github.com/plotly/plotly.py/pull/5679).

See #5682 for a demo of the job passing and failing.

### Guidelines

- [x] I have reviewed the [pull request guidelines](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md#opening-a-pull-request) and the [Code of Conduct](https://github.com/plotly/plotly.py/blob/main/CODE_OF_CONDUCT.md) and confirm that this PR follows them.
- [x] I have added an entry to the [changelog](https://github.com/plotly/plotly.py/blob/main/CHANGELOG.md) if needed (not required for documentation PRs).
