### PR TITLE
docs: explain Jupyter blank-render workaround

### DIFF
--- a/doc/python/troubleshooting.md
+++ b/doc/python/troubleshooting.md
@@ -35,6 +35,21 @@ jupyter:
 ---
 
 <!-- #region -->
+### Jupyter and JupyterLab Problems
+
+If a figure appears blank in JupyterLab, first check that the Jupyter server
+environment and the environment used by the notebook kernel can both access the
+Plotly packages they need. This is especially important when JupyterLab and
+`plotly` are installed in separate virtual environments.
+
+As a workaround, try the `notebook` renderer explicitly:
+
+```python
+fig.show(renderer="notebook")
+```
+
+This can help when the default renderer does not display the figure correctly.
+
 ### Version Problems
 
 In order to follow the examples in this documentation site, you should have the latest version of `plotly` installed (5.x), as detailed in the [Getting Started](/python/getting-started) guide. This documentation (under https://plotly.com/python) is compatible with `plotly` version 4.x but *not* with version 3.x, for which the documentation is available under https://plotly.com/python/v3. In general you must also have the correct version of the underlying Plotly.js rendering engine installed, and the way to do that depends on the environment in which you are rendering figures: Dash, Jupyter Lab or Classic Notebook, VSCode etc. Read on for details about troubleshooting `plotly` in these environments.

--- a/doc/python/troubleshooting.md
+++ b/doc/python/troubleshooting.md
@@ -35,21 +35,6 @@ jupyter:
 ---
 
 <!-- #region -->
-### Jupyter and JupyterLab Problems
-
-If a figure appears blank in JupyterLab, first check that the Jupyter server
-environment and the environment used by the notebook kernel can both access the
-Plotly packages they need. This is especially important when JupyterLab and
-`plotly` are installed in separate virtual environments.
-
-As a workaround, try the `notebook` renderer explicitly:
-
-```python
-fig.show(renderer="notebook")
-```
-
-This can help when the default renderer does not display the figure correctly.
-
 ### Version Problems
 
 In order to follow the examples in this documentation site, you should have the latest version of `plotly` installed (5.x), as detailed in the [Getting Started](/python/getting-started) guide. This documentation (under https://plotly.com/python) is compatible with `plotly` version 4.x but *not* with version 3.x, for which the documentation is available under https://plotly.com/python/v3. In general you must also have the correct version of the underlying Plotly.js rendering engine installed, and the way to do that depends on the environment in which you are rendering figures: Dash, Jupyter Lab or Classic Notebook, VSCode etc. Read on for details about troubleshooting `plotly` in these environments.
@@ -97,3 +82,18 @@ The situation is similar for environments like Nteract and Streamlit: in these e
 If you get an error message stating that the `orca` executable that was found is not valid, this may be because another executable with the same name was found on your system. Please specify the complete path to the Plotly-Orca binary that you downloaded (for instance in the Miniconda folder) with the following command:
 
 `plotly.io.orca.config.executable = '/home/your_name/miniconda3/bin/orca'`
+
+### Jupyter and JupyterLab Problems
+
+If a figure appears blank in JupyterLab, first check that the Jupyter server
+environment and the environment used by the notebook kernel can both access the
+Plotly packages they need. This is especially important when JupyterLab and
+`plotly` are installed in separate virtual environments.
+
+As a workaround, try the `notebook` renderer explicitly:
+
+```python
+fig.show(renderer="notebook")
+```
+
+This can help when the default renderer does not display the figure correctly.

--- a/doc/python/troubleshooting.md
+++ b/doc/python/troubleshooting.md
@@ -35,21 +35,6 @@ jupyter:
 ---
 
 <!-- #region -->
-### Jupyter and JupyterLab Problems
-
-If a figure appears blank in JupyterLab, first check that the Jupyter server
-environment and the environment used by the notebook kernel can both access the
-Plotly packages they need. This is especially important when JupyterLab and
-`plotly` are installed in separate virtual environments.
-
-As a workaround, try the `notebook` renderer explicitly:
-
-```python
-fig.show(renderer="notebook")
-```
-
-This can help when the default renderer does not display the figure correctly.
-
 ### Version Problems
 
 In order to follow the examples in this documentation site, you should have the latest version of `plotly` installed (5.x), as detailed in the [Getting Started](/python/getting-started) guide. This documentation (under https://plotly.com/python) is compatible with `plotly` version 4.x but *not* with version 3.x, for which the documentation is available under https://plotly.com/python/v3. In general you must also have the correct version of the underlying Plotly.js rendering engine installed, and the way to do that depends on the environment in which you are rendering figures: Dash, Jupyter Lab or Classic Notebook, VSCode etc. Read on for details about troubleshooting `plotly` in these environments.
@@ -93,3 +78,18 @@ The situation is similar for environments like Nteract and Streamlit: in these e
 ### Orca Problems
 
 > The Orca image-generation utility is no longer supported in Plotly.py as of version 7.0.0. See the [Static Image Export page](/python/static-image-export/) for details on using Kaleido for static image generation.
+
+### Jupyter and JupyterLab Problems
+
+If a figure appears blank in JupyterLab, first check that the Jupyter server
+environment and the environment used by the notebook kernel can both access the
+Plotly packages they need. This is especially important when JupyterLab and
+`plotly` are installed in separate virtual environments.
+
+As a workaround, try the `notebook` renderer explicitly:
+
+```python
+fig.show(renderer="notebook")
+```
+
+This can help when the default renderer does not display the figure correctly.

--- a/doc/python/troubleshooting.md
+++ b/doc/python/troubleshooting.md
@@ -81,10 +81,7 @@ The situation is similar for environments like Nteract and Streamlit: in these e
 
 ### Jupyter and JupyterLab Problems
 
-If a figure appears blank in JupyterLab, first check that the Jupyter server
-environment and the environment used by the notebook kernel can both access the
-Plotly packages they need. This is especially important when JupyterLab and
-`plotly` are installed in separate virtual environments.
+If a figure appears blank in JupyterLab, first check that the Jupyter server environment and the environment used by the notebook kernel can both access the Plotly packages they need. This is especially important when JupyterLab and `plotly` are installed in separate virtual environments.
 
 As a workaround, try the `notebook` renderer explicitly:
 

--- a/doc/python/troubleshooting.md
+++ b/doc/python/troubleshooting.md
@@ -85,8 +85,8 @@ If a figure appears blank in JupyterLab, first check that the Jupyter server env
 
 As a workaround, try the `notebook` renderer explicitly:
 
-```python
+~~~python
 fig.show(renderer="notebook")
-```
+~~~
 
 This can help when the default renderer does not display the figure correctly.


### PR DESCRIPTION
## What changed

I added a short Jupyter and JupyterLab troubleshooting section to the existing troubleshooting page. It calls out the separate-server and kernel environment setup, then documents the `fig.show(renderer=notebook)` workaround from #5664.

This is intentionally documentation only. It does not claim to fix the underlying blank-render bug.

## Validation

- `git diff --check` passed
- The repository's docs conversion tool was not available locally, so the full notebook build was not run

This follows the scope suggested in #5664. Let me know what you think.

Closes #5664