### PR TITLE
Fix boxplot conversion by mapping 'none' colors to transparent rgba

### DIFF
--- a/plotly/matplotlylib/renderer.py
+++ b/plotly/matplotlylib/renderer.py
@@ -336,7 +336,7 @@ class PlotlyRenderer(Renderer):
             yaxis="y{0}".format(self.axis_ct),
             opacity=trace[0]["alpha"],  # TODO: get all alphas if array?
             marker=go.bar.Marker(
-                color=trace[0]["facecolor"],  # TODO: get all
+                color=_export_color(trace[0]["facecolor"]),  # TODO: get all
                 line=dict(width=trace[0]["edgewidth"]),
             ),
         )  # TODO ditto
@@ -398,9 +398,13 @@ class PlotlyRenderer(Renderer):
             self.msg += "... with just markers\n"
             mode = "markers"
         if props["linestyle"]:
-            color = mpltools.merge_color_and_opacity(
-                props["linestyle"]["color"], props["linestyle"]["alpha"]
-            )
+            if props["linestyle"]["color"] == "none":
+                # a fully transparent line; plotly rejects "none" as a color
+                color = "rgba(0,0,0,0)"
+            else:
+                color = mpltools.merge_color_and_opacity(
+                    props["linestyle"]["color"], props["linestyle"]["alpha"]
+                )
 
             if props["coordinates"] == "data":
                 line = go.scatter.Line(
@@ -420,22 +424,22 @@ class PlotlyRenderer(Renderer):
             if props["coordinates"] == "data":
                 marker = go.scatter.Marker(
                     opacity=props["markerstyle"]["alpha"],
-                    color=props["markerstyle"]["facecolor"],
+                    color=_export_color(props["markerstyle"]["facecolor"]),
                     symbol=mpltools.convert_symbol(props["markerstyle"]["marker"]),
                     size=props["markerstyle"]["markersize"],
                     line=dict(
-                        color=props["markerstyle"]["edgecolor"],
+                        color=_export_color(props["markerstyle"]["edgecolor"]),
                         width=props["markerstyle"]["edgewidth"],
                     ),
                 )
             else:
                 shape = dict(
                     opacity=props["markerstyle"]["alpha"],
-                    fillcolor=props["markerstyle"]["facecolor"],
+                    fillcolor=_export_color(props["markerstyle"]["facecolor"]),
                     symbol=mpltools.convert_symbol(props["markerstyle"]["marker"]),
                     size=props["markerstyle"]["markersize"],
                     line=dict(
-                        color=props["markerstyle"]["edgecolor"],
+                        color=_export_color(props["markerstyle"]["edgecolor"]),
                         width=props["markerstyle"]["edgewidth"],
                     ),
                 )

--- a/plotly/matplotlylib/tests/test_renderer.py
+++ b/plotly/matplotlylib/tests/test_renderer.py
@@ -107,6 +107,28 @@ def test_pcolor_rectangles_render():
     assert all(len(t.x) >= 4 for t in plotly_fig.data)
 
 
+def test_boxplot_converts_with_none_marker_facecolor():
+    """Boxplot outlier markers use facecolor 'none', which plotly rejects."""
+    fig, ax = plt.subplots()
+    ax.boxplot(np.random.randn(100, 4))
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert len(plotly_fig.data) > 0
+
+
+def test_line_with_none_color_converts():
+    """Lines with color='none' use the string 'none' for the line color,
+    which plotly rejects; it must be exported as a transparent line."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1], color="none")
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert len(plotly_fig.data) == 1
+    assert plotly_fig.data[0].line.color == "rgba(0,0,0,0)"
+
+
 def test_eventplot_segments_render():
     fig, ax = plt.subplots()
     ax.eventplot([np.random.randn(20) for _ in range(5)])


### PR DESCRIPTION
mpl_to_plotly crashes when converting boxplots:

```
ValueError: Invalid value of type 'builtins.str' received for the 'color' property of scatter.marker
    Received value: 'none'
```

Boxplot outlier markers use facecolor="none" (fully transparent) in matplotlib. The converter passes that color verbatim into the plotly trace, and plotly.py's validators reject "none" for color property.

Fix: transparent matplotlib colors are mapped to rgba(0,0,0,0), which plotly accepts.

Snippet to reproduce:
```
import matplotlib
matplotlib.use("Agg")
import matplotlib.pyplot as plt
import numpy as np
import plotly.tools as tls

fig, ax = plt.subplots()
ax.boxplot(np.random.randn(100, 4))
fig.savefig("boxplot_mpl.png")

p = tls.mpl_to_plotly(fig)   # raised ValueError before the fix
p.write_image("boxplot_plotly.png")
```