### PR TITLE
Drop space in rgb and rgba color strings

### DIFF
--- a/plotly/matplotlylib/mpltools.py
+++ b/plotly/matplotlylib/mpltools.py
@@ -120,10 +120,10 @@ def merge_color_and_opacity(color, opacity):
 
     rgb_tup = hex_to_rgb(color)
     if opacity is None:
-        return "rgb {}".format(rgb_tup)
+        return "rgb{}".format(rgb_tup)
 
     rgba_tup = rgb_tup + (opacity,)
-    return "rgba {}".format(rgba_tup)
+    return "rgba{}".format(rgba_tup)
 
 
 def convert_va(mpl_va):

--- a/plotly/matplotlylib/tests/test_renderer.py
+++ b/plotly/matplotlylib/tests/test_renderer.py
@@ -233,3 +233,14 @@ def test_semitransparent_axes_background_preserved():
     plotly_fig = tls.mpl_to_plotly(fig)
 
     assert plotly_fig.layout.plot_bgcolor == "rgba(26, 51, 76, 0.4)"
+
+
+def test_line_color_is_valid_plotly_color():
+    """Converted line colors are valid plotly color strings: plotly rejects
+    a space between 'rgba' and the opening parenthesis."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1], color="red")
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.data[0].line.color == "rgba(255, 0, 0, 1)"


### PR DESCRIPTION
Color strings with a space between "rgb" and parenthesis are accepted in plotly.js 3.6.0, but fail to parse in 4.0.0, so the trace silently falls back to the default.

This affects every color routed through `merge_color_and_opacity`.

Snippet to reproduce:
```
import matplotlib.pyplot as plt
from plotly.tools import mpl_to_plotly

fig, ax = plt.subplots()
ax.plot([0, 1], [0, 1], color="red")

plotly_fig = mpl_to_plotly(fig)
print(plotly_fig.data[0].line.color)

# plotly.py bundles plotly.js 4.0.0 -> line renders blue, NOT red
plotly_fig.write_html("repro_v4.html", include_plotlyjs=True)

# same figure with the last pre-4.0.0 bundle -> line renders red
plotly_fig.write_html(
    "repro_v3.html",
    include_plotlyjs="https://cdn.plot.ly/plotly-3.6.0.min.js",
)

```