### PR TITLE
Convert axhline, axvline, and axline to layout shapes

### DIFF
--- a/plotly/matplotlylib/renderer.py
+++ b/plotly/matplotlylib/renderer.py
@@ -9,6 +9,7 @@ with the matplotlylib package.
 
 import warnings
 
+from matplotlib import transforms
 import plotly.graph_objs as go
 from plotly.matplotlylib.mplexporter import Renderer
 from plotly.matplotlylib import mpltools
@@ -459,8 +460,18 @@ class PlotlyRenderer(Renderer):
             self.plotly_fig.add_trace(marked_line)
             self.msg += "    Heck yeah, I drew that line\n"
         elif props["coordinates"] == "axes":
-            # dealing with legend graphical elements
-            self.msg += "    Using native legend\n"
+            if self._processing_legend:
+                # dealing with legend graphical elements
+                self.msg += "    Using native legend\n"
+            else:
+                # horizontal/vertical reference lines (axhline/axvline)
+                self._draw_axes_line(props)
+        elif props["coordinates"] == "display" and isinstance(
+            props["mplobj"].get_transform(), transforms.BlendedGenericTransform
+        ):
+            # axhline/axvline: blended axes/data transforms are reported as
+            # display coordinates by the exporter
+            self._draw_axes_line(props)
         else:
             self.msg += "    Line didn't have 'data' coordinates, not drawing\n"
             warnings.warn(
@@ -468,6 +479,37 @@ class PlotlyRenderer(Renderer):
                 "objects from matplotlib that are in 'data' "
                 "coordinates!"
             )
+
+    def _draw_axes_line(self, props):
+        """Draw an axes-coordinate reference line (axhline/axvline) as a
+        layout shape spanning the line's endpoints in data coordinates."""
+        ax = self.current_mpl_ax
+        trans = props["mplobj"].get_transform()
+        if props["coordinates"] == "display":
+            px_points = props["data"]
+        else:
+            px_points = [trans.transform(pt) for pt in props["data"]]
+        (x0, y0), (x1, y1) = [ax.transData.inverted().transform(pt) for pt in px_points]
+        color = mpltools.merge_color_and_opacity(
+            props["linestyle"]["color"], props["linestyle"]["alpha"]
+        )
+        shape = go.layout.Shape(
+            type="line",
+            x0=x0,
+            y0=y0,
+            x1=x1,
+            y1=y1,
+            xref="x{0}".format(self.axis_ct),
+            yref="y{0}".format(self.axis_ct),
+            line=go.layout.shape.Line(
+                color=color,
+                width=props["linestyle"]["linewidth"],
+                dash=mpltools.convert_dash(props["linestyle"]["dasharray"]),
+            ),
+            layer="above",
+        )
+        self.plotly_fig["layout"]["shapes"] += (shape,)
+        self.msg += "    Heck yeah, I drew that reference line\n"
 
     def draw_image(self, **props):
         """Draw image.

--- a/plotly/matplotlylib/tests/test_renderer.py
+++ b/plotly/matplotlylib/tests/test_renderer.py
@@ -315,6 +315,64 @@ def test_custom_date_xtickvals_are_converted():
     )
 
 
+def test_axhline_converts():
+    """axhline converts to a layout shape spanning the axes width."""
+    fig, ax = plt.subplots()
+    ax.axhline(0.5)
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert len(plotly_fig.data) == 0
+    assert len(plotly_fig.layout.shapes) == 1
+    shape = plotly_fig.layout.shapes[0]
+    assert shape.type == "line"
+    x0, x1 = ax.get_xlim()
+    assert abs(shape.x0 - x0) < 1e-9
+    assert abs(shape.x1 - x1) < 1e-9
+    assert abs(shape.y0 - 0.5) < 1e-9
+    assert abs(shape.y1 - 0.5) < 1e-9
+    assert shape.xref == "x"
+    assert shape.yref == "y"
+    assert shape.line.color == "rgba(31, 119, 180, 1)"
+
+
+def test_axvline_converts():
+    """axvline converts to a layout shape spanning the axes height."""
+    fig, ax = plt.subplots()
+    ax.axvline(0.5)
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert len(plotly_fig.data) == 0
+    assert len(plotly_fig.layout.shapes) == 1
+    shape = plotly_fig.layout.shapes[0]
+    assert shape.type == "line"
+    y0, y1 = ax.get_ylim()
+    assert abs(shape.x0 - 0.5) < 1e-9
+    assert abs(shape.x1 - 0.5) < 1e-9
+    assert abs(shape.y0 - y0) < 1e-9
+    assert abs(shape.y1 - y1) < 1e-9
+
+
+def test_axline_converts():
+    """axline converts to a layout shape spanning the whole axes box."""
+    fig, ax = plt.subplots()
+    ax.axline((0.5, 0.5), slope=1)
+
+    plotly_fig = tls.mpl_to_plotly(fig)
+
+    assert len(plotly_fig.data) == 0
+    assert len(plotly_fig.layout.shapes) == 1
+    shape = plotly_fig.layout.shapes[0]
+    assert shape.type == "line"
+    x0, x1 = ax.get_xlim()
+    y0, y1 = ax.get_ylim()
+    assert abs(shape.x0 - x0) < 1e-9
+    assert abs(shape.x1 - x1) < 1e-9
+    assert abs(shape.y0 - y0) < 1e-9
+    assert abs(shape.y1 - y1) < 1e-9
+
+
 def test_uneven_custom_date_xtickvals_are_converted():
     """Unevenly spaced custom date ticks must be converted to date strings."""
     dates = [datetime.datetime(2023, 1, i) for i in range(1, 11)]


### PR DESCRIPTION
`mpl_to_plotly` silently drops reference lines. `axhline`, `axvline`, and `axline` produce lines with blended or axes transforms, which the renderer skipped with "I found a line that didn't have 'data' coordinates! I will not draw it, but I did not crash.". The converted figure ends up with the reference lines missing completely.

Fix: reference lines are now drawn as layout line shapes:
- endpoints are mapped to data coordinates using `ax.transData.inverted()`
- added as `go.layout.Shape(type="line")` on the current subplot
- color, alpha, linewidth, and dash styles are preserved

Before: 0 shapes (lines dropped with a warning).
After: lines render as layout shapes spanning the axis limits.

Snippet to reproduce:
```python
import matplotlib
matplotlib.use("Agg")
import matplotlib.pyplot as plt
import plotly.tools as tls

cases = {
    "axhline": lambda: plt.axhline(0.5, color="red", linestyle="--"),
    "axvline": lambda: plt.axvline(2.0, color="blue", linestyle="-"),
    "axline":  lambda: plt.axline((1, 0.5), slope=0.5, color="green", linestyle="-."),
}

for name, build in cases.items():
    fig, ax = plt.subplots()
    ax.set_xlim(0, 4)
    ax.set_ylim(0, 2)
    build()

    p = tls.mpl_to_plotly(fig)  # 0 shapes before this fix
    print(f"{name:10s} -> {len(p.layout.shapes)} shape(s)")
    p.write_image(f"{name}_plotly.png")
```

| axhline | axline | axvline |
|---|---|---|
| <img width="640" height="480" alt="axhline_plotly" src="https://github.com/user-attachments/assets/870625d5-9808-40c4-9685-6f09941b3f3d" /> | <img width="640" height="480" alt="axline_plotly" src="https://github.com/user-attachments/assets/030a184c-527f-49e6-a6cf-c4d8e6d5faa0" /> | <img width="640" height="480" alt="axvline_plotly" src="https://github.com/user-attachments/assets/581bd907-9f27-4a39-827b-dd3b10035ff8" /> |
