### PR TITLE
Set `full_html=False` for Google Colab renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix `mpl_to_plotly` not setting `paper_bgcolor` and `plot_bgcolor` from the matplotlib figure and axes backgrounds, so converted figures match the source figure's background colors [[#5285](https://github.com/plotly/plotly.py/pull/5285)], with thanks to @robertoffmoura for the contribution!
+- Fix rendering issue causing a too-large div when calling `Figure.show()` in Google Colab [[#5718](https://github.com/plotly/plotly.py/pull/5718)]
 
 ## [7.0.0] - 2026-08-25
 

--- a/plotly/io/_base_renderers.py
+++ b/plotly/io/_base_renderers.py
@@ -452,7 +452,7 @@ class ColabRenderer(HtmlRenderer):
     ):
         super(ColabRenderer, self).__init__(
             connected=True,
-            full_html=True,
+            full_html=False,
             global_init=False,
             config=config,
             auto_play=auto_play,

--- a/tests/test_io/test_renderers.py
+++ b/tests/test_io/test_renderers.py
@@ -154,7 +154,7 @@ def test_colab_renderer_show(fig1):
 
     # Check html contents
     html = mock_arg1["text/html"]
-    assert_full_html(html)
+    assert_not_full_html(html)
     assert_html_renderer_connected(html)
 
     # check kwargs


### PR DESCRIPTION
Resolves https://github.com/plotly/plotly.py/issues/5717

Based on the conversation in https://github.com/plotly/plotly.py/issues/5717, I believe the root cause of the issue is:

1. The `ColabRenderer` constructor passes `full_html=True` through to the `to_html()` function, resulting in the _entire_ HTML document getting embedded in the Colab notebook
2. v7.0.0 [added](https://github.com/plotly/plotly.py/pull/5693) `<!doctype html>` and `<style>html, body {{height: 100%;}}</style>` to the full HTML template, causing them to be added into the Colab document and causing the `height: 100%` to fight with the height setting of the surrounding div.

As far as I can tell it's just a mistake that `ColabRenderer` was setting `full_html=True`; the `<html></html>`, etc. tags should definitely not be included in the Colab output. This change brings `ColabRenderer` more in line with the behavior of `NotebookRenderer`.

Further evidence for this fix: Calling `fig.show(render="notebook")` resolves the issue, and `NotebookRenderer` passes `full_html=False`.

### Steps for testing

1. Build a `.whl` file from this branch (`python -m build` ; the `.whl` will be added to the `dist/` folder).
    - Ideally change the version number in `pyproject.toml` first, so you can distinguish it from the actual plotly v7.0.0.

2. Create a new notebook in [Google Colab](https://colab.research.google.com) 
<details>
<summary>Show image</summary>
<img width="176" height="49" alt="Screenshot 2026-09-03 at 3 39 16 PM" src="https://github.com/user-attachments/assets/a7f5b6c9-4dea-46f8-83be-57b8e3e85888" />
</details>

3. Upload the `.whl` file
<details>
<summary>Show image</summary>
<img width="475" height="446" alt="Screenshot 2026-09-03 at 3 40 14 PM" src="https://github.com/user-attachments/assets/8ef378f1-b979-443b-8984-ed2ef0127387" />
</details>

4. Click the **Terminal** button at the bottom of the page to open the terminal
<details>
<summary>Show image</summary>
<img width="397" height="248" alt="Screenshot 2026-09-03 at 3 40 51 PM" src="https://github.com/user-attachments/assets/ca75f5bb-fcee-45a4-ad75-2c4420843e70" />
</details>

5. Run `pip install plotly-[...].whl`, filling in the correct filename for the `.whl` file

6. Click **Runtime** > **Restart session**

<details>
<summary>Show image</summary>
<img width="618" height="371" alt="Screenshot 2026-09-03 at 3 43 38 PM" src="https://github.com/user-attachments/assets/ea4cca1b-e35b-48c9-a6d0-5028a062f67d" />
</details>

7. Enter the following code in a notebook cell:

```python
import plotly
import plotly.express as px

print(plotly.__version__)

fig = px.scatter(x=[1,2,3], y=[1,2,3], title=plotly.__version__)
fig.show()
```

8. Verify that the correct plotly version is running and that there's no weird empty space inside the cell below the chart:
<img width="811" height="770" alt="Screenshot 2026-09-03 at 3 45 26 PM" src="https://github.com/user-attachments/assets/8b886ee4-449d-49c8-a302-3e8c5fb50313" />


The cell should render more like the first image in [this comment](https://github.com/plotly/plotly.py/issues/5717#issuecomment-5530538868), rather than the second.