### PR TITLE
Convert matplotlib stairs plots to plotly step lines

### DIFF
--- a/plotly/matplotlylib/renderer.py
+++ b/plotly/matplotlylib/renderer.py
@@ -9,6 +9,7 @@ with the matplotlylib package.
 
 import warnings
 
+import matplotlib.patches as mpatches
 import plotly.graph_objs as go
 from plotly.matplotlylib.mplexporter import Renderer
 from plotly.matplotlylib import mpltools
@@ -602,12 +603,47 @@ class PlotlyRenderer(Renderer):
         is_bar = mpltools.is_bar(self.current_mpl_ax.containers, **props)
         if is_bar:
             self.current_bars += [props]
+        elif isinstance(props["mplobj"], mpatches.StepPatch):
+            self.msg += "    Drawing a step path\n"
+            self._draw_step_path(props)
         else:
             self.msg += "    This path isn't a bar, not drawing\n"
             warnings.warn(
                 "I found a path object that I don't think is part "
                 "of a bar chart. Ignoring."
             )
+
+    def _draw_step_path(self, props):
+        """Draw a matplotlib StepPatch as a step line trace."""
+        if props["coordinates"] != "data":
+            self.msg += "    Step path is not in data coordinates, not drawing\n"
+            return
+        style = props["style"]
+        x = []
+        y = []
+        for x0, y0 in props["data"]:
+            if not x or x0 != x[-1] or y0 != y[-1]:
+                x.append(x0)
+                y.append(y0)
+        if len(x) < 2:
+            self.msg += "    Step path has fewer than 2 points, not drawing\n"
+            return
+        self.plotly_fig.add_trace(
+            go.Scatter(
+                x=x,
+                y=y,
+                mode="lines",
+                line=go.scatter.Line(
+                    color=mpltools.merge_color_and_opacity(
+                        style["edgecolor"], style["alpha"]
+                    ),
+                    width=style["edgewidth"],
+                    dash=mpltools.convert_dash(style["dasharray"]),
+                ),
+                xaxis="x{0}".format(self.axis_ct),
+                yaxis="y{0}".format(self.axis_ct),
+            )
+        )
 
     def draw_text(self, **props):
         """Create an annotation dict for a text obj.

--- a/plotly/matplotlylib/tests/test_renderer.py
+++ b/plotly/matplotlylib/tests/test_renderer.py
@@ -211,6 +211,17 @@ def test_background_colors_from_matplotlib_defaults():
     assert plotly_fig.layout.paper_bgcolor == "#FFFFFF"
 
 
+def test_stairs_converts_to_step_line():
+    fig, ax = plt.subplots()
+    ax.stairs([0.0, 1.0, 0.0], [0.0, 1.0, 2.0, 3.0])
+    plotly_fig = tls.mpl_to_plotly(fig)
+    assert len(plotly_fig.data) == 1
+    trace = plotly_fig.data[0]
+    assert trace.mode == "lines"
+    assert tuple(trace.x) == (0.0, 1.0, 1.0, 2.0, 2.0, 3.0)
+    assert tuple(trace.y) == (0.0, 0.0, 1.0, 1.0, 0.0, 0.0)
+
+
 def test_custom_background_colors_are_preserved():
     fig, ax = plt.subplots()
     fig.patch.set_facecolor("lightyellow")


### PR DESCRIPTION
mpl_to_plotly currently drops plt.stairs plots entirely. Matplotlib's stairs creates a StepPatch artist, which the exporter treats as a generic path, and the renderer only handles bar-chart paths, so the stairs plot is skipped with the warning "I found a path object that I don't think is part of a bar chart. Ignoring." The converted figure has zero traces.

Fix: draw_path now recognizes StepPatch artists and draws them as a line trace:
- the StepPatch's path vertices already describe the horizontal/vertical step outline, so they're used directly (consecutive duplicates removed)
- line styling (color, width, dash) comes from the patch's edge properties

Snippet to reproduce:
```
import matplotlib
matplotlib.use("Agg")
import matplotlib.pyplot as plt
import numpy as np
import plotly.tools as tls

x = np.linspace(0, 10, 20)

fig, ax = plt.subplots()
ax.stairs(np.sin(x))
fig.savefig("stairs_mpl.png")

p = tls.mpl_to_plotly(fig)
p.write_image("stairs_plotly.png") 
```

| matplotlib | plotly before | plotly after |
|---|---|---|
| <img width="640" height="480" alt="stairs_mpl" src="https://github.com/user-attachments/assets/fad5d63a-a340-4f3b-a722-8739cd668687" /> | <img width="640" height="480" alt="stairs_plotly" src="https://github.com/user-attachments/assets/d5faa2f6-e22b-4dfb-8459-f0f06b6dace8" /> | <img width="640" height="480" alt="stairs_plotly_after" src="https://github.com/user-attachments/assets/b7c7b1e9-3f1d-4536-b844-8e9389b29566" /> |
