### PR TITLE
Remove `locationmode` warning

### DIFF
--- a/codegen/datatypes.py
+++ b/codegen/datatypes.py
@@ -5,12 +5,6 @@ from io import StringIO
 from codegen.utils import CAVEAT, write_source_py
 
 
-locationmode_traces = [
-    "choropleth",
-    "scattergeo",
-]
-
-
 def get_typing_type(plotly_type, array_ok=False):
     """
     Get Python type corresponding to a valType string from the plotly schema
@@ -97,7 +91,7 @@ def build_datatype_py(node):
     )
     buffer.write("import copy as _copy\n")
 
-    if node.name_property in locationmode_traces or node.name_property == "template":
+    if node.name_property == "template":
         buffer.write("import warnings\n")
 
     # Write class definition

--- a/codegen/datatypes.py
+++ b/codegen/datatypes.py
@@ -340,22 +340,6 @@ an instance of :class:`{class_name}`\"\"\")
         """
     )
 
-    # Add warning for 'country names' locationmode
-    if node.name_property in locationmode_traces:
-        buffer.write(
-            f"""
-        if locationmode == "country names" and kwargs.get("_validate"):
-            warnings.warn(
-                "The library used by the *country names* `locationmode` option is changing in an upcoming version. "
-                "Country names in existing plots may not work in the new version. "
-                "To ensure consistent behavior, consider setting `locationmode` to *ISO-3*.",
-                DeprecationWarning,
-                stacklevel=5,
-            )
-
-            """
-        )
-
     buffer.write(
         f"""
         self._skip_invalid = kwargs.pop("skip_invalid", False)

--- a/plotly/express/_chart_types.py
+++ b/plotly/express/_chart_types.py
@@ -1111,15 +1111,6 @@ def choropleth(
     colored region mark on a map.
     """
 
-    if locationmode == "country names":
-        warn(
-            "The library used by the *country names* `locationmode` option is changing in an upcoming version. "
-            "Country names in existing plots may not work in the new version. "
-            "To ensure consistent behavior, consider setting `locationmode` to *ISO-3*.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
     return make_figure(
         args=locals(),
         constructor=go.Choropleth,
@@ -1178,15 +1169,6 @@ def scatter_geo(
     In a geographic scatter plot, each row of `data_frame` is represented
     by a symbol mark on a map.
     """
-
-    if locationmode == "country names":
-        warn(
-            "The library used by the *country names* `locationmode` option is changing in an upcoming version. "
-            "Country names in existing plots may not work in the new version. "
-            "To ensure consistent behavior, consider setting `locationmode` to *ISO-3*.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
 
     return make_figure(
         args=locals(),

--- a/plotly/graph_objs/_choropleth.py
+++ b/plotly/graph_objs/_choropleth.py
@@ -3,7 +3,6 @@
 
 from plotly.basedatatypes import BaseTraceType as _BaseTraceType
 import copy as _copy
-import warnings
 
 
 class Choropleth(_BaseTraceType):
@@ -1485,15 +1484,6 @@ class Choropleth(_BaseTraceType):
 The first argument to the plotly.graph_objs.Choropleth
 constructor must be a dict or
 an instance of :class:`plotly.graph_objs.Choropleth`""")
-
-        if locationmode == "country names" and kwargs.get("_validate"):
-            warnings.warn(
-                "The library used by the *country names* `locationmode` option is changing in an upcoming version. "
-                "Country names in existing plots may not work in the new version. "
-                "To ensure consistent behavior, consider setting `locationmode` to *ISO-3*.",
-                DeprecationWarning,
-                stacklevel=5,
-            )
 
         self._skip_invalid = kwargs.pop("skip_invalid", False)
         self._validate = kwargs.pop("_validate", True)

--- a/plotly/graph_objs/_scattergeo.py
+++ b/plotly/graph_objs/_scattergeo.py
@@ -3,7 +3,6 @@
 
 from plotly.basedatatypes import BaseTraceType as _BaseTraceType
 import copy as _copy
-import warnings
 
 
 class Scattergeo(_BaseTraceType):
@@ -1549,15 +1548,6 @@ class Scattergeo(_BaseTraceType):
 The first argument to the plotly.graph_objs.Scattergeo
 constructor must be a dict or
 an instance of :class:`plotly.graph_objs.Scattergeo`""")
-
-        if locationmode == "country names" and kwargs.get("_validate"):
-            warnings.warn(
-                "The library used by the *country names* `locationmode` option is changing in an upcoming version. "
-                "Country names in existing plots may not work in the new version. "
-                "To ensure consistent behavior, consider setting `locationmode` to *ISO-3*.",
-                DeprecationWarning,
-                stacklevel=5,
-            )
 
         self._skip_invalid = kwargs.pop("skip_invalid", False)
         self._validate = kwargs.pop("_validate", True)


### PR DESCRIPTION
### Link to issue
Closes #5628 

### Description of change
The change mentioned in the deprecation warning has now happened, with the switch to plotly.js v4.0. The deprecation warning can therefore be removed.

### Guidelines

- [x] I have reviewed the [pull request guidelines](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md#opening-a-pull-request) and the [Code of Conduct](https://github.com/plotly/plotly.py/blob/main/CODE_OF_CONDUCT.md) and confirm that this PR follows them.
- [x] I have added an entry to the [changelog](https://github.com/plotly/plotly.py/blob/main/CHANGELOG.md) if needed (not required for documentation PRs).
