### PR TITLE
Convert matplotlib step drawstyles to plotly line shapes

### DIFF
--- a/plotly/matplotlylib/mpltools.py
+++ b/plotly/matplotlylib/mpltools.py
@@ -272,6 +272,23 @@ def get_bar_gap(bar_starts, bar_ends, tol=1e-10):
             return gap0
 
 
+DRAWSTYLE_SHAPE_MAP = {
+    "steps": "vh",
+    "steps-pre": "vh",
+    "steps-post": "hv",
+    "steps-mid": "hvh",
+}
+
+
+def convert_drawstyle(drawstyle):
+    """Convert a matplotlib line drawstyle to a plotly line shape.
+
+    Matplotlib draws steps as vertical/horizontal segments; plotly's
+    ``line.shape`` expresses the same via "vh", "hv" and "hvh".
+    """
+    return DRAWSTYLE_SHAPE_MAP.get(drawstyle)
+
+
 def convert_rgba_array(color_list):
     clean_color_list = list()
     for c in color_list:

--- a/plotly/matplotlylib/renderer.py
+++ b/plotly/matplotlylib/renderer.py
@@ -407,6 +407,9 @@ class PlotlyRenderer(Renderer):
                     color=color,
                     width=props["linestyle"]["linewidth"],
                     dash=mpltools.convert_dash(props["linestyle"]["dasharray"]),
+                    shape=mpltools.convert_drawstyle(
+                        props["linestyle"]["drawstyle"]
+                    ),
                 )
             else:
                 shape = dict(

--- a/plotly/matplotlylib/tests/test_renderer.py
+++ b/plotly/matplotlylib/tests/test_renderer.py
@@ -37,6 +37,22 @@ def test_no_fake_legend_shapes_with_native_legend():
     assert len(plotly_fig.layout.annotations) == 0
 
 
+def test_drawstyle_maps_to_line_shape():
+    cases = {
+        "steps-pre": "vh",
+        "steps": "vh",
+        "steps-post": "hv",
+        "steps-mid": "hvh",
+    }
+    for drawstyle, shape in cases.items():
+        fig, ax = plt.subplots()
+        ax.plot([0, 1, 2], [0, 1, 0], drawstyle=drawstyle)
+
+        plotly_fig = tls.mpl_to_plotly(fig)
+
+        assert plotly_fig.data[0].line.shape == shape
+
+
 def test_legend_disabled_when_no_matplotlib_legend():
     """Test that legend is not enabled when no matplotlib legend is present."""
     fig, ax = plt.subplots()


### PR DESCRIPTION
mpl_to_plotly converts plt.step plots (and any drawstyle="steps-*" line) as ordinary straight lines, connecting the points with diagonals instead of the vertical/horizontal step segments matplotlib draws.

Before: the converted trace has line.shape = None, so plotly draws diagonal connections between consecutive points.

After: the drawstyle is mapped to plotly's step shapes, matching matplotlib's geometry exactly:

| matplotlib drawstyle | plotly line.shape |
|---|---|
| steps-pre (and plt.step, steps) | vh |
| steps-post | hv |
| steps-mid | hvh |

Steps to reproduce:
```
import matplotlib
matplotlib.use("Agg")
import matplotlib.pyplot as plt
import numpy as np
import plotly.tools as tls

x = np.linspace(0, 10, 20)
y = np.sin(x)

fig, ax = plt.subplots()
ax.step(x, y)
fig.savefig("step_mpl.png")

p = tls.mpl_to_plotly(fig)
p.write_image("step_plotly.png")

print(p.data[0].line.shape)   # "vh" with the fix; None before
```

| matplotlib | plotly before | plotly after |
|---|---|---|
| <img width="640" height="480" alt="step_mpl" src="https://github.com/user-attachments/assets/bdeeccea-faf3-4154-aa9a-fe36d9de5594" /> | <img width="640" height="480" alt="step_plotly_before" src="https://github.com/user-attachments/assets/86f43d2d-b6ce-440d-87da-39ff5ffb65fc" /> | <img width="640" height="480" alt="step_plotly_after" src="https://github.com/user-attachments/assets/6b64f202-deb4-4844-892f-e5f037b64be5" /> |