### PR TITLE
Only show a legend when the matplotlib figure has one

### DIFF
--- a/plotly/matplotlylib/renderer.py
+++ b/plotly/matplotlylib/renderer.py
@@ -100,6 +100,10 @@ class PlotlyRenderer(Renderer):
             height=int(props["figheight"] * props["dpi"]),
             autosize=False,
             hovermode="closest",
+            # plotly.js auto-names unnamed traces "trace N" and shows them
+            # in the legend; the legend is only enabled when the mpl figure
+            # actually has one (see open_legend)
+            showlegend=False,
         )
         self.plotly_fig["layout"].paper_bgcolor = _export_color(props["figbg"])
         self.mpl_x_bounds, self.mpl_y_bounds = mpltools.get_axes_bounds(fig)
@@ -440,13 +444,14 @@ class PlotlyRenderer(Renderer):
                     ),
                 )
         if props["coordinates"] == "data":
+            label = props["label"]
+            # matplotlib uses "_nolegend_" and auto-generated "_childN"
+            # labels for artists that must not appear in a legend
+            if isinstance(label, str) and label.startswith("_"):
+                label = None
             marked_line = go.Scatter(
                 mode=mode,
-                name=(
-                    str(props["label"])
-                    if isinstance(props["label"], str)
-                    else props["label"]
-                ),
+                name=label,
                 x=[xy_pair[0] for xy_pair in props["data"]],
                 y=[xy_pair[1] for xy_pair in props["data"]],
                 xaxis="x{0}".format(self.axis_ct),

--- a/plotly/matplotlylib/tests/test_renderer.py
+++ b/plotly/matplotlylib/tests/test_renderer.py
@@ -297,6 +297,17 @@ def test_fixed_formatter_ticktext():
     assert plotly_fig.layout.xaxis.ticktext == ("Baseline", "param = 1", "param = 2")
 
 
+def test_no_legend_entries_for_internal_mpl_labels():
+    """mpl internal labels (_nolegend_, _childN) must not become legend entries."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1, 2, 3], [0, 1, 0, 1], "b", [0, 1, 2, 3], [1, 0, 1, 0], "r--")
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.layout.showlegend == False
+    assert all(t.name is None for t in plotly_fig.data)
+
+
 def test_custom_date_xtickvals_are_converted():
     """Custom tick values on a date axis must be converted to date strings,
     not left as raw matplotlib date numbers or datetime objects."""


### PR DESCRIPTION
Converted matplotlib figures without legends unexpectedly show legends in plotly. mpl_to_plotly left layout.showlegend unset, and plotly.js defaults it to True, auto-naming unnamed traces, so every conversion without an explicit mpl legend (e.g. plt.plot(x, y) with no labels, boxplots) rendered with a legend of junk entries.

Fix:
- open_figure now sets showlegend=False by default; the legend is only enabled by open_legend when the matplotlib figure actually has one (existing behavior, unchanged)

Snippet to reproduce:
```
import matplotlib
matplotlib.use("Agg")
import matplotlib.pyplot as plt
import plotly.tools as tls

fig, ax = plt.subplots()
ax.plot([0, 1, 2, 3], [0, 1, 0, 1], "b", [0, 1, 2, 3], [1, 0, 1, 0], "r--")
fig.savefig("legend_mpl.png")

p = tls.mpl_to_plotly(fig)
p.write_image("legend_plotly.png")
```

| matplotlib | plotly before | plotly after |
|---|---|---|
| <img width="640" height="480" alt="legend_mpl" src="https://github.com/user-attachments/assets/5813b451-b9f7-443a-8350-689c00c5e635" /> | <img width="640" height="480" alt="legend_plotly_before" src="https://github.com/user-attachments/assets/0afb9000-78d2-4aa0-9b90-aed7fb006957" /> | <img width="640" height="480" alt="legend_plotly_after" src="https://github.com/user-attachments/assets/fab09a60-b4ba-473b-aa71-89c87ae4881c" /> |