### PR TITLE
Add <!doctype html> to the to_html template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix `hex_to_rgb` parsing of 3-digit shorthand hexadecimal colors such as `#FFF` [[#5662](https://github.com/plotly/plotly.py/pull/5662)], with thanks to @genrichez for the contribution!
-- Add <!doctype html> to the `to_html()` template to comply with modern web standards [[#5693](https://github.com/plotly/plotly.py/pull/5693)], with thanks to @mishrakushal for the contribution!
+- Add `<!doctype html>` to the `to_html()` template to comply with modern web standards [[#5693](https://github.com/plotly/plotly.py/pull/5693)], with thanks to @mishrakushal for the contribution!
 
 
 ## [6.9.0] - 2026-07-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix `hex_to_rgb` parsing of 3-digit shorthand hexadecimal colors such as `#FFF` [[#5662](https://github.com/plotly/plotly.py/pull/5662)], with thanks to @genrichez for the contribution!
+- Add <!doctype html> to the `to_html()` template to comply with modern web standards [[#5693](https://github.com/plotly/plotly.py/pull/5693)], with thanks to @mishrakushal for the contribution!
 
 
 ## [6.9.0] - 2026-07-09

--- a/plotly/io/_html.py
+++ b/plotly/io/_html.py
@@ -339,6 +339,7 @@ style="height:100%; width:100%;"></div>\
 
     if full_html:
         return """\
+<!doctype html>
 <html>
 <head><meta charset="utf-8" /></head>
 <body>

--- a/plotly/io/_html.py
+++ b/plotly/io/_html.py
@@ -341,7 +341,10 @@ style="height:100%; width:100%;"></div>\
         return """\
 <!doctype html>
 <html>
-<head><meta charset="utf-8" /></head>
+<head>
+    <meta charset="utf-8" />
+    <style>html, body {{height: 100%;}}</style>
+</head>
 <body>
     {div}
 </body>

--- a/tests/test_core/test_offline/test_offline.py
+++ b/tests/test_core/test_offline/test_offline.py
@@ -108,7 +108,7 @@ class PlotlyOfflineTestCase(PlotlyOfflineBaseTestCase):
         self.assertIn(plotly_config_script, html)  # so is config
         self.assertIn(PLOTLYJS, html)  # and the source code
         # and it's an <html> doc
-        self.assertTrue(html.startswith("<html>") and html.endswith("</html>"))
+        self.assertTrue(html.startswith("<!doctype html>") and html.endswith("</html>"))
 
     def test_including_plotlyjs_truthy_html(self):
         # For backwards compatibility all truthy values that aren't otherwise

--- a/tests/test_io/test_renderers.py
+++ b/tests/test_io/test_renderers.py
@@ -133,11 +133,11 @@ def test_plotly_mimetype_renderer_show(fig1, renderer):
 # HTML
 # ----
 def assert_full_html(html):
-    assert html.startswith("<html")
+    assert html.startswith("<!doctype html")
 
 
 def assert_not_full_html(html):
-    assert not html.startswith("<html")
+    assert not html.startswith("<!doctype html") and not html.startswith("<html")
 
 
 def assert_html_renderer_connected(html):

--- a/tests/test_optional/test_offline/test_offline.py
+++ b/tests/test_optional/test_offline/test_offline.py
@@ -88,4 +88,4 @@ class PlotlyOfflineMPLTestCase(TestCase):
             self.assertTrue(data_json in html)  # data is in there
             self.assertTrue(PLOTLYJS in html)  # and the source code
             # and it's an <html> doc
-            self.assertTrue(html.startswith("<html>") and html.endswith("</html>"))
+            self.assertTrue(html.startswith("<!doctype html>") and html.endswith("</html>"))

--- a/tests/test_optional/test_offline/test_offline.py
+++ b/tests/test_optional/test_offline/test_offline.py
@@ -88,4 +88,6 @@ class PlotlyOfflineMPLTestCase(TestCase):
             self.assertTrue(data_json in html)  # data is in there
             self.assertTrue(PLOTLYJS in html)  # and the source code
             # and it's an <html> doc
-            self.assertTrue(html.startswith("<!doctype html>") and html.endswith("</html>"))
+            self.assertTrue(
+                html.startswith("<!doctype html>") and html.endswith("</html>")
+            )


### PR DESCRIPTION
### Link to issue
<!-- Link to the issue closed by this PR. If the issue doesn't exist yet, create it. -->

Closes #4847

Continuation of PR #4848 by @mishrakushal

### Description of change
Add `<!doctype html>` at top of HTML template for compliance with modern web standards.

### Demo
n/a

### Testing strategy

Call `fig.to_html()` and verify that the generated HTML file has `<!doctype html>` at the very top.

### Additional information (optional)

Updated unit tests accordingly.

Note: Adding `<!doctype html>` changed the chart rendering behaviour and made charts render at 450px high rather than filling the browser window. To keep the existing behaviour, this PR adds a small HTML snippet to the template:

`<style>html, body {{height: 100%;}}</style>`

### Guidelines

- [x] I have reviewed the [pull request guidelines](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md#opening-a-pull-request) and the [Code of Conduct](https://github.com/plotly/plotly.py/blob/main/CODE_OF_CONDUCT.md) and confirm that this PR follows them.
- [x] I have added an entry to the [changelog](https://github.com/plotly/plotly.py/blob/main/CHANGELOG.md) if needed (not required for documentation PRs).
