### PR TITLE
Export tick label colors to the plotly tickfont

### DIFF
--- a/plotly/matplotlylib/mplexporter/utils.py
+++ b/plotly/matplotlylib/mplexporter/utils.py
@@ -239,12 +239,15 @@ def get_axis_properties(axis):
     # Get axis scale
     props["scale"] = axis.get_scale()
 
-    # Get major tick label size (assumes that's all we really care about!)
+    # Get major tick label size and color (assumes that's all we really
+    # care about!)
     labels = axis.get_ticklabels()
     if labels:
         props["fontsize"] = labels[0].get_fontsize()
+        props["fontcolor"] = export_color(labels[0].get_color())
     else:
         props["fontsize"] = None
+        props["fontcolor"] = None
 
     # Get associated grid
     props["grid"] = get_grid_style(axis)

--- a/plotly/matplotlylib/mpltools.py
+++ b/plotly/matplotlylib/mpltools.py
@@ -517,7 +517,10 @@ def prep_xy_axis(ax, props, x_bounds, y_bounds):
         showgrid=props["axes"][0]["grid"]["gridOn"],
         domain=convert_x_domain(props["bounds"], x_bounds),
         side=props["axes"][0]["position"],
-        tickfont=dict(size=props["axes"][0]["fontsize"]),
+        tickfont=dict(
+            size=props["axes"][0]["fontsize"],
+            color=props["axes"][0]["fontcolor"],
+        ),
     )
     xaxis.update(prep_ticks(ax, 0, "x", props))
     yaxis = dict(
@@ -526,7 +529,10 @@ def prep_xy_axis(ax, props, x_bounds, y_bounds):
         showgrid=props["axes"][1]["grid"]["gridOn"],
         domain=convert_y_domain(props["bounds"], y_bounds),
         side=props["axes"][1]["position"],
-        tickfont=dict(size=props["axes"][1]["fontsize"]),
+        tickfont=dict(
+            size=props["axes"][1]["fontsize"],
+            color=props["axes"][1]["fontcolor"],
+        ),
     )
     yaxis.update(prep_ticks(ax, 1, "y", props))
     return xaxis, yaxis

--- a/plotly/matplotlylib/tests/test_renderer.py
+++ b/plotly/matplotlylib/tests/test_renderer.py
@@ -351,3 +351,25 @@ def test_custom_date_xtickvals_given_as_numbers_are_converted():
         "2023-01-07 00:00:00",
         "2023-01-10 00:00:00",
     )
+
+
+def test_tick_label_color_exports():
+    """Tick label colors are exported to the plotly tickfont."""
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.layout.xaxis.tickfont.color == "#000000"
+
+
+def test_dark_tick_label_color_exports():
+    """Dark-background tick label colors are exported to the plotly
+    tickfont."""
+    with plt.style.context("dark_background"):
+        fig, ax = plt.subplots()
+        ax.plot([0, 1], [0, 1])
+
+        plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert plotly_fig.layout.xaxis.tickfont.color == "#FFFFFF"


### PR DESCRIPTION
Tick label colors are dropped by the converter. The mplexporter does not export the tick label color, so the plotly tickfont gets a size with no color and tick labels always render in plotly's default dark grey, which is nearly invisible on dark figures (e.g. `plt.style.use("dark_background")`).

Fix: the mplexporter axis properties now export the tick label color, and prep_xy_axis passes it through to the plotly tickfont.

Snippet to reproduce:
```
import matplotlib
matplotlib.use("Agg")
import matplotlib.pyplot as plt
import numpy as np
import plotly.tools as tls

plt.style.use("dark_background")

fig, ax = plt.subplots()
ax.plot(np.sin(np.linspace(0, 6, 100)))
fig.savefig("ticks_mpl.png")

p = tls.mpl_to_plotly(fig)   # tickfont.color was None before the fix
p.write_image("ticks_plotly.png")
```

| matplotlib | plotly before | plotly after |
|---|---|---|
| <img width="640" height="480" alt="ticks_mpl" src="https://github.com/user-attachments/assets/1cd87ffc-32af-4d55-be55-14d2be754938" /> | <img width="640" height="480" alt="ticks_plotly_before" src="https://github.com/user-attachments/assets/6ba75b97-aa80-42dd-ae31-ede8e95950de" /> | <img width="640" height="480" alt="ticks_plotly_after" src="https://github.com/user-attachments/assets/293ca491-ff86-46b7-99c4-e378c32184a7" /> |