### PR TITLE
Fix thread safety of lazy graph object properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix `hex_to_rgb` parsing of 3-digit shorthand hexadecimal colors such as `#FFF` [[#5662](https://github.com/plotly/plotly.py/pull/5662)], with thanks to @genrichez for the contribution!
+- Fix concurrent first access to lazily initialized graph object properties, which could raise `ValueError("Invalid value")` [[#3441](https://github.com/plotly/plotly.py/issues/3441)]
 
 
 ## [6.9.0] - 2026-07-09

--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -4784,24 +4784,27 @@ class BasePlotlyType(object):
             if isinstance(validator, CompoundValidator):
                 if self._compound_props.get(prop, None) is None:
                     # Init compound objects
-                    self._compound_props[prop] = validator.data_class(
-                        _parent=self, plotly_name=prop
-                    )
+                    child = validator.data_class(_parent=self, plotly_name=prop)
                     # Update plotly_name value in case the validator applies
                     # non-standard name (e.g. imagedefaults instead of image)
-                    self._compound_props[prop]._plotly_name = prop
+                    child._plotly_name = prop
+                    # Concurrent readers may both construct a child, but they
+                    # must use the first child published to the cache.
+                    self._compound_props.setdefault(prop, child)
 
                 return validator.present(self._compound_props[prop])
             elif isinstance(validator, (CompoundArrayValidator, BaseDataValidator)):
                 if self._compound_array_props.get(prop, None) is None:
                     # Init list of compound objects
                     if self._props is not None:
-                        self._compound_array_props[prop] = [
+                        children = [
                             validator.data_class(_parent=self)
                             for _ in self._props.get(prop, [])
                         ]
                     else:
-                        self._compound_array_props[prop] = []
+                        children = []
+                    # Keep every concurrent reader attached to the same list.
+                    self._compound_array_props.setdefault(prop, children)
 
                 return validator.present(self._compound_array_props[prop])
             elif self._props is not None and prop in self._props:

--- a/tests/test_core/test_graph_objs/test_thread_safety.py
+++ b/tests/test_core/test_graph_objs/test_thread_safety.py
@@ -1,0 +1,89 @@
+import threading
+
+import pytest
+
+import plotly.graph_objs as go
+
+
+@pytest.mark.parametrize(
+    ("target_type", "target_kwargs", "property_name", "child_property", "expected"),
+    [
+        pytest.param(
+            go.Layout,
+            {"font": {"family": "Arial"}},
+            "font",
+            "family",
+            "Arial",
+            id="compound-property",
+        ),
+        pytest.param(
+            go.layout.template.Data,
+            {"bar": [{"name": "template bar"}]},
+            "bar",
+            "name",
+            "template bar",
+            id="compound-array-property",
+        ),
+    ],
+)
+def test_concurrent_first_read_keeps_children_attached(
+    monkeypatch,
+    target_type,
+    target_kwargs,
+    property_name,
+    child_property,
+    expected,
+):
+    target = target_type(**target_kwargs)
+    target._compound_props.pop(property_name, None)
+    target._compound_array_props.pop(property_name, None)
+    validator = target._get_validator(property_name)
+    data_class = validator.data_class
+    constructors_ready = threading.Barrier(2)
+    first_read_complete = threading.Event()
+    second_read_complete = threading.Event()
+    children = []
+    results = []
+    errors = []
+
+    def build_child(*args, **kwargs):
+        child = data_class(*args, **kwargs)
+        constructors_ready.wait(timeout=5)
+        if threading.current_thread().name == "second-reader":
+            if not first_read_complete.wait(timeout=5):
+                raise TimeoutError("First reader did not receive its child")
+        return child
+
+    monkeypatch.setattr(validator, "_data_class", build_child)
+
+    def read_child():
+        try:
+            value = target[property_name]
+            if threading.current_thread().name == "first-reader":
+                first_read_complete.set()
+                if not second_read_complete.wait(timeout=5):
+                    raise TimeoutError("Second reader did not receive its child")
+            else:
+                second_read_complete.set()
+
+            child = value[0] if isinstance(value, tuple) else value
+            children.append(child)
+            results.append(child[child_property])
+        except Exception as error:
+            errors.append(error)
+            first_read_complete.set()
+            second_read_complete.set()
+
+    workers = [
+        threading.Thread(target=read_child, name="first-reader"),
+        threading.Thread(target=read_child, name="second-reader"),
+    ]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=5)
+
+    assert all(not worker.is_alive() for worker in workers)
+    assert not errors
+    assert children[0] is children[1]
+    assert results == [expected, expected]


### PR DESCRIPTION
### Link to issue

Closes #3441

### Description of change

Make lazy initialization of compound graph-object properties safe for concurrent first reads. Concurrent readers now converge on the first child or child list published to the cache, preventing a later initializer from orphaning objects already returned to another thread.

### Demo

Not applicable; this fixes an intermittent server-side exception without changing rendered figures.

### Testing strategy

Added a deterministic two-thread regression test for both compound and compound-array properties. The test forces the failing interleaving: it fails on unpatched `main` with distinct compound children and `ValueError("Invalid value")` for the compound array, then passes with this change.

Validation performed:

- `python -m pytest tests/test_core -q` — 456 passed, 1 skipped
- Ruff 0.11.12 check and format check on the changed Python files
- Five end-to-end cold-template reproduction runs — 0 of 11 templates raced in every run

### Additional information (optional)

The cache still permits duplicate construction during a concurrent cold read, but `dict.setdefault` makes publication single-winner so all readers receive objects that remain attached to their parent. This avoids adding a lock to every graph object and its associated memory, re-entrancy, deepcopy, and pickling considerations.

### Guidelines

- [x] I have reviewed the [pull request guidelines](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md#opening-a-pull-request) and the [Code of Conduct](https://github.com/plotly/plotly.py/blob/main/CODE_OF_CONDUCT.md) and confirm that this PR follows them.
- [x] I have added an entry to the [changelog](https://github.com/plotly/plotly.py/blob/main/CHANGELOG.md) if needed (not required for documentation PRs).
