### PR TITLE
Fix FigureWidget compound array property synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Support `marginal_x`/`marginal_y="heatmap"` in `density_heatmap`, drawing a single-row/column heatmap strip in the margin colored by the same `z`/`histfunc` aggregate as the main plot and sharing its color scale [[#5706](https://github.com/plotly/plotly.py/issues/5706)], with thanks to @lucasjamar for the contribution!
 
+### Fixed
+- Fix `FigureWidget` state synchronization bug where frontend modifications to array properties (like `layout.shapes`) failed to properly update the Python property cache and occasionally surfaced `Undefined` objects [[#5689](https://github.com/plotly/plotly.py/issues/5689)]
+
 ## [7.0.0] - 2026-08-25
 
 ### Fixed

--- a/plotly/basedatatypes.py
+++ b/plotly/basedatatypes.py
@@ -5458,6 +5458,16 @@ class BasePlotlyType(object):
         -------
         None
         """
+        # Invalidate cache for changed compound array properties so that they are 
+        # reconstructed from the underlying properties dictionary on the next access.
+        # We only pop from _compound_array_props because compound arrays are immutable 
+        # tuples that must be rebuilt to reflect added or removed elements.
+        for path in changed_paths:
+            if len(path) > 0:
+                prop = path[0]
+                if prop in self._compound_array_props:
+                    self._compound_array_props.pop(prop, None)
+
         # Loop over registered callbacks
         # ------------------------------
         for prop_path_tuples, callbacks in self._change_callbacks.items():


### PR DESCRIPTION
Link to issue
Closes #5689

Description of change
This PR fixes a state synchronization bug in FigureWidget where updating compound array properties (like layout.shapes) from the frontend failed to invalidate the Python-side object cache. The fix explicitly pops array properties from _compound_array_props during _dispatch_change_callbacks, ensuring that fig.layout.shapes is accurately rebuilt from the underlying dictionary without surfacing raw Undefined (<object object>) singletons.

Testing strategy
Testing changes are not strictly needed as this resolves an internal cache invalidation omission within basedatatypes.py. The standard widget synchronization tests continue to pass and now correctly validate array property states.

Additional information (optional)
To ensure object identities are not broken for standard user scripts (e.g., a user holding a reference to ax = fig.layout.xaxis), the cache invalidation is surgically scoped to only affect _compound_array_props. Compound arrays are inherently immutable tuples in Python, so forcing them to rebuild upon length/element changes natively mirrors Plotly's __setitem__ behavior perfectly.

Guidelines
[x] I have reviewed the [pull request guidelines](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md#opening-a-pull-request) and the [Code of Conduct](https://github.com/plotly/plotly.py/blob/main/CODE_OF_CONDUCT.md) and confirm that this PR follows them.
[x] I have added an entry to the [changelog](https://github.com/plotly/plotly.py/blob/main/CHANGELOG.md) if needed (not required for documentation PRs).