### PR TITLE
enable support for more recent versions of sphinx for documentation generation

### DIFF
--- a/doc/apidoc/conf.py
+++ b/doc/apidoc/conf.py
@@ -202,4 +202,4 @@ todo_include_todos = True
 
 
 def setup(app):
-    app.add_stylesheet("plotly-style.css")  # also can be a full URL
+    app.add_css_file("plotly-style.css")  # also can be a full URL


### PR DESCRIPTION
### Link to issue

This PR fixes the documentation issue reported in #4085: corrects `app.add_stylesheet("plotly-style.css")  # also can be a full URL` to `app.add_css_file("plotly-style.css")  # also can be a full URL` in `doc/apidoc/conf.py`.

Fixes #4085

Closes #(issue number)

### Description of change

### Demo

### Testing strategy

### Additional information (optional)

### Guidelines

- [ ] I have reviewed the [pull request guidelines](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md#opening-a-pull-request) and the [Code of Conduct](https://github.com/plotly/plotly.py/blob/main/CODE_OF_CONDUCT.md) and confirm that this PR follows them.
- [ ] I have added an entry to the [changelog](https://github.com/plotly/plotly.py/blob/main/CHANGELOG.md) if needed (not required for documentation PRs).

Fixes #4085