### PR TITLE
Accept NumPy axis labels in annotated heatmaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fix `hex_to_rgb` parsing of 3-digit shorthand hexadecimal colors such as `#FFF` [[#5662](https://github.com/plotly/plotly.py/pull/5662)], with thanks to @genrichez for the contribution!
 - Add `<!doctype html>` to the `to_html()` template to comply with modern web standards [[#5693](https://github.com/plotly/plotly.py/pull/5693)], with thanks to @mishrakushal for the contribution!
+- Accept NumPy arrays for the `x` and `y` arguments of `figure_factory.create_annotated_heatmap`, which previously raised `ValueError: The truth value of an array with more than one element is ambiguous` [[#4160](https://github.com/plotly/plotly.py/issues/4160)]
 
 
 ## [6.9.0] - 2026-07-09

--- a/plotly/figure_factory/_annotated_heatmap.py
+++ b/plotly/figure_factory/_annotated_heatmap.py
@@ -28,7 +28,7 @@ def validate_annotated_heatmap(z, x, y, annotation_text):
                     "z and text should have the same dimensions"
                 )
 
-    if x:
+    if x is not None:
         if len(x) != len(z[0]):
             raise exceptions.PlotlyError(
                 "oops, the x list that you "
@@ -36,7 +36,7 @@ def validate_annotated_heatmap(z, x, y, annotation_text):
                 "width of your z matrix "
             )
 
-    if y:
+    if y is not None:
         if len(y) != len(z):
             raise exceptions.PlotlyError(
                 "oops, the y list that you "
@@ -65,8 +65,8 @@ def create_annotated_heatmap(
     This function adds annotations to each cell of the heatmap.
 
     :param (list[list]|ndarray) z: z matrix to create heatmap.
-    :param (list) x: x axis labels.
-    :param (list) y: y axis labels.
+    :param (list|ndarray) x: x axis labels.
+    :param (list|ndarray) y: y axis labels.
     :param (list[list]|ndarray) annotation_text: Text strings for
         annotations. Should have the same dimensions as the z matrix. If no
         text is added, the values of the z matrix are annotated. Default =
@@ -109,7 +109,7 @@ def create_annotated_heatmap(
         z, x, y, annotation_text, colorscale, font_colors, reversescale, **kwargs
     ).make_annotations()
 
-    if x or y:
+    if x is not None or y is not None:
         trace = dict(
             type="heatmap",
             z=z,
@@ -174,11 +174,11 @@ class _AnnotatedHeatmap(object):
         self, z, x, y, annotation_text, colorscale, font_colors, reversescale, **kwargs
     ):
         self.z = z
-        if x:
+        if x is not None:
             self.x = x
         else:
             self.x = range(len(z[0]))
-        if y:
+        if y is not None:
             self.y = y
         else:
             self.y = range(len(z))

--- a/tests/test_optional/test_tools/test_figure_factory.py
+++ b/tests/test_optional/test_tools/test_figure_factory.py
@@ -1,6 +1,7 @@
 import math
 
 import datetime
+import numpy as np
 import plotly.figure_factory as ff
 
 from plotly.exceptions import PlotlyError
@@ -779,6 +780,25 @@ class TestAnnotatedHeatmap(TestCaseNoTemplate, NumpyTestUtilsMixin):
         # check: PlotlyError if y is the wrong size
 
         kwargs = {"z": [[1, 2], [1, 2]], "y": [1, 2, 3]}
+        self.assertRaises(PlotlyError, ff.create_annotated_heatmap, **kwargs)
+
+    def test_numpy_x_and_y(self):
+        # check: numpy arrays are accepted as x and y axis labels
+
+        a_heat = ff.create_annotated_heatmap(
+            [[1, 2], [3, 4]], x=np.array(["A", "B"]), y=np.array(["C", "D"])
+        )
+
+        self.assertEqual(list(a_heat["data"][0]["x"]), ["A", "B"])
+        self.assertEqual(list(a_heat["data"][0]["y"]), ["C", "D"])
+        # tick labels are shown when x and y are supplied
+        self.assertNotEqual(a_heat["layout"]["xaxis"]["showticklabels"], False)
+        self.assertNotEqual(a_heat["layout"]["yaxis"]["showticklabels"], False)
+
+    def test_numpy_x_wrong_size(self):
+        # check: PlotlyError if a numpy x is the wrong size
+
+        kwargs = {"z": [[1, 2], [1, 2]], "x": np.array(["A", "B", "C"])}
         self.assertRaises(PlotlyError, ff.create_annotated_heatmap, **kwargs)
 
     def test_simple_annotated_heatmap(self):


### PR DESCRIPTION
## Description

`figure_factory.create_annotated_heatmap()` documents NumPy arrays for `z`, but passing NumPy arrays for the corresponding `x` or `y` labels raises:

```text
ValueError: The truth value of an array with more than one element is ambiguous
```

The factory uses truthiness checks for these optional arguments in validation, trace construction, and annotation setup. This change checks explicitly for `None`, allowing NumPy arrays (and other array-like labels) while still validating their dimensions.

Regression tests cover NumPy arrays for both axes and a mismatched array length. The accepted types in the docstring and the changelog are updated as well.

Fixes #4160.

## Tests

- `python -m pytest tests/test_optional/test_tools/test_figure_factory.py -q` ? 34 passed
- `ruff check plotly/figure_factory/_annotated_heatmap.py tests/test_optional/test_tools/test_figure_factory.py`
- `git diff --check upstream/main...HEAD`
