### PR TITLE
Fix flaky matplotlib-to-plotly conversion of touching bars (negative bargap)

### DIFF
--- a/plotly/matplotlylib/mpltools.py
+++ b/plotly/matplotlylib/mpltools.py
@@ -269,7 +269,9 @@ def get_bar_gap(bar_starts, bar_ends, tol=1e-10):
         gap0 = gaps[0]
         uniform = all([abs(gap0 - gap) < tol for gap in gaps])
         if uniform:
-            return gap0
+            # plotly's bargap must be in [0, 1]; clamp to guard against
+            # floating point noise (e.g. -8.9e-16 for touching bars)
+            return min(max(gap0, 0.0), 1.0)
 
 
 def convert_rgba_array(color_list):

--- a/plotly/matplotlylib/tests/test_renderer.py
+++ b/plotly/matplotlylib/tests/test_renderer.py
@@ -235,6 +235,19 @@ def test_semitransparent_axes_background_preserved():
     assert plotly_fig.layout.plot_bgcolor == "rgba(26, 51, 76, 0.4)"
 
 
+def test_histogram_converts():
+    """Histograms must convert without error and keep bargap in plotly's
+    valid [0, 1] range; get_bar_gap can return a gap with floating point
+    noise for touching bars, which plotly rejects."""
+    fig, ax = plt.subplots()
+    ax.hist(np.random.randn(1000), 30)
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert len(plotly_fig.data) == 1
+    assert 0 <= plotly_fig.layout.bargap <= 1
+
+
 def test_line_color_is_valid_plotly_color():
     """Converted line colors are valid plotly color strings: plotly rejects
     a space between 'rgba' and the opening parenthesis."""


### PR DESCRIPTION
mpl_to_plotly intermittently crashes when converting figures with touching bars (e.g. plt.hist). The bar gap is computed as bar_start[i+1] - bar_end[i], and for adjacent bars floating-point noise can make this a tiny negative number (e.g. -8.88e-16). Plotly's bargap property only accepts values in [0, 1], so the conversion fails with:
```
ValueError: Invalid value of type 'numpy.float64' received for the 'bargap' property of layout
    Received value: np.float64(-8.881784197001252e-16)
```
Reproduces with:

```
import warnings
import matplotlib
matplotlib.use("Agg")
import matplotlib.pyplot as plt
import numpy as np
import plotly.tools as tls

np.random.seed(0)
plt.hist(np.random.randn(10000), 30)

with warnings.catch_warnings():
    warnings.simplefilter("ignore")
    tls.mpl_to_plotly(plt.gcf())
```

Fix: get_bar_gap now clamps the gap to [0, 1], so float noise around zero maps to bargap = 0 (touching bars) and genuine gaps are unchanged.