### PR TITLE
[CHORE]: Add CI workflow to make sure changelog gets updated with every PR

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -1,0 +1,18 @@
+name: Check changelog
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  check-changelog:
+    name: Check if CHANGELOG.md was updated
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api "repos/${{ github.repository }}/pulls/${{ github.event.number }}/files" --paginate --jq '.[].filename' \
+            | grep -qx CHANGELOG.md \
+            || { echo "::error::CHANGELOG.md was not updated. Either add a changelog entry, or add the 'no-changelog' label to this PR if a changelog entry is not needed."; exit 1; }

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -2,7 +2,15 @@ name: Check changelog
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
+    types: [opened, reopened, synchronize, labeled, unlabeled, ready_for_review]
+
+concurrency:
+  group: check-changelog-${{ github.event.pull_request.number }}
+  cancel-in-progress: true  
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   check-changelog:

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -15,12 +15,18 @@ permissions:
 jobs:
   check-changelog:
     name: Check if CHANGELOG.md was updated
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      HAS_SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'no-changelog') }}
     steps:
-      - env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api "repos/${{ github.repository }}/pulls/${{ github.event.number }}/files" --paginate --jq '.[].filename' \
-            | grep -qx CHANGELOG.md \
-            || { echo "::error::CHANGELOG.md was not updated. Either add a changelog entry, or add the 'no-changelog' label to this PR if a changelog entry is not needed."; exit 1; }
+      - run: |
+          if [ "$HAS_SKIP_LABEL" = true ]; then
+            echo "::notice::This PR has the 'no-changelog' label, so a change to CHANGELOG.md is not required."
+          elif gh api "repos/${{ github.repository }}/pulls/${{ github.event.number }}/files" --paginate --jq '.[].filename' | grep -qx CHANGELOG.md; then
+            echo "::notice::CHANGELOG.md was updated."
+          else
+            echo "::error::CHANGELOG.md was not updated. Either add a changelog entry, or add the 'no-changelog' label to this PR if a changelog entry is not needed."
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+Adding a line here for demonstration purposes
+
 ### Added
 - Support `marginal_x`/`marginal_y="heatmap"` in `density_heatmap`, drawing a single-row/column heatmap strip in the margin colored by the same `z`/`histfunc` aggregate as the main plot and sharing its color scale [[#5706](https://github.com/plotly/plotly.py/issues/5706)], with thanks to @lucasjamar for the contribution!
 - Add support for custom tick values in `mpl_to_plotly` when the matplotlib tick positions don't follow an arithmetic progression, including custom tick labels and tick values on date axes [[#5262](https://github.com/plotly/plotly.py/pull/5262)], with thanks to @robertoffmoura for the contribution!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-Adding a line here for demonstration purposes
-
 ### Added
 - Support `marginal_x`/`marginal_y="heatmap"` in `density_heatmap`, drawing a single-row/column heatmap strip in the margin colored by the same `z`/`histfunc` aggregate as the main plot and sharing its color scale [[#5706](https://github.com/plotly/plotly.py/issues/5706)], with thanks to @lucasjamar for the contribution!
 - Add support for custom tick values in `mpl_to_plotly` when the matplotlib tick positions don't follow an arithmetic progression, including custom tick labels and tick values on date axes [[#5262](https://github.com/plotly/plotly.py/pull/5262)], with thanks to @robertoffmoura for the contribution!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,7 +181,8 @@ When creating your pull request, please follow the guidelines below.
 - If your PR modifies code of `plotly.graph_objects`, the modifications should be made to the code generator, *not* the generated files.
 - You have added tests or modified existing tests, as needed.
 - For a new feature, you have added documentation examples (please see the doc checklist as well).
-- You have added a CHANGELOG entry if changing anything substantial.
+- You have added a changelog entry to `CHANGELOG.md` if changing anything substantial.
+  - The CI job "Check changelog" will fail if the PR does not update `CHANGELOG.md`. To bypass this check for PRs which don't require a changelog entry (e.g. docs updates), add the `no-changelog` label to the PR.
 - For a new feature or a change in behavior, you have updated the relevant docstrings in the code.
 
 ### Documentation pull request


### PR DESCRIPTION

### Link to issue

Closes https://github.com/plotly/plotly.py/issues/5723

### Description of change

Add a CI job to check that `CHANGELOG.md` is updated for every PR, unless the `no-changelog` label is added to the PR.

This implementation is pretty naïve; it only checks that `CHANGELOG.md` has been modified, not whether the new entry follows the correct format. Feel free to complexify in the future.

### Demo

❌ Run failed (`CHANGELOG.md` not updated):
https://github.com/plotly/plotly.py/actions/runs/34384286059/job/102576548616

⚪ Run skipped (`no-changelog` label added):
https://github.com/plotly/plotly.py/actions/runs/34384435370/job/102577056340?pr=5724

✅ Run passed (`CHANGELOG.md` updated with dummy entry for demo purposes):
https://github.com/plotly/plotly.py/actions/runs/34385144520/job/102579417311?pr=5724

### Guidelines

- [x] I have reviewed the [pull request guidelines](https://github.com/plotly/plotly.py/blob/main/CONTRIBUTING.md#opening-a-pull-request) and the [Code of Conduct](https://github.com/plotly/plotly.py/blob/main/CODE_OF_CONDUCT.md) and confirm that this PR follows them.
- [x] I have added an entry to the [changelog](https://github.com/plotly/plotly.py/blob/main/CHANGELOG.md) if needed (not required for documentation PRs).
